### PR TITLE
fix(p2p): hub PushLog admission control — nack overload instead of acking success (#1088 W1/W4/W5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,7 @@ Rust node via CLI + HTTP API. Each area is a `[[test]]` binary with submodules:
 | P2P Iroh ACP | `--test p2p_iroh` | acp, dac, nac, trust_boundary |
 | NAC | `--test nac` | document_acp, operations, core_operations, p2p_management, relation_admin, cross_compartment_isolation, policy_evolution |
 | P2P | `--test p2p` | document, sync, management, trust_boundary, replication, replication_advanced, stubs |
+| P2P Admission | `--test p2p_admission` | fan-in backpressure (own binary: injects `DEFRA_P2P_MAX_PENDING_DAGS`) |
 | FTS | `--test fts` | basic, edge_cases, lifecycle, scoring |
 | Encryption | `--test encryption` | index, acp, block_verify, stubs |
 | Identity | `--test identity` | lifecycle, types, negative, node_identity, keyring_lifecycle |

--- a/crates/cli/src/commands/start/mod.rs
+++ b/crates/cli/src/commands/start/mod.rs
@@ -217,6 +217,11 @@ pub struct StartArgs {
     #[arg(long)]
     pub p2p_max_doc_sync_request_doc_ids: Option<usize>,
 
+    /// Max pending-DAG registrations awaiting Bitswap completion; overflow is
+    /// nacked back to the pusher. Default: 1000.
+    #[arg(long, env = "DEFRA_P2P_MAX_PENDING_DAGS")]
+    pub p2p_max_pending_dags: Option<usize>,
+
     /// P2P transport backend: "libp2p" (default) or "iroh"
     #[arg(long)]
     pub p2p_transport: Option<String>,
@@ -442,6 +447,9 @@ impl StartArgs {
         }
         if let Some(max) = self.p2p_max_doc_sync_request_doc_ids {
             config.net.p2p_max_doc_sync_request_doc_ids = max;
+        }
+        if let Some(max) = self.p2p_max_pending_dags {
+            config.net.p2p_max_pending_dags = max;
         }
         if let Some(ref transport) = self.p2p_transport {
             config.net.transport = transport.parse()?;

--- a/crates/cli/src/commands/start/mod.rs
+++ b/crates/cli/src/commands/start/mod.rs
@@ -206,11 +206,11 @@ pub struct StartArgs {
     pub query_max_filter_depth: Option<usize>,
 
     /// Per-peer rate limit burst capacity (max tokens). Default: 500.
-    #[arg(long)]
+    #[arg(long, env = "DEFRA_P2P_RATE_LIMIT_BURST")]
     pub p2p_rate_limit_burst: Option<u32>,
 
     /// Per-peer rate limit refill rate (tokens per second). Default: 50.
-    #[arg(long)]
+    #[arg(long, env = "DEFRA_P2P_RATE_LIMIT_RATE")]
     pub p2p_rate_limit_rate: Option<f64>,
 
     /// Max document IDs accepted in one DocSync request. Default: 1000.

--- a/crates/cli/src/commands/start/server_p2p.rs
+++ b/crates/cli/src/commands/start/server_p2p.rs
@@ -1272,6 +1272,7 @@ impl Node {
             rate_limit_burst: config.net.p2p_rate_limit_burst,
             rate_limit_rate: config.net.p2p_rate_limit_rate,
             max_doc_sync_request_doc_ids: config.net.p2p_max_doc_sync_request_doc_ids,
+            max_pending_dags: config.net.p2p_max_pending_dags,
             ..Default::default()
         }
     }

--- a/crates/cli/src/config/sections.rs
+++ b/crates/cli/src/config/sections.rs
@@ -321,6 +321,10 @@ pub struct NetConfig {
     /// Max document IDs accepted in one DocSync request. Default: 1000.
     #[serde(default = "default_max_doc_sync_request_doc_ids")]
     pub p2p_max_doc_sync_request_doc_ids: usize,
+    /// Max pending-DAG registrations held while Bitswap completes missing
+    /// links; overflow is nacked back to the pusher. Default: 1000.
+    #[serde(default = "default_max_pending_dags")]
+    pub p2p_max_pending_dags: usize,
 }
 
 fn default_max_msg_size() -> u64 {
@@ -356,6 +360,9 @@ fn default_rate_limit_rate() -> f64 {
 fn default_max_doc_sync_request_doc_ids() -> usize {
     p2p::sync::DEFAULT_MAX_DOC_SYNC_REQUEST_DOC_IDS
 }
+fn default_max_pending_dags() -> usize {
+    p2p::sync::DEFAULT_MAX_PENDING_DAGS
+}
 fn default_true() -> bool {
     true
 }
@@ -388,6 +395,7 @@ impl Default for NetConfig {
             p2p_rate_limit_burst: default_rate_limit_burst(),
             p2p_rate_limit_rate: default_rate_limit_rate(),
             p2p_max_doc_sync_request_doc_ids: default_max_doc_sync_request_doc_ids(),
+            p2p_max_pending_dags: default_max_pending_dags(),
         }
     }
 }

--- a/crates/cli/tests/start_tests.rs
+++ b/crates/cli/tests/start_tests.rs
@@ -44,6 +44,7 @@ fn default_start_args() -> StartArgs {
         p2p_rate_limit_burst: None,
         p2p_rate_limit_rate: None,
         p2p_max_doc_sync_request_doc_ids: None,
+        p2p_max_pending_dags: None,
         max_merge_depth: None,
         query_timeout: None,
         transaction_idle_timeout: None,
@@ -152,6 +153,7 @@ fn test_apply_to_config_all_flags() {
         p2p_rate_limit_burst: Some(32),
         p2p_rate_limit_rate: Some(4.5),
         p2p_max_doc_sync_request_doc_ids: Some(64),
+        p2p_max_pending_dags: Some(7),
         max_merge_depth: Some(2048),
         query_timeout: Some(45),
         transaction_idle_timeout: Some(900),
@@ -185,6 +187,7 @@ fn test_apply_to_config_all_flags() {
     assert_eq!(config.net.p2p_rate_limit_burst, 32);
     assert_eq!(config.net.p2p_rate_limit_rate, 4.5);
     assert_eq!(config.net.p2p_max_doc_sync_request_doc_ids, 64);
+    assert_eq!(config.net.p2p_max_pending_dags, 7);
     assert_eq!(config.datastore.max_merge_depth, 2048);
     assert_eq!(config.api.max_body_size, 1024);
     assert_eq!(config.api.max_schema_size, 2048);

--- a/crates/defra-node/src/config.rs
+++ b/crates/defra-node/src/config.rs
@@ -113,4 +113,7 @@ pub struct P2PConfig {
     pub rate_limit_burst: u32,
     /// Per-peer rate limit refill rate (tokens per second). Default: 50.
     pub rate_limit_rate: f64,
+    /// Maximum pending-DAG registrations held while Bitswap completes missing
+    /// links; overflow is nacked back to the pusher. Default: 1000.
+    pub max_pending_dags: usize,
 }

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -1371,6 +1371,7 @@ impl NodeBuilder {
             max_doc_sync_request_doc_ids: config.max_doc_sync_request_doc_ids,
             rate_limit_burst: config.rate_limit_burst,
             rate_limit_rate: config.rate_limit_rate,
+            max_pending_dags: config.max_pending_dags,
             ..Default::default()
         };
         let (mut coordinator, sync_events) =

--- a/crates/defra-node/src/p2p_tests.rs
+++ b/crates/defra-node/src/p2p_tests.rs
@@ -43,6 +43,7 @@ fn test_p2p_config() -> P2PConfig {
         max_doc_sync_request_doc_ids: p2p::sync::DEFAULT_MAX_DOC_SYNC_REQUEST_DOC_IDS,
         rate_limit_burst: p2p::sync::DEFAULT_RATE_LIMIT_BURST,
         rate_limit_rate: p2p::sync::DEFAULT_RATE_LIMIT_RATE,
+        max_pending_dags: p2p::sync::DEFAULT_MAX_PENDING_DAGS,
     }
 }
 

--- a/crates/p2p/src/error.rs
+++ b/crates/p2p/src/error.rs
@@ -203,6 +203,16 @@ pub enum Error {
         collection_id: String,
     },
 
+    /// The pending-DAG map is at capacity, so an incoming push with missing
+    /// links could not be registered. Reply seams map this to the byte-exact
+    /// `RATE_LIMITED_MESSAGE` nack so the pusher retries instead of treating
+    /// the push as landed (#1088 W1).
+    #[error("pending DAG registrations at capacity ({max}), retry later")]
+    PendingDagCapacity {
+        /// The configured `SyncConfig::max_pending_dags` in effect.
+        max: usize,
+    },
+
     /// Request rejected because the caller is not authorized.
     #[error("unauthorized: {0}")]
     Unauthorized(String),
@@ -348,6 +358,17 @@ impl Error {
             } if collection_id == "rate-limited"
         )
     }
+
+    /// Reply text for hub-side backpressure rejections (rate limit or
+    /// pending-DAG capacity overflow), or `None` for every other error.
+    ///
+    /// The pusher matches replies byte-exactly against `RATE_LIMITED_MESSAGE`
+    /// (`is_rate_limited_message`) to drive its retry/backoff, so all
+    /// backpressure shapes must collapse onto that one sentinel.
+    pub fn backpressure_reply_message(&self) -> Option<&'static str> {
+        (self.is_rate_limited() || matches!(self, Error::PendingDagCapacity { .. }))
+            .then_some(RATE_LIMITED_MESSAGE)
+    }
 }
 
 /// Returns true when a peer reply carries the coordinator's explicit rate-limit signal.
@@ -400,7 +421,7 @@ impl From<libp2p::multiaddr::Error> for Error {
 
 #[cfg(test)]
 mod tests {
-    use super::Error;
+    use super::{is_rate_limited_message, Error, RATE_LIMITED_MESSAGE};
 
     #[test]
     fn txn_conflict_detection_matches_wrapped_storage_messages() {
@@ -455,6 +476,36 @@ mod tests {
 
         assert!(rate_limited.is_rate_limited());
         assert!(!ordinary_denial.is_rate_limited());
+    }
+
+    #[test]
+    fn backpressure_errors_map_to_the_exact_rate_limited_reply() {
+        // #1088 W1: the pusher matches replies with `message == RATE_LIMITED_MESSAGE`
+        // (is_rate_limited_message), so both backpressure shapes must map to the
+        // byte-exact sentinel and everything else must not.
+        let capacity = Error::PendingDagCapacity { max: 1000 };
+        assert_eq!(
+            capacity.backpressure_reply_message(),
+            Some(RATE_LIMITED_MESSAGE)
+        );
+        assert!(is_rate_limited_message(
+            capacity.backpressure_reply_message().unwrap()
+        ));
+
+        let rate_limited = Error::AccessDenied {
+            peer_id: "peer-1".into(),
+            collection_id: "rate-limited".into(),
+        };
+        assert_eq!(
+            rate_limited.backpressure_reply_message(),
+            Some(RATE_LIMITED_MESSAGE)
+        );
+
+        let ordinary_denial = Error::AccessDenied {
+            peer_id: "peer-1".into(),
+            collection_id: "users".into(),
+        };
+        assert_eq!(ordinary_denial.backpressure_reply_message(), None);
     }
 
     #[test]

--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -68,12 +68,50 @@ fn create_test_coordinator_with_rate_limiter(
     SyncCoordinator<TestBlockstore, NoopTransport>,
     tokio::sync::mpsc::Receiver<crate::sync::manager::SyncEvent>,
 ) {
+    create_test_coordinator_with_options(
+        access_mode,
+        replicators,
+        peer_state,
+        rate_limiter,
+        SyncConfig::default(),
+    )
+}
+
+fn create_test_coordinator_with_sync_config(
+    access_mode: AccessMode,
+    replicators: Arc<ReplicatorRegistry>,
+    peer_state: Arc<PeerStateTracker>,
+    sync_config: SyncConfig,
+) -> (
+    SyncCoordinator<TestBlockstore, NoopTransport>,
+    tokio::sync::mpsc::Receiver<crate::sync::manager::SyncEvent>,
+) {
+    create_test_coordinator_with_options(
+        access_mode,
+        replicators,
+        peer_state,
+        Arc::new(PeerRateLimiter::default()),
+        sync_config,
+    )
+}
+
+fn create_test_coordinator_with_options(
+    access_mode: AccessMode,
+    replicators: Arc<ReplicatorRegistry>,
+    peer_state: Arc<PeerStateTracker>,
+    rate_limiter: Arc<PeerRateLimiter>,
+    sync_config: SyncConfig,
+) -> (
+    SyncCoordinator<TestBlockstore, NoopTransport>,
+    tokio::sync::mpsc::Receiver<crate::sync::manager::SyncEvent>,
+) {
     let transport = NoopTransport::new();
     let local_peer_id = transport.local_peer_id().to_string();
     let broadcaster = Broadcaster::new(transport.clone());
     let store = Arc::new(MemoryStore::new());
     let blockstore = Arc::new(DefraBlockstore::new(store, true));
     create_test_coordinator_with_blockstore(TestCoordinatorParams {
+        sync_config,
         access_mode,
         replicators,
         peer_state,
@@ -89,6 +127,7 @@ fn create_test_coordinator_with_rate_limiter(
 /// Grouped so the test helper stays under clippy's `too_many_arguments` budget
 /// without hiding the list of inputs behind a builder pattern.
 struct TestCoordinatorParams<B: Blockstore + 'static> {
+    sync_config: SyncConfig,
     access_mode: AccessMode,
     replicators: Arc<ReplicatorRegistry>,
     peer_state: Arc<PeerStateTracker>,
@@ -116,6 +155,7 @@ fn create_test_coordinator_with_blockstore_and_head_provider<B: Blockstore + 'st
     tokio::sync::mpsc::Receiver<crate::sync::manager::SyncEvent>,
 ) {
     let TestCoordinatorParams {
+        sync_config,
         access_mode,
         replicators,
         peer_state,
@@ -126,7 +166,7 @@ fn create_test_coordinator_with_blockstore_and_head_provider<B: Blockstore + 'st
         rate_limiter,
     } = params;
 
-    let (manager, events) = SyncManager::new(blockstore, peer_state.clone(), SyncConfig::default());
+    let (manager, events) = SyncManager::new(blockstore, peer_state.clone(), sync_config);
 
     let authorizer = Arc::new(RuntimeAuthorizer::new(
         transport.clone(),
@@ -272,6 +312,9 @@ struct NoopTransport {
     connected_peers: Arc<RwLock<Vec<PeerId>>>,
     doc_sync_replies: Arc<RwLock<Vec<DocSyncReply>>>,
     car_responses: Arc<RwLock<Vec<Vec<u8>>>>,
+    pushlog_replies: Arc<RwLock<Vec<crate::message::PushLogReply>>>,
+    two_stream_replies: Arc<RwLock<Vec<crate::message::PushLogReply>>>,
+    branchable_replies: Arc<RwLock<Vec<BranchableSyncReply>>>,
 }
 
 impl NoopTransport {
@@ -283,6 +326,9 @@ impl NoopTransport {
             connected_peers: Arc::new(RwLock::new(Vec::new())),
             doc_sync_replies: Arc::new(RwLock::new(Vec::new())),
             car_responses: Arc::new(RwLock::new(Vec::new())),
+            pushlog_replies: Arc::new(RwLock::new(Vec::new())),
+            two_stream_replies: Arc::new(RwLock::new(Vec::new())),
+            branchable_replies: Arc::new(RwLock::new(Vec::new())),
         }
     }
 
@@ -292,6 +338,18 @@ impl NoopTransport {
 
     fn doc_sync_replies(&self) -> Vec<DocSyncReply> {
         self.doc_sync_replies.read().clone()
+    }
+
+    fn pushlog_replies(&self) -> Vec<crate::message::PushLogReply> {
+        self.pushlog_replies.read().clone()
+    }
+
+    fn two_stream_replies(&self) -> Vec<crate::message::PushLogReply> {
+        self.two_stream_replies.read().clone()
+    }
+
+    fn branchable_replies(&self) -> Vec<BranchableSyncReply> {
+        self.branchable_replies.read().clone()
     }
 
     /// CARv1 payloads the coordinator sent, in order (used to assert which
@@ -372,8 +430,9 @@ impl P2PTransport for NoopTransport {
     async fn send_pushlog_response(
         &self,
         _token: Self::ResponseToken,
-        _reply: crate::message::PushLogReply,
+        reply: crate::message::PushLogReply,
     ) -> crate::Result<()> {
+        self.pushlog_replies.write().push(reply);
         Ok(())
     }
 
@@ -388,8 +447,9 @@ impl P2PTransport for NoopTransport {
     async fn send_two_stream_response(
         &self,
         _peer_id: &PeerId,
-        _reply: crate::message::PushLogReply,
+        reply: crate::message::PushLogReply,
     ) -> crate::Result<()> {
+        self.two_stream_replies.write().push(reply);
         Ok(())
     }
 
@@ -421,8 +481,9 @@ impl P2PTransport for NoopTransport {
     async fn send_branchable_sync_response(
         &self,
         _peer_id: &PeerId,
-        _reply: crate::message::BranchableSyncReply,
+        reply: crate::message::BranchableSyncReply,
     ) -> crate::Result<()> {
+        self.branchable_replies.write().push(reply);
         Ok(())
     }
 
@@ -456,8 +517,9 @@ impl P2PTransport for NoopTransport {
     async fn send_branchable_sync_response_token(
         &self,
         _token: Self::ResponseToken,
-        _reply: crate::message::BranchableSyncReply,
+        reply: crate::message::BranchableSyncReply,
     ) -> crate::Result<()> {
+        self.branchable_replies.write().push(reply);
         Ok(())
     }
 
@@ -833,6 +895,7 @@ async fn doc_sync_filters_heads_outside_replicator_collection() {
 
     let (coordinator, _events) = create_test_coordinator_with_blockstore_and_head_provider(
         TestCoordinatorParams {
+            sync_config: SyncConfig::default(),
             access_mode: AccessMode::Controlled,
             replicators,
             peer_state,
@@ -898,6 +961,7 @@ async fn car_fetch_controlled_mode_filters_unauthorized_data_block() {
     blockstore.put(&cid, &block_data).await.unwrap();
 
     let (coordinator, _events) = create_test_coordinator_with_blockstore(TestCoordinatorParams {
+        sync_config: SyncConfig::default(),
         access_mode: AccessMode::Controlled,
         replicators,
         peer_state,
@@ -1158,6 +1222,7 @@ async fn branchable_sync_reply_remerges_locally_complete_unmerged_head() {
 
     let (coordinator, mut events) =
         create_test_coordinator_with_blockstore(TestCoordinatorParams {
+            sync_config: SyncConfig::default(),
             access_mode: AccessMode::Open,
             replicators,
             peer_state,
@@ -1639,6 +1704,7 @@ async fn gossip_ignores_transport_replicator_state_for_directionality() {
         .unwrap();
 
     let (coordinator, _events) = create_test_coordinator_with_blockstore(TestCoordinatorParams {
+        sync_config: SyncConfig::default(),
         access_mode: AccessMode::Controlled,
         replicators: replicators.clone(),
         peer_state,
@@ -1683,6 +1749,7 @@ async fn delete_replicator_removes_gossip_access_without_subscription() {
     transport.set_connected_peers(vec![peer.clone()]);
 
     let (coordinator, _events) = create_test_coordinator_with_blockstore(TestCoordinatorParams {
+        sync_config: SyncConfig::default(),
         access_mode: AccessMode::Controlled,
         replicators,
         peer_state,
@@ -1724,6 +1791,7 @@ async fn create_replicator_update_keeps_outbound_targets_from_gossip_sources() {
     transport.set_connected_peers(vec![peer.clone()]);
 
     let (coordinator, _events) = create_test_coordinator_with_blockstore(TestCoordinatorParams {
+        sync_config: SyncConfig::default(),
         access_mode: AccessMode::Controlled,
         replicators,
         peer_state,
@@ -1793,30 +1861,13 @@ async fn two_stream_authenticated_explicit_replicator_is_marked_explicit_replica
     }
 }
 
-#[tokio::test]
-async fn two_stream_bypasses_gossip_rate_limiter_for_authenticated_sync() {
-    let replicators = Arc::new(ReplicatorRegistry::new());
-    let peer_state = Arc::new(PeerStateTracker::new());
-    let (coordinator, mut events) = create_test_coordinator_with_rate_limiter(
-        AccessMode::Open,
-        replicators,
-        peer_state,
-        Arc::new(PeerRateLimiter::new(0, 0.0)),
-    );
-
-    let peer = random_peer_id();
-    coordinator
-        .handle_transport_event(two_stream_event(peer.clone(), "collection1", false))
-        .await
-        .unwrap();
-
-    match recv_block_received(&mut events).await {
-        SyncEvent::BlockReceived { sender_peer, .. } => {
-            assert_eq!(sender_peer.as_deref(), Some(peer.as_str()));
-        }
-        other => panic!("expected BlockReceived, got {:?}", other),
-    }
-}
+// fa4a84f7's `two_stream_bypasses_gossip_rate_limiter_for_authenticated_sync`
+// asserted that authenticated two-stream pushes skip the rate limiter entirely.
+// #1088 W4 re-lands #592's intake admission: the concern that test protected —
+// authenticated sync must never be SILENTLY dropped like gossip — is preserved
+// and strengthened by `two_stream_rate_limited_replies_backpressure_nack` below:
+// over-budget pushes now get an explicit RATE_LIMITED_MESSAGE nack that the
+// pusher's backoff consumer (#843) turns into a retry, never a lost document.
 
 #[tokio::test]
 async fn gossip_remains_rate_limited_when_bucket_is_empty() {
@@ -1852,6 +1903,7 @@ async fn pushlog_retries_transient_transaction_conflicts_without_sync_error() {
 
     let (coordinator, mut events) =
         create_test_coordinator_with_blockstore(TestCoordinatorParams {
+            sync_config: SyncConfig::default(),
             access_mode: AccessMode::Open,
             replicators,
             peer_state,
@@ -1888,6 +1940,7 @@ async fn gossip_retries_transient_transaction_conflicts_without_sync_error() {
 
     let (coordinator, mut events) =
         create_test_coordinator_with_blockstore(TestCoordinatorParams {
+            sync_config: SyncConfig::default(),
             access_mode: AccessMode::Open,
             replicators,
             peer_state,
@@ -1911,4 +1964,313 @@ async fn gossip_retries_transient_transaction_conflicts_without_sync_error() {
         }
         other => panic!("expected BlockReceived after gossip retry, got {:?}", other),
     }
+}
+
+// --- #1088 W1/W4: intake backpressure nacks (re-land #592, regressed by fa4a84f7) ---
+//
+// The M1 invariant: a success PushLogReply implies the pushed block is either
+// merged or registered as pending on the hub. Capacity overflow and rate-limit
+// rejections must reply the byte-exact RATE_LIMITED_MESSAGE so the pusher's
+// backoff consumer (send_ordered_pushlogs_via_transport) and persisted retry
+// ladder keep the doc queued instead of laundering the failure as success.
+
+/// A PushLog request whose composite block links to a field block that is never
+/// stored, so `process_pushlog` must register a pending DAG to track it.
+fn pushlog_request_with_missing_link(collection_id: &str, doc_id: &str) -> PushLogRequest {
+    let field_block = defra_core::Block::new(
+        defra_core::CrdtDelta::Lww(defra_core::LwwDeltaPayload {
+            doc_id: doc_id.as_bytes().to_vec(),
+            field_name: "field".to_string(),
+            priority: 1,
+            schema_version_id: "schema1".to_string(),
+            data: b"value".to_vec(),
+        }),
+        vec![],
+        vec![],
+    );
+    let field_cid = field_block.generate_cid().expect("field cid");
+
+    let composite = defra_core::Block::new(
+        defra_core::CrdtDelta::Composite(defra_core::CompositeDeltaPayload {
+            doc_id: doc_id.as_bytes().to_vec(),
+            schema_version_id: "schema1".to_string(),
+            priority: 1,
+            status: 1,
+        }),
+        vec![],
+        vec![defra_core::DAGLink::new("field", field_cid)],
+    );
+    let composite_bytes = composite.to_dag_cbor().expect("encode composite");
+    let composite_cid = composite.generate_cid().expect("composite cid");
+
+    PushLogRequest::new(
+        doc_id.to_string(),
+        bytes::Bytes::from(composite_cid.to_bytes()),
+        collection_id.to_string(),
+        "creator1".to_string(),
+        bytes::Bytes::from(composite_bytes),
+    )
+}
+
+fn always_limited_rate_limiter() -> Arc<PeerRateLimiter> {
+    Arc::new(PeerRateLimiter::with_backoff_steps(
+        0,
+        0.0,
+        vec![Duration::from_secs(60)],
+    ))
+}
+
+#[tokio::test]
+async fn pushlog_request_at_pending_capacity_replies_rate_limited_nack() {
+    let replicators = Arc::new(ReplicatorRegistry::new());
+    let peer_state = Arc::new(PeerStateTracker::new());
+    let (coordinator, _events) = create_test_coordinator_with_sync_config(
+        AccessMode::Open,
+        replicators,
+        peer_state,
+        SyncConfig {
+            max_pending_dags: 1,
+            ..SyncConfig::default()
+        },
+    );
+    let transport = coordinator.runtime.transport.clone();
+    let peer = random_peer_id();
+
+    coordinator
+        .handle_transport_event(TransportEvent::PushLogRequest {
+            peer_id: peer.clone(),
+            request: pushlog_request_with_missing_link("collection1", "docA"),
+            token: (),
+        })
+        .await
+        .unwrap();
+    let first = transport.pushlog_replies().pop().expect("first reply");
+    assert_eq!(
+        first.err_message, None,
+        "registered pending DAG must ack success"
+    );
+
+    let result = coordinator
+        .handle_transport_event(TransportEvent::PushLogRequest {
+            peer_id: peer.clone(),
+            request: pushlog_request_with_missing_link("collection1", "docB"),
+            token: (),
+        })
+        .await;
+    assert!(
+        result.is_err(),
+        "capacity drop must surface as an error, got {:?}",
+        result
+    );
+
+    let reply = transport.pushlog_replies().pop().expect("overflow reply");
+    assert_eq!(
+        reply.err_message.as_deref(),
+        Some(crate::error::RATE_LIMITED_MESSAGE),
+        "capacity overflow must nack with the byte-exact backpressure sentinel, never success"
+    );
+}
+
+#[tokio::test]
+async fn two_stream_at_pending_capacity_replies_rate_limited_nack() {
+    let replicators = Arc::new(ReplicatorRegistry::new());
+    let peer_state = Arc::new(PeerStateTracker::new());
+    let (coordinator, _events) = create_test_coordinator_with_sync_config(
+        AccessMode::Open,
+        replicators,
+        peer_state,
+        SyncConfig {
+            max_pending_dags: 1,
+            ..SyncConfig::default()
+        },
+    );
+    let transport = coordinator.runtime.transport.clone();
+    let peer = random_peer_id();
+
+    coordinator
+        .handle_transport_event(TransportEvent::TwoStreamRequest {
+            peer_id: peer.clone(),
+            request: pushlog_request_with_missing_link("collection1", "docA"),
+            token: None,
+            is_explicit_replicator: false,
+            explicit_replay_authorization: None,
+        })
+        .await
+        .unwrap();
+    let first = transport.two_stream_replies().pop().expect("first reply");
+    assert_eq!(
+        first.err_message, None,
+        "registered pending DAG must ack success"
+    );
+
+    let result = coordinator
+        .handle_transport_event(TransportEvent::TwoStreamRequest {
+            peer_id: peer.clone(),
+            request: pushlog_request_with_missing_link("collection1", "docB"),
+            token: None,
+            is_explicit_replicator: false,
+            explicit_replay_authorization: None,
+        })
+        .await;
+    assert!(
+        result.is_err(),
+        "capacity drop must surface as an error, got {:?}",
+        result
+    );
+
+    let reply = transport.two_stream_replies().pop().expect("overflow reply");
+    assert_eq!(
+        reply.err_message.as_deref(),
+        Some(crate::error::RATE_LIMITED_MESSAGE),
+        "capacity overflow must nack with the byte-exact backpressure sentinel, never success"
+    );
+}
+
+#[tokio::test]
+async fn pushlog_request_rate_limited_replies_backpressure_nack() {
+    let replicators = Arc::new(ReplicatorRegistry::new());
+    let peer_state = Arc::new(PeerStateTracker::new());
+    let (coordinator, _events) = create_test_coordinator_with_rate_limiter(
+        AccessMode::Open,
+        replicators,
+        peer_state,
+        always_limited_rate_limiter(),
+    );
+    let transport = coordinator.runtime.transport.clone();
+    let peer = random_peer_id();
+
+    let result = coordinator
+        .handle_transport_event(pushlog_event(peer.clone(), "collection1"))
+        .await;
+    assert!(
+        matches!(&result, Err(e) if e.is_rate_limited()),
+        "expected rate-limited rejection, got {:?}",
+        result
+    );
+
+    let reply = transport.pushlog_replies().pop().expect("nack reply sent");
+    assert_eq!(
+        reply.err_message.as_deref(),
+        Some(crate::error::RATE_LIMITED_MESSAGE)
+    );
+}
+
+#[tokio::test]
+async fn two_stream_rate_limited_replies_backpressure_nack() {
+    let replicators = Arc::new(ReplicatorRegistry::new());
+    let peer_state = Arc::new(PeerStateTracker::new());
+    let (coordinator, _events) = create_test_coordinator_with_rate_limiter(
+        AccessMode::Open,
+        replicators,
+        peer_state,
+        always_limited_rate_limiter(),
+    );
+    let transport = coordinator.runtime.transport.clone();
+    let peer = random_peer_id();
+
+    let result = coordinator
+        .handle_transport_event(two_stream_event(peer.clone(), "collection1", false))
+        .await;
+    assert!(
+        matches!(&result, Err(e) if e.is_rate_limited()),
+        "expected rate-limited rejection, got {:?}",
+        result
+    );
+
+    let reply = transport
+        .two_stream_replies()
+        .pop()
+        .expect("nack reply sent");
+    assert_eq!(
+        reply.err_message.as_deref(),
+        Some(crate::error::RATE_LIMITED_MESSAGE)
+    );
+}
+
+#[tokio::test]
+async fn doc_sync_rate_limited_replies_backpressure_nack() {
+    let replicators = Arc::new(ReplicatorRegistry::new());
+    let peer_state = Arc::new(PeerStateTracker::new());
+    let (coordinator, _events) = create_test_coordinator_with_rate_limiter(
+        AccessMode::Open,
+        replicators,
+        peer_state,
+        always_limited_rate_limiter(),
+    );
+    let transport = coordinator.runtime.transport.clone();
+    let peer = random_peer_id();
+
+    let result = coordinator
+        .handle_transport_event(doc_sync_event(peer.clone()))
+        .await;
+    assert!(
+        matches!(&result, Err(e) if e.is_rate_limited()),
+        "expected rate-limited rejection, got {:?}",
+        result
+    );
+
+    let reply = transport.doc_sync_replies().pop().expect("nack reply sent");
+    assert_eq!(
+        reply.err_message.as_deref(),
+        Some(crate::error::RATE_LIMITED_MESSAGE)
+    );
+}
+
+#[tokio::test]
+async fn branchable_sync_rate_limited_replies_backpressure_nack() {
+    let replicators = Arc::new(ReplicatorRegistry::new());
+    let peer_state = Arc::new(PeerStateTracker::new());
+    let (coordinator, _events) = create_test_coordinator_with_rate_limiter(
+        AccessMode::Open,
+        replicators,
+        peer_state,
+        always_limited_rate_limiter(),
+    );
+    let transport = coordinator.runtime.transport.clone();
+    let peer = random_peer_id();
+
+    let result = coordinator
+        .handle_transport_event(branchable_sync_event(peer.clone(), "collection1"))
+        .await;
+    assert!(
+        matches!(&result, Err(e) if e.is_rate_limited()),
+        "expected rate-limited rejection, got {:?}",
+        result
+    );
+
+    let reply = transport
+        .branchable_replies()
+        .pop()
+        .expect("nack reply sent");
+    assert_eq!(
+        reply.err_message.as_deref(),
+        Some(crate::error::RATE_LIMITED_MESSAGE)
+    );
+}
+
+#[tokio::test]
+async fn car_fetch_rate_limited_replies_empty_response() {
+    let replicators = Arc::new(ReplicatorRegistry::new());
+    let peer_state = Arc::new(PeerStateTracker::new());
+    let (coordinator, _events) = create_test_coordinator_with_rate_limiter(
+        AccessMode::Open,
+        replicators,
+        peer_state,
+        always_limited_rate_limiter(),
+    );
+    let transport = coordinator.runtime.transport.clone();
+    let peer = random_peer_id();
+
+    let result = coordinator
+        .handle_transport_event(car_fetch_event(peer.clone(), cid_for(BLOCK_DATA)))
+        .await;
+    assert!(
+        matches!(&result, Err(e) if e.is_rate_limited()),
+        "expected rate-limited rejection, got {:?}",
+        result
+    );
+
+    // CAR has no error reply type - an explicit empty response beats a hung stream.
+    let responses = transport.car_responses();
+    assert_eq!(responses.last().map(Vec::len), Some(0));
 }

--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -105,6 +105,50 @@ fn create_test_coordinator_with_options(
     SyncCoordinator<TestBlockstore, NoopTransport>,
     tokio::sync::mpsc::Receiver<crate::sync::manager::SyncEvent>,
 ) {
+    // Most limiter tests exercise one path at a time; share the injected
+    // limiter across gossip and request intake so either path sees it.
+    let request_rate_limiter = rate_limiter.clone();
+    create_test_coordinator_full(
+        access_mode,
+        replicators,
+        peer_state,
+        rate_limiter,
+        request_rate_limiter,
+        sync_config,
+    )
+}
+
+fn create_test_coordinator_with_split_limiters(
+    access_mode: AccessMode,
+    replicators: Arc<ReplicatorRegistry>,
+    peer_state: Arc<PeerStateTracker>,
+    rate_limiter: Arc<PeerRateLimiter>,
+    request_rate_limiter: Arc<PeerRateLimiter>,
+) -> (
+    SyncCoordinator<TestBlockstore, NoopTransport>,
+    tokio::sync::mpsc::Receiver<crate::sync::manager::SyncEvent>,
+) {
+    create_test_coordinator_full(
+        access_mode,
+        replicators,
+        peer_state,
+        rate_limiter,
+        request_rate_limiter,
+        SyncConfig::default(),
+    )
+}
+
+fn create_test_coordinator_full(
+    access_mode: AccessMode,
+    replicators: Arc<ReplicatorRegistry>,
+    peer_state: Arc<PeerStateTracker>,
+    rate_limiter: Arc<PeerRateLimiter>,
+    request_rate_limiter: Arc<PeerRateLimiter>,
+    sync_config: SyncConfig,
+) -> (
+    SyncCoordinator<TestBlockstore, NoopTransport>,
+    tokio::sync::mpsc::Receiver<crate::sync::manager::SyncEvent>,
+) {
     let transport = NoopTransport::new();
     let local_peer_id = transport.local_peer_id().to_string();
     let broadcaster = Broadcaster::new(transport.clone());
@@ -112,6 +156,7 @@ fn create_test_coordinator_with_options(
     let blockstore = Arc::new(DefraBlockstore::new(store, true));
     create_test_coordinator_with_blockstore(TestCoordinatorParams {
         sync_config,
+        request_rate_limiter,
         access_mode,
         replicators,
         peer_state,
@@ -128,6 +173,7 @@ fn create_test_coordinator_with_options(
 /// without hiding the list of inputs behind a builder pattern.
 struct TestCoordinatorParams<B: Blockstore + 'static> {
     sync_config: SyncConfig,
+    request_rate_limiter: Arc<PeerRateLimiter>,
     access_mode: AccessMode,
     replicators: Arc<ReplicatorRegistry>,
     peer_state: Arc<PeerStateTracker>,
@@ -156,6 +202,7 @@ fn create_test_coordinator_with_blockstore_and_head_provider<B: Blockstore + 'st
 ) {
     let TestCoordinatorParams {
         sync_config,
+        request_rate_limiter,
         access_mode,
         replicators,
         peer_state,
@@ -185,6 +232,7 @@ fn create_test_coordinator_with_blockstore_and_head_provider<B: Blockstore + 'st
                 DEFAULT_MAX_CONCURRENT_PUSH_TASKS,
             )),
             rate_limiter,
+            request_rate_limiter,
             push_send_timeout: DEFAULT_PUSH_SEND_TIMEOUT,
             max_doc_sync_request_doc_ids: DEFAULT_MAX_DOC_SYNC_REQUEST_DOC_IDS,
             shutdown: SyncShutdownHandle::new(),
@@ -896,6 +944,7 @@ async fn doc_sync_filters_heads_outside_replicator_collection() {
     let (coordinator, _events) = create_test_coordinator_with_blockstore_and_head_provider(
         TestCoordinatorParams {
             sync_config: SyncConfig::default(),
+            request_rate_limiter: Arc::new(PeerRateLimiter::default()),
             access_mode: AccessMode::Controlled,
             replicators,
             peer_state,
@@ -962,6 +1011,7 @@ async fn car_fetch_controlled_mode_filters_unauthorized_data_block() {
 
     let (coordinator, _events) = create_test_coordinator_with_blockstore(TestCoordinatorParams {
         sync_config: SyncConfig::default(),
+        request_rate_limiter: Arc::new(PeerRateLimiter::default()),
         access_mode: AccessMode::Controlled,
         replicators,
         peer_state,
@@ -1223,6 +1273,7 @@ async fn branchable_sync_reply_remerges_locally_complete_unmerged_head() {
     let (coordinator, mut events) =
         create_test_coordinator_with_blockstore(TestCoordinatorParams {
             sync_config: SyncConfig::default(),
+            request_rate_limiter: Arc::new(PeerRateLimiter::default()),
             access_mode: AccessMode::Open,
             replicators,
             peer_state,
@@ -1705,6 +1756,7 @@ async fn gossip_ignores_transport_replicator_state_for_directionality() {
 
     let (coordinator, _events) = create_test_coordinator_with_blockstore(TestCoordinatorParams {
         sync_config: SyncConfig::default(),
+        request_rate_limiter: Arc::new(PeerRateLimiter::default()),
         access_mode: AccessMode::Controlled,
         replicators: replicators.clone(),
         peer_state,
@@ -1750,6 +1802,7 @@ async fn delete_replicator_removes_gossip_access_without_subscription() {
 
     let (coordinator, _events) = create_test_coordinator_with_blockstore(TestCoordinatorParams {
         sync_config: SyncConfig::default(),
+        request_rate_limiter: Arc::new(PeerRateLimiter::default()),
         access_mode: AccessMode::Controlled,
         replicators,
         peer_state,
@@ -1792,6 +1845,7 @@ async fn create_replicator_update_keeps_outbound_targets_from_gossip_sources() {
 
     let (coordinator, _events) = create_test_coordinator_with_blockstore(TestCoordinatorParams {
         sync_config: SyncConfig::default(),
+        request_rate_limiter: Arc::new(PeerRateLimiter::default()),
         access_mode: AccessMode::Controlled,
         replicators,
         peer_state,
@@ -1904,6 +1958,7 @@ async fn pushlog_retries_transient_transaction_conflicts_without_sync_error() {
     let (coordinator, mut events) =
         create_test_coordinator_with_blockstore(TestCoordinatorParams {
             sync_config: SyncConfig::default(),
+            request_rate_limiter: Arc::new(PeerRateLimiter::default()),
             access_mode: AccessMode::Open,
             replicators,
             peer_state,
@@ -1941,6 +1996,7 @@ async fn gossip_retries_transient_transaction_conflicts_without_sync_error() {
     let (coordinator, mut events) =
         create_test_coordinator_with_blockstore(TestCoordinatorParams {
             sync_config: SyncConfig::default(),
+            request_rate_limiter: Arc::new(PeerRateLimiter::default()),
             access_mode: AccessMode::Open,
             replicators,
             peer_state,
@@ -2348,5 +2404,91 @@ async fn fan_in_pushes_keep_pending_depth_bounded_and_account_every_reply() {
     assert_eq!(
         diagnostics.missing_link_retries, 0,
         "capacity overflow must not cause retry walks"
+    );
+}
+
+/// An error DocSyncReply (e.g. a RATE_LIMITED_MESSAGE nack from #1088 W4)
+/// carries no results; it must surface as an error, not be consumed as an
+/// empty successful sync.
+#[tokio::test]
+async fn doc_sync_error_reply_is_not_consumed_as_empty_success() {
+    let replicators = Arc::new(ReplicatorRegistry::new());
+    let peer_state = Arc::new(PeerStateTracker::new());
+    let (coordinator, _events) = create_test_coordinator(AccessMode::Open, replicators, peer_state);
+    let peer = random_peer_id();
+
+    let result = coordinator
+        .handle_transport_event(TransportEvent::DocSyncReply {
+            peer_id: peer.clone(),
+            reply: DocSyncReply::error("doc-sync-1", crate::error::RATE_LIMITED_MESSAGE),
+        })
+        .await;
+
+    assert!(
+        result.is_err(),
+        "an error reply must not be treated as an empty successful sync, got {:?}",
+        result
+    );
+}
+
+/// Same for BranchableSync: an error reply has empty heads and must not be
+/// mistaken for "peer has no heads for collection".
+#[tokio::test]
+async fn branchable_sync_error_reply_is_not_consumed_as_no_heads() {
+    let replicators = Arc::new(ReplicatorRegistry::new());
+    let peer_state = Arc::new(PeerStateTracker::new());
+    let (coordinator, _events) = create_test_coordinator(AccessMode::Open, replicators, peer_state);
+    let peer = random_peer_id();
+
+    let result = coordinator
+        .handle_transport_event(TransportEvent::BranchableSyncReply {
+            peer_id: peer.clone(),
+            reply: BranchableSyncReply::error(
+                "branchable-1",
+                "collection1",
+                crate::error::RATE_LIMITED_MESSAGE,
+            ),
+        })
+        .await;
+
+    assert!(
+        result.is_err(),
+        "an error reply must not be treated as \"peer has no heads\", got {:?}",
+        result
+    );
+}
+
+/// The gossip limiter (abuse ladder) and the request-intake limiter (pacing)
+/// are separate: an exhausted gossip bucket must not block replicator pushes,
+/// which have their own paced bucket.
+#[tokio::test]
+async fn request_intake_uses_paced_limiter_separate_from_gossip_ladder() {
+    let replicators = Arc::new(ReplicatorRegistry::new());
+    let peer_state = Arc::new(PeerStateTracker::new());
+    let (coordinator, _events) = create_test_coordinator_with_split_limiters(
+        AccessMode::Open,
+        replicators,
+        peer_state,
+        always_limited_rate_limiter(),
+        Arc::new(PeerRateLimiter::default()),
+    );
+    let peer = random_peer_id();
+
+    let gossip_result = coordinator
+        .handle_transport_event(gossip_event(peer.clone(), "collection1"))
+        .await;
+    assert!(
+        matches!(&gossip_result, Err(e) if e.is_rate_limited()),
+        "gossip must still be governed by the ladder limiter, got {:?}",
+        gossip_result
+    );
+
+    let push_result = coordinator
+        .handle_transport_event(two_stream_event(peer.clone(), "collection1", false))
+        .await;
+    assert!(
+        push_result.is_ok(),
+        "request intake must use its own paced limiter, got {:?}",
+        push_result
     );
 }

--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -2118,7 +2118,10 @@ async fn two_stream_at_pending_capacity_replies_rate_limited_nack() {
         result
     );
 
-    let reply = transport.two_stream_replies().pop().expect("overflow reply");
+    let reply = transport
+        .two_stream_replies()
+        .pop()
+        .expect("overflow reply");
     assert_eq!(
         reply.err_message.as_deref(),
         Some(crate::error::RATE_LIMITED_MESSAGE),
@@ -2273,4 +2276,77 @@ async fn car_fetch_rate_limited_replies_empty_response() {
     // CAR has no error reply type - an explicit empty response beats a hung stream.
     let responses = transport.car_responses();
     assert_eq!(responses.last().map(Vec::len), Some(0));
+}
+
+/// #1088 W5 (in-process half): 8 pushers × 6 docs fan into a hub whose pending
+/// map holds 2 slots. Nothing drains (no Bitswap in NoopTransport), so exactly
+/// `cap` pushes can be admitted; every other push must be nacked — never
+/// success-acked (M1) — and the pending depth must never exceed the cap.
+#[tokio::test]
+async fn fan_in_pushes_keep_pending_depth_bounded_and_account_every_reply() {
+    const CAP: usize = 2;
+    const FAN_IN_PUSHERS: usize = 8;
+    const DOCS_PER_PUSHER: usize = 6;
+
+    let replicators = Arc::new(ReplicatorRegistry::new());
+    let peer_state = Arc::new(PeerStateTracker::new());
+    let (coordinator, _events) = create_test_coordinator_with_sync_config(
+        AccessMode::Open,
+        replicators,
+        peer_state,
+        SyncConfig {
+            max_pending_dags: CAP,
+            ..SyncConfig::default()
+        },
+    );
+    let transport = coordinator.runtime.transport.clone();
+
+    for pusher in 0..FAN_IN_PUSHERS {
+        let peer = random_peer_id();
+        for doc in 0..DOCS_PER_PUSHER {
+            let _ = coordinator
+                .handle_transport_event(TransportEvent::TwoStreamRequest {
+                    peer_id: peer.clone(),
+                    request: pushlog_request_with_missing_link(
+                        "collection1",
+                        &format!("p{pusher}-d{doc}"),
+                    ),
+                    token: None,
+                    is_explicit_replicator: false,
+                    explicit_replay_authorization: None,
+                })
+                .await;
+            assert!(
+                coordinator.manager.pending_dag_count() <= CAP,
+                "pending depth exceeded the configured cap"
+            );
+        }
+    }
+
+    let replies = transport.two_stream_replies();
+    let total = FAN_IN_PUSHERS * DOCS_PER_PUSHER;
+    assert_eq!(replies.len(), total, "every push must receive a reply");
+
+    let successes = replies.iter().filter(|r| r.err_message.is_none()).count();
+    let nacks = replies
+        .iter()
+        .filter(|r| r.err_message.as_deref() == Some(crate::error::RATE_LIMITED_MESSAGE))
+        .count();
+    assert_eq!(
+        successes, CAP,
+        "only registered pushes may be success-acked (M1: success => registered-or-merged)"
+    );
+    assert_eq!(
+        nacks,
+        total - CAP,
+        "every dropped registration must be nacked with the backpressure sentinel"
+    );
+
+    // No completed DAGs and no arriving link blocks here, so admission overflow
+    // must not trigger any pending-DAG re-walks (the M4 CPU burn shape).
+    let diagnostics = coordinator.manager.diagnostics().snapshot();
+    assert_eq!(
+        diagnostics.missing_link_retries, 0,
+        "capacity overflow must not cause retry walks"
+    );
 }

--- a/crates/p2p/src/sync/coordinator/broadcast.rs
+++ b/crates/p2p/src/sync/coordinator/broadcast.rs
@@ -1007,6 +1007,62 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn ordered_pushlogs_back_off_on_capacity_nack_reply() {
+        // #1088 W1: the hub maps Error::PendingDagCapacity to the same byte-exact
+        // backpressure sentinel, so the pusher's retry/backoff engages unchanged.
+        let capacity_nack = crate::error::Error::PendingDagCapacity { max: 1 }
+            .backpressure_reply_message()
+            .expect("capacity error maps to the backpressure sentinel");
+        let transport = TestTransport::new(vec![
+            PushLogReply::error("first", capacity_nack),
+            PushLogReply::success("first"),
+            PushLogReply::success("second"),
+        ]);
+        let peer_id = PeerId::new("remote-peer".to_string());
+        let cid1 = Cid::new_v1(0x55, Code::Sha2_256.digest(b"cid-1"));
+        let cid2 = Cid::new_v1(0x55, Code::Sha2_256.digest(b"cid-2"));
+        let requests = vec![
+            (
+                cid1,
+                PushLogRequest::new(
+                    "doc-1".to_string(),
+                    Bytes::from(cid1.to_bytes()),
+                    "collection".to_string(),
+                    "creator".to_string(),
+                    Bytes::from_static(b"block-1"),
+                ),
+            ),
+            (
+                cid2,
+                PushLogRequest::new(
+                    "doc-1".to_string(),
+                    Bytes::from(cid2.to_bytes()),
+                    "collection".to_string(),
+                    "creator".to_string(),
+                    Bytes::from_static(b"block-2"),
+                ),
+            ),
+        ];
+
+        let any_failed = SyncCoordinator::<
+            blockstore::DefraBlockstore<storage::backends::MemoryStore>,
+            TestTransport,
+        >::send_ordered_pushlogs_via_transport(
+            &transport,
+            &peer_id,
+            requests,
+            Duration::from_secs(1),
+        )
+        .await;
+
+        assert!(!any_failed);
+        assert_eq!(
+            transport.sent_cids(),
+            vec![cid1.to_bytes(), cid1.to_bytes(), cid2.to_bytes()]
+        );
+    }
+
+    #[tokio::test]
     async fn ordered_pushlogs_stop_after_bounded_rate_limit_retries() {
         let transport = TestTransport::new(
             std::iter::repeat_with(|| PushLogReply::error("first", RATE_LIMITED_MESSAGE))

--- a/crates/p2p/src/sync/coordinator/constructor.rs
+++ b/crates/p2p/src/sync/coordinator/constructor.rs
@@ -214,6 +214,10 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                         rate_limit_rate,
                         rate_limit_backoff,
                     )),
+                    request_rate_limiter: Arc::new(PeerRateLimiter::new_request_paced(
+                        rate_limit_burst,
+                        rate_limit_rate,
+                    )),
                     push_send_timeout,
                     max_doc_sync_request_doc_ids,
                     shutdown: super::SyncShutdownHandle::new(),

--- a/crates/p2p/src/sync/coordinator/event_handler/branchable_sync.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/branchable_sync.rs
@@ -114,6 +114,30 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             "Received BranchableSync reply"
         );
 
+        // Error replies carry empty heads; without this branch a backpressure
+        // nack or access denial would read as "peer has no heads". Like
+        // DocSync, this is a pull — surfacing the error is the correct
+        // terminal handling; the next sync trigger re-requests.
+        if let Some(err) = reply.err_message.as_deref() {
+            if crate::error::is_rate_limited_message(err) {
+                tracing::warn!(
+                    peer_id = %peer_id,
+                    collection_id = %reply.collection_id,
+                    "Peer rate-limited our BranchableSync request; will re-request on the next sync trigger"
+                );
+            } else {
+                tracing::warn!(
+                    peer_id = %peer_id,
+                    collection_id = %reply.collection_id,
+                    error = %err,
+                    "BranchableSync request rejected by peer"
+                );
+            }
+            return Err(crate::error::Error::Transport(format!(
+                "BranchableSync request rejected by peer {peer_id}: {err}"
+            )));
+        }
+
         if reply.heads.is_empty() {
             tracing::debug!(
                 collection_id = %reply.collection_id,

--- a/crates/p2p/src/sync/coordinator/event_handler/doc_sync.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/doc_sync.rs
@@ -215,6 +215,32 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         peer_id: PeerId,
         reply: DocSyncReply,
     ) -> Result<()> {
+        // Error replies (backpressure nacks, access denials) carry no results;
+        // without this branch they would read as an empty successful sync.
+        // DocSync is a pull — the peer discarded no state on rejection — so
+        // surfacing the error is the correct terminal handling here: the next
+        // sync trigger (subscription event, reconnect) re-requests. A
+        // puller-side backoff ladder is #1088 follow-up scope.
+        if let Some(err) = reply.err_message.as_deref() {
+            if crate::error::is_rate_limited_message(err) {
+                tracing::warn!(
+                    peer_id = %peer_id,
+                    message_id = %reply.message_id,
+                    "Peer rate-limited our DocSync request; will re-request on the next sync trigger"
+                );
+            } else {
+                tracing::warn!(
+                    peer_id = %peer_id,
+                    message_id = %reply.message_id,
+                    error = %err,
+                    "DocSync request rejected by peer"
+                );
+            }
+            return Err(Error::Transport(format!(
+                "DocSync request rejected by peer {peer_id}: {err}"
+            )));
+        }
+
         tracing::info!(
             peer_id = %peer_id,
             message_id = %reply.message_id,

--- a/crates/p2p/src/sync/coordinator/event_handler/mod.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/mod.rs
@@ -63,6 +63,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         tracing::debug!(peer_id = %peer_id, "Peer disconnected");
         self.access.peer_state.peer_disconnected(peer_id.as_str());
         self.runtime.rate_limiter.remove_peer(&peer_id);
+        self.runtime.request_rate_limiter.remove_peer(&peer_id);
     }
 
     fn handle_peer_subscribed(&self, peer_id: PeerId, topic: String) {
@@ -97,8 +98,13 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     /// channel drives its retryInterval ladder off error replies
     /// (`replicator.go`); overload replies are orthogonal to the trust/ACP
     /// bypasses fa4a84f7 aligned with Go.
-    fn check_rate_limit(&self, peer_id: &PeerId, event_kind: &'static str) -> Result<()> {
-        match self.runtime.rate_limiter.check(peer_id) {
+    fn check_rate_limit(
+        &self,
+        limiter: &crate::sync::rate_limiter::PeerRateLimiter,
+        peer_id: &PeerId,
+        event_kind: &'static str,
+    ) -> Result<()> {
+        match limiter.check(peer_id) {
             RateLimitDecision::Allowed => Ok(()),
             RateLimitDecision::Limited {
                 retry_after,
@@ -244,7 +250,11 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 topic,
                 ..
             } => {
-                self.check_rate_limit(&propagation_source, "GossipMessage")?;
+                self.check_rate_limit(
+                    &self.runtime.rate_limiter,
+                    &propagation_source,
+                    "GossipMessage",
+                )?;
                 self.handle_gossip_message(propagation_source, message, topic)
                     .await?;
             }
@@ -254,7 +264,11 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 data,
                 ..
             } => {
-                self.check_rate_limit(&propagation_source, "GossipRawMessage")?;
+                self.check_rate_limit(
+                    &self.runtime.rate_limiter,
+                    &propagation_source,
+                    "GossipRawMessage",
+                )?;
                 self.handle_gossip_raw_message(propagation_source, topic, data)
                     .await?;
             }
@@ -263,7 +277,11 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 request,
                 token,
             } => {
-                if let Err(error) = self.check_rate_limit(&peer_id, "PushLogRequest") {
+                if let Err(error) = self.check_rate_limit(
+                    &self.runtime.request_rate_limiter,
+                    &peer_id,
+                    "PushLogRequest",
+                ) {
                     return Err(self
                         .reject_rate_limited_pushlog(&request.message_id, token, error)
                         .await);
@@ -277,7 +295,11 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 is_explicit_replicator,
                 explicit_replay_authorization,
             } => {
-                if let Err(error) = self.check_rate_limit(&peer_id, "TwoStreamRequest") {
+                if let Err(error) = self.check_rate_limit(
+                    &self.runtime.request_rate_limiter,
+                    &peer_id,
+                    "TwoStreamRequest",
+                ) {
                     return Err(self
                         .reject_rate_limited_two_stream(&peer_id, &request.message_id, token, error)
                         .await);
@@ -314,7 +336,11 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 request,
                 token,
             } => {
-                if let Err(error) = self.check_rate_limit(&peer_id, "DocSyncRequest") {
+                if let Err(error) = self.check_rate_limit(
+                    &self.runtime.request_rate_limiter,
+                    &peer_id,
+                    "DocSyncRequest",
+                ) {
                     return Err(self
                         .reject_rate_limited_doc_sync(&peer_id, &request.message_id, token, error)
                         .await);
@@ -330,7 +356,11 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 request,
                 token,
             } => {
-                if let Err(error) = self.check_rate_limit(&peer_id, "BranchableSyncRequest") {
+                if let Err(error) = self.check_rate_limit(
+                    &self.runtime.request_rate_limiter,
+                    &peer_id,
+                    "BranchableSyncRequest",
+                ) {
                     return Err(self
                         .reject_rate_limited_branchable_sync(
                             &peer_id,
@@ -352,7 +382,11 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 request,
                 token,
             } => {
-                if let Err(error) = self.check_rate_limit(&peer_id, "CarFetchRequest") {
+                if let Err(error) = self.check_rate_limit(
+                    &self.runtime.request_rate_limiter,
+                    &peer_id,
+                    "CarFetchRequest",
+                ) {
                     return Err(self
                         .reject_rate_limited_car_fetch(&peer_id, token, error)
                         .await);

--- a/crates/p2p/src/sync/coordinator/event_handler/mod.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/mod.rs
@@ -12,7 +12,9 @@ use blockstore::Blockstore;
 use std::time::Duration;
 
 use super::SyncCoordinator;
-use crate::error::{Error, Result};
+use crate::error::{Error, Result, RATE_LIMITED_MESSAGE};
+use crate::message::{BranchableSyncReply, DocSyncReply, PushLogReply};
+use crate::signing::sign_with_transport;
 use crate::sync::rate_limiter::RateLimitDecision;
 use crate::transport::{P2PTransport, PeerId, TransportEvent};
 
@@ -77,7 +79,25 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             .peer_unsubscribed(peer_id.as_str(), &topic);
     }
 
-    fn enforce_gossip_rate_limit(&self, peer_id: &PeerId, event_kind: &'static str) -> Result<()> {
+    fn rate_limited_error(peer_id: &PeerId) -> Error {
+        Error::AccessDenied {
+            peer_id: peer_id.to_string(),
+            collection_id: "rate-limited".into(),
+        }
+    }
+
+    /// Consume one rate-limiter token for `peer_id`, returning the synthetic
+    /// rate-limit error when the peer is over budget.
+    ///
+    /// Gossip events are simply dropped on rejection (no reply channel), while
+    /// request events (#1088 W4, re-landing #592's intake scope removed by
+    /// fa4a84f7) additionally send a `RATE_LIMITED_MESSAGE` nack via the
+    /// `reject_rate_limited_*` helpers so the pusher's retry/backoff engages.
+    /// Nack-on-overload is the Go-aligned behavior: Go's direct replicator
+    /// channel drives its retryInterval ladder off error replies
+    /// (`replicator.go`); overload replies are orthogonal to the trust/ACP
+    /// bypasses fa4a84f7 aligned with Go.
+    fn check_rate_limit(&self, peer_id: &PeerId, event_kind: &'static str) -> Result<()> {
         match self.runtime.rate_limiter.check(peer_id) {
             RateLimitDecision::Allowed => Ok(()),
             RateLimitDecision::Limited {
@@ -89,14 +109,108 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                     event_kind,
                     retry_after_ms = retry_after.as_millis(),
                     consecutive_failures,
-                    "Rate limit exceeded for gossip event, dropping"
+                    "Rate limit exceeded, rejecting event"
                 );
-                Err(Error::AccessDenied {
-                    peer_id: peer_id.to_string(),
-                    collection_id: "rate-limited".into(),
-                })
+                Err(Self::rate_limited_error(peer_id))
             }
         }
+    }
+
+    async fn reject_rate_limited_pushlog(
+        &self,
+        message_id: &str,
+        token: T::ResponseToken,
+        error: Error,
+    ) -> Error {
+        let reply = PushLogReply::error(message_id, RATE_LIMITED_MESSAGE);
+        let _ = self
+            .runtime
+            .transport
+            .send_pushlog_response(token, reply)
+            .await;
+        error
+    }
+
+    async fn reject_rate_limited_two_stream(
+        &self,
+        peer_id: &PeerId,
+        message_id: &str,
+        token: Option<T::ResponseToken>,
+        error: Error,
+    ) -> Error {
+        let mut reply = PushLogReply::error(message_id, RATE_LIMITED_MESSAGE);
+        let _ = sign_with_transport(&self.runtime.transport, &mut reply);
+        self.send_two_stream_reply(peer_id, reply, token).await;
+        error
+    }
+
+    async fn reject_rate_limited_doc_sync(
+        &self,
+        peer_id: &PeerId,
+        message_id: &str,
+        token: Option<T::ResponseToken>,
+        error: Error,
+    ) -> Error {
+        let mut reply = DocSyncReply::error(message_id, RATE_LIMITED_MESSAGE);
+        let _ = sign_with_transport(&self.runtime.transport, &mut reply);
+        let _ = if let Some(token) = token {
+            self.runtime
+                .transport
+                .send_doc_sync_response_token(token, reply)
+                .await
+        } else {
+            self.runtime
+                .transport
+                .send_doc_sync_response(peer_id, reply)
+                .await
+        };
+        error
+    }
+
+    async fn reject_rate_limited_branchable_sync(
+        &self,
+        peer_id: &PeerId,
+        message_id: &str,
+        collection_id: &str,
+        token: Option<T::ResponseToken>,
+        error: Error,
+    ) -> Error {
+        let mut reply = BranchableSyncReply::error(message_id, collection_id, RATE_LIMITED_MESSAGE);
+        let _ = sign_with_transport(&self.runtime.transport, &mut reply);
+        let _ = if let Some(token) = token {
+            self.runtime
+                .transport
+                .send_branchable_sync_response_token(token, reply)
+                .await
+        } else {
+            self.runtime
+                .transport
+                .send_branchable_sync_response(peer_id, reply)
+                .await
+        };
+        error
+    }
+
+    async fn reject_rate_limited_car_fetch(
+        &self,
+        peer_id: &PeerId,
+        token: Option<T::ResponseToken>,
+        error: Error,
+    ) -> Error {
+        // CAR has no error reply type — send an empty response so the sender
+        // sees an explicit (parseable) rejection rather than a hung stream.
+        let _ = if let Some(token) = token {
+            self.runtime
+                .transport
+                .send_car_response_token(token, Vec::new())
+                .await
+        } else {
+            self.runtime
+                .transport
+                .send_car_response(peer_id, Vec::new())
+                .await
+        };
+        error
     }
 
     /// Handle an event from the transport layer.
@@ -130,7 +244,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 topic,
                 ..
             } => {
-                self.enforce_gossip_rate_limit(&propagation_source, "GossipMessage")?;
+                self.check_rate_limit(&propagation_source, "GossipMessage")?;
                 self.handle_gossip_message(propagation_source, message, topic)
                     .await?;
             }
@@ -140,7 +254,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 data,
                 ..
             } => {
-                self.enforce_gossip_rate_limit(&propagation_source, "GossipRawMessage")?;
+                self.check_rate_limit(&propagation_source, "GossipRawMessage")?;
                 self.handle_gossip_raw_message(propagation_source, topic, data)
                     .await?;
             }
@@ -149,6 +263,11 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 request,
                 token,
             } => {
+                if let Err(error) = self.check_rate_limit(&peer_id, "PushLogRequest") {
+                    return Err(self
+                        .reject_rate_limited_pushlog(&request.message_id, token, error)
+                        .await);
+                }
                 self.handle_pushlog_request(peer_id, request, token).await?;
             }
             TransportEvent::TwoStreamRequest {
@@ -158,6 +277,16 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 is_explicit_replicator,
                 explicit_replay_authorization,
             } => {
+                if let Err(error) = self.check_rate_limit(&peer_id, "TwoStreamRequest") {
+                    return Err(self
+                        .reject_rate_limited_two_stream(
+                            &peer_id,
+                            &request.message_id,
+                            token,
+                            error,
+                        )
+                        .await);
+                }
                 self.handle_two_stream_request(
                     peer_id,
                     request,
@@ -190,6 +319,11 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 request,
                 token,
             } => {
+                if let Err(error) = self.check_rate_limit(&peer_id, "DocSyncRequest") {
+                    return Err(self
+                        .reject_rate_limited_doc_sync(&peer_id, &request.message_id, token, error)
+                        .await);
+                }
                 self.handle_doc_sync_request(peer_id, request, token)
                     .await?;
             }
@@ -201,6 +335,17 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 request,
                 token,
             } => {
+                if let Err(error) = self.check_rate_limit(&peer_id, "BranchableSyncRequest") {
+                    return Err(self
+                        .reject_rate_limited_branchable_sync(
+                            &peer_id,
+                            &request.message_id,
+                            &request.collection_id,
+                            token,
+                            error,
+                        )
+                        .await);
+                }
                 self.handle_branchable_sync_request(peer_id, request, token)
                     .await?;
             }
@@ -212,6 +357,11 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 request,
                 token,
             } => {
+                if let Err(error) = self.check_rate_limit(&peer_id, "CarFetchRequest") {
+                    return Err(self
+                        .reject_rate_limited_car_fetch(&peer_id, token, error)
+                        .await);
+                }
                 self.handle_car_fetch_request(peer_id, request, token)
                     .await?;
             }

--- a/crates/p2p/src/sync/coordinator/event_handler/mod.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/mod.rs
@@ -279,12 +279,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             } => {
                 if let Err(error) = self.check_rate_limit(&peer_id, "TwoStreamRequest") {
                     return Err(self
-                        .reject_rate_limited_two_stream(
-                            &peer_id,
-                            &request.message_id,
-                            token,
-                            error,
-                        )
+                        .reject_rate_limited_two_stream(&peer_id, &request.message_id, token, error)
                         .await);
                 }
                 self.handle_two_stream_request(

--- a/crates/p2p/src/sync/coordinator/event_handler/mod.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/mod.rs
@@ -87,17 +87,18 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         }
     }
 
-    /// Consume one rate-limiter token for `peer_id`, returning the synthetic
-    /// rate-limit error when the peer is over budget.
+    /// Consume one token from `limiter` for `peer_id`, returning the
+    /// synthetic rate-limit error when the peer is over budget.
     ///
-    /// Gossip events are simply dropped on rejection (no reply channel), while
-    /// request events (#1088 W4, re-landing #592's intake scope removed by
-    /// fa4a84f7) additionally send a `RATE_LIMITED_MESSAGE` nack via the
-    /// `reject_rate_limited_*` helpers so the pusher's retry/backoff engages.
+    /// Two limiters exist on purpose and must stay separate: gossip has no
+    /// reply channel, so refusals are silent drops governed by the long abuse
+    /// ladder; request events are nacked with `RATE_LIMITED_MESSAGE` (via the
+    /// `reject_rate_limited_*` helpers) and use the paced limiter, whose
+    /// retry horizon is ~one token refill — a long lockout here wedges any
+    /// full-DAG push deeper than the burst (see `p2p_deep_catchup`).
     /// Nack-on-overload is the Go-aligned behavior: Go's direct replicator
-    /// channel drives its retryInterval ladder off error replies
-    /// (`replicator.go`); overload replies are orthogonal to the trust/ACP
-    /// bypasses fa4a84f7 aligned with Go.
+    /// channel drives its retry ladder off error replies; overload replies
+    /// are orthogonal to its trust/ACP bypasses.
     fn check_rate_limit(
         &self,
         limiter: &crate::sync::rate_limiter::PeerRateLimiter,
@@ -129,11 +130,16 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         error: Error,
     ) -> Error {
         let reply = PushLogReply::error(message_id, RATE_LIMITED_MESSAGE);
-        let _ = self
+        // Best-effort: if the nack cannot be sent, the pusher times out and
+        // lands in the same retry path; no state was discarded.
+        if let Err(send_err) = self
             .runtime
             .transport
             .send_pushlog_response(token, reply)
-            .await;
+            .await
+        {
+            tracing::debug!(error = %send_err, "Failed to send PushLog backpressure nack");
+        }
         error
     }
 
@@ -145,7 +151,11 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         error: Error,
     ) -> Error {
         let mut reply = PushLogReply::error(message_id, RATE_LIMITED_MESSAGE);
-        let _ = sign_with_transport(&self.runtime.transport, &mut reply);
+        // Best-effort: send_two_stream_reply logs its own failures; an unsent
+        // nack degrades to a pusher-side timeout on the same retry path.
+        if let Err(sign_err) = sign_with_transport(&self.runtime.transport, &mut reply) {
+            tracing::debug!(error = %sign_err, "Failed to sign two-stream backpressure nack");
+        }
         self.send_two_stream_reply(peer_id, reply, token).await;
         error
     }
@@ -158,8 +168,10 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         error: Error,
     ) -> Error {
         let mut reply = DocSyncReply::error(message_id, RATE_LIMITED_MESSAGE);
-        let _ = sign_with_transport(&self.runtime.transport, &mut reply);
-        let _ = if let Some(token) = token {
+        if let Err(sign_err) = sign_with_transport(&self.runtime.transport, &mut reply) {
+            tracing::debug!(error = %sign_err, "Failed to sign DocSync backpressure nack");
+        }
+        let send_result = if let Some(token) = token {
             self.runtime
                 .transport
                 .send_doc_sync_response_token(token, reply)
@@ -170,6 +182,9 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 .send_doc_sync_response(peer_id, reply)
                 .await
         };
+        if let Err(send_err) = send_result {
+            tracing::debug!(error = %send_err, "Failed to send DocSync backpressure nack");
+        }
         error
     }
 
@@ -182,8 +197,10 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         error: Error,
     ) -> Error {
         let mut reply = BranchableSyncReply::error(message_id, collection_id, RATE_LIMITED_MESSAGE);
-        let _ = sign_with_transport(&self.runtime.transport, &mut reply);
-        let _ = if let Some(token) = token {
+        if let Err(sign_err) = sign_with_transport(&self.runtime.transport, &mut reply) {
+            tracing::debug!(error = %sign_err, "Failed to sign BranchableSync backpressure nack");
+        }
+        let send_result = if let Some(token) = token {
             self.runtime
                 .transport
                 .send_branchable_sync_response_token(token, reply)
@@ -194,6 +211,9 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 .send_branchable_sync_response(peer_id, reply)
                 .await
         };
+        if let Err(send_err) = send_result {
+            tracing::debug!(error = %send_err, "Failed to send BranchableSync backpressure nack");
+        }
         error
     }
 
@@ -205,7 +225,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     ) -> Error {
         // CAR has no error reply type — send an empty response so the sender
         // sees an explicit (parseable) rejection rather than a hung stream.
-        let _ = if let Some(token) = token {
+        let send_result = if let Some(token) = token {
             self.runtime
                 .transport
                 .send_car_response_token(token, Vec::new())
@@ -216,6 +236,9 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 .send_car_response(peer_id, Vec::new())
                 .await
         };
+        if let Err(send_err) = send_result {
+            tracing::debug!(error = %send_err, "Failed to send CAR backpressure rejection");
+        }
         error
     }
 

--- a/crates/p2p/src/sync/coordinator/event_handler/pushlog.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/pushlog.rs
@@ -10,6 +10,26 @@ use crate::signing::sign_with_transport;
 use crate::transport::{P2PTransport, PeerId};
 use crate::ExplicitReplayAuthorization;
 
+/// Build the PushLogReply for a `process_pushlog` outcome.
+///
+/// Invariant (#1088 M1): a success reply implies the block is either merged or
+/// registered as pending — no path may ack success after discarding state.
+/// Backpressure failures (pending-DAG capacity, rate limit) reply the
+/// byte-exact `RATE_LIMITED_MESSAGE` the pusher matches to drive its
+/// retry/backoff. Nack-on-overload is the Go-aligned behavior: Go's direct
+/// replicator channel drives its retryInterval ladder off error replies
+/// (`replicator.go`), so these overload nacks are orthogonal to the trust/ACP
+/// bypasses fa4a84f7 aligned with Go when it removed the #592 nacks.
+fn build_pushlog_reply(message_id: &str, process_result: &Result<()>) -> PushLogReply {
+    match process_result {
+        Ok(()) => PushLogReply::success(message_id),
+        Err(e) => match e.backpressure_reply_message() {
+            Some(nack) => PushLogReply::error(message_id, nack),
+            None => PushLogReply::error(message_id, &e.to_string()),
+        },
+    }
+}
+
 impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     pub(super) async fn handle_pushlog_request(
         &self,
@@ -114,10 +134,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             );
         }
 
-        let reply = match &process_result {
-            Ok(()) => PushLogReply::success(&request.message_id),
-            Err(e) => PushLogReply::error(&request.message_id, &e.to_string()),
-        };
+        let reply = build_pushlog_reply(&request.message_id, &process_result);
 
         if let Err(e) = self
             .runtime
@@ -200,10 +217,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             )
             .await;
 
-        let mut reply = match &process_result {
-            Ok(()) => PushLogReply::success(&request.message_id),
-            Err(e) => PushLogReply::error(&request.message_id, &e.to_string()),
-        };
+        let mut reply = build_pushlog_reply(&request.message_id, &process_result);
 
         if let Err(e) = sign_with_transport(&self.runtime.transport, &mut reply) {
             tracing::error!(

--- a/crates/p2p/src/sync/coordinator/mod.rs
+++ b/crates/p2p/src/sync/coordinator/mod.rs
@@ -255,8 +255,12 @@ pub(super) struct SyncRuntime<T: P2PTransport> {
     /// Semaphore limiting concurrent push tasks (configurable via SyncConfig).
     pub(super) push_semaphore: Arc<tokio::sync::Semaphore>,
 
-    /// Per-peer rate limiter applied at event dispatch to throttle abusive peers.
+    /// Per-peer rate limiter for gossip dispatch (abuse ladder; drop-only).
     pub(super) rate_limiter: Arc<PeerRateLimiter>,
+
+    /// Per-peer rate limiter for request intake (pacing backoff; refusals are
+    /// nacked with `RATE_LIMITED_MESSAGE` so pushers retry at the refill rate).
+    pub(super) request_rate_limiter: Arc<PeerRateLimiter>,
 
     /// Timeout for one outbound PushLog send to a replicator peer.
     pub(super) push_send_timeout: Duration,

--- a/crates/p2p/src/sync/manager/config.rs
+++ b/crates/p2p/src/sync/manager/config.rs
@@ -33,6 +33,13 @@ pub const DEFAULT_RATE_LIMIT_BACKOFF_SECS: &[u64] = &[
 /// Default timeout for one outbound PushLog send to a replicator peer.
 pub const DEFAULT_PUSH_SEND_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Default maximum number of entries in the pending DAGs map.
+///
+/// Prevents unbounded memory growth when many DAGs arrive faster than they
+/// can be resolved via Bitswap. Overflow is nacked back to the pusher with
+/// `RATE_LIMITED_MESSAGE` (#1088 W1) so its retry ladder keeps the doc queued.
+pub const DEFAULT_MAX_PENDING_DAGS: usize = 1000;
+
 /// Default rate-limit backoff ladder as durations.
 pub fn default_rate_limit_backoff() -> Vec<Duration> {
     DEFAULT_RATE_LIMIT_BACKOFF_SECS
@@ -76,6 +83,10 @@ pub struct SyncConfig {
 
     /// Timeout for one outbound PushLog send to a replicator peer.
     pub push_send_timeout: Duration,
+
+    /// Maximum number of pending-DAG registrations held while Bitswap
+    /// completes missing links. Overflow is rejected with a backpressure nack.
+    pub max_pending_dags: usize,
 }
 
 impl Default for SyncConfig {
@@ -89,6 +100,7 @@ impl Default for SyncConfig {
             rate_limit_rate: DEFAULT_RATE_LIMIT_RATE,
             rate_limit_backoff: default_rate_limit_backoff(),
             push_send_timeout: DEFAULT_PUSH_SEND_TIMEOUT,
+            max_pending_dags: DEFAULT_MAX_PENDING_DAGS,
         }
     }
 }

--- a/crates/p2p/src/sync/manager/config.rs
+++ b/crates/p2p/src/sync/manager/config.rs
@@ -86,6 +86,8 @@ pub struct SyncConfig {
 
     /// Maximum number of pending-DAG registrations held while Bitswap
     /// completes missing links. Overflow is rejected with a backpressure nack.
+    /// Values below 1 are normalized to 1 (a zero cap would reject every
+    /// missing-link push forever).
     pub max_pending_dags: usize,
 }
 

--- a/crates/p2p/src/sync/manager/mod.rs
+++ b/crates/p2p/src/sync/manager/mod.rs
@@ -22,8 +22,8 @@ mod process;
 pub use config::{
     default_rate_limit_backoff, SyncConfig, DEFAULT_MAX_CONCURRENT_DAG_FETCHES,
     DEFAULT_MAX_CONCURRENT_PUSH_TASKS, DEFAULT_MAX_DOC_SYNC_REQUEST_DOC_IDS,
-    DEFAULT_PUSH_SEND_TIMEOUT, DEFAULT_RATE_LIMIT_BACKOFF_SECS, DEFAULT_RATE_LIMIT_BURST,
-    DEFAULT_RATE_LIMIT_RATE,
+    DEFAULT_MAX_PENDING_DAGS, DEFAULT_PUSH_SEND_TIMEOUT, DEFAULT_RATE_LIMIT_BACKOFF_SECS,
+    DEFAULT_RATE_LIMIT_BURST, DEFAULT_RATE_LIMIT_RATE,
 };
 #[cfg(any(feature = "libp2p-transport", feature = "iroh-transport"))]
 pub(crate) use diagnostics::record_gossip_decode_failure_sample;

--- a/crates/p2p/src/sync/manager/pending.rs
+++ b/crates/p2p/src/sync/manager/pending.rs
@@ -7,12 +7,6 @@ use cid::Cid;
 
 use crate::ExplicitReplayAuthorization;
 
-/// Maximum number of entries in the pending DAGs map.
-///
-/// Prevents unbounded memory growth when many DAGs arrive faster than they
-/// can be resolved via Bitswap.
-pub const MAX_PENDING_DAGS: usize = 1000;
-
 /// Time-to-live for a pending DAG entry.
 ///
 /// Entries older than this are evicted during insertion to prevent

--- a/crates/p2p/src/sync/manager/process/mod.rs
+++ b/crates/p2p/src/sync/manager/process/mod.rs
@@ -114,7 +114,9 @@ impl<B: Blockstore + 'static> SyncManager<B> {
             pending_dags: Arc::new(RwLock::new(HashMap::new())),
             query_to_root: Arc::new(RwLock::new(HashMap::new())),
             diagnostics: Arc::new(SyncDiagnostics::default()),
-            max_pending_dags: config.max_pending_dags,
+            // A zero cap would reject every missing-link push forever
+            // (permanent admission outage); normalize to a 1-slot map.
+            max_pending_dags: config.max_pending_dags.max(1),
         };
 
         (manager, event_rx)

--- a/crates/p2p/src/sync/manager/process/mod.rs
+++ b/crates/p2p/src/sync/manager/process/mod.rs
@@ -84,6 +84,9 @@ pub struct SyncManager<B: Blockstore> {
 
     /// Observability counters (see `SyncDiagnostics`).
     pub(crate) diagnostics: Arc<SyncDiagnostics>,
+
+    /// Capacity of `pending_dags`; overflow is rejected with a backpressure nack.
+    pub(super) max_pending_dags: usize,
 }
 
 impl<B: Blockstore + 'static> SyncManager<B> {
@@ -111,6 +114,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
             pending_dags: Arc::new(RwLock::new(HashMap::new())),
             query_to_root: Arc::new(RwLock::new(HashMap::new())),
             diagnostics: Arc::new(SyncDiagnostics::default()),
+            max_pending_dags: config.max_pending_dags,
         };
 
         (manager, event_rx)

--- a/crates/p2p/src/sync/manager/process/pending_dag.rs
+++ b/crates/p2p/src/sync/manager/process/pending_dag.rs
@@ -10,7 +10,7 @@ use blockstore::Blockstore;
 use crate::error::{Error, Result};
 use crate::sync::manager::events::SyncEvent;
 use crate::sync::manager::links::find_all_missing_links;
-use crate::sync::manager::pending::{PendingDag, MAX_PENDING_DAGS, PENDING_DAG_TTL};
+use crate::sync::manager::pending::{PendingDag, PENDING_DAG_TTL};
 
 use super::SyncManager;
 
@@ -134,13 +134,14 @@ impl<B: Blockstore + 'static> SyncManager<B> {
     /// Insert a pending DAG entry, enforcing TTL eviction and capacity limits.
     ///
     /// Expired entries (older than `PENDING_DAG_TTL`) are removed before checking
-    /// the capacity. If the map is still at `MAX_PENDING_DAGS` after eviction the
-    /// new entry is silently dropped and `false` is returned so callers can log.
+    /// the capacity. If the map is still at `max_pending_dags` after eviction the
+    /// new entry is dropped and `false` is returned so callers can reject with a
+    /// backpressure nack (#1088 W1) instead of acking a discarded registration.
     pub(super) fn insert_pending_dag(&self, root_cid: Cid, dag: PendingDag) -> bool {
         let mut pending = self.pending_dags.write();
         evict_expired_pending_dags(&mut pending, Instant::now());
 
-        if pending.len() >= MAX_PENDING_DAGS && !pending.contains_key(&root_cid) {
+        if pending.len() >= self.max_pending_dags && !pending.contains_key(&root_cid) {
             return false;
         }
 
@@ -223,7 +224,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                 cid = %root_cid,
                 doc_id = %doc_id,
                 source_peer = %source_peer,
-                max = MAX_PENDING_DAGS,
+                max = self.max_pending_dags,
                 "Pending DAGs at capacity, dropping DocSync registration"
             );
         }
@@ -266,7 +267,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                 cid = %root_cid,
                 collection_id = %collection_id,
                 source_peer = %source_peer,
-                max = MAX_PENDING_DAGS,
+                max = self.max_pending_dags,
                 "Pending DAGs at capacity, dropping branchable DAG registration"
             );
         }
@@ -445,6 +446,7 @@ mod tests {
     use multihash_codetable::{Code, MultihashDigest};
     use storage::backends::MemoryStore;
 
+    use crate::sync::manager::DEFAULT_MAX_PENDING_DAGS;
     use crate::sync::{PeerStateTracker, SyncConfig};
 
     fn test_cid(label: usize) -> Cid {
@@ -484,16 +486,16 @@ mod tests {
         let root = test_cid(0);
 
         assert!(manager.insert_pending_dag(root, pending_dag("original", Instant::now())));
-        for idx in 1..MAX_PENDING_DAGS {
+        for idx in 1..DEFAULT_MAX_PENDING_DAGS {
             assert!(manager.insert_pending_dag(
                 test_cid(idx),
                 pending_dag(&format!("doc-{idx}"), Instant::now()),
             ));
         }
-        assert_eq!(manager.pending_dag_count(), MAX_PENDING_DAGS);
+        assert_eq!(manager.pending_dag_count(), DEFAULT_MAX_PENDING_DAGS);
 
         assert!(manager.insert_pending_dag(root, pending_dag("replacement", Instant::now())));
-        assert_eq!(manager.pending_dag_count(), MAX_PENDING_DAGS);
+        assert_eq!(manager.pending_dag_count(), DEFAULT_MAX_PENDING_DAGS);
         assert_eq!(
             manager
                 .pending_dags
@@ -542,6 +544,6 @@ mod tests {
             handle.join().expect("insert worker should not panic");
         }
 
-        assert!(manager.pending_dag_count() <= MAX_PENDING_DAGS);
+        assert!(manager.pending_dag_count() <= DEFAULT_MAX_PENDING_DAGS);
     }
 }

--- a/crates/p2p/src/sync/manager/process/pushlog.rs
+++ b/crates/p2p/src/sync/manager/process/pushlog.rs
@@ -11,7 +11,7 @@ use crate::error::{Error, Result};
 use crate::message::PushLogBroadcast;
 use crate::sync::manager::events::SyncEvent;
 use crate::sync::manager::links::find_all_missing_links;
-use crate::sync::manager::pending::{PendingDag, MAX_PENDING_DAGS};
+use crate::sync::manager::pending::PendingDag;
 use crate::ExplicitReplayAuthorization;
 
 use super::SyncManager;
@@ -376,16 +376,23 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                     },
                 );
                 if !inserted {
+                    // #1088 M1: the block is stored but its DAG completion is no
+                    // longer tracked. Returning Ok here made the reply seams ack
+                    // success, which deletes the pusher's retry record and loses
+                    // the document silently. The typed error becomes a
+                    // RATE_LIMITED_MESSAGE nack so the pusher re-pushes later.
                     tracing::warn!(
                         cid = %cid,
                         doc_id = %msg.doc_id,
                         collection_id = %msg.collection_id,
                         source_peer = ?sender_peer,
                         missing_count = missing.len(),
-                        max = MAX_PENDING_DAGS,
-                        "Pending DAGs at capacity, dropping PushLog DAG registration"
+                        max = self.max_pending_dags,
+                        "Pending DAGs at capacity, rejecting PushLog DAG registration"
                     );
-                    return Ok(());
+                    return Err(Error::PendingDagCapacity {
+                        max: self.max_pending_dags,
+                    });
                 }
             }
 

--- a/crates/p2p/src/sync/manager/process/pushlog.rs
+++ b/crates/p2p/src/sync/manager/process/pushlog.rs
@@ -376,10 +376,10 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                     },
                 );
                 if !inserted {
-                    // #1088 M1: the block is stored but its DAG completion is no
-                    // longer tracked. Returning Ok here made the reply seams ack
-                    // success, which deletes the pusher's retry record and loses
-                    // the document silently. The typed error becomes a
+                    // The block is stored but its DAG completion is not
+                    // tracked. This must surface as an error: a success reply
+                    // deletes the pusher's retry record, silently losing the
+                    // document. The reply seams map this typed error to the
                     // RATE_LIMITED_MESSAGE nack so the pusher re-pushes later.
                     tracing::warn!(
                         cid = %cid,

--- a/crates/p2p/src/sync/mod.rs
+++ b/crates/p2p/src/sync/mod.rs
@@ -37,7 +37,7 @@ pub use manager::{
     default_rate_limit_backoff, GossipDecodeFailureSample, GossipTransport, SyncConfig,
     SyncDiagnostics, SyncDiagnosticsSnapshot, SyncEvent, SyncManager,
     DEFAULT_MAX_CONCURRENT_DAG_FETCHES, DEFAULT_MAX_CONCURRENT_PUSH_TASKS,
-    DEFAULT_MAX_DOC_SYNC_REQUEST_DOC_IDS, DEFAULT_PUSH_SEND_TIMEOUT,
+    DEFAULT_MAX_DOC_SYNC_REQUEST_DOC_IDS, DEFAULT_MAX_PENDING_DAGS, DEFAULT_PUSH_SEND_TIMEOUT,
     DEFAULT_RATE_LIMIT_BACKOFF_SECS, DEFAULT_RATE_LIMIT_BURST, DEFAULT_RATE_LIMIT_RATE,
 };
 pub use merge::{BlockMetadata, MergeBlock, MergeHandler, MergeOutcome, RecoveredBlockMetadata};

--- a/crates/p2p/src/sync/rate_limiter.rs
+++ b/crates/p2p/src/sync/rate_limiter.rs
@@ -93,6 +93,13 @@ fn backoff_for_failure(backoff_steps: &[Duration], consecutive_failures: u32) ->
         .unwrap_or_else(|| Duration::from_secs(1))
 }
 
+/// Minimum effective refill rate for the request-intake limiter (tokens/s).
+///
+/// One token per second keeps the refill horizon well inside the deployed
+/// pusher's bounded in-batch retry budget (~3.3s of backoff sleeps before it
+/// abandons an ordered push and later restarts it from block one).
+pub const MIN_REQUEST_REFILL_RATE: f64 = 1.0;
+
 /// One-token refill horizon for request-intake pacing, clamped to [5ms, 1s].
 fn request_pacing_backoff(refill_rate: f64) -> Vec<Duration> {
     let rate = if refill_rate.is_finite() && refill_rate > 0.0 {
@@ -147,12 +154,24 @@ impl PeerRateLimiter {
     /// Request paths (PushLog, TwoStream, DocSync, ...) have a reply channel
     /// and a well-behaved retry protocol, so the bucket itself is the flow
     /// control: a legitimate deep full-DAG push that exhausts the burst must
-    /// resume at the refill rate. The 30s..12h ladder would wedge any DAG
-    /// deeper than the burst - each ladder-spaced re-push restarts from block
-    /// one and re-burns the burst on already-sent blocks before reaching new
-    /// ones. Gossip keeps the ladder (drop-only, no reply channel).
+    /// resume at the refill rate. A long lockout would wedge any DAG deeper
+    /// than the burst - each spaced-out re-push restarts from block one and
+    /// re-burns the burst on already-sent blocks before reaching new ones
+    /// (fenced by the `p2p_deep_catchup` integration test). Gossip keeps the
+    /// abuse ladder (drop-only, no reply channel).
+    ///
+    /// The effective refill rate is floored at
+    /// [`MIN_REQUEST_REFILL_RATE`]: deployed pushers retry a nacked block
+    /// in-batch for only ~3.3s before giving up and re-pushing from block one
+    /// later, so a token must arrive within that budget or deep pushes wedge
+    /// exactly as above.
     pub fn new_request_paced(capacity: u32, refill_rate: f64) -> Self {
-        Self::with_backoff_steps(capacity, refill_rate, request_pacing_backoff(refill_rate))
+        let rate = if refill_rate.is_finite() && refill_rate > MIN_REQUEST_REFILL_RATE {
+            refill_rate
+        } else {
+            MIN_REQUEST_REFILL_RATE
+        };
+        Self::with_backoff_steps(capacity, rate, request_pacing_backoff(rate))
     }
 
     /// Create a new limiter with explicit rate-limit backoff steps.
@@ -264,6 +283,31 @@ mod tests {
             limiter.check(&peer),
             RateLimitDecision::Allowed,
             "must recover as soon as a token refills"
+        );
+    }
+
+    #[test]
+    fn request_paced_limiter_floors_pathological_refill_rates() {
+        // A configured rate of 0.1 tokens/s refills one token per 10s, but the
+        // deployed pusher's in-batch retry budget is ~3.3s and every persisted
+        // re-push restarts from block one — so any DAG deeper than the burst
+        // would wedge forever. The request limiter floors the refill rate so a
+        // token always arrives within the pusher's retry budget.
+        let limiter = PeerRateLimiter::new_request_paced(1, 0.1);
+        let peer = PeerId::new("peer-1".to_string());
+
+        assert_eq!(limiter.check(&peer), RateLimitDecision::Allowed);
+        let (retry_after, _) = limited(limiter.check(&peer));
+        assert!(
+            retry_after <= Duration::from_secs(1),
+            "retry horizon must stay within the pusher's in-batch budget: {retry_after:?}"
+        );
+
+        std::thread::sleep(retry_after + Duration::from_millis(120));
+        assert_eq!(
+            limiter.check(&peer),
+            RateLimitDecision::Allowed,
+            "a token must actually refill within the advertised horizon, not at the raw 0.1/s rate"
         );
     }
 

--- a/crates/p2p/src/sync/rate_limiter.rs
+++ b/crates/p2p/src/sync/rate_limiter.rs
@@ -93,6 +93,16 @@ fn backoff_for_failure(backoff_steps: &[Duration], consecutive_failures: u32) ->
         .unwrap_or_else(|| Duration::from_secs(1))
 }
 
+/// One-token refill horizon for request-intake pacing, clamped to [5ms, 1s].
+fn request_pacing_backoff(refill_rate: f64) -> Vec<Duration> {
+    let rate = if refill_rate.is_finite() && refill_rate > 0.0 {
+        refill_rate
+    } else {
+        1.0
+    };
+    vec![Duration::from_secs_f64((1.0 / rate).clamp(0.005, 1.0))]
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum RateLimitDecision {
     Allowed,
@@ -128,6 +138,21 @@ impl PeerRateLimiter {
     /// * `refill_rate` – Tokens added per second per peer.
     pub fn new(capacity: u32, refill_rate: f64) -> Self {
         Self::with_backoff_steps(capacity, refill_rate, default_rate_limit_backoff())
+    }
+
+    /// Create a request-intake limiter: same bucket parameters, but the retry
+    /// horizon after a refusal is ~one token refill instead of the abuse
+    /// ladder.
+    ///
+    /// Request paths (PushLog, TwoStream, DocSync, ...) have a reply channel
+    /// and a well-behaved retry protocol, so the bucket itself is the flow
+    /// control: a legitimate deep full-DAG push that exhausts the burst must
+    /// resume at the refill rate. The 30s..12h ladder would wedge any DAG
+    /// deeper than the burst - each ladder-spaced re-push restarts from block
+    /// one and re-burns the burst on already-sent blocks before reaching new
+    /// ones. Gossip keeps the ladder (drop-only, no reply channel).
+    pub fn new_request_paced(capacity: u32, refill_rate: f64) -> Self {
+        Self::with_backoff_steps(capacity, refill_rate, request_pacing_backoff(refill_rate))
     }
 
     /// Create a new limiter with explicit rate-limit backoff steps.
@@ -215,6 +240,31 @@ mod tests {
         std::thread::sleep(Duration::from_millis(3));
         let (_, failures) = limited(limiter.check(&peer));
         assert_eq!(failures, 3);
+    }
+
+    #[test]
+    fn request_paced_limiter_recovers_at_refill_horizon_not_ladder() {
+        // #1088 W4 follow-up: request-intake limiting is flow control, not
+        // abuse control. A deep full-DAG push that exhausts the bucket must be
+        // able to resume at the token-refill rate; the 30s..12h abuse ladder
+        // would wedge any DAG deeper than the burst (each ladder re-push
+        // restarts from block 1 and re-burns the burst on already-sent blocks).
+        let limiter = PeerRateLimiter::new_request_paced(1, 200.0);
+        let peer = PeerId::new("peer-1".to_string());
+
+        assert_eq!(limiter.check(&peer), RateLimitDecision::Allowed);
+        let (retry_after, _) = limited(limiter.check(&peer));
+        assert!(
+            retry_after <= Duration::from_millis(50),
+            "retry horizon must be ~one token refill, not the abuse ladder: {retry_after:?}"
+        );
+
+        std::thread::sleep(retry_after + Duration::from_millis(20));
+        assert_eq!(
+            limiter.check(&peer),
+            RateLimitDecision::Allowed,
+            "must recover as soon as a token refills"
+        );
     }
 
     #[test]

--- a/crates/p2p/tests/sync_manager_tests.rs
+++ b/crates/p2p/tests/sync_manager_tests.rs
@@ -691,3 +691,30 @@ async fn test_process_pushlog_pending_capacity_returns_typed_error() {
     // The block itself is kept (a later retry can complete without re-sending it).
     assert!(blockstore.has(&comp_b_cid).await.unwrap());
 }
+
+#[tokio::test]
+async fn test_max_pending_dags_zero_is_normalized_to_one() {
+    // A zero cap would reject every missing-link push forever (permanent
+    // admission outage); the manager normalizes it to a 1-slot map.
+    let store = Arc::new(MemoryStore::new());
+    let blockstore = Arc::new(DefraBlockstore::new(store, true));
+    let config = SyncConfig {
+        max_pending_dags: 0,
+        ..SyncConfig::default()
+    };
+    let (manager, mut events) = SyncManager::new(blockstore, test_peer_state(), config);
+
+    let (field_cid, _) = create_lww_block("field_a");
+    let (comp_cid, comp_block) = create_composite_block(vec![DAGLink::new("field_a", field_cid)]);
+    manager
+        .process_pushlog(
+            &broadcast_for(&comp_cid, "docA", comp_block),
+            Some("peer-1"),
+            false,
+            None,
+        )
+        .await
+        .expect("a single pending registration must be admitted even with cap 0");
+    let _ = events.try_recv().expect("DagNeedsFetch for composite");
+    assert_eq!(manager.pending_dag_count(), 1);
+}

--- a/crates/p2p/tests/sync_manager_tests.rs
+++ b/crates/p2p/tests/sync_manager_tests.rs
@@ -627,3 +627,67 @@ async fn test_blockstore_accessor() {
     manager.blockstore().put(&cid, BLOCK_DATA).await.unwrap();
     assert!(blockstore.has(&cid).await.unwrap());
 }
+
+// --- #1088 W1: pending-DAG capacity must surface as a typed error ---
+
+fn broadcast_for(cid: &Cid, doc_id: &str, block: Vec<u8>) -> PushLogBroadcast {
+    PushLogBroadcast::new(
+        doc_id.to_string(),
+        Bytes::from(cid.to_bytes()),
+        "collection1".to_string(),
+        "creator1".to_string(),
+        Bytes::from(block),
+    )
+}
+
+#[tokio::test]
+async fn test_process_pushlog_pending_capacity_returns_typed_error() {
+    let store = Arc::new(MemoryStore::new());
+    let blockstore = Arc::new(DefraBlockstore::new(store, true));
+    let config = SyncConfig {
+        max_pending_dags: 1,
+        ..SyncConfig::default()
+    };
+    let (manager, mut events) = SyncManager::new(blockstore.clone(), test_peer_state(), config);
+
+    // Composite A links to a field block that is never stored -> registers pending.
+    let (field_a_cid, _) = create_lww_block("field_a");
+    let (comp_a_cid, comp_a_block) =
+        create_composite_block(vec![DAGLink::new("field_a", field_a_cid)]);
+    manager
+        .process_pushlog(
+            &broadcast_for(&comp_a_cid, "docA", comp_a_block),
+            Some("peer-1"),
+            false,
+            None,
+        )
+        .await
+        .unwrap();
+    let _ = events.try_recv().expect("DagNeedsFetch for composite A");
+    assert_eq!(manager.pending_dag_count(), 1);
+
+    // Composite B overflows the single-slot pending map: the registration is
+    // dropped, and the caller MUST see a typed capacity error so the reply
+    // seams can nack instead of acking success (#1088 M1 invariant:
+    // success reply => merged or registered as pending).
+    let (field_b_cid, _) = create_lww_block("field_b");
+    let (comp_b_cid, comp_b_block) =
+        create_composite_block(vec![DAGLink::new("field_b", field_b_cid)]);
+    let result = manager
+        .process_pushlog(
+            &broadcast_for(&comp_b_cid, "docB", comp_b_block),
+            Some("peer-2"),
+            false,
+            None,
+        )
+        .await;
+
+    assert!(
+        matches!(result, Err(Error::PendingDagCapacity { .. })),
+        "capacity drop must be a typed error, got {:?}",
+        result
+    );
+    assert_eq!(manager.pending_dag_count(), 1, "registration was dropped");
+    // The block itself is kept (a later retry can complete without re-sending it).
+    assert!(blockstore.has(&comp_b_cid).await.unwrap());
+}

--- a/proofs/tla/MC_PushLogAdmission_Common.tla
+++ b/proofs/tla/MC_PushLogAdmission_Common.tla
@@ -1,0 +1,9 @@
+---- MODULE MC_PushLogAdmission_Common ----
+EXTENDS PushLogAdmission
+\* Shared model values for the PushLogAdmission GREEN/RED configs. Three docs against a
+\* single pending slot so admission overflow is reachable with concurrent inflight pushes
+\* (fan-in: any second push while one registration is outstanding overflows), while the
+\* state space stays tiny. Pusher identity is abstracted away - see PushLogAdmission.tla.
+mcDocs == {1, 2, 3}
+mcCap  == 1
+====

--- a/proofs/tla/MC_PushLogAdmission_Green.cfg
+++ b/proofs/tla/MC_PushLogAdmission_Green.cfg
@@ -1,0 +1,12 @@
+\* GREEN (#1088 W1 fix): capacity overflow replies RATE_LIMITED_MESSAGE, so the pusher
+\* keeps its retry record and re-pushes. Every success reply corresponds to kept hub
+\* state (merged or pending), and under per-doc fairness every doc eventually merges.
+SPECIFICATION FairSpec
+CHECK_DEADLOCK TRUE
+CONSTANTS
+  Docs      <- mcDocs
+  Cap       <- mcCap
+  ReplyMode = "NackOnFull"
+INVARIANT INV_TypeOK
+INVARIANT INV_SuccessImpliesRegisteredOrMerged
+PROPERTY EventuallyAllMerged

--- a/proofs/tla/MC_PushLogAdmission_Red_SuccessOnFull.cfg
+++ b/proofs/tla/MC_PushLogAdmission_Red_SuccessOnFull.cfg
@@ -1,0 +1,12 @@
+\* RED (current main, fa4a84f7 regression of #592): capacity overflow drops the pending
+\* registration but replies success, so the pusher deletes its retry record while the hub
+\* holds neither a merge nor a registration. INV_SuccessImpliesRegisteredOrMerged is
+\* violated at the overflow step - the #1088 M1 silent-divergence laundering.
+SPECIFICATION Spec
+CHECK_DEADLOCK TRUE
+CONSTANTS
+  Docs      <- mcDocs
+  Cap       <- mcCap
+  ReplyMode = "SuccessOnFull"
+INVARIANT INV_TypeOK
+INVARIANT INV_SuccessImpliesRegisteredOrMerged

--- a/proofs/tla/PushLogAdmission.tla
+++ b/proofs/tla/PushLogAdmission.tla
@@ -1,0 +1,169 @@
+---- MODULE PushLogAdmission ----
+\* PushLog admission at the hub's sync manager (#1088 slice 1 / W1), abstracting
+\* crates/p2p/src/sync/manager/process/pushlog.rs (process_pushlog + insert_pending_dag)
+\* and the reply seams in crates/p2p/src/sync/coordinator/event_handler/pushlog.rs.
+\*
+\* THE MECHANISM: a pushed head block whose DAG has missing links must be REGISTERED in
+\* the hub's bounded pending-DAG map (capacity = SyncConfig::max_pending_dags, Go-era
+\* MAX_PENDING_DAGS) before the hub can complete it via Bitswap and merge. The pusher
+\* drives its persisted retry ladder off the PushLogReply: a success reply is TERMINAL —
+\* the pusher deletes its retry record for the doc (defra-node/src/lib.rs remove_retry_doc)
+\* and will never re-push it unless an unrelated later update arrives.
+\*
+\* THE BUG (fa4a84f7 regression of #592): when the pending map is at capacity the hub
+\* drops the registration and returns Ok(()) — which both reply seams turn into
+\* PushLogReply::success. The pusher's retry record is destroyed while the hub holds
+\* neither a merge nor a registration: silent, permanent divergence (issue #1088 M1).
+\*
+\* THE INVARIANT (heart of the fix): a success PushLogReply implies the pushed block is
+\* either MERGED or REGISTERED AS PENDING on the hub. No code path may reply success
+\* after discarding state. On capacity overflow the hub must nack (RATE_LIMITED_MESSAGE),
+\* which the pusher's live backoff consumer (broadcast.rs send_ordered_pushlogs_via_transport)
+\* and persisted retry ladder both handle — so the doc stays queued and eventually merges.
+\*
+\* One knob:
+\*   ReplyMode = "NackOnFull"    - capacity overflow replies RATE_LIMITED_MESSAGE; the
+\*                                 pusher keeps its retry record and re-pushes. [GREEN]
+\*             = "SuccessOnFull" - current-main behavior: drop registration, reply
+\*                                 success; the pusher deletes its retry record. [RED]
+\*
+\* Abstractions: pusher identity is irrelevant to the invariant (any fan-in of pushers
+\* contends for the same global capacity), so docs are the unit and "the pusher" is the
+\* per-doc ack/retry record. HOW a push comes to have missing links (single-head-block
+\* live update, M3 send-timeout truncation) is likewise abstracted: HubComplete models an
+\* arrival whose DAG is already complete, HubAdmit/HubOverflow* model one that is not.
+\* TTL eviction of an admitted entry is deliberately NOT modeled: it is the residual
+\* divergence window of the pending map itself (issue #844 / #1088 W2-W3 follow-ups),
+\* orthogonal to the reply decision this slice fixes.
+EXTENDS Naturals, FiniteSets
+
+CONSTANTS
+  Docs,        \* pushed documents (each = one head push contending for admission)
+  Cap,         \* pending-DAG capacity (SyncConfig::max_pending_dags)
+  ReplyMode    \* "NackOnFull" | "SuccessOnFull"
+
+ASSUME Docs # {}
+ASSUME Cap \in Nat /\ Cap >= 1
+ASSUME ReplyMode \in {"NackOnFull", "SuccessOnFull"}
+
+\* Pusher-side per-doc record:
+\*   unsent       - not yet pushed
+\*   inflight     - push sent, awaiting PushLogReply
+\*   ackedSuccess - success reply consumed; retry record DELETED (terminal on the pusher)
+\*   retryQueued  - error reply consumed; retry record persisted, will re-push
+PusherStates == {"unsent", "inflight", "ackedSuccess", "retryQueued"}
+
+VARIABLES
+  pending,   \* SUBSET Docs - hub pending-DAG registrations awaiting missing links
+  merged,    \* SUBSET Docs - merged on the hub
+  pusher     \* [Docs -> PusherStates]
+
+vars == <<pending, merged, pusher>>
+
+TypeOK ==
+  /\ pending \subseteq Docs
+  /\ merged \subseteq Docs
+  /\ pending \cap merged = {}
+  /\ Cardinality(pending) <= Cap
+  /\ pusher \in [Docs -> PusherStates]
+
+Init ==
+  /\ pending = {}
+  /\ merged = {}
+  /\ pusher = [d \in Docs |-> "unsent"]
+
+\* Pusher sends (or re-sends from its persisted retry ladder) the doc's head push.
+Send(d) ==
+  /\ pusher[d] \in {"unsent", "retryQueued"}
+  /\ pusher' = [pusher EXCEPT ![d] = "inflight"]
+  /\ UNCHANGED <<pending, merged>>
+
+\* The pushed DAG is complete on arrival (all links present or already merged):
+\* the hub merges and replies success. Success here is honest - state is kept.
+HubComplete(d) ==
+  /\ pusher[d] = "inflight"
+  /\ merged' = merged \cup {d}
+  /\ pending' = pending \ {d}
+  /\ pusher' = [pusher EXCEPT ![d] = "ackedSuccess"]
+  /\ UNCHANGED <<>>
+
+\* Missing links and a free slot (or an existing registration for the same root -
+\* insert_pending_dag replaces in place at capacity): register pending, reply success.
+\* Success here is honest - the registration guarantees Bitswap completion is tracked.
+HubAdmit(d) ==
+  /\ pusher[d] = "inflight"
+  /\ d \notin merged
+  /\ (Cardinality(pending) < Cap \/ d \in pending)
+  /\ pending' = pending \cup {d}
+  /\ pusher' = [pusher EXCEPT ![d] = "ackedSuccess"]
+  /\ UNCHANGED merged
+
+\* Capacity overflow, current-main behavior (process/pushlog.rs WARN + Ok(()) ->
+\* PushLogReply::success): the registration is DROPPED but the pusher is told success,
+\* so it deletes its retry record. The laundering step. [RED path]
+HubOverflowSuccess(d) ==
+  /\ ReplyMode = "SuccessOnFull"
+  /\ pusher[d] = "inflight"
+  /\ d \notin merged
+  /\ d \notin pending
+  /\ Cardinality(pending) >= Cap
+  /\ pusher' = [pusher EXCEPT ![d] = "ackedSuccess"]
+  /\ UNCHANGED <<pending, merged>>
+
+\* Capacity overflow, fixed behavior: reply RATE_LIMITED_MESSAGE. The pusher's
+\* backoff consumer keeps the doc queued for retry. [GREEN path]
+HubOverflowNack(d) ==
+  /\ ReplyMode = "NackOnFull"
+  /\ pusher[d] = "inflight"
+  /\ d \notin merged
+  /\ d \notin pending
+  /\ Cardinality(pending) >= Cap
+  /\ pusher' = [pusher EXCEPT ![d] = "retryQueued"]
+  /\ UNCHANGED <<pending, merged>>
+
+\* Bitswap completes a registered DAG (retry_pending_dag -> DagReady -> merge).
+Resolve(d) ==
+  /\ d \in pending
+  /\ pending' = pending \ {d}
+  /\ merged' = merged \cup {d}
+  /\ UNCHANGED pusher
+
+Next ==
+  \E d \in Docs :
+    \/ Send(d)
+    \/ HubComplete(d)
+    \/ HubAdmit(d)
+    \/ HubOverflowSuccess(d)
+    \/ HubOverflowNack(d)
+    \/ Resolve(d)
+
+\* All docs merged: stutter so TLC does not flag deadlock on a finished schedule.
+\* (Under SuccessOnFull a schedule can also WEDGE with merged # Docs - every pusher
+\* record acked, nothing pending, nothing re-pushable. That dead end is the bug's
+\* operational signature, but the invariant below catches it earlier and crisper.)
+Done == merged = Docs
+Terminating == Done /\ UNCHANGED vars
+
+Spec == Init /\ [][Next \/ Terminating]_vars
+
+\* Weak fairness per doc: retries keep getting sent, registered DAGs keep resolving,
+\* and an admissible inflight push is eventually admitted or completed.
+FairSpec ==
+  Spec /\ \A d \in Docs :
+    /\ WF_vars(Send(d))
+    /\ WF_vars(Resolve(d))
+    /\ WF_vars(HubAdmit(d))
+    /\ WF_vars(HubComplete(d))
+
+INV_TypeOK == TypeOK
+
+\* THE #1088 M1 INVARIANT: a success reply implies the hub kept state for the doc -
+\* it is merged or registered as pending. SuccessOnFull violates this at the
+\* overflow step; NackOnFull preserves it in every reachable state.
+INV_SuccessImpliesRegisteredOrMerged ==
+  \A d \in Docs : pusher[d] = "ackedSuccess" => d \in pending \cup merged
+
+\* Liveness (GREEN, under FairSpec): with overflow nacked and retries fair, every
+\* pushed doc eventually merges - the loop has a fixed point.
+EventuallyAllMerged == <>(merged = Docs)
+====

--- a/proofs/tla/PushLogAdmission_DESIGN.md
+++ b/proofs/tla/PushLogAdmission_DESIGN.md
@@ -1,0 +1,68 @@
+# PushLogAdmission — hub PushLog admission control (TLA+ design)
+
+Models the hub-side admission decision for incoming PushLog pushes for issue **#1088**
+(slice 1, W1), abstracting `crates/p2p/src/sync/manager/process/pushlog.rs`
+(`process_pushlog` + `insert_pending_dag`) and the reply seams in
+`crates/p2p/src/sync/coordinator/event_handler/pushlog.rs` (gossip-token and two-stream
+paths). Companion to `Replicator.tla`, which models the pusher's resumable retry
+lifecycle over a source→target edge; this slice isolates the **hub's reply decision**
+when its bounded pending-DAG map is full.
+
+> **Status: the RED config is current-main behavior.** The hub-side backpressure nacks
+> delivered for #592 were removed by `fa4a84f7` ("align iroh replay and shutdown with go
+> model", 2026-04-18) while the pusher-side consumer of those nacks
+> (`broadcast.rs::send_ordered_pushlogs_via_transport`, #843) stayed live and tested.
+> The GREEN config is the re-landed W1 behavior.
+
+## Mechanism
+
+A pushed head block whose DAG has missing links must be **registered** in the hub's
+bounded pending-DAG map (`SyncConfig::max_pending_dags`) so Bitswap completion is
+tracked and the DAG eventually merges. The pusher drives its **persisted retry ladder**
+off the `PushLogReply`: a success reply is terminal — the pusher deletes its retry
+record (`defra-node/src/lib.rs` `remove_retry_doc`) and never re-pushes unless an
+unrelated later update arrives. Go's direct replicator channel has the same shape: its
+retry ladder is driven by **error replies** (Go `replicator.go` retryInterval ladder),
+so nack-on-overload is the Go-aligned behavior; overload nacks are orthogonal to the
+trust/ACP bypasses that `fa4a84f7` was aligning.
+
+When the map is at capacity, current main **drops the registration and replies
+success** (`process/pushlog.rs` WARN + `Ok(())` → `PushLogReply::success`): the pusher's
+retry record is destroyed while the hub holds neither a merge nor a registration.
+Silent, permanent divergence (#1088 M1).
+
+## Property
+
+`INV_SuccessImpliesRegisteredOrMerged` — **a success PushLogReply implies the pushed
+block is either merged or registered as pending on the hub.** No code path may reply
+success after discarding state.
+
+GREEN additionally checks `EventuallyAllMerged` under per-doc weak fairness: with
+overflow nacked (`RATE_LIMITED_MESSAGE`) and retries fair, every pushed doc eventually
+merges — the drop/re-push loop has a fixed point.
+
+## Abstractions
+
+- **Pusher identity is dropped**: any fan-in of pushers contends for the same global
+  capacity, so docs are the unit and "the pusher" is the per-doc ack/retry record.
+- **How a push comes to have missing links** (single-head-block live update, M3
+  send-timeout truncation) is irrelevant to the reply decision: `HubComplete` models a
+  complete arrival, `HubAdmit`/`HubOverflow*` an incomplete one.
+- **TTL eviction of an admitted entry is not modeled.** Evicting a registered DAG after
+  a success reply is the pending map's residual divergence window (#844, #1088 W2/W3
+  follow-ups), orthogonal to the reply decision this slice fixes. With eviction the
+  invariant would need reply-time phrasing; without it, the state invariant is exact.
+
+## Configs
+
+| Config | Knob | Verdict | Meaning |
+|--------|------|---------|---------|
+| `MC_PushLogAdmission_Green.cfg` | `ReplyMode="NackOnFull"` | GREEN | W1 fix: overflow nacks; invariant + liveness hold |
+| `MC_PushLogAdmission_Red_SuccessOnFull.cfg` | `ReplyMode="SuccessOnFull"` | RED | current main: overflow acks success → invariant violated in 5 states |
+
+## Conformance fence
+
+The Rust-side fence for the same invariant is the fan-in integration test
+(`tools/integration-test/tests/p2p/`, #1088 W5) plus the coordinator unit tests around
+the capacity-nack reply — both assert that no document is success-acked on a pusher
+while unmerged and unregistered on the hub.

--- a/proofs/tla/run-all.sh
+++ b/proofs/tla/run-all.sh
@@ -81,6 +81,8 @@ RUNS=(
   "MC_InteractiveTxnCounter_Green.cfg MC_InteractiveTxnCounter_Common.tla GREEN" # #1044: gate On + commit-only finalize -> deadlock-free + gate never held across idle
   "MC_InteractiveTxnCounter_Red_NoGate.cfg MC_InteractiveTxnCounter_Common.tla RED" # gate Off -> arbitrary-order batch vs finalize circular-wait DEADLOCK (gate is load-bearing)
   "MC_InteractiveTxnCounter_Red_AcrossLifetime.cfg MC_InteractiveTxnCounter_Common.tla RED" # #1041 old path: gate held across user-controlled idle lifetime (INV_GateBoundedHold)
+  "MC_PushLogAdmission_Green.cfg MC_PushLogAdmission_Common.tla GREEN" # #1088 W1: capacity overflow nacks -> success implies registered-or-merged + all docs merge
+  "MC_PushLogAdmission_Red_SuccessOnFull.cfg MC_PushLogAdmission_Common.tla RED" # fa4a84f7 regression: overflow drops registration but acks success (INV_SuccessImpliesRegisteredOrMerged)
   "MC_Jwt_Green.cfg                MC_Jwt_Green.tla                GREEN" # token->DID binds genuine signer DID
   "MC_Jwt_Red_NoAlgBinding.cfg     MC_Jwt_Red_NoAlgBinding.tla     RED"   # alg-confusion: header alg not bound to key type
   "MC_Jwt_Red_NoIssBinding.cfg     MC_Jwt_Red_NoIssBinding.tla     RED"   # iss not bound to did(pubkey)

--- a/tools/integration-test/Cargo.toml
+++ b/tools/integration-test/Cargo.toml
@@ -27,6 +27,10 @@ name = "p2p"
 path = "tests/p2p.rs"
 
 [[test]]
+name = "p2p_admission"
+path = "tests/p2p_admission.rs"
+
+[[test]]
 name = "encryption"
 path = "tests/encryption.rs"
 

--- a/tools/integration-test/Cargo.toml
+++ b/tools/integration-test/Cargo.toml
@@ -31,6 +31,10 @@ name = "p2p_admission"
 path = "tests/p2p_admission.rs"
 
 [[test]]
+name = "p2p_deep_catchup"
+path = "tests/p2p_deep_catchup.rs"
+
+[[test]]
 name = "encryption"
 path = "tests/encryption.rs"
 

--- a/tools/integration-test/tests/p2p_admission.rs
+++ b/tools/integration-test/tests/p2p_admission.rs
@@ -1,0 +1,162 @@
+//! #1088 W5: replicator fan-in against a hub with a tiny pending-DAG cap.
+//!
+//! Lives in its own test binary because the cap is injected via the
+//! `DEFRA_P2P_MAX_PENDING_DAGS` env var, which every node spawned by this
+//! process inherits — it must not leak into other tests' clusters.
+
+use std::time::{Duration, Instant};
+
+use integration_test::{DefraClient, TestCluster};
+
+const SCHEMA: &str = "type User { name: String  age: Int }";
+const PUSHERS: usize = 8;
+const DOCS_PER_PUSHER: usize = 8;
+
+/// N pushers replicate concurrent document-create bursts into one hub whose
+/// pending-DAG map holds a single slot, so almost every push overflows
+/// admission (each unfiltered replicator push carries only the head block;
+/// its field links are missing on the hub and need a pending registration).
+///
+/// The #1088 M1 invariant under test: **no document may be success-acked on a
+/// pusher while unmerged and unregistered on the hub.** Before the W1 fix the
+/// hub acked success on overflow and the pusher deleted its retry record, so
+/// overflowed documents never merged — this test fails on that behavior. With
+/// overflow nacked (`RATE_LIMITED_MESSAGE`), the pushers' backoff and
+/// persisted retry ladder re-push until every document lands, so eventual
+/// hub-side completeness is exactly the observable form of the invariant:
+/// a dropped registration can only ever complete through a re-push, and
+/// re-pushes only happen when the hub refuses to launder the drop as success.
+#[tokio::test]
+async fn fan_in_pushlog_admission_no_silent_divergence() {
+    std::env::set_var("DEFRA_P2P_MAX_PENDING_DAGS", "1");
+
+    let cluster = TestCluster::builder()
+        .rust_nodes(1 + PUSHERS)
+        .with_p2p()
+        .build()
+        .await
+        .expect("cluster start");
+
+    let startup_timeout = Duration::from_secs(30);
+    for node in 0..=PUSHERS {
+        cluster
+            .wait_for_log(node, "p2p_listening", startup_timeout)
+            .await
+            .unwrap_or_else(|e| panic!("node{node} P2P listener did not start: {e}"));
+    }
+
+    let hub = cluster.client(0);
+    let hub_info = hub.p2p_info().expect("hub p2p info");
+    let hub_addr = hub_info
+        .as_array()
+        .and_then(|arr| arr.first())
+        .and_then(|v| v.as_str())
+        .expect("hub has no P2P address")
+        .to_string();
+
+    hub.schema_add(SCHEMA).expect("hub schema");
+    for pusher in 1..=PUSHERS {
+        let client = cluster.client(pusher);
+        client.schema_add(SCHEMA).expect("pusher schema");
+        client.p2p_connect(&[&hub_addr]).expect("connect to hub");
+        client
+            .p2p_replicator_set(&["User"], &hub_addr)
+            .expect("replicator pusher -> hub");
+    }
+
+    // Concurrent create bursts, one thread per pusher: each create commits
+    // locally and pushes its head block to the hub from a background task, so
+    // pushes from all 8 pushers race for the hub's single pending-DAG slot.
+    // The hub handles transport events serially, so any push that arrives
+    // while another registration is still waiting on its Bitswap round trip
+    // overflows admission.
+    let pusher_clients: Vec<DefraClient> = (1..=PUSHERS).map(|i| cluster.client(i)).collect();
+    let expected_doc_ids: Vec<String> = std::thread::scope(|scope| {
+        let handles: Vec<_> = pusher_clients
+            .into_iter()
+            .enumerate()
+            .map(|(idx, client)| {
+                scope.spawn(move || {
+                    let pusher = idx + 1;
+                    (0..DOCS_PER_PUSHER)
+                        .map(|doc| {
+                            let mutation = format!(
+                                r#"mutation {{ add_User(input: {{name: "p{pusher}-d{doc}", age: {doc}}}) {{ _docID }} }}"#
+                            );
+                            let data = client.query(&mutation).expect("create doc on pusher");
+                            data["add_User"][0]["_docID"]
+                                .as_str()
+                                .expect("missing _docID")
+                                .to_string()
+                        })
+                        .collect::<Vec<String>>()
+                })
+            })
+            .collect();
+        handles
+            .into_iter()
+            .flat_map(|handle| handle.join().expect("pusher thread panicked"))
+            .collect()
+    });
+    assert_eq!(expected_doc_ids.len(), PUSHERS * DOCS_PER_PUSHER);
+
+    // Anti-vacuity: the hub must actually have hit admission capacity —
+    // otherwise this test would pass without exercising the overflow path.
+    // (`wait_for_log` only knows pre-registered named patterns, so read the
+    // hub's stdout log directly: it lives at <node_dir>/logs/stdout.log next
+    // to the <node_dir>/data rootdir.)
+    let hub_log = cluster.nodes[0]
+        .rootdir
+        .parent()
+        .expect("hub rootdir has a parent")
+        .join("logs/stdout.log");
+    let capacity_deadline = Instant::now() + Duration::from_secs(60);
+    loop {
+        let log = std::fs::read_to_string(&hub_log).unwrap_or_default();
+        if log.contains("Pending DAGs at capacity") {
+            break;
+        }
+        assert!(
+            Instant::now() < capacity_deadline,
+            "hub never hit pending-DAG capacity; the fan-in did not stress admission"
+        );
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+
+    // M1: every success-acked document must eventually merge on the hub.
+    // Overflowed pushes are nacked, kept in the pushers' retry ladders, and
+    // re-pushed until the hub admits them — so completeness within the
+    // deadline is the invariant. On pre-fix code the overflowed documents are
+    // success-acked, their retry records deleted, and they never arrive.
+    let deadline = Instant::now() + Duration::from_secs(180);
+    loop {
+        let result = hub
+            .query("query { User { _docID } }")
+            .expect("query hub Users");
+        let present: std::collections::HashSet<&str> = result["User"]
+            .as_array()
+            .map(|rows| {
+                rows.iter()
+                    .filter_map(|row| row["_docID"].as_str())
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let missing: Vec<&String> = expected_doc_ids
+            .iter()
+            .filter(|id| !present.contains(id.as_str()))
+            .collect();
+        if missing.is_empty() {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "{} of {} documents were success-acked on pushers but never merged on the hub \
+             (silent divergence, #1088 M1): {:?}",
+            missing.len(),
+            expected_doc_ids.len(),
+            missing
+        );
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}

--- a/tools/integration-test/tests/p2p_deep_catchup.rs
+++ b/tools/integration-test/tests/p2p_deep_catchup.rs
@@ -1,0 +1,144 @@
+//! #1088 W4 liveness: a deep full-DAG push must complete under intake rate
+//! limiting instead of sawtoothing against a lockout ladder.
+//!
+//! Filtered replicators receive the full transitive DAG on every update with
+//! no client-side pacer (unlike the initial-replay path, whose ReplayPushGate
+//! self-paces). With the pre-split limiter, the first over-budget block armed
+//! a 30s lockout: the pusher's ~2.3s of in-batch retries all fell inside it,
+//! the batch aborted, and every ladder-spaced re-push restarted from block one
+//! — re-burning the burst on already-sent blocks — so any DAG deeper than
+//! roughly the burst never converged. The request-intake limiter now paces at
+//! the token-refill horizon, so the push throttles to the refill rate and
+//! completes.
+//!
+//! Own test binary: the burst/rate env overrides must not leak into other
+//! tests' clusters.
+
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use integration_test::TestCluster;
+
+const SCHEMA: &str = "type User { name: String @immutable  age: Int }";
+const UPDATES: usize = 50;
+
+fn socket_addr(cluster: &TestCluster, node: usize) -> String {
+    cluster.api_url(node).replace("http://", "")
+}
+
+fn add_filtered_replicator(cluster: &TestCluster, node: usize, addr: &str) {
+    let client = cluster.client(node);
+    let output = Command::new(client.binary_path())
+        .arg("--url")
+        .arg(socket_addr(cluster, node))
+        .args([
+            "client",
+            "p2p",
+            "replicator",
+            "add",
+            "-c",
+            "User",
+            "--filter-field",
+            "name",
+            "--filter-value",
+            "deep",
+            addr,
+        ])
+        .output()
+        .expect("exec filtered replicator add");
+    assert!(
+        output.status.success(),
+        "filtered replicator add failed: status={} stderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[tokio::test]
+async fn deep_dag_push_completes_under_intake_rate_limiting() {
+    // Hub bucket far smaller than the DAG so the live full-DAG push must be
+    // paced across many refill windows: ~150 blocks vs a 50-token burst.
+    std::env::set_var("DEFRA_P2P_RATE_LIMIT_BURST", "50");
+    std::env::set_var("DEFRA_P2P_RATE_LIMIT_RATE", "20");
+
+    let cluster = TestCluster::builder()
+        .rust_nodes(2)
+        .with_p2p()
+        .build()
+        .await
+        .expect("cluster start");
+
+    let startup_timeout = Duration::from_secs(30);
+    for node in 0..2 {
+        cluster
+            .wait_for_log(node, "p2p_listening", startup_timeout)
+            .await
+            .unwrap_or_else(|e| panic!("node{node} P2P listener did not start: {e}"));
+    }
+
+    let pusher = cluster.client(0);
+    let hub = cluster.client(1);
+    let hub_info = hub.p2p_info().expect("hub p2p info");
+    let hub_addr = hub_info
+        .as_array()
+        .and_then(|arr| arr.first())
+        .and_then(|v| v.as_str())
+        .expect("hub has no P2P address")
+        .to_string();
+
+    pusher.schema_add(SCHEMA).expect("pusher schema");
+    hub.schema_add(SCHEMA).expect("hub schema");
+    pusher.p2p_connect(&[&hub_addr]).expect("connect to hub");
+
+    // Build a deep DAG before any replication: 1 create + UPDATES updates,
+    // each adding a composite + field block to the document's history.
+    let created = pusher
+        .query(r#"mutation { add_User(input: {name: "deep", age: 0}) { _docID } }"#)
+        .expect("create doc");
+    let doc_id = created["add_User"][0]["_docID"]
+        .as_str()
+        .expect("missing _docID")
+        .to_string();
+    for age in 1..=UPDATES {
+        let mutation = format!(
+            r#"mutation {{ update_User(docID: "{doc_id}", input: {{age: {age}}}) {{ _docID }} }}"#
+        );
+        pusher.query(&mutation).expect("update doc");
+    }
+
+    add_filtered_replicator(&cluster, 0, &hub_addr);
+    // Let the initial replay attempt (client-paced at defaults, which exceed
+    // this hub's shrunken bucket) finish nacking and the bucket refill.
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    // One live update pushes the ENTIRE transitive DAG (~3 blocks per update
+    // deep by now) through send_ordered_pushlogs_via_transport: it must pace
+    // through the limiter and converge, not wedge.
+    let final_age = 999;
+    let mutation = format!(
+        r#"mutation {{ update_User(docID: "{doc_id}", input: {{age: {final_age}}}) {{ _docID }} }}"#
+    );
+    pusher.query(&mutation).expect("final update");
+
+    let deadline = Instant::now() + Duration::from_secs(120);
+    loop {
+        let result = hub
+            .query("query { User { _docID age } }")
+            .expect("query hub");
+        let converged = result["User"].as_array().is_some_and(|rows| {
+            rows.iter().any(|row| {
+                row["_docID"].as_str() == Some(doc_id.as_str())
+                    && row["age"].as_i64() == Some(final_age)
+            })
+        });
+        if converged {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "deep-DAG push did not converge under intake rate limiting (sawtooth/wedge): {}",
+            serde_json::to_string_pretty(&result).unwrap()
+        );
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}


### PR DESCRIPTION
Fixes the M1/M2 halves of #1088 (slice 1: W1 + W4 + W5). W2 (per-peer quotas) and W3 (reverse index for the pending map) are follow-up PRs.

## The defect

A hub at pending-DAG capacity dropped an incoming PushLog's DAG registration but replied **success**. The pusher treats a success reply as terminal — it deletes its persisted retry record (`defra-node/src/lib.rs` `remove_retry_doc`) — so the document silently never merged on the hub and nothing would ever re-push it. Meanwhile the pusher-side backoff for `RATE_LIMITED_MESSAGE` nacks (`broadcast.rs::send_ordered_pushlogs_via_transport`, #843) was live and tested, but nothing emitted that nack anymore.

## The invariant (heart of the PR)

**A success `PushLogReply` implies the block is either merged or registered as pending on the hub. No code path may reply success after discarding state.**

Specified first in `proofs/tla/PushLogAdmission.tla` (`INV_SuccessImpliesRegisteredOrMerged`):
- `MC_PushLogAdmission_Red_SuccessOnFull.cfg` — current-main behavior; TLC finds the divergence in 5 states (push A admitted → push B overflows → B success-acked while neither merged nor pending).
- `MC_PushLogAdmission_Green.cfg` — nack-on-overflow; invariant holds **and** `EventuallyAllMerged` holds under per-doc fairness (the drop/re-push loop has a fixed point).

Both wired into `proofs/tla/run-all.sh`.

## W1 — capacity drop nacks, never acks

- `insert_pending_dag` overflow now returns typed `Error::PendingDagCapacity` from `process_pushlog` (`sync/manager/process/pushlog.rs`) instead of WARN + `Ok(())`.
- Both reply seams — the gossip-token path and the two-stream path (`event_handler/pushlog.rs`) — map backpressure errors through one helper (`build_pushlog_reply` + `Error::backpressure_reply_message`) to the **byte-exact** `RATE_LIMITED_MESSAGE`, which the pusher matches (`is_rate_limited_message`) to drive its retry/backoff. All other errors keep their descriptive text.
- Checked for a third reply-construction seam: `two_stream/handler/mod.rs` `success_reply`/`error_reply` are transport-plumbing helpers used only by unit tests; `two_stream/handler/inbound.rs` only routes replies. The two coordinator seams are the only live ones.
- The event loops (`cli/server_p2p.rs`, `defra-node/lib.rs`, `embedded/node_tasks.rs`) all log-and-continue on handler errors, so the typed error nack-and-continues — it cannot kill the event loop.
- `MAX_PENDING_DAGS` is now `SyncConfig::max_pending_dags` (default unchanged at 1000), exposed as `--p2p-max-pending-dags` / `DEFRA_P2P_MAX_PENDING_DAGS` on the CLI and `P2PConfig::max_pending_dags` on defra-node. **defra-agent note:** `P2PConfig` gained a required field — the pin bump needs a one-line `max_pending_dags: p2p::sync::DEFAULT_MAX_PENDING_DAGS` (or a tuned value for the Amy hub).

## W4 — intake admission re-landed (re-fix of #592)

`PeerRateLimiter` now gates `PushLogRequest`, `TwoStreamRequest`, `DocSyncRequest`, `BranchableSyncRequest`, and `CarFetchRequest` intake (the full scope fa4a84f7 removed), with `reject_rate_limited_*` helpers sending the `RATE_LIMITED_MESSAGE` nack (empty response for CAR, which has no error reply type). Gossip keeps its existing drop-only enforcement.

### The fa4a84f7 regression story — why this won't be re-reverted

`fa4a84f7` ("align iroh replay and shutdown with go model", 2026-04-18) removed the #592 nacks and added `two_stream_bypasses_gossip_rate_limiter_for_authenticated_sync` asserting that authenticated replicator pushes skip the limiter entirely. That conflated two things:

1. **Trust/ACP bypass** — Go's direct replicator channel does skip the receiver-side collection access gate. That alignment is correct and untouched here.
2. **Overload handling** — Go's replicator channel drives its retry ladder off **error replies** (Go `replicator.go` retryInterval ladder). Nack-on-overload IS the Go-aligned behavior; silently dropping (or success-acking) overload is not Go's model on any axis.

The bypass test's real concern — authenticated sync must never be *silently dropped* like gossip — is preserved and strengthened: over-budget pushes now get an explicit nack that the pusher's #843 backoff consumer turns into a retry, never a lost document (superseding test: `two_stream_rate_limited_replies_backpressure_nack`; comment left in place at the old test's location). This is stated in code comments at the emit sites (`check_rate_limit`, `build_pushlog_reply`).

The fleet consequence of the bypass is #1088's incident data (sourcenetwork/defra-agent#630): pending map pinned at cap, ~10 cores of DAG re-walks, and silently diverged documents.

## W5 — fan-in tests

**Integration** (`tools/integration-test/tests/p2p_admission.rs`, own `[[test]]` binary so the `DEFRA_P2P_MAX_PENDING_DAGS=1` override can't leak into other tests' clusters): 8 pushers × 8 docs of concurrent create bursts through unfiltered replicators into one hub. Unfiltered replicator pushes carry only the head block, so every doc needs a pending registration — the deterministic capacity stressor. Asserts:
- (anti-vacuity) the hub actually overflows admission (hub log check — the run recorded 317 capacity rejections);
- (M1) every success-acked document eventually merges on the hub. A dropped registration can only complete through a re-push, and re-pushes only happen when the hub refuses to launder the drop as success — so eventual completeness is exactly the invariant.

**Verified red-then-green:** with the nack suppressed (pre-fix drop-and-ack semantics), **37 of 64 documents were success-acked on pushers but never merged on the hub**; with the fix the same test converges in ~10s. Pusher logs show the backoff machinery engaging (72 rate-limited backoff events on one pusher alone).

**In-process** (`access_tests.rs::fan_in_pushes_keep_pending_depth_bounded_and_account_every_reply`): 8 pushers × 6 docs against a 2-slot map — pending depth never exceeds the cap, exactly `cap` pushes are success-acked, every other push carries the byte-exact nack, and overflow causes **zero** pending-DAG re-walks (the M4 CPU-burn shape).

**Unit:** capacity-typed-error at the manager (`sync_manager_tests`), nack replies on both seams and all five W4 intake arms (`access_tests`), sentinel mapping (`error.rs`), and pusher-side consumption of a capacity nack (`broadcast.rs::ordered_pushlogs_back_off_on_capacity_nack_reply`, extending the #843 tests).

## Out of scope / findings

- **DocSync/branchable registration overflow** (`register_docsync_dag` / `register_branchable_dag`) still drops with a WARN: there the node registering the pending DAG is the local *puller* consuming a reply it requested — there is no remote pusher to nack. Bounding that path is W2/W3 territory.
- **TTL eviction after a success reply** is the pending map's residual divergence window (#844, W2/W3) — deliberately not modeled in the TLA spec (documented in `PushLogAdmission_DESIGN.md`).
- **No pusher-side changes** — deployed fleets get the fix from a hub upgrade alone.
- M3 (send-timeout truncation manufacturing pending entries) and M5 (restart resistance) are addressed indirectly (the loop now has a fixed point) but their structural fixes are W2/W3.

## Validation

- `cargo test -p p2p -p defra-node -p cli` — 440 passed, 0 failed
- `cargo test -p integration-test --test p2p_iroh` — 227 passed, 0 failed
- `cargo test -p integration-test --test p2p_admission` — passed (and verified to fail on pre-fix semantics)
- `cargo test -p integration-test --test p2p` — 66 passed / 29 failed, **byte-identical failure set on unmodified main** (24 `go_*` parity tests needing the Go defradb binary on PATH + 5 load-sensitive `rust_filtered_replication_*_iroh` tests that pass in isolation on this branch); this PR does not change the suite's failure profile
- `cargo clippy -p p2p -p cli -p defra-node -p integration-test --all-targets -- -D warnings` — clean
- `proofs/tla/run-all.sh` — all verdicts match (including the two new PushLogAdmission rows)

Closes the W1/W4/W5 checkboxes on #1088. Downstream: defra-agent pin bump + 16-leg fleet re-enable sweep tracked in sourcenetwork/defra-agent#630.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
