### PR TITLE
fix(p2p): rotate providers and retry incomplete DAG fetches instead of silently dropping roots (#1093)

### DIFF
--- a/crates/p2p/src/sync/coordinator/dag_context.rs
+++ b/crates/p2p/src/sync/coordinator/dag_context.rs
@@ -27,12 +27,18 @@ pub(crate) fn block_context_from_data(block_data: &[u8]) -> BlockContext {
     }
 }
 
+/// Ceiling on alternate providers kept per fetch, so a stalled batch never
+/// rotates through an unbounded peer list (each dead provider costs a full
+/// 30s selective-fetch timeout).
+const MAX_ALTERNATE_PROVIDERS: usize = 3;
+
 #[derive(Debug, Clone)]
 pub(crate) struct DagFetchContext {
     pub(crate) doc_id: String,
     pub(crate) collection_id: String,
     pub(crate) creator: String,
     pub(crate) source_peer: PeerId,
+    alternate_providers: Vec<PeerId>,
     pub(crate) is_explicit_replicator: bool,
     explicit_replicator_collections: Option<Vec<String>>,
     pub(crate) explicit_replay_authorization: Option<ExplicitReplayAuthorization>,
@@ -50,10 +56,32 @@ impl DagFetchContext {
             collection_id,
             creator,
             source_peer,
+            alternate_providers: Vec::new(),
             is_explicit_replicator: false,
             explicit_replicator_collections: None,
             explicit_replay_authorization: None,
         }
+    }
+
+    pub(crate) fn with_alternate_providers(mut self, providers: Vec<PeerId>) -> Self {
+        self.alternate_providers.clear();
+        for peer in providers {
+            if peer != self.source_peer && !self.alternate_providers.contains(&peer) {
+                self.alternate_providers.push(peer);
+            }
+            if self.alternate_providers.len() == MAX_ALTERNATE_PROVIDERS {
+                break;
+            }
+        }
+        self
+    }
+
+    /// Ordered fetch providers: the announcing peer first, then alternates.
+    pub(crate) fn providers(&self) -> Vec<PeerId> {
+        let mut providers = Vec::with_capacity(1 + self.alternate_providers.len());
+        providers.push(self.source_peer.clone());
+        providers.extend(self.alternate_providers.iter().cloned());
+        providers
     }
 
     pub(crate) fn with_explicit_replicator(mut self, is_explicit_replicator: bool) -> Self {

--- a/crates/p2p/src/sync/coordinator/dag_fetcher.rs
+++ b/crates/p2p/src/sync/coordinator/dag_fetcher.rs
@@ -2,8 +2,10 @@
 //!
 //! Tries CAR fetch first (single round-trip for entire DAG), then falls back
 //! to batched selective block fetch + blockstore polling for any remaining blocks.
-//! Stalled batches rotate across the context's providers, and incomplete
-//! fetches are retried with backoff before the failure is escalated (#1093).
+//! Stalled batches rotate across the context's providers under a per-attempt
+//! stall budget, timed-out transport queries are cancelled at the end of their
+//! poll window, and incomplete fetches are retried with backoff before the
+//! failure is escalated (#1093).
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -42,6 +44,18 @@ enum FetchBatchOutcome {
     NoProgress,
 }
 
+/// Outcome of one provider's poll window, as seen by the rotation loop.
+///
+/// `Stalled` (a full window with zero blocks) consumes attempt stall budget;
+/// `SendFailed` (the query never left) costs a rotation slot but no time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProviderWindowOutcome {
+    Complete,
+    Partial,
+    Stalled,
+    SendFailed,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum FetchAttemptOutcome {
     Complete,
@@ -57,7 +71,9 @@ enum FetchAttemptOutcome {
 ///
 /// A limiter permit is held only for the duration of each attempt — it is
 /// released during backoff sleeps so a fetch stuck on dead providers does not
-/// starve other roots under fan-in pressure.
+/// starve other roots under fan-in pressure. Every issued transport query is
+/// reaped via `cancel_sync` at the end of its poll window, so releasing the
+/// permit never leaves stalled fetch work running in the transport.
 pub async fn poll_fetch_dag<B: Blockstore + 'static, T: P2PTransport>(
     transport: T,
     blockstore: Arc<B>,
@@ -160,6 +176,13 @@ async fn fetch_dag_attempt<B: Blockstore + 'static, T: P2PTransport>(
     context: &DagFetchContext,
     providers: &mut ProviderRotation,
 ) -> FetchAttemptOutcome {
+    // One full rotation's worth of stalled 30s windows per attempt. Productive
+    // windows (any block arrived) never consume it, so a large DAG that is
+    // actually transferring is unbounded, while a dead provider set costs at
+    // most providers × 30s of stalled waiting per attempt regardless of how
+    // many batches the missing frontier spans.
+    let mut stall_budget = providers.len();
+
     let car_missing_watch = match blockstore.get(&root_cid).await {
         Ok(Some(root_data)) => find_all_missing_links(blockstore.as_ref(), &root_data)
             .await
@@ -203,6 +226,7 @@ async fn fetch_dag_attempt<B: Blockstore + 'static, T: P2PTransport>(
             transport,
             blockstore,
             providers,
+            &mut stall_budget,
         )
         .await,
         FetchBatchOutcome::Complete
@@ -244,8 +268,15 @@ async fn fetch_dag_attempt<B: Blockstore + 'static, T: P2PTransport>(
 
         let mut made_progress = false;
         for batch in missing.chunks(SELECTIVE_FETCH_BATCH_SIZE) {
-            match poll_fetch_blocks_rotating(&root_cid, batch, transport, blockstore, providers)
-                .await
+            match poll_fetch_blocks_rotating(
+                &root_cid,
+                batch,
+                transport,
+                blockstore,
+                providers,
+                &mut stall_budget,
+            )
+            .await
             {
                 FetchBatchOutcome::Complete => {
                     made_progress = true;
@@ -351,17 +382,33 @@ async fn try_car_fetch<B: Blockstore, T: P2PTransport>(
 
 /// Fetch one batch of exact blocks, rotating to the next provider whenever
 /// the current one yields nothing within the fetch window.
+///
+/// `stall_budget` caps the stalled (timed-out) provider windows one attempt
+/// may burn across all of its batches; once it reaches zero, stalled batches
+/// fail fast without issuing further transport queries.
 async fn poll_fetch_blocks_rotating<B: Blockstore, T: P2PTransport>(
     root_cid: &Cid,
     cids: &[Cid],
     transport: &T,
     blockstore: &Arc<B>,
     providers: &mut ProviderRotation,
+    stall_budget: &mut usize,
 ) -> FetchBatchOutcome {
     for _ in 0..providers.len() {
+        if *stall_budget == 0 {
+            debug!(
+                root_cid = %root_cid,
+                requested_count = cids.len(),
+                "Attempt stall budget exhausted, failing batch without fetching"
+            );
+            return FetchBatchOutcome::NoProgress;
+        }
         let provider = providers.current().clone();
         match poll_fetch_blocks(root_cid, cids, transport, blockstore, &provider).await {
-            FetchBatchOutcome::NoProgress => {
+            ProviderWindowOutcome::Complete => return FetchBatchOutcome::Complete,
+            ProviderWindowOutcome::Partial => return FetchBatchOutcome::Partial,
+            ProviderWindowOutcome::Stalled => {
+                *stall_budget -= 1;
                 providers.advance();
                 if providers.len() > 1 {
                     warn!(
@@ -372,20 +419,26 @@ async fn poll_fetch_blocks_rotating<B: Blockstore, T: P2PTransport>(
                     );
                 }
             }
-            outcome => return outcome,
+            ProviderWindowOutcome::SendFailed => providers.advance(),
         }
     }
     FetchBatchOutcome::NoProgress
 }
 
 /// Fetch one batch of exact blocks via the transport's block-sync path.
+///
+/// The issued transport query is always reaped via `cancel_sync` before this
+/// returns, so no query outlives its poll window: a stalled provider's
+/// transport work cannot pile up behind rotation, keep consuming connections
+/// after the fetch's limiter permit is released, or deliver blocks after the
+/// fetch has terminally failed.
 async fn poll_fetch_blocks<B: Blockstore, T: P2PTransport>(
     root_cid: &Cid,
     cids: &[Cid],
     transport: &T,
     blockstore: &Arc<B>,
     source_peer: &PeerId,
-) -> FetchBatchOutcome {
+) -> ProviderWindowOutcome {
     let mut missing = Vec::new();
     for cid in cids {
         if matches!(blockstore.has(cid).await, Ok(true)) {
@@ -395,24 +448,28 @@ async fn poll_fetch_blocks<B: Blockstore, T: P2PTransport>(
     }
 
     if missing.is_empty() {
-        return FetchBatchOutcome::Complete;
+        return ProviderWindowOutcome::Complete;
     }
 
-    if let Err(e) = transport
+    let query_id = match transport
         .sync_blocks(*root_cid, vec![source_peer.clone()], missing.clone())
         .await
     {
-        warn!(
-            root_cid = %root_cid,
-            requested_count = missing.len(),
-            error = %e,
-            "selective block fetch failed"
-        );
-        return FetchBatchOutcome::NoProgress;
-    }
+        Ok(query_id) => query_id,
+        Err(e) => {
+            warn!(
+                root_cid = %root_cid,
+                requested_count = missing.len(),
+                error = %e,
+                "selective block fetch failed"
+            );
+            return ProviderWindowOutcome::SendFailed;
+        }
+    };
 
     let timeout = Duration::from_secs(30);
     let start = Instant::now();
+    let mut outcome = ProviderWindowOutcome::Stalled;
     while start.elapsed() < timeout {
         let mut remaining = 0usize;
         for cid in &missing {
@@ -421,15 +478,25 @@ async fn poll_fetch_blocks<B: Blockstore, T: P2PTransport>(
             }
         }
         if remaining == 0 {
-            return FetchBatchOutcome::Complete;
+            outcome = ProviderWindowOutcome::Complete;
+            break;
         }
         if remaining < missing.len() {
-            return FetchBatchOutcome::Partial;
+            outcome = ProviderWindowOutcome::Partial;
+            break;
         }
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
 
-    FetchBatchOutcome::NoProgress
+    if let Err(e) = transport.cancel_sync(query_id).await {
+        debug!(
+            root_cid = %root_cid,
+            query_id = query_id.0,
+            error = %e,
+            "Failed to cancel block-sync query after poll window"
+        );
+    }
+    outcome
 }
 
 #[cfg(test)]
@@ -480,6 +547,7 @@ mod tests {
         dead_providers: Arc<Mutex<HashSet<String>>>,
         skip_serving_syncs: Arc<AtomicUsize>,
         fail_connected_peers: Arc<AtomicBool>,
+        cancelled_queries: Arc<Mutex<Vec<u64>>>,
     }
 
     impl TestTransport {
@@ -504,6 +572,7 @@ mod tests {
                 dead_providers: Arc::new(Mutex::new(HashSet::new())),
                 skip_serving_syncs: Arc::new(AtomicUsize::new(0)),
                 fail_connected_peers: Arc::new(AtomicBool::new(false)),
+                cancelled_queries: Arc::new(Mutex::new(Vec::new())),
             }
         }
 
@@ -529,6 +598,10 @@ mod tests {
 
         fn set_fail_connected_peers(&self) {
             self.fail_connected_peers.store(true, Ordering::SeqCst);
+        }
+
+        fn cancelled_queries(&self) -> Vec<u64> {
+            self.cancelled_queries.lock().unwrap().clone()
         }
     }
 
@@ -728,15 +801,16 @@ mod tests {
                 .lock()
                 .unwrap()
                 .extend(providers.iter().map(|peer| peer.to_string()));
+            let query_id = QueryId(call_index as u64 + 1);
             if call_index < self.skip_serving_syncs.load(Ordering::SeqCst) {
-                return Ok(QueryId(1));
+                return Ok(query_id);
             }
             let all_dead = {
                 let dead = self.dead_providers.lock().unwrap();
                 providers.iter().all(|peer| dead.contains(peer.as_str()))
             };
             if all_dead {
-                return Ok(QueryId(1));
+                return Ok(query_id);
             }
             for cid in missing {
                 if let Some(data) = self.selective_blocks.get(&cid) {
@@ -746,10 +820,11 @@ mod tests {
                         .map_err(|e| crate::error::Error::BlockstoreError(e.to_string()))?;
                 }
             }
-            Ok(QueryId(1))
+            Ok(query_id)
         }
 
-        async fn cancel_sync(&self, _query_id: QueryId) -> P2PResult<bool> {
+        async fn cancel_sync(&self, query_id: QueryId) -> P2PResult<bool> {
+            self.cancelled_queries.lock().unwrap().push(query_id.0);
             Ok(true)
         }
 
@@ -1184,6 +1259,110 @@ mod tests {
         // One CAR try and one selective batch per attempt, all exhausted.
         assert_eq!(transport.car_request_count(), MAX_FETCH_ATTEMPTS as usize);
         assert_eq!(transport.sync_batches().len(), MAX_FETCH_ATTEMPTS as usize);
+    }
+
+    /// Every issued block-sync query must be reaped via `cancel_sync` at the
+    /// end of its poll window: a stalled provider's transport-side work must
+    /// not outlive rotation, the limiter permit, or terminal failure.
+    #[tokio::test(start_paused = true)]
+    async fn poll_fetch_dag_cancels_every_issued_query() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let (root_cid, root_data, child_cid, child_data) = single_child_dag();
+
+        let transport = TestTransport::new(
+            blockstore.clone(),
+            root_cid,
+            root_data,
+            HashMap::new(),
+            HashMap::from([(child_cid, child_data)]),
+        );
+        transport.mark_provider_dead("dead-peer");
+
+        let (event_tx, mut event_rx) = mpsc::channel(1);
+        poll_fetch_dag(
+            transport.clone(),
+            blockstore.clone(),
+            event_tx,
+            root_cid,
+            DagFetchContext::new(
+                "doc-id".to_string(),
+                "collection-id".to_string(),
+                "creator-id".to_string(),
+                PeerId::new("dead-peer".to_string()),
+            ),
+            DagFetchLimiter::new(2),
+        )
+        .await;
+
+        assert!(event_rx.recv().await.is_none());
+        let issued: Vec<u64> = (1..=transport.sync_batches().len() as u64).collect();
+        assert_eq!(
+            transport.cancelled_queries(),
+            issued,
+            "every stalled query must be cancelled, in issue order"
+        );
+    }
+
+    /// The per-attempt stall budget must cap stalled-batch work: once every
+    /// provider has burned a full window, remaining batches in the attempt
+    /// fail fast without issuing transport queries, so dead-provider attempt
+    /// time does not scale with the width of the missing frontier.
+    #[tokio::test(start_paused = true)]
+    async fn poll_fetch_dag_stall_budget_caps_stalled_batches_per_attempt() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+
+        let width = SELECTIVE_FETCH_BATCH_SIZE + 1;
+        let mut children = Vec::with_capacity(width);
+        for i in 0..width {
+            let data = encode_ipld(ipld!({ "value": i as i64 }));
+            children.push(make_cid(&data));
+        }
+        let root_data = encode_ipld(Ipld::List(
+            children.iter().map(|cid| Ipld::Link(*cid)).collect(),
+        ));
+        let root_cid = make_cid(&root_data);
+        blockstore.put(&root_cid, &root_data).await.unwrap();
+
+        let transport = TestTransport::new(
+            blockstore.clone(),
+            root_cid,
+            root_data,
+            HashMap::new(),
+            HashMap::new(),
+        );
+        transport.mark_provider_dead("dead-peer");
+
+        let (event_tx, mut event_rx) = mpsc::channel(1);
+        poll_fetch_dag(
+            transport.clone(),
+            blockstore.clone(),
+            event_tx,
+            root_cid,
+            DagFetchContext::new(
+                "doc-id".to_string(),
+                "collection-id".to_string(),
+                "creator-id".to_string(),
+                PeerId::new("dead-peer".to_string()),
+            ),
+            DagFetchLimiter::new(2),
+        )
+        .await;
+
+        assert!(event_rx.recv().await.is_none());
+        // Two batches per attempt are missing, but the single provider's stall
+        // budget is spent on the first, so the second issues no query: one
+        // stalled (and cancelled) query per attempt, not two.
+        let batches = transport.sync_batches();
+        assert_eq!(batches.len(), MAX_FETCH_ATTEMPTS as usize);
+        for batch in &batches {
+            assert_eq!(batch.len(), SELECTIVE_FETCH_BATCH_SIZE);
+        }
+        assert_eq!(
+            transport.cancelled_queries(),
+            (1..=MAX_FETCH_ATTEMPTS as u64).collect::<Vec<_>>()
+        );
     }
 
     /// A `connected_peers()` failure must degrade to an empty alternates list

--- a/crates/p2p/src/sync/coordinator/dag_fetcher.rs
+++ b/crates/p2p/src/sync/coordinator/dag_fetcher.rs
@@ -128,6 +128,29 @@ pub async fn poll_fetch_dag<B: Blockstore + 'static, T: P2PTransport>(
     );
 }
 
+/// Connected peers to offer as alternate providers for a DAG fetch.
+///
+/// A transport lookup failure costs only rotation capability, not the fetch
+/// itself, so it degrades to source-peer-only fetching — with a WARN trace,
+/// because a silently empty alternates list is indistinguishable from a
+/// healthy but sparsely connected node.
+pub(crate) async fn connected_alternate_providers<T: P2PTransport>(
+    transport: &T,
+    root_cid: &Cid,
+) -> Vec<PeerId> {
+    match transport.connected_peers().await {
+        Ok(peers) => peers,
+        Err(e) => {
+            warn!(
+                root_cid = %root_cid,
+                error = %e,
+                "Failed to list connected peers for DAG fetch alternates; fetching from source peer only"
+            );
+            Vec::new()
+        }
+    }
+}
+
 /// One full CAR-first + selective-walk attempt over the current provider set.
 async fn fetch_dag_attempt<B: Blockstore + 'static, T: P2PTransport>(
     transport: &T,
@@ -427,7 +450,7 @@ mod tests {
     use multihash_codetable::{Code, MultihashDigest};
     use serde_ipld_dagcbor::codec::DagCborCodec;
     use std::collections::{HashMap, HashSet};
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
     use storage::backends::MemoryStore;
@@ -456,6 +479,7 @@ mod tests {
         sync_providers: Arc<Mutex<Vec<String>>>,
         dead_providers: Arc<Mutex<HashSet<String>>>,
         skip_serving_syncs: Arc<AtomicUsize>,
+        fail_connected_peers: Arc<AtomicBool>,
     }
 
     impl TestTransport {
@@ -479,6 +503,7 @@ mod tests {
                 sync_providers: Arc::new(Mutex::new(Vec::new())),
                 dead_providers: Arc::new(Mutex::new(HashSet::new())),
                 skip_serving_syncs: Arc::new(AtomicUsize::new(0)),
+                fail_connected_peers: Arc::new(AtomicBool::new(false)),
             }
         }
 
@@ -500,6 +525,10 @@ mod tests {
 
         fn set_skip_serving_syncs(&self, count: usize) {
             self.skip_serving_syncs.store(count, Ordering::SeqCst);
+        }
+
+        fn set_fail_connected_peers(&self) {
+            self.fail_connected_peers.store(true, Ordering::SeqCst);
         }
     }
 
@@ -532,6 +561,11 @@ mod tests {
         }
 
         async fn connected_peers(&self) -> P2PResult<Vec<PeerId>> {
+            if self.fail_connected_peers.load(Ordering::SeqCst) {
+                return Err(crate::error::Error::Transport(
+                    "peer listing unavailable".to_string(),
+                ));
+            }
             Ok(Vec::new())
         }
 
@@ -1150,6 +1184,56 @@ mod tests {
         // One CAR try and one selective batch per attempt, all exhausted.
         assert_eq!(transport.car_request_count(), MAX_FETCH_ATTEMPTS as usize);
         assert_eq!(transport.sync_batches().len(), MAX_FETCH_ATTEMPTS as usize);
+    }
+
+    /// A `connected_peers()` failure must degrade to an empty alternates list
+    /// (source-peer-only rotation), not abort the fetch: composed exactly as
+    /// the event-handler call sites do, the fetch still completes from the
+    /// source peer.
+    #[tokio::test(start_paused = true)]
+    async fn poll_fetch_dag_completes_from_source_when_peer_listing_fails() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let (root_cid, root_data, child_cid, child_data) = single_child_dag();
+
+        let transport = TestTransport::new(
+            blockstore.clone(),
+            root_cid,
+            root_data,
+            HashMap::new(),
+            HashMap::from([(child_cid, child_data)]),
+        );
+        transport.set_fail_connected_peers();
+
+        let alternate_providers = connected_alternate_providers(&transport, &root_cid).await;
+        assert!(
+            alternate_providers.is_empty(),
+            "transport failure must degrade to no alternates"
+        );
+
+        let (event_tx, mut event_rx) = mpsc::channel(1);
+        poll_fetch_dag(
+            transport.clone(),
+            blockstore.clone(),
+            event_tx,
+            root_cid,
+            DagFetchContext::new(
+                "doc-id".to_string(),
+                "collection-id".to_string(),
+                "creator-id".to_string(),
+                PeerId::new("remote-peer".to_string()),
+            )
+            .with_alternate_providers(alternate_providers),
+            DagFetchLimiter::new(2),
+        )
+        .await;
+
+        assert!(matches!(
+            event_rx.recv().await,
+            Some(SyncEvent::DagReady { root_cid: ready_cid, .. }) if ready_cid == root_cid
+        ));
+        assert!(matches!(blockstore.has(&child_cid).await, Ok(true)));
+        assert_eq!(transport.sync_providers(), vec!["remote-peer".to_string()]);
     }
 
     /// The limiter permit must be released during retry backoff: a second

--- a/crates/p2p/src/sync/coordinator/dag_fetcher.rs
+++ b/crates/p2p/src/sync/coordinator/dag_fetcher.rs
@@ -2,6 +2,8 @@
 //!
 //! Tries CAR fetch first (single round-trip for entire DAG), then falls back
 //! to batched selective block fetch + blockstore polling for any remaining blocks.
+//! Stalled batches rotate across the context's providers, and incomplete
+//! fetches are retried with backoff before the failure is escalated (#1093).
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -9,9 +11,11 @@ use std::time::Duration;
 use blockstore::Blockstore;
 use cid::Cid;
 use tokio::sync::mpsc;
-use tracing::{debug, info, warn};
+use tokio::time::Instant;
+use tracing::{debug, error, info, warn};
 
 use super::dag_context::DagFetchContext;
+use super::dag_retry::{retry_backoff, ProviderRotation, MAX_FETCH_ATTEMPTS};
 use crate::sync::manager::links::find_all_missing_links;
 use crate::sync::manager::SyncEvent;
 use crate::transport::{P2PTransport, PeerId};
@@ -37,10 +41,18 @@ enum FetchBatchOutcome {
     NoProgress,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FetchAttemptOutcome {
+    Complete,
+    Incomplete { remaining: usize },
+}
+
 /// Fetch an entire DAG rooted at `root_cid`.
 ///
 /// Strategy: try CAR fetch first (one round-trip), then selective block fetch
-/// for any missing blocks.
+/// for any missing blocks, rotating providers on stalls. Incomplete attempts
+/// are retried with backoff; terminal failure is logged at ERROR because the
+/// document cannot converge until the root is announced again.
 pub async fn poll_fetch_dag<B: Blockstore + 'static, T: P2PTransport>(
     transport: T,
     blockstore: Arc<B>,
@@ -48,15 +60,67 @@ pub async fn poll_fetch_dag<B: Blockstore + 'static, T: P2PTransport>(
     root_cid: Cid,
     context: DagFetchContext,
 ) {
+    let mut providers = ProviderRotation::new(context.providers());
     debug!(
         root_cid = %root_cid,
         doc_id = %context.doc_id,
         collection_id = %context.collection_id,
         source_peer = %context.source_peer,
+        provider_count = providers.len(),
         is_explicit_replicator = context.is_explicit_replicator,
         "Starting DAG fetch (CAR-first, selective block fallback)"
     );
 
+    let mut remaining_count = 0usize;
+    for attempt in 1..=MAX_FETCH_ATTEMPTS {
+        if attempt > 1 {
+            let backoff = retry_backoff(attempt);
+            warn!(
+                root_cid = %root_cid,
+                doc_id = %context.doc_id,
+                attempt = attempt,
+                remaining_count = remaining_count,
+                backoff_ms = backoff.as_millis() as u64,
+                "DAG fetch incomplete, retrying after backoff"
+            );
+            tokio::time::sleep(backoff).await;
+        }
+
+        match fetch_dag_attempt(
+            &transport,
+            &blockstore,
+            &event_tx,
+            root_cid,
+            &context,
+            &mut providers,
+        )
+        .await
+        {
+            FetchAttemptOutcome::Complete => return,
+            FetchAttemptOutcome::Incomplete { remaining } => remaining_count = remaining,
+        }
+    }
+
+    error!(
+        root_cid = %root_cid,
+        doc_id = %context.doc_id,
+        collection_id = %context.collection_id,
+        remaining_count = remaining_count,
+        attempts = MAX_FETCH_ATTEMPTS,
+        providers = ?providers.peers(),
+        "DAG fetch failed after exhausting retries and providers; document will not converge until the root is re-announced"
+    );
+}
+
+/// One full CAR-first + selective-walk attempt over the current provider set.
+async fn fetch_dag_attempt<B: Blockstore + 'static, T: P2PTransport>(
+    transport: &T,
+    blockstore: &Arc<B>,
+    event_tx: &mpsc::Sender<SyncEvent>,
+    root_cid: Cid,
+    context: &DagFetchContext,
+    providers: &mut ProviderRotation,
+) -> FetchAttemptOutcome {
     let car_missing_watch = match blockstore.get(&root_cid).await {
         Ok(Some(root_data)) => find_all_missing_links(blockstore.as_ref(), &root_data)
             .await
@@ -67,10 +131,10 @@ pub async fn poll_fetch_dag<B: Blockstore + 'static, T: P2PTransport>(
 
     // Try CAR fetch first
     if try_car_fetch(
-        &transport,
-        &blockstore,
+        transport,
+        blockstore,
         &root_cid,
-        &context.source_peer,
+        providers.current(),
         car_missing_watch.as_deref(),
     )
     .await
@@ -81,8 +145,8 @@ pub async fn poll_fetch_dag<B: Blockstore + 'static, T: P2PTransport>(
                 .unwrap_or_default();
             if missing.is_empty() {
                 info!(root_cid = %root_cid, doc_id = %context.doc_id, "DAG fetch complete via CAR");
-                emit_dag_ready(&event_tx, root_cid, &context, &root_data).await;
-                return;
+                emit_dag_ready(event_tx, root_cid, context, &root_data).await;
+                return FetchAttemptOutcome::Complete;
             }
             debug!(
                 root_cid = %root_cid,
@@ -94,18 +158,18 @@ pub async fn poll_fetch_dag<B: Blockstore + 'static, T: P2PTransport>(
 
     // Fallback fetch: fetch the root block first so we can enumerate missing links.
     if !matches!(
-        poll_fetch_blocks(
+        poll_fetch_blocks_rotating(
             &root_cid,
             std::slice::from_ref(&root_cid),
-            &transport,
-            &blockstore,
-            &context.source_peer,
+            transport,
+            blockstore,
+            providers,
         )
         .await,
         FetchBatchOutcome::Complete
     ) {
         warn!(root_cid = %root_cid, "Failed to fetch root block");
-        return;
+        return FetchAttemptOutcome::Incomplete { remaining: 1 };
     }
 
     // Walk DAG, fetching missing blocks level by level. The walk stops as soon
@@ -116,7 +180,7 @@ pub async fn poll_fetch_dag<B: Blockstore + 'static, T: P2PTransport>(
             Ok(Some(data)) => data,
             _ => {
                 warn!(root_cid = %root_cid, "Root block disappeared from blockstore");
-                return;
+                return FetchAttemptOutcome::Incomplete { remaining: 1 };
             }
         };
 
@@ -124,7 +188,7 @@ pub async fn poll_fetch_dag<B: Blockstore + 'static, T: P2PTransport>(
             Ok(m) => m,
             Err(e) => {
                 warn!(root_cid = %root_cid, error = %e, "find_all_missing_links failed");
-                return;
+                return FetchAttemptOutcome::Incomplete { remaining: 0 };
             }
         };
 
@@ -141,14 +205,8 @@ pub async fn poll_fetch_dag<B: Blockstore + 'static, T: P2PTransport>(
 
         let mut made_progress = false;
         for batch in missing.chunks(SELECTIVE_FETCH_BATCH_SIZE) {
-            match poll_fetch_blocks(
-                &root_cid,
-                batch,
-                &transport,
-                &blockstore,
-                &context.source_peer,
-            )
-            .await
+            match poll_fetch_blocks_rotating(&root_cid, batch, transport, blockstore, providers)
+                .await
             {
                 FetchBatchOutcome::Complete => {
                     made_progress = true;
@@ -165,7 +223,8 @@ pub async fn poll_fetch_dag<B: Blockstore + 'static, T: P2PTransport>(
                     warn!(
                         root_cid = %root_cid,
                         requested_count = batch.len(),
-                        "Timeout fetching selective block batch (30s)"
+                        providers_tried = providers.len(),
+                        "Timeout fetching selective block batch (30s per provider)"
                     );
                 }
             }
@@ -178,7 +237,7 @@ pub async fn poll_fetch_dag<B: Blockstore + 'static, T: P2PTransport>(
     // Verify DAG is complete
     let root_data = match blockstore.get(&root_cid).await {
         Ok(Some(data)) => data,
-        _ => return,
+        _ => return FetchAttemptOutcome::Incomplete { remaining: 1 },
     };
     let remaining = find_all_missing_links(blockstore.as_ref(), &root_data)
         .await
@@ -186,14 +245,12 @@ pub async fn poll_fetch_dag<B: Blockstore + 'static, T: P2PTransport>(
 
     if remaining.is_empty() {
         info!(root_cid = %root_cid, doc_id = %context.doc_id, "DAG fetch complete");
-        emit_dag_ready(&event_tx, root_cid, &context, &root_data).await;
+        emit_dag_ready(event_tx, root_cid, context, &root_data).await;
+        FetchAttemptOutcome::Complete
     } else {
-        warn!(
-            root_cid = %root_cid,
-            doc_id = %context.doc_id,
-            remaining_count = remaining.len(),
-            "DAG fetch incomplete"
-        );
+        FetchAttemptOutcome::Incomplete {
+            remaining: remaining.len(),
+        }
     }
 }
 
@@ -231,7 +288,7 @@ async fn try_car_fetch<B: Blockstore, T: P2PTransport>(
     }
 
     let timeout = Duration::from_secs(10);
-    let start = std::time::Instant::now();
+    let start = Instant::now();
     while start.elapsed() < timeout {
         if let Some(missing) = watch_missing {
             let mut remaining = 0usize;
@@ -251,6 +308,35 @@ async fn try_car_fetch<B: Blockstore, T: P2PTransport>(
 
     debug!(root_cid = %root_cid, "CAR fetch timed out (10s), falling back to selective block fetch");
     false
+}
+
+/// Fetch one batch of exact blocks, rotating to the next provider whenever
+/// the current one yields nothing within the fetch window.
+async fn poll_fetch_blocks_rotating<B: Blockstore, T: P2PTransport>(
+    root_cid: &Cid,
+    cids: &[Cid],
+    transport: &T,
+    blockstore: &Arc<B>,
+    providers: &mut ProviderRotation,
+) -> FetchBatchOutcome {
+    for _ in 0..providers.len() {
+        let provider = providers.current().clone();
+        match poll_fetch_blocks(root_cid, cids, transport, blockstore, &provider).await {
+            FetchBatchOutcome::NoProgress => {
+                providers.advance();
+                if providers.len() > 1 {
+                    warn!(
+                        root_cid = %root_cid,
+                        provider = %provider,
+                        requested_count = cids.len(),
+                        "No blocks from provider within fetch window, rotating to next provider"
+                    );
+                }
+            }
+            outcome => return outcome,
+        }
+    }
+    FetchBatchOutcome::NoProgress
 }
 
 /// Fetch one batch of exact blocks via the transport's block-sync path.
@@ -287,7 +373,7 @@ async fn poll_fetch_blocks<B: Blockstore, T: P2PTransport>(
     }
 
     let timeout = Duration::from_secs(30);
-    let start = std::time::Instant::now();
+    let start = Instant::now();
     while start.elapsed() < timeout {
         let mut remaining = 0usize;
         for cid in &missing {
@@ -351,6 +437,9 @@ mod tests {
         selective_blocks: Arc<HashMap<Cid, Vec<u8>>>,
         car_requests: Arc<AtomicUsize>,
         sync_batches: Arc<Mutex<Vec<Vec<Cid>>>>,
+        sync_providers: Arc<Mutex<Vec<String>>>,
+        dead_providers: Arc<Mutex<HashSet<String>>>,
+        skip_serving_syncs: Arc<AtomicUsize>,
     }
 
     impl TestTransport {
@@ -371,6 +460,9 @@ mod tests {
                 selective_blocks: Arc::new(selective_blocks),
                 car_requests: Arc::new(AtomicUsize::new(0)),
                 sync_batches: Arc::new(Mutex::new(Vec::new())),
+                sync_providers: Arc::new(Mutex::new(Vec::new())),
+                dead_providers: Arc::new(Mutex::new(HashSet::new())),
+                skip_serving_syncs: Arc::new(AtomicUsize::new(0)),
             }
         }
 
@@ -380,6 +472,18 @@ mod tests {
 
         fn sync_batches(&self) -> Vec<Vec<Cid>> {
             self.sync_batches.lock().unwrap().clone()
+        }
+
+        fn sync_providers(&self) -> Vec<String> {
+            self.sync_providers.lock().unwrap().clone()
+        }
+
+        fn mark_provider_dead(&self, peer: &str) {
+            self.dead_providers.lock().unwrap().insert(peer.to_string());
+        }
+
+        fn set_skip_serving_syncs(&self, count: usize) {
+            self.skip_serving_syncs.store(count, Ordering::SeqCst);
         }
     }
 
@@ -562,10 +666,28 @@ mod tests {
         async fn sync_blocks(
             &self,
             _root: Cid,
-            _providers: Vec<PeerId>,
+            providers: Vec<PeerId>,
             missing: Vec<Cid>,
         ) -> P2PResult<QueryId> {
-            self.sync_batches.lock().unwrap().push(missing.clone());
+            let call_index = {
+                let mut batches = self.sync_batches.lock().unwrap();
+                batches.push(missing.clone());
+                batches.len() - 1
+            };
+            self.sync_providers
+                .lock()
+                .unwrap()
+                .extend(providers.iter().map(|peer| peer.to_string()));
+            if call_index < self.skip_serving_syncs.load(Ordering::SeqCst) {
+                return Ok(QueryId(1));
+            }
+            let all_dead = {
+                let dead = self.dead_providers.lock().unwrap();
+                providers.iter().all(|peer| dead.contains(peer.as_str()))
+            };
+            if all_dead {
+                return Ok(QueryId(1));
+            }
             for cid in missing {
                 if let Some(data) = self.selective_blocks.get(&cid) {
                     self.blockstore
@@ -868,5 +990,142 @@ mod tests {
         }
         // One selective iteration per ancestor: DEPTH - 1 batches.
         assert_eq!(transport.sync_batches().len(), DEPTH - 1);
+    }
+
+    fn single_child_dag() -> (Cid, Vec<u8>, Cid, Vec<u8>) {
+        let child_data = encode_ipld(ipld!({ "value": 1 }));
+        let child_cid = make_cid(&child_data);
+        let root_data = encode_ipld(ipld!({ "child": child_cid }));
+        let root_cid = make_cid(&root_data);
+        (root_cid, root_data, child_cid, child_data)
+    }
+
+    /// A dead source peer must not fail the walk: the batch rotates to the
+    /// alternate provider and the fetch completes on the first attempt.
+    #[tokio::test(start_paused = true)]
+    async fn poll_fetch_dag_rotates_to_alternate_provider_on_no_progress() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let (root_cid, root_data, child_cid, child_data) = single_child_dag();
+
+        let transport = TestTransport::new(
+            blockstore.clone(),
+            root_cid,
+            root_data,
+            HashMap::new(),
+            HashMap::from([(child_cid, child_data)]),
+        );
+        transport.mark_provider_dead("dead-peer");
+
+        let (event_tx, mut event_rx) = mpsc::channel(1);
+        poll_fetch_dag(
+            transport.clone(),
+            blockstore.clone(),
+            event_tx,
+            root_cid,
+            DagFetchContext::new(
+                "doc-id".to_string(),
+                "collection-id".to_string(),
+                "creator-id".to_string(),
+                PeerId::new("dead-peer".to_string()),
+            )
+            .with_alternate_providers(vec![PeerId::new("alt-peer".to_string())]),
+        )
+        .await;
+
+        assert!(matches!(
+            event_rx.recv().await,
+            Some(SyncEvent::DagReady { root_cid: ready_cid, .. }) if ready_cid == root_cid
+        ));
+        assert!(matches!(blockstore.has(&child_cid).await, Ok(true)));
+        assert_eq!(transport.car_request_count(), 1);
+        assert_eq!(
+            transport.sync_providers(),
+            vec!["dead-peer".to_string(), "alt-peer".to_string()]
+        );
+    }
+
+    /// An attempt that stalls (no blocks served) must be retried after
+    /// backoff and succeed once the provider starts serving.
+    #[tokio::test(start_paused = true)]
+    async fn poll_fetch_dag_retries_incomplete_fetch_and_succeeds() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let (root_cid, root_data, child_cid, child_data) = single_child_dag();
+
+        let transport = TestTransport::new(
+            blockstore.clone(),
+            root_cid,
+            root_data,
+            HashMap::new(),
+            HashMap::from([(child_cid, child_data)]),
+        );
+        transport.set_skip_serving_syncs(1);
+
+        let (event_tx, mut event_rx) = mpsc::channel(1);
+        poll_fetch_dag(
+            transport.clone(),
+            blockstore.clone(),
+            event_tx,
+            root_cid,
+            DagFetchContext::new(
+                "doc-id".to_string(),
+                "collection-id".to_string(),
+                "creator-id".to_string(),
+                PeerId::new("remote-peer".to_string()),
+            ),
+        )
+        .await;
+
+        assert!(matches!(
+            event_rx.recv().await,
+            Some(SyncEvent::DagReady { root_cid: ready_cid, .. }) if ready_cid == root_cid
+        ));
+        assert!(matches!(blockstore.has(&child_cid).await, Ok(true)));
+        // One CAR try and one selective batch per attempt; success on attempt 2.
+        assert_eq!(transport.car_request_count(), 2);
+        assert_eq!(transport.sync_batches().len(), 2);
+    }
+
+    /// When every attempt stalls against every provider the fetcher stops
+    /// after MAX_FETCH_ATTEMPTS without emitting DagReady (terminal failure).
+    #[tokio::test(start_paused = true)]
+    async fn poll_fetch_dag_exhausted_retries_do_not_emit_dag_ready() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let (root_cid, root_data, child_cid, child_data) = single_child_dag();
+
+        let transport = TestTransport::new(
+            blockstore.clone(),
+            root_cid,
+            root_data,
+            HashMap::new(),
+            HashMap::from([(child_cid, child_data)]),
+        );
+        transport.mark_provider_dead("dead-peer");
+
+        let (event_tx, mut event_rx) = mpsc::channel(1);
+        poll_fetch_dag(
+            transport.clone(),
+            blockstore.clone(),
+            event_tx,
+            root_cid,
+            DagFetchContext::new(
+                "doc-id".to_string(),
+                "collection-id".to_string(),
+                "creator-id".to_string(),
+                PeerId::new("dead-peer".to_string()),
+            ),
+        )
+        .await;
+
+        assert!(
+            event_rx.recv().await.is_none(),
+            "terminal failure must not emit DagReady"
+        );
+        assert!(matches!(blockstore.has(&child_cid).await, Ok(false)));
+        // One CAR try and one selective batch per attempt, all exhausted.
+        assert_eq!(transport.car_request_count(), MAX_FETCH_ATTEMPTS as usize);
+        assert_eq!(transport.sync_batches().len(), MAX_FETCH_ATTEMPTS as usize);
     }
 }

--- a/crates/p2p/src/sync/coordinator/dag_fetcher.rs
+++ b/crates/p2p/src/sync/coordinator/dag_fetcher.rs
@@ -344,6 +344,18 @@ async fn emit_dag_ready(
     }
 }
 
+/// Ceiling on the CAR request round-trip itself.
+///
+/// On iroh, `send_car_request` resolves only after the full connect /
+/// stream-open / response-read cycle (up to ~50s against a half-open peer),
+/// which would silently extend the attempt's CAR phase well past its intended
+/// 10s budget while the limiter permit is held. CAR requests have no
+/// cancellation handle, so on timeout the transport-side task is left to
+/// self-terminate within its own bounded internal timeouts (at most one per
+/// attempt); any late response still lands in the blockstore, where the
+/// selective phase or a later attempt picks it up.
+const CAR_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// Try to fetch an entire DAG via a single CAR request.
 async fn try_car_fetch<B: Blockstore, T: P2PTransport>(
     transport: &T,
@@ -352,9 +364,25 @@ async fn try_car_fetch<B: Blockstore, T: P2PTransport>(
     source_peer: &PeerId,
     watch_missing: Option<&[Cid]>,
 ) -> bool {
-    if let Err(e) = transport.send_car_request(source_peer, *root_cid).await {
-        debug!(root_cid = %root_cid, error = %e, "CAR request failed, will use selective block fetch");
-        return false;
+    match tokio::time::timeout(
+        CAR_REQUEST_TIMEOUT,
+        transport.send_car_request(source_peer, *root_cid),
+    )
+    .await
+    {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => {
+            debug!(root_cid = %root_cid, error = %e, "CAR request failed, will use selective block fetch");
+            return false;
+        }
+        Err(_) => {
+            debug!(
+                root_cid = %root_cid,
+                timeout_secs = CAR_REQUEST_TIMEOUT.as_secs(),
+                "CAR request did not resolve within budget, falling back to selective block fetch"
+            );
+            return false;
+        }
     }
 
     let timeout = Duration::from_secs(10);
@@ -548,6 +576,7 @@ mod tests {
         skip_serving_syncs: Arc<AtomicUsize>,
         fail_connected_peers: Arc<AtomicBool>,
         cancelled_queries: Arc<Mutex<Vec<u64>>>,
+        hang_car_requests: Arc<AtomicBool>,
     }
 
     impl TestTransport {
@@ -573,6 +602,7 @@ mod tests {
                 skip_serving_syncs: Arc::new(AtomicUsize::new(0)),
                 fail_connected_peers: Arc::new(AtomicBool::new(false)),
                 cancelled_queries: Arc::new(Mutex::new(Vec::new())),
+                hang_car_requests: Arc::new(AtomicBool::new(false)),
             }
         }
 
@@ -602,6 +632,10 @@ mod tests {
 
         fn cancelled_queries(&self) -> Vec<u64> {
             self.cancelled_queries.lock().unwrap().clone()
+        }
+
+        fn set_hang_car_requests(&self) {
+            self.hang_car_requests.store(true, Ordering::SeqCst);
         }
     }
 
@@ -737,6 +771,10 @@ mod tests {
         async fn send_car_request(&self, _peer_id: &PeerId, root_cid: Cid) -> P2PResult<()> {
             assert_eq!(root_cid, self.root_cid);
             self.car_requests.fetch_add(1, Ordering::SeqCst);
+            if self.hang_car_requests.load(Ordering::SeqCst) {
+                tokio::time::sleep(Duration::from_secs(600)).await;
+                return Ok(());
+            }
             self.blockstore
                 .put(&self.root_cid, &self.root_data)
                 .await
@@ -1362,6 +1400,55 @@ mod tests {
         assert_eq!(
             transport.cancelled_queries(),
             (1..=MAX_FETCH_ATTEMPTS as u64).collect::<Vec<_>>()
+        );
+    }
+
+    /// A CAR request that never resolves (half-open peer: connected but
+    /// unresponsive) must not stall the attempt beyond the CAR budget — the
+    /// fetch falls back to the selective path and completes, instead of
+    /// waiting out the transport's full internal timeout chain.
+    #[tokio::test(start_paused = true)]
+    async fn poll_fetch_dag_bounds_hung_car_request() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let (root_cid, root_data, child_cid, child_data) = single_child_dag();
+
+        let transport = TestTransport::new(
+            blockstore.clone(),
+            root_cid,
+            root_data.clone(),
+            HashMap::new(),
+            HashMap::from([(root_cid, root_data), (child_cid, child_data)]),
+        );
+        transport.set_hang_car_requests();
+
+        let started = Instant::now();
+        let (event_tx, mut event_rx) = mpsc::channel(1);
+        poll_fetch_dag(
+            transport.clone(),
+            blockstore.clone(),
+            event_tx,
+            root_cid,
+            DagFetchContext::new(
+                "doc-id".to_string(),
+                "collection-id".to_string(),
+                "creator-id".to_string(),
+                PeerId::new("remote-peer".to_string()),
+            ),
+            DagFetchLimiter::new(2),
+        )
+        .await;
+
+        assert!(matches!(
+            event_rx.recv().await,
+            Some(SyncEvent::DagReady { root_cid: ready_cid, .. }) if ready_cid == root_cid
+        ));
+        assert!(matches!(blockstore.has(&child_cid).await, Ok(true)));
+        assert_eq!(transport.car_request_count(), 1);
+        assert!(
+            started.elapsed() < Duration::from_secs(60),
+            "hung CAR request must be cut at its budget, not awaited to transport timeouts; elapsed: {:?}",
+            started.elapsed()
         );
     }
 

--- a/crates/p2p/src/sync/coordinator/dag_fetcher.rs
+++ b/crates/p2p/src/sync/coordinator/dag_fetcher.rs
@@ -16,6 +16,7 @@ use tracing::{debug, error, info, warn};
 
 use super::dag_context::DagFetchContext;
 use super::dag_retry::{retry_backoff, ProviderRotation, MAX_FETCH_ATTEMPTS};
+use super::DagFetchLimiter;
 use crate::sync::manager::links::find_all_missing_links;
 use crate::sync::manager::SyncEvent;
 use crate::transport::{P2PTransport, PeerId};
@@ -53,12 +54,17 @@ enum FetchAttemptOutcome {
 /// for any missing blocks, rotating providers on stalls. Incomplete attempts
 /// are retried with backoff; terminal failure is logged at ERROR because the
 /// document cannot converge until the root is announced again.
+///
+/// A limiter permit is held only for the duration of each attempt — it is
+/// released during backoff sleeps so a fetch stuck on dead providers does not
+/// starve other roots under fan-in pressure.
 pub async fn poll_fetch_dag<B: Blockstore + 'static, T: P2PTransport>(
     transport: T,
     blockstore: Arc<B>,
     event_tx: mpsc::Sender<SyncEvent>,
     root_cid: Cid,
     context: DagFetchContext,
+    limiter: DagFetchLimiter,
 ) {
     let mut providers = ProviderRotation::new(context.providers());
     debug!(
@@ -85,6 +91,16 @@ pub async fn poll_fetch_dag<B: Blockstore + 'static, T: P2PTransport>(
             );
             tokio::time::sleep(backoff).await;
         }
+
+        let Some(_permits) = limiter.acquire(&context.source_peer).await else {
+            debug!(
+                root_cid = %root_cid,
+                doc_id = %context.doc_id,
+                attempt = attempt,
+                "DAG fetch limiter closed, abandoning fetch"
+            );
+            return;
+        };
 
         match fetch_dag_attempt(
             &transport,
@@ -775,6 +791,7 @@ mod tests {
                 source_peer.clone(),
             )
             .with_explicit_replicator(true),
+            DagFetchLimiter::new(2),
         )
         .await;
 
@@ -843,6 +860,7 @@ mod tests {
                 "creator-id".to_string(),
                 source_peer,
             ),
+            DagFetchLimiter::new(2),
         )
         .await;
 
@@ -901,6 +919,7 @@ mod tests {
                 "creator-id".to_string(),
                 source_peer,
             ),
+            DagFetchLimiter::new(2),
         )
         .await;
 
@@ -975,6 +994,7 @@ mod tests {
                 "creator-id".to_string(),
                 source_peer,
             ),
+            DagFetchLimiter::new(2),
         )
         .await;
 
@@ -1030,6 +1050,7 @@ mod tests {
                 PeerId::new("dead-peer".to_string()),
             )
             .with_alternate_providers(vec![PeerId::new("alt-peer".to_string())]),
+            DagFetchLimiter::new(2),
         )
         .await;
 
@@ -1074,6 +1095,7 @@ mod tests {
                 "creator-id".to_string(),
                 PeerId::new("remote-peer".to_string()),
             ),
+            DagFetchLimiter::new(2),
         )
         .await;
 
@@ -1116,6 +1138,7 @@ mod tests {
                 "creator-id".to_string(),
                 PeerId::new("dead-peer".to_string()),
             ),
+            DagFetchLimiter::new(2),
         )
         .await;
 
@@ -1126,6 +1149,66 @@ mod tests {
         assert!(matches!(blockstore.has(&child_cid).await, Ok(false)));
         // One CAR try and one selective batch per attempt, all exhausted.
         assert_eq!(transport.car_request_count(), MAX_FETCH_ATTEMPTS as usize);
+        assert_eq!(transport.sync_batches().len(), MAX_FETCH_ATTEMPTS as usize);
+    }
+
+    /// The limiter permit must be released during retry backoff: a second
+    /// waiter acquires the single permit while the first fetch is sleeping
+    /// between attempts, not after all of its retries complete.
+    #[tokio::test(start_paused = true)]
+    async fn poll_fetch_dag_releases_limiter_permit_during_backoff() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let (root_cid, root_data, child_cid, child_data) = single_child_dag();
+
+        let transport = TestTransport::new(
+            blockstore.clone(),
+            root_cid,
+            root_data,
+            HashMap::new(),
+            HashMap::from([(child_cid, child_data)]),
+        );
+        transport.mark_provider_dead("dead-peer");
+
+        let limiter = DagFetchLimiter::new(1);
+        let (event_tx, mut event_rx) = mpsc::channel(1);
+        let fetch = tokio::spawn(poll_fetch_dag(
+            transport.clone(),
+            blockstore.clone(),
+            event_tx,
+            root_cid,
+            DagFetchContext::new(
+                "doc-id".to_string(),
+                "collection-id".to_string(),
+                "creator-id".to_string(),
+                PeerId::new("dead-peer".to_string()),
+            ),
+            limiter.clone(),
+        ));
+
+        // Let attempt 1 start (and therefore hold the only permit) before
+        // competing for it.
+        while transport.sync_batches().is_empty() {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        // Resolves as soon as attempt 1's permit drops (start of backoff);
+        // if the permit spanned all attempts this would only resolve after
+        // the fetch task finished.
+        let permits = limiter
+            .acquire(&PeerId::new("other-peer".to_string()))
+            .await
+            .expect("limiter must grant a permit while the fetch is backing off");
+        assert!(
+            !fetch.is_finished(),
+            "fetch must still be mid-retry while another waiter holds the permit"
+        );
+        assert_eq!(transport.sync_batches().len(), 1);
+
+        drop(permits);
+        fetch.await.unwrap();
+
+        assert!(event_rx.recv().await.is_none());
         assert_eq!(transport.sync_batches().len(), MAX_FETCH_ATTEMPTS as usize);
     }
 }

--- a/crates/p2p/src/sync/coordinator/dag_retry.rs
+++ b/crates/p2p/src/sync/coordinator/dag_retry.rs
@@ -6,10 +6,11 @@ use crate::transport::PeerId;
 
 /// Total fetch attempts per root before the failure is escalated to ERROR.
 ///
-/// Each attempt spends up to 10s on the CAR try plus a stall budget of one
-/// full provider rotation (providers × 30s) on stalled selective windows, so
-/// three attempts bound the worst-case dead-provider task lifetime at roughly
-/// 6.5 minutes at the 4-provider cap — independent of how many batches the
+/// Each attempt spends up to 20s on the CAR phase (a 10s bounded request
+/// round-trip plus a 10s arrival watch) and a stall budget of one full
+/// provider rotation (providers × 30s) on stalled selective windows, so three
+/// attempts bound the worst-case dead-provider task lifetime at roughly
+/// 7 minutes at the 4-provider cap — independent of how many batches the
 /// missing frontier spans — while still surviving a transiently overloaded or
 /// reconnecting provider set.
 pub(super) const MAX_FETCH_ATTEMPTS: u32 = 3;

--- a/crates/p2p/src/sync/coordinator/dag_retry.rs
+++ b/crates/p2p/src/sync/coordinator/dag_retry.rs
@@ -6,10 +6,12 @@ use crate::transport::PeerId;
 
 /// Total fetch attempts per root before the failure is escalated to ERROR.
 ///
-/// Each attempt already spends up to 10s on the CAR try plus 30s per stalled
-/// selective batch per provider, so three attempts bound the worst-case task
-/// lifetime while still surviving a transiently overloaded or reconnecting
-/// provider set.
+/// Each attempt spends up to 10s on the CAR try plus a stall budget of one
+/// full provider rotation (providers × 30s) on stalled selective windows, so
+/// three attempts bound the worst-case dead-provider task lifetime at roughly
+/// 6.5 minutes at the 4-provider cap — independent of how many batches the
+/// missing frontier spans — while still surviving a transiently overloaded or
+/// reconnecting provider set.
 pub(super) const MAX_FETCH_ATTEMPTS: u32 = 3;
 
 /// Base backoff between attempts; doubles per retry (2s, then 4s).

--- a/crates/p2p/src/sync/coordinator/dag_retry.rs
+++ b/crates/p2p/src/sync/coordinator/dag_retry.rs
@@ -1,0 +1,84 @@
+//! Bounded retry and provider rotation for poll-based DAG fetches (#1093).
+
+use std::time::Duration;
+
+use crate::transport::PeerId;
+
+/// Total fetch attempts per root before the failure is escalated to ERROR.
+///
+/// Each attempt already spends up to 10s on the CAR try plus 30s per stalled
+/// selective batch per provider, so three attempts bound the worst-case task
+/// lifetime while still surviving a transiently overloaded or reconnecting
+/// provider set.
+pub(super) const MAX_FETCH_ATTEMPTS: u32 = 3;
+
+/// Base backoff between attempts; doubles per retry (2s, then 4s).
+///
+/// The backoff mainly de-synchronizes fleet-wide retry waves — the per-batch
+/// 30s fetch window is the dominant wait, not the backoff itself.
+const FETCH_RETRY_BACKOFF_BASE: Duration = Duration::from_secs(2);
+
+/// Backoff to sleep before `attempt` (1-based; only called for attempts >= 2).
+pub(super) fn retry_backoff(attempt: u32) -> Duration {
+    FETCH_RETRY_BACKOFF_BASE * 2u32.saturating_pow(attempt.saturating_sub(2))
+}
+
+/// Round-robin cursor over the fetch providers for one DAG root.
+///
+/// The cursor persists across batches and attempts so a provider that just
+/// timed out is not immediately re-tried while alternates remain.
+pub(super) struct ProviderRotation {
+    peers: Vec<PeerId>,
+    cursor: usize,
+}
+
+impl ProviderRotation {
+    pub(super) fn new(peers: Vec<PeerId>) -> Self {
+        debug_assert!(!peers.is_empty(), "DagFetchContext always has source_peer");
+        Self { peers, cursor: 0 }
+    }
+
+    pub(super) fn current(&self) -> &PeerId {
+        &self.peers[self.cursor % self.peers.len()]
+    }
+
+    pub(super) fn advance(&mut self) {
+        self.cursor = (self.cursor + 1) % self.peers.len();
+    }
+
+    pub(super) fn len(&self) -> usize {
+        self.peers.len()
+    }
+
+    pub(super) fn peers(&self) -> &[PeerId] {
+        &self.peers
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn peer(id: &str) -> PeerId {
+        PeerId::new(id.to_string())
+    }
+
+    #[test]
+    fn provider_rotation_wraps_around() {
+        let mut rotation = ProviderRotation::new(vec![peer("a"), peer("b"), peer("c")]);
+        assert_eq!(rotation.len(), 3);
+        assert_eq!(rotation.current(), &peer("a"));
+        rotation.advance();
+        assert_eq!(rotation.current(), &peer("b"));
+        rotation.advance();
+        assert_eq!(rotation.current(), &peer("c"));
+        rotation.advance();
+        assert_eq!(rotation.current(), &peer("a"));
+    }
+
+    #[test]
+    fn retry_backoff_doubles_per_attempt() {
+        assert_eq!(retry_backoff(2), Duration::from_secs(2));
+        assert_eq!(retry_backoff(3), Duration::from_secs(4));
+    }
+}

--- a/crates/p2p/src/sync/coordinator/event_handler/branchable_sync.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/branchable_sync.rs
@@ -292,9 +292,6 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                     self.is_registered_replicator(peer_id.as_str(), &collection_id);
 
                 self.spawn_background_task("branchable_sync_reply_fetch_dag", async move {
-                    let Some(_permits) = limiter.acquire(&source_peer).await else {
-                        return;
-                    };
                     let alternate_providers = transport.connected_peers().await.unwrap_or_default();
                     super::super::dag_fetcher::poll_fetch_dag(
                         transport,
@@ -309,6 +306,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                         )
                         .with_alternate_providers(alternate_providers)
                         .with_explicit_replicator(is_explicit_replicator),
+                        limiter,
                     )
                     .await;
                 });

--- a/crates/p2p/src/sync/coordinator/event_handler/branchable_sync.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/branchable_sync.rs
@@ -292,7 +292,11 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                     self.is_registered_replicator(peer_id.as_str(), &collection_id);
 
                 self.spawn_background_task("branchable_sync_reply_fetch_dag", async move {
-                    let alternate_providers = transport.connected_peers().await.unwrap_or_default();
+                    let alternate_providers =
+                        super::super::dag_fetcher::connected_alternate_providers(
+                            &transport, &root_cid,
+                        )
+                        .await;
                     super::super::dag_fetcher::poll_fetch_dag(
                         transport,
                         blockstore,

--- a/crates/p2p/src/sync/coordinator/event_handler/branchable_sync.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/branchable_sync.rs
@@ -295,6 +295,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                     let Some(_permits) = limiter.acquire(&source_peer).await else {
                         return;
                     };
+                    let alternate_providers = transport.connected_peers().await.unwrap_or_default();
                     super::super::dag_fetcher::poll_fetch_dag(
                         transport,
                         blockstore,
@@ -306,6 +307,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                             String::new(),
                             source_peer,
                         )
+                        .with_alternate_providers(alternate_providers)
                         .with_explicit_replicator(is_explicit_replicator),
                     )
                     .await;

--- a/crates/p2p/src/sync/coordinator/event_handler/doc_sync.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/doc_sync.rs
@@ -399,9 +399,6 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                     self.access.replicators.get_collections(peer_id.as_str());
 
                 self.spawn_background_task("doc_sync_reply_fetch_dag", async move {
-                    let Some(_permits) = limiter.acquire(&source_peer).await else {
-                        return;
-                    };
                     let alternate_providers = transport.connected_peers().await.unwrap_or_default();
                     super::super::dag_fetcher::poll_fetch_dag(
                         transport,
@@ -411,6 +408,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                         DagFetchContext::new(doc_id, String::new(), String::new(), source_peer)
                             .with_alternate_providers(alternate_providers)
                             .with_explicit_replicator_collections(explicit_replicator_collections),
+                        limiter,
                     )
                     .await;
                 });

--- a/crates/p2p/src/sync/coordinator/event_handler/doc_sync.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/doc_sync.rs
@@ -402,12 +402,14 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                     let Some(_permits) = limiter.acquire(&source_peer).await else {
                         return;
                     };
+                    let alternate_providers = transport.connected_peers().await.unwrap_or_default();
                     super::super::dag_fetcher::poll_fetch_dag(
                         transport,
                         blockstore,
                         event_tx,
                         root_cid,
                         DagFetchContext::new(doc_id, String::new(), String::new(), source_peer)
+                            .with_alternate_providers(alternate_providers)
                             .with_explicit_replicator_collections(explicit_replicator_collections),
                     )
                     .await;

--- a/crates/p2p/src/sync/coordinator/event_handler/doc_sync.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/doc_sync.rs
@@ -399,7 +399,11 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                     self.access.replicators.get_collections(peer_id.as_str());
 
                 self.spawn_background_task("doc_sync_reply_fetch_dag", async move {
-                    let alternate_providers = transport.connected_peers().await.unwrap_or_default();
+                    let alternate_providers =
+                        super::super::dag_fetcher::connected_alternate_providers(
+                            &transport, &root_cid,
+                        )
+                        .await;
                     super::super::dag_fetcher::poll_fetch_dag(
                         transport,
                         blockstore,

--- a/crates/p2p/src/sync/coordinator/mod.rs
+++ b/crates/p2p/src/sync/coordinator/mod.rs
@@ -47,6 +47,7 @@ mod broadcast;
 mod constructor;
 pub(crate) mod dag_context;
 pub(crate) mod dag_fetcher;
+pub(crate) mod dag_retry;
 mod event_handler;
 #[cfg(feature = "libp2p-transport")]
 mod pubsub_client;

--- a/crates/p2p/src/sync/replication/handlers.rs
+++ b/crates/p2p/src/sync/replication/handlers.rs
@@ -125,7 +125,6 @@ where
         let event_tx = coordinator.manager().event_sender();
         let limiter = coordinator.dag_fetch_limiter();
         let source_peer = crate::transport::PeerId::new(source_peer);
-        let permit_peer = source_peer.clone();
         let alternate_providers: Vec<crate::transport::PeerId> = providers
             .into_iter()
             .map(crate::transport::PeerId::new)
@@ -136,11 +135,8 @@ where
             .with_explicit_replay_authorization(explicit_replay_authorization);
 
         coordinator.spawn_background_task("pushlog_fetch_dag", async move {
-            let Some(_permits) = limiter.acquire(&permit_peer).await else {
-                return;
-            };
             crate::sync::coordinator::dag_fetcher::poll_fetch_dag(
-                transport, blockstore, event_tx, root_cid, context,
+                transport, blockstore, event_tx, root_cid, context, limiter,
             )
             .await;
         });

--- a/crates/p2p/src/sync/replication/handlers.rs
+++ b/crates/p2p/src/sync/replication/handlers.rs
@@ -126,7 +126,12 @@ where
         let limiter = coordinator.dag_fetch_limiter();
         let source_peer = crate::transport::PeerId::new(source_peer);
         let permit_peer = source_peer.clone();
+        let alternate_providers: Vec<crate::transport::PeerId> = providers
+            .into_iter()
+            .map(crate::transport::PeerId::new)
+            .collect();
         let context = DagFetchContext::new(doc_id, collection_id, creator, source_peer)
+            .with_alternate_providers(alternate_providers)
             .with_explicit_replicator(is_explicit_replicator)
             .with_explicit_replay_authorization(explicit_replay_authorization);
 

--- a/crates/p2p/src/sync/replication/handlers.rs
+++ b/crates/p2p/src/sync/replication/handlers.rs
@@ -147,11 +147,17 @@ where
     // Convert string peer IDs to transport PeerIds.
     // If the provider list is empty, fall back to all connected transport peers.
     let transport_providers: Vec<crate::transport::PeerId> = if providers.is_empty() {
-        coordinator
-            .transport()
-            .connected_peers()
-            .await
-            .unwrap_or_default()
+        match coordinator.transport().connected_peers().await {
+            Ok(peers) => peers,
+            Err(e) => {
+                tracing::warn!(
+                    cid = %root_cid,
+                    error = %e,
+                    "Failed to list connected peers as Bitswap fetch providers"
+                );
+                Vec::new()
+            }
+        }
     } else {
         providers
             .into_iter()


### PR DESCRIPTION
Closes #1093.

## Problem

`dag_fetcher` used exactly one peer (`context.source_peer`) for every fetch, ignored the providers list already available at the pushlog spawn site, and after "DAG fetch incomplete" dropped the root forever with only a WARN. On the amygdala fleet this produced synchronized fleet-wide zero-block timeout waves where docs silently never converge — "sync is quiet" was indistinguishable from "sync is dead".

## Fix (commit 1: providers + rotation + retry)

- **Provider plumbing**: `DagFetchContext` gains an alternates list (source peer first, deduped, capped at 3 alternates so a fully-dead provider set costs at most 4×30s per stalled batch). The pushlog path now consumes its providers list; DocSync/BranchableSync pass connected peers.
- **Rotation on stall**: a batch that fetches zero blocks within the 30s window rotates to the next provider (round-robin cursor persisted across batches and attempts) before being declared stalled. CAR tries also use the cursor, so later attempts CAR-fetch from alternates.
- **Bounded retry, loud terminal failure**: 3 attempts with 2s→4s backoff (backoff mainly de-synchronizes fleet-wide retry waves; the 30s fetch window dominates). Exhaustion logs at **ERROR** with root_cid, doc_id, attempts, and providers tried. There is no active re-request mechanism in the coordinator to hook (the pending-DAG path is passive re-checking), so the in-task loop is the retry machinery; recovery after exhaustion still rides re-announcement.
- CAR-first strategy and the 10s/30s windows are unchanged. Retry state lives on the (already concurrency-limited) task's stack — no new maps, no extra task spawning.

## Fix (commit 2: permit release during backoff)

Holding the `DagFetchLimiter` permit across all attempts would let dead-provider roots starve other fetches under fan-in pressure (#1088 territory). `poll_fetch_dag` now owns permit acquisition per attempt: acquire → attempt → release → backoff → re-acquire. Retrying fetches queue fairly (FIFO) behind fresh work, and limiter closure aborts fetches between attempts, making shutdown responsive mid-backoff.

## Tests

All new tests are deterministic (`start_paused` virtual clock, zero real waiting): rotation to an alternate on a dead source peer, retry succeeding on attempt 2, exhaustion emitting no DagReady, and a single-permit test proving a second waiter acquires the limiter while the first fetch sleeps in backoff.

- `cargo test -p p2p` — 343 tests, 0 failed
- `cargo clippy --all -- -D warnings` — clean; `cargo fmt --all --check` — clean
- `cargo test -p integration-test --test p2p -- --skip go_ --skip _iroh` — 66 passed
- `cargo test -p integration-test --test p2p -- _iroh` — 5 passed
- `cargo test -p integration-test --test p2p_iroh` — 227 passed (at commit 1; commit 2 touches only paths covered by the runs above)

Note: mixed iroh/non-iroh single-invocation `--test p2p` runs fail environmentally due to a pre-existing harness build race, filed as #1094.

## Behavior notes

- Worst-case permit hold is now one attempt (~10s CAR + up to 4×30s stalled batches), not the retry lifetime.
- Worst-case task lifetime for an all-dead provider set is bounded (~6min including backoffs) and ends in a loud ERROR instead of silence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)