### PR TITLE
fix(p2p): heal dead iroh-gossip send paths instead of retrying a corpse forever (#1092)

### DIFF
--- a/crates/cli/src/commands/start/server_p2p.rs
+++ b/crates/cli/src/commands/start/server_p2p.rs
@@ -765,6 +765,7 @@ impl Node {
                 discovery: Self::iroh_discovery(config)?,
                 bind_port: config.net.iroh_bind_port,
                 bind_addr: config.net.iroh_bind_addr,
+                gossip_heal: p2p::iroh::GossipHealConfig::from_env(),
             })
             .await
             .map_err(Error::P2P)?;

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -1346,6 +1346,7 @@ impl NodeBuilder {
             discovery: config.discovery.clone(),
             bind_port: Some(config.port),
             bind_addr: config.bind_addr,
+            gossip_heal: p2p::iroh::GossipHealConfig::from_env(),
         };
         let (command_tx, iroh_events, replicator_registry, endpoint_task) =
             p2p::iroh::spawn_endpoint(iroh_config)

--- a/crates/embedded/src/node_p2p.rs
+++ b/crates/embedded/src/node_p2p.rs
@@ -398,6 +398,7 @@ where
         discovery: config.discovery.clone(),
         bind_port: config.bind_port,
         bind_addr: config.bind_addr,
+        gossip_heal: p2p::iroh::GossipHealConfig::from_env(),
     };
     let (command_tx, event_rx, replicator_registry, endpoint_task) =
         p2p::iroh::spawn_endpoint(iroh_config)

--- a/crates/ffi/src/collection/view.rs
+++ b/crates/ffi/src/collection/view.rs
@@ -96,7 +96,7 @@ pub unsafe extern "C" fn add_view(
 
             // Parse the GQL query into a Select, matching Go's `addView` behavior:
             // Go wraps query as `query { <input> }` then parses to request.Select
-            let wrapped_query = format!("query {{ {} }}", &query_str);
+            let wrapped_query = format!("query {{ {} }}", query_str);
             let selects = query::parse_query_with_limits(&wrapped_query, None, query_limits)
                 .map_err(|e| format!("failed to parse view query: {}", e))?;
             if selects.is_empty() {

--- a/crates/p2p-adapter/src/iroh.rs
+++ b/crates/p2p-adapter/src/iroh.rs
@@ -1056,6 +1056,7 @@ mod tests {
             discovery: IrohDiscoveryConfig::Disabled,
             bind_port: None,
             bind_addr: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+            gossip_heal: Default::default(),
         }
     }
 

--- a/crates/p2p/src/iroh/endpoint.rs
+++ b/crates/p2p/src/iroh/endpoint.rs
@@ -60,7 +60,11 @@ pub(super) struct ActiveSync {
 pub(super) type SpawnedTasks = Arc<parking_lot::Mutex<Vec<JoinHandle<()>>>>;
 
 pub(super) fn track_task(spawned_tasks: &SpawnedTasks, task: JoinHandle<()>) {
-    spawned_tasks.lock().push(task);
+    let mut tasks = spawned_tasks.lock();
+    // The heal sweep (#1092) pushes tasks on a timer, so finished handles must
+    // be dropped here or the vec grows without bound over a node's lifetime.
+    tasks.retain(|task| !task.is_finished());
+    tasks.push(task);
 }
 
 async fn shutdown_tracked_tasks(spawned_tasks: SpawnedTasks) {

--- a/crates/p2p/src/iroh/endpoint.rs
+++ b/crates/p2p/src/iroh/endpoint.rs
@@ -25,10 +25,23 @@ use super::endpoint_config::{
 };
 use super::endpoint_rpc::ConnectionCache;
 use super::endpoint_streams::handle_incoming;
+use super::gossip_heal::{self, GossipHealer};
 use super::peer_map::{parse_endpoint_id, PeerMap};
 use super::protocols;
 
 const MAX_COMMAND_BATCH: usize = 16;
+
+/// Shared handles to the endpoint's long-lived state, cloneable into spawned
+/// tasks (dials, incoming connections, gossip heals).
+#[derive(Clone)]
+pub(super) struct EndpointResources {
+    pub(super) endpoint: Endpoint,
+    pub(super) gossip: Gossip,
+    pub(super) peer_map: Arc<parking_lot::Mutex<PeerMap>>,
+    pub(super) connection_cache: ConnectionCache,
+    pub(super) healer: Arc<GossipHealer>,
+    pub(super) spawned_tasks: SpawnedTasks,
+}
 
 /// Handle to a gossip topic subscription.
 pub(super) struct TopicSubscription {
@@ -135,9 +148,11 @@ pub async fn spawn_endpoint(
     let (event_tx, event_rx) = mpsc::channel::<TransportEvent<iroh::endpoint::SendStream>>(256);
     let replicators = Arc::new(ReplicatorRegistry::new());
 
+    let gossip_heal = config.gossip_heal.clone();
     let task = tokio::spawn(run_event_loop(
         endpoint,
         gossip,
+        gossip_heal,
         command_rx,
         event_tx,
         replicators.clone(),
@@ -150,6 +165,7 @@ pub async fn spawn_endpoint(
 async fn run_event_loop(
     endpoint: Endpoint,
     gossip: Gossip,
+    gossip_heal_config: super::gossip_heal::GossipHealConfig,
     mut command_rx: mpsc::Receiver<IrohCommand>,
     event_tx: mpsc::Sender<TransportEvent<iroh::endpoint::SendStream>>,
     replicators: Arc<ReplicatorRegistry>,
@@ -167,6 +183,18 @@ async fn run_event_loop(
     let mut active_syncs: HashMap<u64, ActiveSync> = HashMap::new();
     let spawned_tasks: SpawnedTasks = Arc::new(parking_lot::Mutex::new(Vec::new()));
     let mut next_query_id: u64 = 1;
+
+    let heal_enabled = gossip_heal_config.enabled();
+    let mut heal_tick = tokio::time::interval(gossip_heal_config.tick_period());
+    heal_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    let resources = EndpointResources {
+        endpoint: endpoint.clone(),
+        gossip: gossip.clone(),
+        peer_map: Arc::clone(&peer_map),
+        connection_cache: Arc::clone(&connection_cache),
+        healer: Arc::new(GossipHealer::new(gossip_heal_config)),
+        spawned_tasks: Arc::clone(&spawned_tasks),
+    };
 
     // Emit Listening event with our endpoint address
     let addr_str = format!("iroh://{}", endpoint.id());
@@ -186,16 +214,12 @@ async fn run_event_loop(
                 while let Some(cmd) = pending_cmd.take() {
                     let should_shutdown = handle_command(
                         cmd,
-                        &endpoint,
-                        &gossip,
-                        &peer_map,
+                        &resources,
                         &pending_pushlog_replies,
-                        &connection_cache,
                         &mut subscriptions,
                         &raw_topics,
                         &replicators,
                         &mut active_syncs,
-                        &spawned_tasks,
                         &mut next_query_id,
                         &event_tx,
                     ).await;
@@ -213,20 +237,16 @@ async fn run_event_loop(
             incoming = endpoint.accept() => {
                 match incoming {
                     Some(incoming) => {
-                        let gossip = gossip.clone();
-                        let peer_map = Arc::clone(&peer_map);
+                        let resources = resources.clone();
                         let pending_pushlog_replies = Arc::clone(&pending_pushlog_replies);
                         let subscription_senders = snapshot_subscription_senders(&subscriptions);
-                        let spawned_tasks_for_incoming = Arc::clone(&spawned_tasks);
                         let event_tx = event_tx.clone();
                         let task = tokio::spawn(async move {
                             handle_incoming(
                                 incoming,
-                                &gossip,
-                                &peer_map,
+                                &resources,
                                 &pending_pushlog_replies,
                                 &subscription_senders,
-                                &spawned_tasks_for_incoming,
                                 &event_tx,
                             )
                             .await;
@@ -235,6 +255,9 @@ async fn run_event_loop(
                     }
                     None => break,
                 }
+            }
+            _ = heal_tick.tick(), if heal_enabled => {
+                gossip_heal::sweep(&resources, &subscriptions);
             }
             else => break,
         }

--- a/crates/p2p/src/iroh/endpoint_commands.rs
+++ b/crates/p2p/src/iroh/endpoint_commands.rs
@@ -4,7 +4,6 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use bytes::Bytes;
-use iroh::Endpoint;
 use iroh_gossip::net::Gossip;
 use iroh_gossip::proto::TopicId;
 use tokio::sync::mpsc;
@@ -19,14 +18,14 @@ use crate::QueryId;
 use super::addr::{endpoint_addr_from_parts, endpoint_ticket_string};
 use super::command::IrohCommand;
 use super::endpoint::{
-    join_peer_to_subscription_senders, peer_direct_addr, snapshot_subscription_senders, track_task,
-    ActiveSync, SpawnedTasks, SubscriptionSenders, TopicSubscription,
+    peer_direct_addr, snapshot_subscription_senders, track_task, ActiveSync, EndpointResources,
+    SpawnedTasks, SubscriptionSenders, TopicSubscription,
 };
 use super::endpoint_rpc::{
-    close_cached_connections, handle_block_sync, handle_car_request_response,
-    handle_fire_and_forget, handle_request_response, handle_send_only, BlockSyncResources,
-    ConnectionCache,
+    close_peer_connections, handle_block_sync, handle_car_request_response, handle_fire_and_forget,
+    handle_request_response, handle_send_only, BlockSyncResources,
 };
+use super::gossip_heal;
 use super::peer_map::{endpoint_id_to_peer_id, parse_endpoint_id, PeerMap};
 use super::protocols;
 
@@ -36,21 +35,23 @@ use super::protocols;
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn handle_command(
     cmd: IrohCommand,
-    endpoint: &Endpoint,
-    gossip: &Gossip,
-    peer_map: &Arc<parking_lot::Mutex<PeerMap>>,
+    resources: &EndpointResources,
     pending_pushlog_replies: &Arc<
         parking_lot::Mutex<HashMap<String, oneshot::Sender<PushLogReply>>>,
     >,
-    connection_cache: &ConnectionCache,
     subscriptions: &mut HashMap<String, TopicSubscription>,
     raw_topics: &Arc<parking_lot::Mutex<HashSet<String>>>,
     replicators: &Arc<ReplicatorRegistry>,
     active_syncs: &mut HashMap<u64, ActiveSync>,
-    spawned_tasks: &SpawnedTasks,
     next_query_id: &mut u64,
     event_tx: &mpsc::Sender<TransportEvent<iroh::endpoint::SendStream>>,
 ) -> bool {
+    let endpoint = &resources.endpoint;
+    let gossip = &resources.gossip;
+    let peer_map = &resources.peer_map;
+    let connection_cache = &resources.connection_cache;
+    let spawned_tasks = &resources.spawned_tasks;
+
     active_syncs.retain(|_, sync| !sync.abort_handle.is_finished());
 
     match cmd {
@@ -67,11 +68,9 @@ pub(super) async fn handle_command(
             // deadlock. The reply is delivered from the spawned task, so callers
             // still get their result.
             let ctx = DialContext {
-                endpoint: endpoint.clone(),
-                peer_map: Arc::clone(peer_map),
+                resources: resources.clone(),
                 pending_pushlog_replies: Arc::clone(pending_pushlog_replies),
                 subscription_senders: snapshot_subscription_senders(subscriptions),
-                spawned_tasks: Arc::clone(spawned_tasks),
                 event_tx: event_tx.clone(),
             };
             let task = tokio::spawn(async move {
@@ -81,7 +80,7 @@ pub(super) async fn handle_command(
             track_task(spawned_tasks, task);
         }
         IrohCommand::Disconnect { peer_id, reply } => {
-            let result = handle_disconnect(peer_id, peer_map, connection_cache);
+            let result = handle_disconnect(peer_id, resources);
             let _ = reply.send(result);
         }
         IrohCommand::Listen { addr: _, reply } => {
@@ -691,12 +690,10 @@ pub(super) async fn handle_command(
 /// the loop free to accept. `subscriptions` is captured as an owned senders
 /// snapshot (the only previously-borrowed field).
 struct DialContext {
-    endpoint: Endpoint,
-    peer_map: Arc<parking_lot::Mutex<PeerMap>>,
+    resources: EndpointResources,
     pending_pushlog_replies:
         Arc<parking_lot::Mutex<HashMap<String, oneshot::Sender<PushLogReply>>>>,
     subscription_senders: SubscriptionSenders,
-    spawned_tasks: SpawnedTasks,
     event_tx: mpsc::Sender<TransportEvent<iroh::endpoint::SendStream>>,
 }
 
@@ -722,7 +719,7 @@ async fn handle_dial(
     // edge dial back over the path the peer opened to us, instead of failing
     // "Address Lookup failed" under no-relay/no-discovery.
     if endpoint_addr.ip_addrs().next().is_none() {
-        if let Some(observed) = peer_direct_addr(&ctx.peer_map, peer_id) {
+        if let Some(observed) = peer_direct_addr(&ctx.resources.peer_map, peer_id) {
             endpoint_addr = endpoint_addr.with_ip_addr(observed);
         }
     }
@@ -730,6 +727,7 @@ async fn handle_dial(
     let direct_addresses: Vec<std::net::SocketAddr> = endpoint_addr.ip_addrs().copied().collect();
 
     let connection = ctx
+        .resources
         .endpoint
         .connect(endpoint_addr, protocols::ALPN_PUSHLOG)
         .await
@@ -737,7 +735,7 @@ async fn handle_dial(
 
     let conn_alpn = connection.alpn().to_vec();
 
-    let is_new = ctx.peer_map.lock().increment_connections(
+    let is_new = ctx.resources.peer_map.lock().increment_connections(
         endpoint_id,
         direct_addresses.first().copied(),
         connection.clone(),
@@ -754,14 +752,18 @@ async fn handle_dial(
     }
 
     if is_new {
-        join_peer_to_subscription_senders(&ctx.subscription_senders, endpoint_id).await;
+        gossip_heal::spawn_peer_connected_heal(
+            &ctx.resources,
+            &ctx.subscription_senders,
+            endpoint_id,
+        );
     }
 
     // Keep connection alive by spawning a handler for incoming streams.
     let event_tx = ctx.event_tx.clone();
-    let peer_map = Arc::clone(&ctx.peer_map);
+    let peer_map = Arc::clone(&ctx.resources.peer_map);
     let pending_pushlog_replies = Arc::clone(&ctx.pending_pushlog_replies);
-    let spawned_tasks_for_connection = Arc::clone(&ctx.spawned_tasks);
+    let spawned_tasks_for_connection = Arc::clone(&ctx.resources.spawned_tasks);
     let task = tokio::spawn(async move {
         super::endpoint_streams::handle_connection_streams_from_dial(
             connection,
@@ -774,30 +776,31 @@ async fn handle_dial(
         )
         .await;
     });
-    track_task(&ctx.spawned_tasks, task);
+    track_task(&ctx.resources.spawned_tasks, task);
 
     Ok(())
 }
 
 /// Hang up the live connection to a peer.
 ///
-/// Closes both the connection handle retained in `peer_map` (covering dial- and
-/// accept-initiated connections) and any cached outbound-send connections.
-/// iroh `Connection` clones share the underlying QUIC connection, so closing
-/// any handle tears down the connection; the stream task then observes the
-/// `accept_bi` error, decrements the count, and emits `PeerDisconnected`.
+/// Closes the connection handle retained in `peer_map` (covering dial- and
+/// accept-initiated connections), any cached outbound-send connections, and
+/// any gossip connection injected by the heal path. iroh `Connection` clones
+/// share the underlying QUIC connection, so closing any handle tears down the
+/// connection; the stream task then observes the `accept_bi` error, decrements
+/// the count, and emits `PeerDisconnected`.
 ///
 /// Idempotent: disconnecting an already-absent peer returns `Ok(())`.
-fn handle_disconnect(
-    peer_id: PeerId,
-    peer_map: &Arc<parking_lot::Mutex<PeerMap>>,
-    connection_cache: &ConnectionCache,
-) -> crate::error::Result<()> {
+fn handle_disconnect(peer_id: PeerId, resources: &EndpointResources) -> crate::error::Result<()> {
     let endpoint_id = parse_endpoint_id(&peer_id)?;
-    if let Some(connection) = peer_map.lock().take_connection(&endpoint_id) {
+    close_peer_connections(
+        &resources.peer_map,
+        &resources.connection_cache,
+        &endpoint_id,
+    );
+    if let Some(connection) = resources.healer.take_conn(&endpoint_id) {
         connection.close(0u32.into(), b"disconnect");
     }
-    close_cached_connections(connection_cache, &endpoint_id);
     Ok(())
 }
 

--- a/crates/p2p/src/iroh/endpoint_config.rs
+++ b/crates/p2p/src/iroh/endpoint_config.rs
@@ -4,6 +4,7 @@ use iroh::endpoint::BindOpts;
 use iroh::SecretKey;
 
 use super::config::{IrohDiscoveryConfig, IrohRelayModeConfig};
+use super::gossip_heal::GossipHealConfig;
 
 /// Configuration for creating an `IrohEndpoint`.
 pub struct IrohEndpointConfig {
@@ -18,6 +19,8 @@ pub struct IrohEndpointConfig {
     /// interface — prevents advertising unreachable LAN addresses to peers
     /// on different networks. None = 0.0.0.0 (all interfaces).
     pub bind_addr: Option<std::net::IpAddr>,
+    /// Gossip send-path healing (#1092).
+    pub gossip_heal: GossipHealConfig,
 }
 
 impl Default for IrohEndpointConfig {
@@ -28,6 +31,7 @@ impl Default for IrohEndpointConfig {
             discovery: IrohDiscoveryConfig::default(),
             bind_port: None,
             bind_addr: None,
+            gossip_heal: GossipHealConfig::default(),
         }
     }
 }

--- a/crates/p2p/src/iroh/endpoint_rpc.rs
+++ b/crates/p2p/src/iroh/endpoint_rpc.rs
@@ -224,16 +224,17 @@ pub(super) fn close_cached_connections(cache: &ConnectionCache, endpoint_id: &ir
     }
 }
 
-/// Hang up every connection we hold to a peer: the handle retained in
-/// `peer_map` (covering dial- and accept-initiated connections) and any cached
-/// outbound-send connections. The stream task then observes the `accept_bi`
-/// error, decrements the count, and emits `PeerDisconnected`. Idempotent.
+/// Hang up every connection we hold to a peer: all handles retained in
+/// `peer_map` (covering dial- and accept-initiated connections across every
+/// ALPN) and any cached outbound-send connections. Each stream task then
+/// observes the `accept_bi` error and decrements the count until it reaches
+/// zero and `PeerDisconnected` is emitted. Idempotent.
 pub(super) fn close_peer_connections(
     peer_map: &Arc<parking_lot::Mutex<PeerMap>>,
     cache: &ConnectionCache,
     endpoint_id: &iroh::EndpointId,
 ) {
-    if let Some(connection) = peer_map.lock().take_connection(endpoint_id) {
+    for connection in peer_map.lock().take_connections(endpoint_id) {
         connection.close(DISCONNECT_ERROR_CODE.into(), b"disconnect");
     }
     close_cached_connections(cache, endpoint_id);
@@ -869,5 +870,69 @@ mod tests {
         assert!(summary.contains(&cid(b"a").to_string()));
         assert!(summary.contains(&cid(b"d").to_string()));
         assert!(summary.contains("+1 more"));
+    }
+
+    async fn localhost_endpoint(alpns: Vec<Vec<u8>>) -> iroh::Endpoint {
+        iroh::Endpoint::builder(iroh::endpoint::presets::Minimal)
+            .relay_mode(iroh::RelayMode::Disabled)
+            .alpns(alpns)
+            .bind_addr("127.0.0.1:0".parse::<std::net::SocketAddr>().unwrap())
+            .expect("bind addr")
+            .bind()
+            .await
+            .expect("bind endpoint")
+    }
+
+    /// Regression (#1092 review): a peer can hold several live connections
+    /// (one per ALPN, dial + accept). Hanging up must close every retained
+    /// handle — closing only the most recent one leaves the others alive, the
+    /// connection count never reaches zero, and `PeerDisconnected` never
+    /// fires.
+    #[tokio::test]
+    async fn close_peer_connections_closes_every_retained_handle() {
+        let accept_ep = localhost_endpoint(vec![b"test/a".to_vec(), b"test/b".to_vec()]).await;
+        let dial_ep = localhost_endpoint(vec![]).await;
+
+        let accept_task = tokio::spawn({
+            let ep = accept_ep.clone();
+            async move {
+                let mut held = Vec::new();
+                while let Some(incoming) = ep.accept().await {
+                    if let Ok(conn) = incoming.await {
+                        held.push(conn);
+                    }
+                }
+            }
+        });
+
+        let addr = accept_ep.addr();
+        let conn_a = dial_ep
+            .connect(addr.clone(), b"test/a")
+            .await
+            .expect("connect a");
+        let conn_b = dial_ep.connect(addr, b"test/b").await.expect("connect b");
+
+        let peer_map = Arc::new(parking_lot::Mutex::new(PeerMap::new()));
+        let cache: ConnectionCache = Arc::new(parking_lot::Mutex::new(HashMap::new()));
+        let id = accept_ep.id();
+        peer_map
+            .lock()
+            .increment_connections(id, None, conn_a.clone());
+        peer_map
+            .lock()
+            .increment_connections(id, None, conn_b.clone());
+
+        close_peer_connections(&peer_map, &cache, &id);
+
+        assert!(
+            conn_a.close_reason().is_some(),
+            "first retained handle must be closed"
+        );
+        assert!(
+            conn_b.close_reason().is_some(),
+            "second retained handle must be closed"
+        );
+
+        accept_task.abort();
     }
 }

--- a/crates/p2p/src/iroh/endpoint_rpc.rs
+++ b/crates/p2p/src/iroh/endpoint_rpc.rs
@@ -224,6 +224,21 @@ pub(super) fn close_cached_connections(cache: &ConnectionCache, endpoint_id: &ir
     }
 }
 
+/// Hang up every connection we hold to a peer: the handle retained in
+/// `peer_map` (covering dial- and accept-initiated connections) and any cached
+/// outbound-send connections. The stream task then observes the `accept_bi`
+/// error, decrements the count, and emits `PeerDisconnected`. Idempotent.
+pub(super) fn close_peer_connections(
+    peer_map: &Arc<parking_lot::Mutex<PeerMap>>,
+    cache: &ConnectionCache,
+    endpoint_id: &iroh::EndpointId,
+) {
+    if let Some(connection) = peer_map.lock().take_connection(endpoint_id) {
+        connection.close(DISCONNECT_ERROR_CODE.into(), b"disconnect");
+    }
+    close_cached_connections(cache, endpoint_id);
+}
+
 async fn connect_with_cache(
     endpoint: &Endpoint,
     peer_id: &PeerId,
@@ -241,7 +256,7 @@ async fn connect_with_cache(
     Ok(connection)
 }
 
-async fn connect_with_direct_addr_fallback(
+pub(super) async fn connect_with_direct_addr_fallback(
     endpoint: &Endpoint,
     peer_id: &PeerId,
     alpn: &[u8],

--- a/crates/p2p/src/iroh/endpoint_streams.rs
+++ b/crates/p2p/src/iroh/endpoint_streams.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 
 use iroh::endpoint::Connection;
 use iroh::EndpointId;
-use iroh_gossip::net::Gossip;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tracing::{debug, warn};
@@ -14,22 +13,19 @@ use crate::error::Error;
 use crate::message::{Message, PushLogReply};
 use crate::transport::{PeerId, TransportEvent};
 
-use super::endpoint::{
-    join_peer_to_subscription_senders, track_task, SpawnedTasks, SubscriptionSenders,
-};
+use super::endpoint::{track_task, EndpointResources, SpawnedTasks, SubscriptionSenders};
+use super::gossip_heal;
 use super::peer_map::{endpoint_id_to_peer_id, PeerMap};
 use super::protocols;
 
 /// Handle an incoming QUIC connection.
 pub(super) async fn handle_incoming(
     incoming: iroh::endpoint::Incoming,
-    gossip: &Gossip,
-    peer_map: &Arc<parking_lot::Mutex<PeerMap>>,
+    resources: &EndpointResources,
     pending_pushlog_replies: &Arc<
         parking_lot::Mutex<HashMap<String, oneshot::Sender<PushLogReply>>>,
     >,
     subscription_senders: &SubscriptionSenders,
-    spawned_tasks: &SpawnedTasks,
     event_tx: &mpsc::Sender<TransportEvent<iroh::endpoint::SendStream>>,
 ) {
     let remote_addr = match incoming.remote_addr() {
@@ -69,7 +65,7 @@ pub(super) async fn handle_incoming(
 
     // If it's a gossip ALPN, hand off to the gossip layer
     if conn_alpn == iroh_gossip::net::GOSSIP_ALPN {
-        if let Err(e) = gossip.handle_connection(connection).await {
+        if let Err(e) = resources.gossip.handle_connection(connection).await {
             debug!("Gossip handle_connection error: {}", e);
         }
         return;
@@ -77,9 +73,11 @@ pub(super) async fn handle_incoming(
 
     let remote_id = connection.remote_id();
 
-    let is_new = peer_map
-        .lock()
-        .increment_connections(remote_id, remote_addr, connection.clone());
+    let is_new =
+        resources
+            .peer_map
+            .lock()
+            .increment_connections(remote_id, remote_addr, connection.clone());
 
     if is_new
         && event_tx
@@ -93,14 +91,14 @@ pub(super) async fn handle_incoming(
     }
 
     if is_new {
-        join_peer_to_subscription_senders(subscription_senders, remote_id).await;
+        gossip_heal::spawn_peer_connected_heal(resources, subscription_senders, remote_id);
     }
 
     // Spawn handler for this connection's streams
     let event_tx = event_tx.clone();
-    let peer_map = Arc::clone(peer_map);
+    let peer_map = Arc::clone(&resources.peer_map);
     let pending_pushlog_replies = Arc::clone(pending_pushlog_replies);
-    let spawned_tasks_for_connection = Arc::clone(spawned_tasks);
+    let spawned_tasks_for_connection = Arc::clone(&resources.spawned_tasks);
     let task = tokio::spawn(async move {
         handle_connection_streams(
             connection,
@@ -113,7 +111,7 @@ pub(super) async fn handle_incoming(
         )
         .await;
     });
-    track_task(spawned_tasks, task);
+    track_task(&resources.spawned_tasks, task);
 }
 
 /// Process streams on an accepted connection, dispatching by ALPN.

--- a/crates/p2p/src/iroh/gossip_heal.rs
+++ b/crates/p2p/src/iroh/gossip_heal.rs
@@ -56,6 +56,12 @@ pub struct GossipHealConfig {
     /// must close eventually: iroh keep-alives prevent idle cleanup, so
     /// unclosed superseded connections leak one per refresh.
     pub superseded_close_grace: Duration,
+    /// Test seam: incremented on every successful gossip path refresh this
+    /// node performs. A healthy mesh delivers regardless of who injected the
+    /// refresh (and the half-dead state cannot be induced from outside
+    /// iroh-gossip), so tests need this to assert that a specific node's
+    /// refresh path actually ran. `None` in production.
+    pub refresh_probe: Option<std::sync::Arc<std::sync::atomic::AtomicU64>>,
 }
 
 impl Default for GossipHealConfig {
@@ -66,6 +72,7 @@ impl Default for GossipHealConfig {
             backoff_cap: Duration::from_secs(60),
             max_attempts: 5,
             superseded_close_grace: Duration::from_secs(10),
+            refresh_probe: None,
         }
     }
 }
@@ -335,6 +342,9 @@ async fn refresh_peer(
         Ok(()) => {
             join_peer_to_subscription_senders(senders, endpoint_id).await;
             res.healer.record_success(endpoint_id, Instant::now());
+            if let Some(probe) = &res.healer.config().refresh_probe {
+                probe.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            }
             debug!(peer = %endpoint_id, "gossip path refreshed");
         }
         Err(error) => {

--- a/crates/p2p/src/iroh/gossip_heal.rs
+++ b/crates/p2p/src/iroh/gossip_heal.rs
@@ -1,0 +1,562 @@
+//! Gossip send-path healing (#1092).
+//!
+//! iroh-gossip can wedge a peer in `PeerState::Active` with a dead send loop:
+//! a stream-level write error kills the send half of its connection loop while
+//! the QUIC connection stays alive (iroh keep-alives), so the connection task
+//! never finishes and gossip never prunes the peer. Every subsequent send then
+//! warns "connection task send loop terminated" forever, and even our
+//! `join_peers` rejoin on reconnect is blackholed through the same dead
+//! channel.
+//!
+//! The heal: dial the peer on `GOSSIP_ALPN` ourselves and hand the connection
+//! to `Gossip::handle_connection`, which atomically replaces the (possibly
+//! dead) active send path — iroh-gossip's own duplicate-connection handling —
+//! then re-join the peer into all subscribed topics. This runs:
+//!
+//! - event-driven on every 0→1 peer connection (accept and dial), so a
+//!   returning peer heals immediately, and
+//! - on a periodic sweep with per-peer exponential backoff on dial failure,
+//!   which cures the silent half-dead state (no observable signal exists at
+//!   this layer for a dead send loop behind a live QUIC connection).
+//!
+//! After `max_attempts` consecutive failures the sweep gives up and force-
+//! closes the peer's RPC connections so `PeerDisconnected` fires and the peer
+//! is dropped until the next discovery/dial recreates it through the 0→1 path.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use iroh::endpoint::Connection;
+use iroh::EndpointId;
+use tracing::{debug, warn};
+
+use super::endpoint::{
+    join_peer_to_subscription_senders, snapshot_subscription_senders, track_task,
+    EndpointResources, SubscriptionSenders, TopicSubscription,
+};
+use super::endpoint_rpc::{close_peer_connections, connect_with_direct_addr_fallback};
+use super::peer_map::endpoint_id_to_peer_id;
+
+/// Configuration for gossip send-path healing.
+#[derive(Debug, Clone)]
+pub struct GossipHealConfig {
+    /// Cadence of the unconditional per-peer gossip path refresh. Zero
+    /// disables healing entirely (no sweep, no 0→1 refresh).
+    pub refresh_interval: Duration,
+    /// First retry delay after a failed refresh dial; doubles per attempt.
+    pub backoff_base: Duration,
+    /// Upper bound on the retry delay.
+    pub backoff_cap: Duration,
+    /// Consecutive failed attempts before giving up on the peer.
+    pub max_attempts: u32,
+}
+
+impl Default for GossipHealConfig {
+    fn default() -> Self {
+        Self {
+            refresh_interval: Duration::from_secs(60),
+            backoff_base: Duration::from_secs(2),
+            backoff_cap: Duration::from_secs(60),
+            max_attempts: 5,
+        }
+    }
+}
+
+impl GossipHealConfig {
+    /// Defaults with the refresh interval overridable via
+    /// `DEFRA_P2P_GOSSIP_HEAL_INTERVAL_SECS` (0 disables healing).
+    pub fn from_env() -> Self {
+        let mut config = Self::default();
+        if let Ok(value) = std::env::var("DEFRA_P2P_GOSSIP_HEAL_INTERVAL_SECS") {
+            if let Ok(secs) = value.parse::<u64>() {
+                config.refresh_interval = Duration::from_secs(secs);
+            }
+        }
+        config
+    }
+
+    pub fn enabled(&self) -> bool {
+        !self.refresh_interval.is_zero()
+    }
+
+    /// Sweep tick granularity: fine enough to service backoff retries
+    /// promptly, never finer than 100ms or coarser than the refresh interval.
+    pub(super) fn tick_period(&self) -> Duration {
+        if !self.enabled() {
+            return Duration::from_secs(3600);
+        }
+        self.backoff_base
+            .clamp(Duration::from_millis(100), self.refresh_interval)
+    }
+}
+
+/// Treat an in-flight refresh as lost after this long (dial timeouts bound a
+/// refresh to well under this), so a stuck flag cannot block healing forever.
+const IN_FLIGHT_STALE: Duration = Duration::from_secs(60);
+
+/// How long a superseded refresh connection is kept open before we close it.
+/// Both sides must have adopted the replacement as their active gossip
+/// connection first; closing the still-active one would make gossip interpret
+/// it as a peer disconnect and churn the topic mesh. We must close eventually:
+/// iroh keep-alives prevent idle cleanup, so unclosed superseded connections
+/// leak one per refresh.
+const SUPERSEDED_CLOSE_GRACE: Duration = Duration::from_secs(10);
+
+struct PeerHeal {
+    attempts: u32,
+    next_due: Instant,
+    in_flight_since: Option<Instant>,
+}
+
+/// Pure per-peer refresh schedule with exponential backoff. Time is injected
+/// so the state machine is deterministic under test.
+struct HealSchedule {
+    config: GossipHealConfig,
+    peers: HashMap<EndpointId, PeerHeal>,
+}
+
+impl HealSchedule {
+    fn new(config: GossipHealConfig) -> Self {
+        Self {
+            config,
+            peers: HashMap::new(),
+        }
+    }
+
+    fn backoff_delay(&self, attempts: u32) -> Duration {
+        let exp = attempts.saturating_sub(1).min(16);
+        self.config
+            .backoff_base
+            .saturating_mul(1u32 << exp)
+            .min(self.config.backoff_cap)
+    }
+
+    /// Peers whose refresh is due. Prunes departed peers, starts tracking new
+    /// ones (first refresh one interval after they appear — the 0→1 heal
+    /// already covered their connect), and marks returned peers in flight.
+    fn due_peers(&mut self, connected: &[EndpointId], now: Instant) -> Vec<EndpointId> {
+        self.peers.retain(|id, _| connected.contains(id));
+        let mut due = Vec::new();
+        for id in connected {
+            let entry = self.peers.entry(*id).or_insert_with(|| PeerHeal {
+                attempts: 0,
+                next_due: now + self.config.refresh_interval,
+                in_flight_since: None,
+            });
+            if let Some(since) = entry.in_flight_since {
+                if now.duration_since(since) < IN_FLIGHT_STALE {
+                    continue;
+                }
+            }
+            if entry.next_due <= now {
+                entry.in_flight_since = Some(now);
+                due.push(*id);
+            }
+        }
+        due
+    }
+
+    /// A fresh 0→1 connection: reset the schedule and mark the connect-time
+    /// refresh in flight so the sweep does not double-dial.
+    fn note_connected(&mut self, id: EndpointId, now: Instant) {
+        self.peers.insert(
+            id,
+            PeerHeal {
+                attempts: 0,
+                next_due: now + self.config.refresh_interval,
+                in_flight_since: Some(now),
+            },
+        );
+    }
+
+    fn record_success(&mut self, id: EndpointId, now: Instant) {
+        self.peers.insert(
+            id,
+            PeerHeal {
+                attempts: 0,
+                next_due: now + self.config.refresh_interval,
+                in_flight_since: None,
+            },
+        );
+    }
+
+    /// Returns `true` when attempts are exhausted (give up on the peer).
+    fn record_failure(&mut self, id: EndpointId, now: Instant) -> bool {
+        let entry = self.peers.entry(id).or_insert(PeerHeal {
+            attempts: 0,
+            next_due: now,
+            in_flight_since: None,
+        });
+        entry.in_flight_since = None;
+        entry.attempts += 1;
+        let attempts = entry.attempts;
+        if attempts >= self.config.max_attempts {
+            self.peers.remove(&id);
+            return true;
+        }
+        let delay = self.backoff_delay(attempts);
+        if let Some(entry) = self.peers.get_mut(&id) {
+            entry.next_due = now + delay;
+        }
+        false
+    }
+}
+
+/// Shared healer: refresh schedule plus the gossip connections we injected,
+/// retained so each refresh can close the connection it supersedes.
+pub(super) struct GossipHealer {
+    config: GossipHealConfig,
+    schedule: parking_lot::Mutex<HealSchedule>,
+    conns: parking_lot::Mutex<HashMap<EndpointId, Connection>>,
+}
+
+impl GossipHealer {
+    pub(super) fn new(config: GossipHealConfig) -> Self {
+        Self {
+            schedule: parking_lot::Mutex::new(HealSchedule::new(config.clone())),
+            conns: parking_lot::Mutex::new(HashMap::new()),
+            config,
+        }
+    }
+
+    pub(super) fn config(&self) -> &GossipHealConfig {
+        &self.config
+    }
+
+    fn due_peers(&self, connected: &[EndpointId], now: Instant) -> Vec<EndpointId> {
+        self.schedule.lock().due_peers(connected, now)
+    }
+
+    fn note_connected(&self, id: EndpointId, now: Instant) {
+        self.schedule.lock().note_connected(id, now);
+    }
+
+    fn record_success(&self, id: EndpointId, now: Instant) {
+        self.schedule.lock().record_success(id, now);
+    }
+
+    fn record_failure(&self, id: EndpointId, now: Instant) -> bool {
+        self.schedule.lock().record_failure(id, now)
+    }
+
+    fn store_conn(&self, id: EndpointId, conn: Connection) -> Option<Connection> {
+        self.conns.lock().insert(id, conn)
+    }
+
+    pub(super) fn take_conn(&self, id: &EndpointId) -> Option<Connection> {
+        self.conns.lock().remove(id)
+    }
+
+    /// Injected gossip connections whose peer is no longer connected.
+    fn take_departed_conns(&self, connected: &[EndpointId]) -> Vec<Connection> {
+        let mut conns = self.conns.lock();
+        let departed: Vec<EndpointId> = conns
+            .keys()
+            .filter(|id| !connected.contains(id))
+            .copied()
+            .collect();
+        departed
+            .into_iter()
+            .filter_map(|id| conns.remove(&id))
+            .collect()
+    }
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum HealContext {
+    PeerConnected,
+    Sweep,
+}
+
+/// Event-driven heal on a 0→1 peer connection (accept or dial): refresh the
+/// gossip path and rejoin the peer into all subscribed topics. With healing
+/// disabled, falls back to the plain rejoin.
+pub(super) fn spawn_peer_connected_heal(
+    res: &EndpointResources,
+    senders: &SubscriptionSenders,
+    endpoint_id: EndpointId,
+) {
+    if senders.is_empty() {
+        return;
+    }
+    let spawned_tasks = res.spawned_tasks.clone();
+    if !res.healer.config().enabled() {
+        let senders = senders.clone();
+        let task = tokio::spawn(async move {
+            join_peer_to_subscription_senders(&senders, endpoint_id).await;
+        });
+        track_task(&spawned_tasks, task);
+        return;
+    }
+    res.healer.note_connected(endpoint_id, Instant::now());
+    let res = res.clone();
+    let senders = senders.clone();
+    let task = tokio::spawn(async move {
+        refresh_peer(&res, &senders, endpoint_id, HealContext::PeerConnected).await;
+    });
+    track_task(&spawned_tasks, task);
+}
+
+/// Periodic sweep: refresh due peers and drop injected connections to
+/// departed peers.
+pub(super) fn sweep(res: &EndpointResources, subscriptions: &HashMap<String, TopicSubscription>) {
+    let connected: Vec<EndpointId> = res.peer_map.lock().endpoint_ids().collect();
+    for conn in res.healer.take_departed_conns(&connected) {
+        conn.close(0u32.into(), b"gossip-heal");
+    }
+
+    let senders = snapshot_subscription_senders(subscriptions);
+    if senders.is_empty() {
+        return;
+    }
+    for endpoint_id in res.healer.due_peers(&connected, Instant::now()) {
+        let task_res = res.clone();
+        let senders = senders.clone();
+        let task = tokio::spawn(async move {
+            refresh_peer(&task_res, &senders, endpoint_id, HealContext::Sweep).await;
+        });
+        track_task(&res.spawned_tasks, task);
+    }
+}
+
+async fn refresh_peer(
+    res: &EndpointResources,
+    senders: &SubscriptionSenders,
+    endpoint_id: EndpointId,
+    ctx: HealContext,
+) {
+    match dial_and_inject(res, endpoint_id).await {
+        Ok(()) => {
+            join_peer_to_subscription_senders(senders, endpoint_id).await;
+            res.healer.record_success(endpoint_id, Instant::now());
+            debug!(peer = %endpoint_id, "gossip path refreshed");
+        }
+        Err(error) => {
+            if ctx == HealContext::PeerConnected {
+                // Preserve the pre-heal rejoin: gossip's own dialer may still
+                // reach the peer (e.g. via addresses only it has learned).
+                join_peer_to_subscription_senders(senders, endpoint_id).await;
+            }
+            let gave_up = res.healer.record_failure(endpoint_id, Instant::now());
+            if gave_up && ctx == HealContext::Sweep {
+                // Only force-close when we successfully dialed this peer's
+                // gossip path before (a tracked injected connection exists):
+                // dialability regressed, so the remaining RPC connections are
+                // almost certainly stale too. A peer we could never dial back
+                // (e.g. NAT'd inbound, no relay) keeps its healthy inbound
+                // connections; healing just cools down until re-tracked.
+                if let Some(conn) = res.healer.take_conn(&endpoint_id) {
+                    warn!(
+                        peer = %endpoint_id,
+                        error = %error,
+                        "gossip path heal exhausted; dropping peer connections until rediscovery"
+                    );
+                    conn.close(0u32.into(), b"gossip-heal");
+                    close_peer_connections(&res.peer_map, &res.connection_cache, &endpoint_id);
+                } else {
+                    debug!(
+                        peer = %endpoint_id,
+                        error = %error,
+                        "gossip path heal exhausted for undialable peer; cooling down"
+                    );
+                }
+            } else {
+                debug!(
+                    peer = %endpoint_id,
+                    error = %error,
+                    "gossip path refresh failed; retrying with backoff"
+                );
+            }
+        }
+    }
+}
+
+/// Dial `GOSSIP_ALPN` and hand the connection to gossip, replacing the active
+/// send path for the peer. Closes the connection this one supersedes after a
+/// grace period.
+async fn dial_and_inject(
+    res: &EndpointResources,
+    endpoint_id: EndpointId,
+) -> crate::error::Result<()> {
+    let peer_id = endpoint_id_to_peer_id(&endpoint_id);
+    let direct_addr = {
+        let map = res.peer_map.lock();
+        map.get(&endpoint_id).and_then(|info| info.remote_addr)
+    };
+    let conn = connect_with_direct_addr_fallback(
+        &res.endpoint,
+        &peer_id,
+        iroh_gossip::net::GOSSIP_ALPN,
+        direct_addr,
+    )
+    .await?;
+    res.gossip
+        .handle_connection(conn.clone())
+        .await
+        .map_err(|e| crate::error::Error::Transport(format!("gossip handle_connection: {}", e)))?;
+
+    if let Some(previous) = res.healer.store_conn(endpoint_id, conn) {
+        let task = tokio::spawn(async move {
+            tokio::time::sleep(SUPERSEDED_CLOSE_GRACE).await;
+            previous.close(0u32.into(), b"gossip-refresh");
+        });
+        track_task(&res.spawned_tasks, task);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_id() -> EndpointId {
+        iroh::SecretKey::generate().public()
+    }
+
+    fn schedule() -> HealSchedule {
+        HealSchedule::new(GossipHealConfig {
+            refresh_interval: Duration::from_secs(60),
+            backoff_base: Duration::from_secs(2),
+            backoff_cap: Duration::from_secs(30),
+            max_attempts: 3,
+        })
+    }
+
+    #[test]
+    fn new_peer_is_due_one_interval_after_appearing() {
+        let mut s = schedule();
+        let id = test_id();
+        let t0 = Instant::now();
+
+        assert!(s.due_peers(&[id], t0).is_empty());
+        assert!(s.due_peers(&[id], t0 + Duration::from_secs(59)).is_empty());
+        assert_eq!(s.due_peers(&[id], t0 + Duration::from_secs(60)), vec![id]);
+    }
+
+    #[test]
+    fn in_flight_peer_is_not_redialed_until_stale() {
+        let mut s = schedule();
+        let id = test_id();
+        let t0 = Instant::now();
+        let due_at = t0 + Duration::from_secs(60);
+
+        assert!(s.due_peers(&[id], t0).is_empty());
+        assert_eq!(s.due_peers(&[id], due_at), vec![id]);
+        assert!(s
+            .due_peers(&[id], due_at + Duration::from_secs(1))
+            .is_empty());
+        assert_eq!(s.due_peers(&[id], due_at + IN_FLIGHT_STALE), vec![id]);
+    }
+
+    #[test]
+    fn failure_backoff_doubles_and_caps() {
+        let mut s = schedule();
+        let id = test_id();
+        let t0 = Instant::now();
+        s.due_peers(&[id], t0);
+
+        assert!(!s.record_failure(id, t0));
+        assert!(s.due_peers(&[id], t0 + Duration::from_secs(1)).is_empty());
+        assert_eq!(s.due_peers(&[id], t0 + Duration::from_secs(2)), vec![id]);
+
+        let t1 = t0 + Duration::from_secs(2);
+        assert!(!s.record_failure(id, t1));
+        assert!(s.due_peers(&[id], t1 + Duration::from_secs(3)).is_empty());
+        assert_eq!(s.due_peers(&[id], t1 + Duration::from_secs(4)), vec![id]);
+    }
+
+    #[test]
+    fn backoff_delay_is_capped() {
+        let s = schedule();
+        assert_eq!(s.backoff_delay(1), Duration::from_secs(2));
+        assert_eq!(s.backoff_delay(2), Duration::from_secs(4));
+        assert_eq!(s.backoff_delay(4), Duration::from_secs(16));
+        assert_eq!(s.backoff_delay(5), Duration::from_secs(30));
+        assert_eq!(s.backoff_delay(60), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn gives_up_after_max_attempts_and_retracks_after_interval() {
+        let mut s = schedule();
+        let id = test_id();
+        let t0 = Instant::now();
+        s.due_peers(&[id], t0);
+
+        assert!(!s.record_failure(id, t0));
+        assert!(!s.record_failure(id, t0));
+        assert!(s.record_failure(id, t0), "third failure must give up");
+        assert!(!s.peers.contains_key(&id), "given-up peer is untracked");
+
+        // If the peer somehow stays connected, tracking restarts from scratch.
+        assert!(s.due_peers(&[id], t0 + Duration::from_secs(1)).is_empty());
+        assert_eq!(s.due_peers(&[id], t0 + Duration::from_secs(61)), vec![id]);
+    }
+
+    #[test]
+    fn success_resets_attempts() {
+        let mut s = schedule();
+        let id = test_id();
+        let t0 = Instant::now();
+        s.due_peers(&[id], t0);
+
+        assert!(!s.record_failure(id, t0));
+        assert!(!s.record_failure(id, t0));
+        s.record_success(id, t0);
+        assert!(!s.record_failure(id, t0), "attempts restart after success");
+        assert!(!s.record_failure(id, t0));
+    }
+
+    #[test]
+    fn success_schedules_next_refresh_one_interval_out() {
+        let mut s = schedule();
+        let id = test_id();
+        let t0 = Instant::now();
+        s.record_success(id, t0);
+
+        assert!(s.due_peers(&[id], t0 + Duration::from_secs(59)).is_empty());
+        assert_eq!(s.due_peers(&[id], t0 + Duration::from_secs(60)), vec![id]);
+    }
+
+    #[test]
+    fn departed_peers_are_pruned() {
+        let mut s = schedule();
+        let id = test_id();
+        let t0 = Instant::now();
+        s.due_peers(&[id], t0);
+        assert!(s.peers.contains_key(&id));
+
+        s.due_peers(&[], t0 + Duration::from_secs(1));
+        assert!(!s.peers.contains_key(&id));
+    }
+
+    #[test]
+    fn note_connected_marks_in_flight_and_resets() {
+        let mut s = schedule();
+        let id = test_id();
+        let t0 = Instant::now();
+        s.due_peers(&[id], t0);
+        s.record_failure(id, t0);
+
+        s.note_connected(id, t0);
+        assert!(
+            s.due_peers(&[id], t0 + Duration::from_secs(2)).is_empty(),
+            "connect-time refresh is in flight; sweep must not double-dial"
+        );
+        s.record_success(id, t0 + Duration::from_secs(1));
+        assert_eq!(s.peers.get(&id).unwrap().attempts, 0);
+    }
+
+    #[test]
+    fn disabled_config_has_idle_tick() {
+        let config = GossipHealConfig {
+            refresh_interval: Duration::ZERO,
+            ..Default::default()
+        };
+        assert!(!config.enabled());
+        assert_eq!(config.tick_period(), Duration::from_secs(3600));
+
+        let enabled = GossipHealConfig::default();
+        assert!(enabled.enabled());
+        assert_eq!(enabled.tick_period(), Duration::from_secs(2));
+    }
+}

--- a/crates/p2p/src/iroh/gossip_heal.rs
+++ b/crates/p2p/src/iroh/gossip_heal.rs
@@ -49,6 +49,13 @@ pub struct GossipHealConfig {
     pub backoff_cap: Duration,
     /// Consecutive failed attempts before giving up on the peer.
     pub max_attempts: u32,
+    /// How long a superseded refresh connection is kept open before we close
+    /// it. Both sides must have adopted the replacement as their active
+    /// gossip connection first; closing the still-active one would make
+    /// gossip interpret it as a peer disconnect and churn the topic mesh. We
+    /// must close eventually: iroh keep-alives prevent idle cleanup, so
+    /// unclosed superseded connections leak one per refresh.
+    pub superseded_close_grace: Duration,
 }
 
 impl Default for GossipHealConfig {
@@ -58,6 +65,7 @@ impl Default for GossipHealConfig {
             backoff_base: Duration::from_secs(2),
             backoff_cap: Duration::from_secs(60),
             max_attempts: 5,
+            superseded_close_grace: Duration::from_secs(10),
         }
     }
 }
@@ -85,22 +93,17 @@ impl GossipHealConfig {
         if !self.enabled() {
             return Duration::from_secs(3600);
         }
+        let floor = Duration::from_millis(100);
+        // max(floor) keeps the clamp bounds ordered for refresh intervals
+        // under the floor, which would otherwise panic.
         self.backoff_base
-            .clamp(Duration::from_millis(100), self.refresh_interval)
+            .clamp(floor, self.refresh_interval.max(floor))
     }
 }
 
 /// Treat an in-flight refresh as lost after this long (dial timeouts bound a
 /// refresh to well under this), so a stuck flag cannot block healing forever.
 const IN_FLIGHT_STALE: Duration = Duration::from_secs(60);
-
-/// How long a superseded refresh connection is kept open before we close it.
-/// Both sides must have adopted the replacement as their active gossip
-/// connection first; closing the still-active one would make gossip interpret
-/// it as a peer disconnect and churn the topic mesh. We must close eventually:
-/// iroh keep-alives prevent idle cleanup, so unclosed superseded connections
-/// leak one per refresh.
-const SUPERSEDED_CLOSE_GRACE: Duration = Duration::from_secs(10);
 
 struct PeerHeal {
     attempts: u32,
@@ -276,11 +279,11 @@ pub(super) fn spawn_peer_connected_heal(
     senders: &SubscriptionSenders,
     endpoint_id: EndpointId,
 ) {
-    if senders.is_empty() {
-        return;
-    }
     let spawned_tasks = res.spawned_tasks.clone();
     if !res.healer.config().enabled() {
+        if senders.is_empty() {
+            return;
+        }
         let senders = senders.clone();
         let task = tokio::spawn(async move {
             join_peer_to_subscription_senders(&senders, endpoint_id).await;
@@ -288,6 +291,10 @@ pub(super) fn spawn_peer_connected_heal(
         track_task(&spawned_tasks, task);
         return;
     }
+    // Refresh even with no persistent subscriptions: ephemeral publishers
+    // (publish/publish_raw without subscribe) ride the same per-peer gossip
+    // send path, which can be equally dead. The topic rejoin below is then a
+    // no-op.
     res.healer.note_connected(endpoint_id, Instant::now());
     let res = res.clone();
     let senders = senders.clone();
@@ -305,10 +312,9 @@ pub(super) fn sweep(res: &EndpointResources, subscriptions: &HashMap<String, Top
         conn.close(0u32.into(), b"gossip-heal");
     }
 
+    // Sweep even with no persistent subscriptions — ephemeral publishers use
+    // the same per-peer gossip send path (see spawn_peer_connected_heal).
     let senders = snapshot_subscription_senders(subscriptions);
-    if senders.is_empty() {
-        return;
-    }
     for endpoint_id in res.healer.due_peers(&connected, Instant::now()) {
         let task_res = res.clone();
         let senders = senders.clone();
@@ -396,8 +402,9 @@ async fn dial_and_inject(
         .map_err(|e| crate::error::Error::Transport(format!("gossip handle_connection: {}", e)))?;
 
     if let Some(previous) = res.healer.store_conn(endpoint_id, conn) {
+        let grace = res.healer.config().superseded_close_grace;
         let task = tokio::spawn(async move {
-            tokio::time::sleep(SUPERSEDED_CLOSE_GRACE).await;
+            tokio::time::sleep(grace).await;
             previous.close(0u32.into(), b"gossip-refresh");
         });
         track_task(&res.spawned_tasks, task);
@@ -419,6 +426,7 @@ mod tests {
             backoff_base: Duration::from_secs(2),
             backoff_cap: Duration::from_secs(30),
             max_attempts: 3,
+            ..Default::default()
         })
     }
 
@@ -558,5 +566,16 @@ mod tests {
         let enabled = GossipHealConfig::default();
         assert!(enabled.enabled());
         assert_eq!(enabled.tick_period(), Duration::from_secs(2));
+    }
+
+    #[test]
+    fn sub_floor_refresh_interval_does_not_panic() {
+        let config = GossipHealConfig {
+            refresh_interval: Duration::from_millis(50),
+            backoff_base: Duration::from_millis(10),
+            ..Default::default()
+        };
+        assert!(config.enabled());
+        assert_eq!(config.tick_period(), Duration::from_millis(100));
     }
 }

--- a/crates/p2p/src/iroh/mod.rs
+++ b/crates/p2p/src/iroh/mod.rs
@@ -17,6 +17,7 @@ mod endpoint_commands;
 mod endpoint_config;
 mod endpoint_rpc;
 mod endpoint_streams;
+mod gossip_heal;
 mod peer_map;
 mod protocols;
 mod secret_key;
@@ -29,5 +30,6 @@ pub use addr::{
 pub use config::{IrohDiscoveryConfig, IrohRelayModeConfig};
 pub use endpoint::spawn_endpoint;
 pub use endpoint_config::IrohEndpointConfig;
+pub use gossip_heal::GossipHealConfig;
 pub use secret_key::load_or_generate_secret_key;
 pub use transport::IrohTransport;

--- a/crates/p2p/src/iroh/peer_map.rs
+++ b/crates/p2p/src/iroh/peer_map.rs
@@ -26,10 +26,13 @@ pub fn endpoint_id_to_peer_id(id: &EndpointId) -> PeerId {
 pub struct ConnectionInfo {
     pub remote_addr: Option<SocketAddr>,
     pub active_connections: u32,
-    /// A handle to the underlying QUIC connection, used to hang up on
-    /// `disconnect`. iroh `Connection` clones share the same QUIC connection,
-    /// so closing this handle closes the connection for the peer.
-    connection: Option<Connection>,
+    /// Handles to every live QUIC connection, used to hang up on
+    /// `disconnect`. A peer can hold several concurrent connections (one per
+    /// ALPN, dial + accept); all must be closed or the count never reaches
+    /// zero and `PeerDisconnected` never fires. iroh `Connection` clones
+    /// share the underlying QUIC connection, so closing a handle closes that
+    /// connection.
+    handles: Vec<Connection>,
 }
 
 /// Tracks connected peers and their connection info.
@@ -59,7 +62,10 @@ impl PeerMap {
             if let Some(addr) = remote_addr {
                 info.remote_addr = Some(addr);
             }
-            info.connection = Some(connection);
+            // Already-closed handles would otherwise accumulate for a
+            // long-lived peer whose connections churn.
+            info.handles.retain(|conn| conn.close_reason().is_none());
+            info.handles.push(connection);
             false
         } else {
             self.connections.insert(
@@ -67,21 +73,23 @@ impl PeerMap {
                 ConnectionInfo {
                     remote_addr,
                     active_connections: 1,
-                    connection: Some(connection),
+                    handles: vec![connection],
                 },
             );
             true
         }
     }
 
-    /// Take the retained connection handle for a peer without removing the
-    /// connection-count entry. Returns `None` if the peer is unknown or no
-    /// handle was retained. Used by `disconnect` to close the live connection;
-    /// the count entry is then cleared by the stream task on `accept_bi` error.
-    pub fn take_connection(&mut self, id: &EndpointId) -> Option<Connection> {
+    /// Take every retained connection handle for a peer without removing the
+    /// connection-count entry. Returns an empty vec if the peer is unknown or
+    /// no handles were retained. Used by `disconnect` to close the live
+    /// connections; the count entry is then cleared by the stream tasks on
+    /// `accept_bi` error.
+    pub fn take_connections(&mut self, id: &EndpointId) -> Vec<Connection> {
         self.connections
             .get_mut(id)
-            .and_then(|info| info.connection.take())
+            .map(|info| std::mem::take(&mut info.handles))
+            .unwrap_or_default()
     }
 
     /// Decrement connection count for a peer. Returns `true` if the count

--- a/crates/p2p/src/iroh/transport.rs
+++ b/crates/p2p/src/iroh/transport.rs
@@ -519,6 +519,7 @@ mod tests {
             discovery: IrohDiscoveryConfig::Disabled,
             bind_port: None,
             bind_addr: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+            gossip_heal: Default::default(),
         }
     }
 

--- a/tools/integration-test/tests/p2p_iroh/connection/gossip_heal.rs
+++ b/tools/integration-test/tests/p2p_iroh/connection/gossip_heal.rs
@@ -198,6 +198,7 @@ async fn sweep_refresh_preserves_gossip_delivery() {
         backoff_cap: Duration::from_secs(2),
         max_attempts: 5,
         superseded_close_grace: Duration::from_millis(750),
+        refresh_probe: None,
     };
     let config0 = test_config(fast_heal.clone()).await;
     let config1 = test_config(fast_heal).await;
@@ -294,9 +295,19 @@ async fn sweep_refresh_covers_publish_only_node() {
         backoff_cap: Duration::from_secs(2),
         max_attempts: 5,
         superseded_close_grace: Duration::from_millis(750),
+        refresh_probe: None,
     };
+    // A healthy mesh delivers even if node 1 never refreshes (node 0's
+    // healing and gossip's own dialing both suffice), so delivery alone
+    // cannot regress on the empty-subscription guard. The probe asserts that
+    // the publish-only node itself performed refreshes.
+    let publish_only_refreshes = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
     let config0 = test_config(fast_heal.clone()).await;
-    let config1 = test_config(fast_heal).await;
+    let config1 = test_config(GossipHealConfig {
+        refresh_probe: Some(publish_only_refreshes.clone()),
+        ..fast_heal
+    })
+    .await;
     let key0 = config0.secret_key.clone();
     let key1 = config1.secret_key.clone();
 
@@ -336,6 +347,16 @@ async fn sweep_refresh_covers_publish_only_node() {
     // pass on both sides, with node 1's schedule driven purely by the
     // empty-subscription path.
     tokio::time::sleep(Duration::from_secs(3)).await;
+
+    // >= 2 requires at least one sweep-driven refresh on top of the single
+    // connect-time (0->1) refresh, so a regression in either empty-
+    // subscription path fails here.
+    let refreshes = publish_only_refreshes.load(std::sync::atomic::Ordering::Relaxed);
+    assert!(
+        refreshes >= 2,
+        "publish-only node performed {refreshes} gossip path refresh(es); \
+         expected the connect-time refresh plus sweep-driven refreshes"
+    );
 
     assert_raw_delivery(
         &transport1,

--- a/tools/integration-test/tests/p2p_iroh/connection/gossip_heal.rs
+++ b/tools/integration-test/tests/p2p_iroh/connection/gossip_heal.rs
@@ -185,8 +185,11 @@ async fn remesh_after_peer_restart() {
 }
 
 /// The periodic heal sweep unconditionally re-dials the gossip path and swaps
-/// the active gossip connection. Run several sweep cycles on a healthy mesh
-/// and assert gossip delivery still works in both directions afterwards.
+/// the active gossip connection; each superseded connection is closed after a
+/// grace period. Run several sweep cycles on a healthy mesh — long enough
+/// that multiple superseded-connection closes fire while the mesh is live —
+/// and assert the closes cause no neighbor churn (no PeerUnsubscribed) and
+/// gossip delivery still works in both directions afterwards.
 #[tokio::test]
 async fn sweep_refresh_preserves_gossip_delivery() {
     let fast_heal = GossipHealConfig {
@@ -194,6 +197,7 @@ async fn sweep_refresh_preserves_gossip_delivery() {
         backoff_base: Duration::from_millis(200),
         backoff_cap: Duration::from_secs(2),
         max_attempts: 5,
+        superseded_close_grace: Duration::from_millis(750),
     };
     let config0 = test_config(fast_heal.clone()).await;
     let config1 = test_config(fast_heal).await;
@@ -240,8 +244,22 @@ async fn sweep_refresh_preserves_gossip_delivery() {
     wait_peer_subscribed(&mut events0, ENCRYPTION_TOPIC, "initial mesh, node 0").await;
     wait_peer_subscribed(&mut events1, ENCRYPTION_TOPIC, "initial mesh, node 1").await;
 
-    // Let several sweep cycles refresh the gossip path on both sides.
+    // Let several sweep cycles refresh the gossip path on both sides, long
+    // enough (4× the 750ms grace) that superseded-connection closes fire
+    // while the mesh is live — the delayed close must not read as a peer
+    // disconnect.
     tokio::time::sleep(Duration::from_secs(3)).await;
+
+    for (events, node) in [(&mut events0, "node 0"), (&mut events1, "node 1")] {
+        while let Ok(event) = events.try_recv() {
+            if let TransportEvent::PeerUnsubscribed { topic, .. } = &event {
+                assert_ne!(
+                    topic, ENCRYPTION_TOPIC,
+                    "superseded-connection close churned the gossip mesh on {node}"
+                );
+            }
+        }
+    }
 
     assert_raw_delivery(
         &transport0,
@@ -255,6 +273,75 @@ async fn sweep_refresh_preserves_gossip_delivery() {
         &mut events0,
         vec![0xBB, 0x02],
         "1→0 after sweeps",
+    )
+    .await;
+
+    transport0.shutdown().await.expect("shutdown 0");
+    transport1.shutdown().await.expect("shutdown 1");
+    task0.await.expect("endpoint task 0");
+    task1.await.expect("endpoint task 1");
+}
+
+/// A publish-only node (publish_raw without any persistent subscription — the
+/// KMS `_response` responder shape) rides the same per-peer gossip send path,
+/// so the heal sweep must refresh it too, and the refresh must not disrupt
+/// ephemeral publishing.
+#[tokio::test]
+async fn sweep_refresh_covers_publish_only_node() {
+    let fast_heal = GossipHealConfig {
+        refresh_interval: Duration::from_millis(500),
+        backoff_base: Duration::from_millis(200),
+        backoff_cap: Duration::from_secs(2),
+        max_attempts: 5,
+        superseded_close_grace: Duration::from_millis(750),
+    };
+    let config0 = test_config(fast_heal.clone()).await;
+    let config1 = test_config(fast_heal).await;
+    let key0 = config0.secret_key.clone();
+    let key1 = config1.secret_key.clone();
+
+    let (tx0, mut events0, _r0, task0) = spawn_endpoint(config0).await.expect("spawn endpoint 0");
+    let (tx1, _events1, _r1, task1) = spawn_endpoint(config1).await.expect("spawn endpoint 1");
+    let transport0 = IrohTransport::new(tx0, key0);
+    let transport1 = IrohTransport::new(tx1, key1);
+
+    transport0
+        .dial(
+            transport1.local_peer_id(),
+            transport1.listen_addresses().await.expect("addrs 1"),
+        )
+        .await
+        .expect("dial 0→1");
+    transport0
+        .poll_until_connected(transport1.local_peer_id(), Duration::from_secs(5))
+        .await
+        .expect("0 sees 1");
+    transport1
+        .poll_until_connected(transport0.local_peer_id(), Duration::from_secs(5))
+        .await
+        .expect("1 sees 0");
+
+    // Only node 0 subscribes; node 1 never does (publish-only).
+    transport0
+        .subscribe(DefraTopic::Encryption)
+        .await
+        .expect("subscribe 0");
+    transport0
+        .register_pubsub_rpc_topic(ENCRYPTION_TOPIC.to_string())
+        .await
+        .expect("raw topic 0");
+
+    // No PeerSubscribed to wait for: node 1 only joins the topic ephemerally
+    // at publish time. Several sweep cycles and superseded-connection closes
+    // pass on both sides, with node 1's schedule driven purely by the
+    // empty-subscription path.
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    assert_raw_delivery(
+        &transport1,
+        &mut events0,
+        vec![0xEE, 0x03],
+        "publish-only 1→0 after sweeps",
     )
     .await;
 

--- a/tools/integration-test/tests/p2p_iroh/connection/gossip_heal.rs
+++ b/tools/integration-test/tests/p2p_iroh/connection/gossip_heal.rs
@@ -1,0 +1,265 @@
+//! Gossip send-path healing tests (#1092).
+//!
+//! In-process approximation of the acceptance scenario: kill one peer's
+//! transport, bring it back, and assert the survivor re-establishes the
+//! gossip mesh (PeerSubscribed again) and message delivery. Also verifies
+//! that the periodic gossip path refresh (the heal sweep) does not disrupt
+//! a healthy mesh.
+//!
+//! Run with:
+//!   cargo test -p integration-test --test p2p_iroh -- connection::gossip_heal
+
+use std::net::{IpAddr, Ipv4Addr};
+use std::time::Duration;
+
+use p2p::iroh::{
+    load_or_generate_secret_key, spawn_endpoint, GossipHealConfig, IrohDiscoveryConfig,
+    IrohEndpointConfig, IrohRelayModeConfig, IrohTransport,
+};
+use p2p::topics::{DefraTopic, ENCRYPTION_TOPIC};
+use p2p::{P2PTransport, TransportEvent};
+use tokio::sync::mpsc::Receiver;
+use tokio::time::timeout;
+
+async fn test_config(gossip_heal: GossipHealConfig) -> IrohEndpointConfig {
+    IrohEndpointConfig {
+        secret_key: load_or_generate_secret_key(None)
+            .await
+            .expect("generate iroh key"),
+        relay_mode: IrohRelayModeConfig::Disabled,
+        discovery: IrohDiscoveryConfig::Disabled,
+        bind_port: None,
+        bind_addr: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+        gossip_heal,
+    }
+}
+
+async fn wait_peer_subscribed<T>(
+    events: &mut Receiver<TransportEvent<T>>,
+    want_topic: &str,
+    context: &str,
+) {
+    loop {
+        let event = timeout(Duration::from_secs(15), events.recv())
+            .await
+            .unwrap_or_else(|_| panic!("timed out waiting for PeerSubscribed ({context})"))
+            .expect("iroh event channel closed");
+        if let TransportEvent::PeerSubscribed { topic, .. } = &event {
+            if topic == want_topic {
+                return;
+            }
+        }
+    }
+}
+
+async fn wait_peer_unsubscribed<T>(
+    events: &mut Receiver<TransportEvent<T>>,
+    want_topic: &str,
+    context: &str,
+) {
+    loop {
+        let event = timeout(Duration::from_secs(30), events.recv())
+            .await
+            .unwrap_or_else(|_| panic!("timed out waiting for PeerUnsubscribed ({context})"))
+            .expect("iroh event channel closed");
+        if let TransportEvent::PeerUnsubscribed { topic, .. } = &event {
+            if topic == want_topic {
+                return;
+            }
+        }
+    }
+}
+
+async fn assert_raw_delivery<T>(
+    from: &IrohTransport,
+    to_events: &mut Receiver<TransportEvent<T>>,
+    payload: Vec<u8>,
+    context: &str,
+) {
+    from.publish_raw(ENCRYPTION_TOPIC.to_string(), payload.clone())
+        .await
+        .expect("publish_raw");
+    loop {
+        let event = timeout(Duration::from_secs(10), to_events.recv())
+            .await
+            .unwrap_or_else(|_| panic!("timed out waiting for gossip delivery ({context})"))
+            .expect("iroh event channel closed");
+        if let TransportEvent::GossipRawMessage { topic, data, .. } = event {
+            if topic == ENCRYPTION_TOPIC && data == payload {
+                return;
+            }
+        }
+    }
+}
+
+/// Acceptance-shaped regression (#1092): kill one peer's transport, restart
+/// it under the same identity, and assert the survivor's gossip mesh heals —
+/// PeerSubscribed fires again and messages flow — via the 0→1 reconnect heal.
+#[tokio::test]
+async fn remesh_after_peer_restart() {
+    let config0 = test_config(GossipHealConfig::default()).await;
+    let config1 = test_config(GossipHealConfig::default()).await;
+    let key0 = config0.secret_key.clone();
+    let key1 = config1.secret_key.clone();
+
+    let (tx0, mut events0, _r0, task0) = spawn_endpoint(config0).await.expect("spawn endpoint 0");
+    let (tx1, mut events1, _r1, task1) = spawn_endpoint(config1).await.expect("spawn endpoint 1");
+    let transport0 = IrohTransport::new(tx0, key0);
+    let transport1 = IrohTransport::new(tx1, key1.clone());
+
+    transport0
+        .dial(
+            transport1.local_peer_id(),
+            transport1.listen_addresses().await.expect("addrs 1"),
+        )
+        .await
+        .expect("dial 0→1");
+    transport0
+        .poll_until_connected(transport1.local_peer_id(), Duration::from_secs(5))
+        .await
+        .expect("0 sees 1");
+    transport1
+        .poll_until_connected(transport0.local_peer_id(), Duration::from_secs(5))
+        .await
+        .expect("1 sees 0");
+
+    transport0
+        .subscribe(DefraTopic::Encryption)
+        .await
+        .expect("subscribe 0");
+    transport1
+        .subscribe(DefraTopic::Encryption)
+        .await
+        .expect("subscribe 1");
+    transport0
+        .register_pubsub_rpc_topic(ENCRYPTION_TOPIC.to_string())
+        .await
+        .expect("raw topic 0");
+    wait_peer_subscribed(&mut events0, ENCRYPTION_TOPIC, "initial mesh, node 0").await;
+    wait_peer_subscribed(&mut events1, ENCRYPTION_TOPIC, "initial mesh, node 1").await;
+
+    // Kill node 1's transport entirely.
+    transport1.shutdown().await.expect("shutdown 1");
+    task1.await.expect("endpoint task 1");
+    drop(transport1);
+    wait_peer_unsubscribed(&mut events0, ENCRYPTION_TOPIC, "after node 1 death").await;
+
+    // Bring node 1 back under the same identity (new ephemeral port).
+    let mut config1b = test_config(GossipHealConfig::default()).await;
+    config1b.secret_key = key1.clone();
+    let (tx1b, mut events1b, _r1b, task1b) =
+        spawn_endpoint(config1b).await.expect("respawn endpoint 1");
+    let transport1b = IrohTransport::new(tx1b, key1);
+    transport1b
+        .subscribe(DefraTopic::Encryption)
+        .await
+        .expect("resubscribe 1");
+
+    transport0
+        .dial(
+            transport1b.local_peer_id(),
+            transport1b.listen_addresses().await.expect("addrs 1b"),
+        )
+        .await
+        .expect("redial 0→1");
+    transport0
+        .poll_until_connected(transport1b.local_peer_id(), Duration::from_secs(5))
+        .await
+        .expect("0 sees 1 again");
+
+    wait_peer_subscribed(&mut events0, ENCRYPTION_TOPIC, "healed mesh, node 0").await;
+    wait_peer_subscribed(&mut events1b, ENCRYPTION_TOPIC, "healed mesh, node 1").await;
+
+    assert_raw_delivery(
+        &transport1b,
+        &mut events0,
+        vec![0xCB, 0x01, 0x02],
+        "1→0 after heal",
+    )
+    .await;
+
+    transport0.shutdown().await.expect("shutdown 0");
+    transport1b.shutdown().await.expect("shutdown 1b");
+    task0.await.expect("endpoint task 0");
+    task1b.await.expect("endpoint task 1b");
+}
+
+/// The periodic heal sweep unconditionally re-dials the gossip path and swaps
+/// the active gossip connection. Run several sweep cycles on a healthy mesh
+/// and assert gossip delivery still works in both directions afterwards.
+#[tokio::test]
+async fn sweep_refresh_preserves_gossip_delivery() {
+    let fast_heal = GossipHealConfig {
+        refresh_interval: Duration::from_millis(500),
+        backoff_base: Duration::from_millis(200),
+        backoff_cap: Duration::from_secs(2),
+        max_attempts: 5,
+    };
+    let config0 = test_config(fast_heal.clone()).await;
+    let config1 = test_config(fast_heal).await;
+    let key0 = config0.secret_key.clone();
+    let key1 = config1.secret_key.clone();
+
+    let (tx0, mut events0, _r0, task0) = spawn_endpoint(config0).await.expect("spawn endpoint 0");
+    let (tx1, mut events1, _r1, task1) = spawn_endpoint(config1).await.expect("spawn endpoint 1");
+    let transport0 = IrohTransport::new(tx0, key0);
+    let transport1 = IrohTransport::new(tx1, key1);
+
+    transport0
+        .dial(
+            transport1.local_peer_id(),
+            transport1.listen_addresses().await.expect("addrs 1"),
+        )
+        .await
+        .expect("dial 0→1");
+    transport0
+        .poll_until_connected(transport1.local_peer_id(), Duration::from_secs(5))
+        .await
+        .expect("0 sees 1");
+    transport1
+        .poll_until_connected(transport0.local_peer_id(), Duration::from_secs(5))
+        .await
+        .expect("1 sees 0");
+
+    transport0
+        .subscribe(DefraTopic::Encryption)
+        .await
+        .expect("subscribe 0");
+    transport1
+        .subscribe(DefraTopic::Encryption)
+        .await
+        .expect("subscribe 1");
+    transport0
+        .register_pubsub_rpc_topic(ENCRYPTION_TOPIC.to_string())
+        .await
+        .expect("raw topic 0");
+    transport1
+        .register_pubsub_rpc_topic(ENCRYPTION_TOPIC.to_string())
+        .await
+        .expect("raw topic 1");
+    wait_peer_subscribed(&mut events0, ENCRYPTION_TOPIC, "initial mesh, node 0").await;
+    wait_peer_subscribed(&mut events1, ENCRYPTION_TOPIC, "initial mesh, node 1").await;
+
+    // Let several sweep cycles refresh the gossip path on both sides.
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    assert_raw_delivery(
+        &transport0,
+        &mut events1,
+        vec![0xAA, 0x01],
+        "0→1 after sweeps",
+    )
+    .await;
+    assert_raw_delivery(
+        &transport1,
+        &mut events0,
+        vec![0xBB, 0x02],
+        "1→0 after sweeps",
+    )
+    .await;
+
+    transport0.shutdown().await.expect("shutdown 0");
+    transport1.shutdown().await.expect("shutdown 1");
+    task0.await.expect("endpoint task 0");
+    task1.await.expect("endpoint task 1");
+}

--- a/tools/integration-test/tests/p2p_iroh/connection/mod.rs
+++ b/tools/integration-test/tests/p2p_iroh/connection/mod.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::module_inception)]
 
 mod connection;
+mod gossip_heal;
 mod manage_relay;
 mod management;
 mod se_query;

--- a/tools/integration-test/tests/p2p_iroh/connection/se_query.rs
+++ b/tools/integration-test/tests/p2p_iroh/connection/se_query.rs
@@ -23,6 +23,7 @@ async fn test_config() -> IrohEndpointConfig {
         discovery: IrohDiscoveryConfig::Disabled,
         bind_port: None,
         bind_addr: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+        gossip_heal: Default::default(),
     }
 }
 


### PR DESCRIPTION
Closes #1092.

## Problem

When an iroh-gossip send loop dies, the peer stays in `PeerState::Active` with a closed send channel forever: gossip only prunes a neighbor when its connection task finishes, but a stream-level write error kills only the send half while iroh keep-alives hold the QUIC connection open. Every send then warns `connection task send loop terminated` and is dropped — 452k warns/48h on the fleet hub, ~144/h at idle, healed only by process restart. Even our existing `join_peers` rejoin on reconnect was blackholed through the same dead channel.

## Why the obvious fix doesn't work

iroh-gossip owns **separate QUIC connections on `GOSSIP_ALPN`**, disjoint from our RPC connections — force-closing our connections never touches gossip's path. And there is no per-peer signal at our layer for a dead send loop behind a live connection: `broadcast()` returns Ok, `NeighborDown` never fires in the wedged state.

## Fix (no iroh/iroh-gossip forks or patches)

The heal lever is `Gossip::handle_connection`: dial `GOSSIP_ALPN` ourselves and hand gossip the fresh connection — its own duplicate-connection handling atomically swaps the active send path and the old send loop drains out. Wrapped in:

- **Event-driven 0→1 heal** (accept and dial paths): a returning peer heals immediately. Dial failure falls back to the pre-fix plain `join_peers`.
- **Periodic sweep** (default 60s, `DEFRA_P2P_GOSSIP_HEAL_INTERVAL_SECS` override, 0 disables): since a successful dial IS the only possible probe, probe and heal are the same cheap action — the silent half-dead state is cured within one interval, giving zero warns at steady state.
- **Per-peer exponential backoff** (2s base, doubling, 60s cap, 5 attempts, in-flight guard) as a pure time-injected state machine.
- **Bounded give-up**: if attempts exhaust *and* we had previously injected a gossip connection for that peer (dialability regressed → its state is stale), force-close its RPC connections so `PeerDisconnected` fires and the peer is dropped until rediscovery — driving the existing 0→1 machinery on return. Peers we could never dial back (NAT'd inbound, no relay) keep their healthy inbound connections and just cool down.
- Superseded injected connections close after a 10s grace (both sides must adopt the replacement first; iroh keep-alives mean they'd otherwise leak one per refresh).

## Tests

- 10 deterministic unit tests on the backoff/schedule state machine (injected time).
- 2 new integration tests: `remesh_after_peer_restart` (kill a peer's transport, restart under the same identity, assert the survivor re-establishes gossip and raw delivery — the issue's acceptance shape) and `sweep_refresh_preserves_gossip_delivery` (~6 sweep cycles at 500ms, asserts bidirectional delivery — guards the assumption that injection is non-disruptive on a healthy mesh). Re-run 5× consecutively, stable.
- True half-dead injection (send loop dead behind live QUIC) is not deterministically reproducible from outside iroh-gossip without faking its wire protocol; the sweep path that cures it is exercised by the tests above.

Results: `cargo test -p p2p --features iroh-transport` 367 passed; `cargo test -p integration-test --test p2p_iroh` **229 passed, 0 failed**; workspace tests green; clippy `-D warnings` clean; fmt clean.

## Operational notes

- Acceptance check on the fleet after a pin bump: warns decay under backoff, heal on peer return, zero warns at steady state within one refresh interval; watch `gossip path refreshed` / `heal exhausted` lines.
- Sweep cost: ~1 QUIC dial per connected peer per interval per side (trivial at 16 peers); `DEFRA_P2P_GOSSIP_HEAL_INTERVAL_SECS` is a no-deploy knob if telemetry shows churn.
- defra-agent embeds via `crates/embedded`, which reads the env override automatically — no P2PConfig change needed for defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)