### PR TITLE
feat(ffi): expose the node's shareable P2P address

### DIFF
--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -257,7 +257,7 @@ pub use mobile::{
     defra_mobile_add_replicator, defra_mobile_close_node, defra_mobile_connect,
     defra_mobile_disconnect, defra_mobile_ensure_schema, defra_mobile_execute, defra_mobile_init,
     defra_mobile_notify_network_change, defra_mobile_open_node, defra_mobile_peer_info,
-    defra_mobile_sync_collection,
+    defra_mobile_shareable_address, defra_mobile_sync_collection,
 };
 pub use node::{new_node, node_close};
 pub use p2p::{
@@ -265,7 +265,8 @@ pub use p2p::{
     p2p_add_replicator, p2p_add_replicator_with_filter, p2p_connect, p2p_delete_collections,
     p2p_delete_documents, p2p_delete_replicator, p2p_disconnect, p2p_list_collections,
     p2p_list_documents, p2p_list_replicators, p2p_notify_network_change, p2p_peer_info,
-    p2p_sync_branchable_collection, p2p_sync_collection_versions, p2p_sync_documents,
+    p2p_shareable_address, p2p_sync_branchable_collection, p2p_sync_collection_versions,
+    p2p_sync_documents,
 };
 pub use query::exec_request;
 pub use schema::{add_schema, add_schema_in_txn, get_collections, get_collections_in_txn};

--- a/crates/ffi/src/mobile.rs
+++ b/crates/ffi/src/mobile.rs
@@ -15,8 +15,8 @@ use crate::nac_check::check_nac_for_node;
 use crate::node::{new_node, node_close};
 use crate::p2p::{
     new_node_with_p2p, p2p_add_replicator_with_filter, p2p_connect, p2p_disconnect,
-    p2p_notify_network_change, p2p_peer_info, p2p_sync_branchable_collection,
-    p2p_sync_collection_versions, p2p_sync_documents,
+    p2p_notify_network_change, p2p_peer_info, p2p_shareable_address,
+    p2p_sync_branchable_collection, p2p_sync_collection_versions, p2p_sync_documents,
 };
 use crate::query::exec_request;
 use crate::schema::validate_collection_policy;
@@ -525,6 +525,19 @@ pub extern "C" fn defra_mobile_peer_info(node_ptr: usize) -> FfiResult {
     }
 }
 
+/// Return the node's best shareable P2P address (JSON string, or JSON null
+/// when the transport has no dialable shareable address yet).
+#[no_mangle]
+pub extern "C" fn defra_mobile_shareable_address(node_ptr: usize) -> FfiResult {
+    ffi_entry! {
+        let identity = match default_identity_cstring(node_ptr) {
+            Ok(value) => value,
+            Err(error) => return FfiResult::error(error),
+        };
+        unsafe { p2p_shareable_address(node_ptr, c_string_ptr(&identity)) }
+    }
+}
+
 /// Connect the node to a peer address.
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[no_mangle]
@@ -710,6 +723,12 @@ pub extern "C" fn defra_mobile_add_replicator(
 mod tests {
     use super::*;
     use std::ffi::CStr;
+
+    #[test]
+    fn mobile_shareable_address_exports_node_only_ffi_signature() {
+        let symbol: extern "C" fn(usize) -> FfiResult = defra_mobile_shareable_address;
+        let _ = symbol;
+    }
 
     #[test]
     fn test_mobile_add_replicator_request_parse() {

--- a/crates/ffi/src/p2p/mod.rs
+++ b/crates/ffi/src/p2p/mod.rs
@@ -21,6 +21,7 @@ pub use documents::{p2p_add_documents, p2p_delete_documents, p2p_list_documents}
 pub use node::new_node_with_p2p;
 pub use peer::{
     p2p_active_peers, p2p_connect, p2p_disconnect, p2p_notify_network_change, p2p_peer_info,
+    p2p_shareable_address,
 };
 pub use push::p2p_retry_replicators;
 pub use replicator::{

--- a/crates/ffi/src/p2p/peer.rs
+++ b/crates/ffi/src/p2p/peer.rs
@@ -83,6 +83,75 @@ pub unsafe extern "C" fn p2p_peer_info(node_ptr: usize, identity_did: *const c_c
     }
 }
 
+/// Get the node's best shareable P2P address as a JSON value.
+///
+/// Returns the address another node can dial (a `p2p_connect` / replicator
+/// target) as a JSON string, or JSON `null` when the node has no P2P transport
+/// or the transport has no shareable address yet (e.g. an iroh endpoint before
+/// relay/direct-address discovery completes — an identity-only ticket is not
+/// shareable because a dialing peer resolves it to zero transport addresses).
+///
+/// This is a stronger contract than `p2p_peer_info`: callers get the one
+/// address selected for remote sharing instead of guessing among the formatted
+/// listen addresses.
+///
+/// # Safety
+///
+/// `identity_did` must be a valid null-terminated UTF-8 string when non-null. `node_ptr` must
+/// reference a live node handle created by this library.
+#[no_mangle]
+pub unsafe extern "C" fn p2p_shareable_address(
+    node_ptr: usize,
+    identity_did: *const c_char,
+) -> FfiResult {
+    ffi_entry! {
+        let rt = try_ffi!(get_rt());
+        try_ffi!(check_nac_for_node(
+            rt,
+            node_ptr,
+            identity_did,
+            NodePermission::P2pPeerInfo
+        ));
+
+        // Bind the caller's identity so the adapter's inner NAC check resolves the
+        // actual caller instead of the wildcard. The body runs on this thread via
+        // `block_on`, so the thread-local is visible throughout; the guard restores
+        // on drop so it never leaks into the next request on this pooled thread.
+        let _identity_guard = defra_core::current_identity::scoped_current_identity(
+            crate::types::c_str_to_string(identity_did).filter(|s| !s.is_empty()),
+        );
+
+        let result = NODES
+            .get(node_ptr, |state| {
+                let p2p = match &state.p2p {
+                    Some(p2p) => p2p,
+                    None => return Ok("null".to_string()),
+                };
+
+                rt.block_on(async {
+                    let address = p2p
+                        .system
+                        .ops()
+                        .shareable_address()
+                        .await
+                        .map_err(FfiP2PError::from)?;
+
+                    serde_json::to_string(&address)
+                        .map_err(|error| {
+                            FfiP2PError::internal(format!(
+                                "failed to serialize shareable address: {}",
+                                error
+                            ))
+                        })
+                })
+            })
+            .ok_or_else(FfiP2PError::invalid_node_handle)
+            .and_then(|result| result);
+
+        into_ffi_result(result)
+    }
+}
+
 /// Notify the active P2P transport that the network may have changed.
 ///
 /// # Safety
@@ -299,6 +368,12 @@ pub unsafe extern "C" fn p2p_disconnect(
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::CStr;
+    use std::ptr;
+
+    use crate::node::{new_node, node_close};
+    use crate::types::{defra_free_string, NodeInitOptions};
+
     use super::*;
 
     #[test]
@@ -306,5 +381,39 @@ mod tests {
         let symbol: unsafe extern "C" fn(usize, *const c_char, *const c_char) -> FfiResult =
             p2p_disconnect;
         let _ = symbol;
+    }
+
+    #[test]
+    fn p2p_shareable_address_exports_peer_info_style_ffi_signature() {
+        let symbol: unsafe extern "C" fn(usize, *const c_char) -> FfiResult = p2p_shareable_address;
+        let _ = symbol;
+    }
+
+    /// A node without a P2P transport has no shareable address: the call must
+    /// succeed with JSON `null`, not error, so callers can poll it while the
+    /// transport (or address discovery) is still coming up.
+    #[test]
+    fn p2p_shareable_address_without_transport_is_json_null() {
+        assert!(crate::runtime::init_runtime(), "runtime init must succeed");
+        let result = new_node(NodeInitOptions::default());
+        assert_eq!(result.status, 0, "new_node must succeed");
+        let node = result.node_ptr;
+
+        let result = unsafe { p2p_shareable_address(node, ptr::null()) };
+        assert_eq!(result.status, 0, "no-transport lookup must succeed");
+        assert!(!result.value.is_null());
+        let value = unsafe { CStr::from_ptr(result.value).to_string_lossy().to_string() };
+        assert_eq!(value, "null");
+        unsafe { defra_free_string(result.value) };
+        node_close(node);
+    }
+
+    #[test]
+    fn p2p_shareable_address_invalid_handle_is_error() {
+        assert!(crate::runtime::init_runtime(), "runtime init must succeed");
+        let result = unsafe { p2p_shareable_address(usize::MAX, ptr::null()) };
+        assert_eq!(result.status, 1, "invalid handle must be an error");
+        assert!(!result.error.is_null());
+        unsafe { defra_free_string(result.error) };
     }
 }


### PR DESCRIPTION
Closes #1097.

## What

Two new FFI symbols, mirroring the existing `p2p_peer_info` / `defra_mobile_peer_info` pair:

- **`p2p_shareable_address(node_ptr, identity_did)`** — NAC-gated on `NodePermission::P2pPeerInfo`, returns `ops().shareable_address()` as a JSON value: `"<address>"`, or `null` when the node has no P2P transport or the transport has no dialable shareable address yet (identity-only iroh tickets are excluded by the existing `best_shareable_public_addr` policy).
- **`defra_mobile_shareable_address(node_ptr)`** — mobile wrapper resolving the node's default identity.

No new capability: `P2POperations::shareable_address()` already exists on the trait, is implemented for iroh, and is exposed over HTTP — this only lifts it across the FFI boundary so the address-selection policy stays in one place instead of being reimplemented in Swift/Kotlin from `p2p_peer_info`'s formatted listen-address list.

## Why

Mobile clients publishing a signed `PeerEndpoint` for automated reciprocal replication (sourcenetwork/defra-agent#665) must advertise the one address a server can actually dial. Publishing a wrong self-address is worse than none — defra-agent's own endpoint heartbeat uses `shareable_address()` for the same reason.

## Tests

- `p2p_shareable_address_without_transport_is_json_null` — no-P2P node succeeds with `null` (pollable during transport/discovery startup).
- `p2p_shareable_address_invalid_handle_is_error`.
- Signature-export tests for both symbols.
- `cargo test -p ffi` (plain + `--features iroh`), `cargo fmt --check`, `cargo clippy -p ffi --all-features`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)