### PR TITLE
fix(p2p): serve selective CAR blocks for pushed DAG recovery

### DIFF
--- a/crates/p2p/src/sync/car.rs
+++ b/crates/p2p/src/sync/car.rs
@@ -501,6 +501,67 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn collect_exact_blocks_serves_field_and_composite_history_subsets() {
+        use defra_core::{Block, CompositeDeltaPayload, CrdtDelta, DAGLink, LwwDeltaPayload};
+
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, true);
+        let mut previous_field = None;
+        let mut previous_composite = None;
+        let mut field_blocks = Vec::new();
+        let mut composite_blocks = Vec::new();
+
+        for height in 1..=17 {
+            let field = Block::new(
+                CrdtDelta::Lww(LwwDeltaPayload {
+                    doc_id: b"doc1".to_vec(),
+                    field_name: "status".to_string(),
+                    priority: height,
+                    schema_version_id: "version1".to_string(),
+                    data: vec![height as u8],
+                }),
+                previous_field.into_iter().collect(),
+                vec![],
+            );
+            let field_data = field.to_dag_cbor().unwrap();
+            let field_cid = field.generate_cid().unwrap();
+            blockstore.put(&field_cid, &field_data).await.unwrap();
+            field_blocks.push((field_cid, field_data));
+            previous_field = Some(field_cid);
+
+            let composite = Block::new(
+                CrdtDelta::Composite(CompositeDeltaPayload {
+                    doc_id: b"doc1".to_vec(),
+                    schema_version_id: "version1".to_string(),
+                    priority: height,
+                    status: 1,
+                }),
+                previous_composite.into_iter().collect(),
+                vec![DAGLink::new("status", field_cid)],
+            );
+            let composite_data = composite.to_dag_cbor().unwrap();
+            let composite_cid = composite.generate_cid().unwrap();
+            blockstore
+                .put(&composite_cid, &composite_data)
+                .await
+                .unwrap();
+            composite_blocks.push((composite_cid, composite_data));
+            previous_composite = Some(composite_cid);
+        }
+
+        let expected: Vec<(Cid, Bytes)> =
+            [&field_blocks[3], &field_blocks[13], &composite_blocks[16]]
+                .into_iter()
+                .map(|(cid, data)| (*cid, Bytes::from(data.clone())))
+                .collect();
+        let wanted: Vec<Cid> = expected.iter().map(|(cid, _)| *cid).collect();
+        let collected = collect_exact_blocks(&blockstore, &wanted).await.unwrap();
+
+        assert_eq!(collected.blocks, expected);
+        assert!(!collected.truncated());
+    }
+
+    #[tokio::test]
     async fn collect_dag_blocks_handles_deep_chains_iteratively() {
         let store = Arc::new(MemoryStore::new());
         let blockstore = DefraBlockstore::new(store, true);

--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -3,9 +3,10 @@
 //! Verifies that DocSync and BranchableSync handlers enforce access checks
 //! in Controlled mode before processing requests.
 
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
+use std::{future::Future, pin::Pin};
 
 use blockstore::{Blockstore, DefraBlockstore, Error as BlockstoreError};
 use cid::Cid;
@@ -17,7 +18,7 @@ use crate::bitswap::{AccessMode, ReplicatorRegistry};
 use crate::error::Error;
 use crate::message::{
     BranchableSyncReply, BranchableSyncRequest, CarFetchRequest, DocSyncReply, DocSyncRequest,
-    PushLogBroadcast, PushLogRequest,
+    PushLogBroadcast, PushLogReply, PushLogRequest,
 };
 use crate::sync::broadcaster::Broadcaster;
 use crate::sync::collection_store::NoOpCollectionStorage;
@@ -41,6 +42,14 @@ use super::{
 };
 
 type TestBlockstore = DefraBlockstore<MemoryStore>;
+type TwoStreamHandler = Arc<
+    dyn Fn(
+            PeerId,
+            PushLogRequest,
+        ) -> Pin<Box<dyn Future<Output = crate::Result<PushLogReply>> + Send>>
+        + Send
+        + Sync,
+>;
 const BLOCK_DATA: &[u8] = b"block data";
 
 fn create_test_coordinator(
@@ -234,6 +243,9 @@ fn create_test_coordinator_with_blockstore_and_head_provider<B: Blockstore + 'st
                 crate::sync::DEFAULT_MAX_ACTIVE_PUSHES_PER_PEER,
                 DEFAULT_MAX_CONCURRENT_PUSH_TASKS,
             ),
+            selective_car_access: Arc::new(
+                super::selective_car_access::SelectiveCarAccess::default(),
+            ),
             rate_limiter,
             request_rate_limiter,
             max_doc_sync_request_doc_ids: DEFAULT_MAX_DOC_SYNC_REQUEST_DOC_IDS,
@@ -364,6 +376,7 @@ struct NoopTransport {
     car_responses: Arc<RwLock<Vec<Vec<u8>>>>,
     pushlog_replies: Arc<RwLock<Vec<crate::message::PushLogReply>>>,
     two_stream_replies: Arc<RwLock<Vec<crate::message::PushLogReply>>>,
+    two_stream_handler: Arc<RwLock<Option<TwoStreamHandler>>>,
     branchable_replies: Arc<RwLock<Vec<BranchableSyncReply>>>,
 }
 
@@ -378,6 +391,7 @@ impl NoopTransport {
             car_responses: Arc::new(RwLock::new(Vec::new())),
             pushlog_replies: Arc::new(RwLock::new(Vec::new())),
             two_stream_replies: Arc::new(RwLock::new(Vec::new())),
+            two_stream_handler: Arc::new(RwLock::new(None)),
             branchable_replies: Arc::new(RwLock::new(Vec::new())),
         }
     }
@@ -396,6 +410,10 @@ impl NoopTransport {
 
     fn two_stream_replies(&self) -> Vec<crate::message::PushLogReply> {
         self.two_stream_replies.read().clone()
+    }
+
+    fn set_two_stream_handler(&self, handler: TwoStreamHandler) {
+        *self.two_stream_handler.write() = Some(handler);
     }
 
     fn branchable_replies(&self) -> Vec<BranchableSyncReply> {
@@ -488,9 +506,13 @@ impl P2PTransport for NoopTransport {
 
     async fn send_two_stream_request(
         &self,
-        _peer_id: &PeerId,
-        _req: PushLogRequest,
+        peer_id: &PeerId,
+        req: PushLogRequest,
     ) -> crate::Result<crate::message::PushLogReply> {
+        let handler = self.two_stream_handler.read().clone();
+        if let Some(handler) = handler {
+            return handler(peer_id.clone(), req).await;
+        }
         Ok(crate::message::PushLogReply::success("noop"))
     }
 
@@ -736,6 +758,18 @@ fn car_fetch_event(peer_id: PeerId, root_cid: Cid) -> TransportEvent<()> {
     TransportEvent::CarFetchRequest {
         peer_id,
         request: CarFetchRequest::full_dag(root_cid),
+        token: None,
+    }
+}
+
+fn selective_car_fetch_event(
+    peer_id: PeerId,
+    root_cid: Cid,
+    wanted_cids: Vec<Cid>,
+) -> TransportEvent<()> {
+    TransportEvent::CarFetchRequest {
+        peer_id,
+        request: CarFetchRequest::selective_blocks(root_cid, wanted_cids),
         token: None,
     }
 }
@@ -1038,6 +1072,205 @@ async fn car_fetch_controlled_mode_filters_unauthorized_data_block() {
         "no data blocks may be served for a classifier-denied block, got {}",
         served.len()
     );
+}
+
+#[tokio::test]
+async fn selective_car_serves_field_delta_from_active_push_dag() {
+    use defra_core::{Block, CompositeDeltaPayload, CrdtDelta, DAGLink, LwwDeltaPayload};
+
+    let peer = random_peer_id();
+    let transport = NoopTransport::new();
+    let transport_handle = transport.clone();
+    let local_peer_id = transport.local_peer_id().to_string();
+    let broadcaster = Broadcaster::new(transport.clone());
+    let store = Arc::new(MemoryStore::new());
+    let blockstore = Arc::new(DefraBlockstore::new(store, true));
+
+    let field_block = Block::new(
+        CrdtDelta::Lww(LwwDeltaPayload {
+            doc_id: b"doc1".to_vec(),
+            field_name: "status".to_string(),
+            priority: 14,
+            schema_version_id: "version1".to_string(),
+            data: b"ready".to_vec(),
+        }),
+        vec![],
+        vec![],
+    );
+    let field_data = field_block.to_dag_cbor().unwrap();
+    let field_cid = field_block.generate_cid().unwrap();
+    blockstore.put(&field_cid, &field_data).await.unwrap();
+
+    let root_block = Block::new(
+        CrdtDelta::Composite(CompositeDeltaPayload {
+            doc_id: b"doc1".to_vec(),
+            schema_version_id: "version1".to_string(),
+            priority: 17,
+            status: 1,
+        }),
+        vec![],
+        vec![DAGLink::new("status".to_string(), field_cid)],
+    );
+    let root_data = root_block.to_dag_cbor().unwrap();
+    let root_cid = root_block.generate_cid().unwrap();
+    blockstore.put(&root_cid, &root_data).await.unwrap();
+
+    let (coordinator, _events) = create_test_coordinator_with_blockstore(TestCoordinatorParams {
+        sync_config: SyncConfig::default(),
+        request_rate_limiter: Arc::new(PeerRateLimiter::default()),
+        access_mode: AccessMode::Controlled,
+        replicators: Arc::new(ReplicatorRegistry::new()),
+        peer_state: Arc::new(PeerStateTracker::new()),
+        transport,
+        local_peer_id,
+        broadcaster,
+        blockstore,
+        rate_limiter: Arc::new(PeerRateLimiter::default()),
+    });
+    let _active_push = coordinator
+        .runtime
+        .selective_car_access
+        .register(peer.clone(), [root_cid, field_cid]);
+
+    coordinator
+        .handle_transport_event(selective_car_fetch_event(peer, root_cid, vec![field_cid]))
+        .await
+        .unwrap();
+
+    let responses = transport_handle.car_responses();
+    let (_roots, blocks) = crate::sync::car::decode_car(&responses[0]).unwrap();
+    assert_eq!(blocks, vec![(field_cid, field_data)]);
+}
+
+#[tokio::test]
+async fn active_push_recovers_missing_interior_block_and_acks() {
+    use defra_core::{Block, CompositeDeltaPayload, CrdtDelta, DAGLink, LwwDeltaPayload};
+
+    let receiver = random_peer_id();
+    let transport = NoopTransport::new();
+    transport
+        .create_replicator(&receiver, vec!["collection1".to_string()])
+        .await
+        .unwrap();
+
+    let store = Arc::new(MemoryStore::new());
+    let blockstore = Arc::new(DefraBlockstore::new(store, true));
+    let field_block = Block::new(
+        CrdtDelta::Lww(LwwDeltaPayload {
+            doc_id: b"doc1".to_vec(),
+            field_name: "status".to_string(),
+            priority: 14,
+            schema_version_id: "version1".to_string(),
+            data: b"ready".to_vec(),
+        }),
+        vec![],
+        vec![],
+    );
+    let field_data = field_block.to_dag_cbor().unwrap();
+    let field_cid = field_block.generate_cid().unwrap();
+    blockstore.put(&field_cid, &field_data).await.unwrap();
+
+    let root_block = Block::new(
+        CrdtDelta::Composite(CompositeDeltaPayload {
+            doc_id: b"doc1".to_vec(),
+            schema_version_id: "version1".to_string(),
+            priority: 17,
+            status: 1,
+        }),
+        vec![],
+        vec![DAGLink::new("status".to_string(), field_cid)],
+    );
+    let root_data = root_block.to_dag_cbor().unwrap();
+    let root_cid = root_block.generate_cid().unwrap();
+    blockstore.put(&root_cid, &root_data).await.unwrap();
+
+    let (coordinator, _events) = SyncCoordinator::with_access_control(
+        transport.clone(),
+        blockstore,
+        SyncConfig::default(),
+        AccessMode::Controlled,
+        Arc::new(ReplicatorRegistry::new()),
+        Arc::new(NoOpCollectionStorage),
+        Arc::new(crate::replicator::EqOnlyFilterMatcher),
+    )
+    .await
+    .unwrap();
+    let coordinator = Arc::new(coordinator);
+    let sender = Arc::new(std::sync::OnceLock::new());
+    sender.set(Arc::downgrade(&coordinator)).unwrap();
+
+    let receiver_blocks = Arc::new(RwLock::new(std::collections::HashSet::new()));
+    let root_acked = Arc::new(AtomicBool::new(false));
+    transport.set_two_stream_handler(Arc::new({
+        let sender = Arc::clone(&sender);
+        let transport = transport.clone();
+        let receiver_blocks = Arc::clone(&receiver_blocks);
+        let root_acked = Arc::clone(&root_acked);
+        move |peer_id, request| {
+            let sender = Arc::clone(&sender);
+            let transport = transport.clone();
+            let receiver_blocks = Arc::clone(&receiver_blocks);
+            let root_acked = Arc::clone(&root_acked);
+            Box::pin(async move {
+                let pushed_cid = Cid::try_from(request.cid.as_ref()).unwrap();
+                if pushed_cid == field_cid {
+                    // Simulate a receiver hole: the dependency PushLog was acked
+                    // but its block is absent when the later root arrives.
+                    return Ok(PushLogReply::success("field-ack"));
+                }
+
+                receiver_blocks.write().insert(pushed_cid);
+                assert_eq!(pushed_cid, root_cid);
+                assert!(!receiver_blocks.read().contains(&field_cid));
+
+                let coordinator = sender.get().unwrap().upgrade().unwrap();
+                coordinator
+                    .handle_transport_event(selective_car_fetch_event(
+                        peer_id,
+                        root_cid,
+                        vec![field_cid],
+                    ))
+                    .await?;
+
+                let response = transport.car_responses().last().cloned().unwrap();
+                let (_roots, blocks) = crate::sync::car::decode_car(&response)?;
+                for (cid, _data) in blocks {
+                    receiver_blocks.write().insert(cid);
+                }
+
+                if receiver_blocks.read().contains(&field_cid) {
+                    root_acked.store(true, Ordering::SeqCst);
+                    Ok(PushLogReply::success("root-ack"))
+                } else {
+                    Ok(PushLogReply::error("root", "interior block still missing"))
+                }
+            })
+        }
+    }));
+
+    coordinator
+        .push_dag_to_replicators(&root_cid, &root_data, "doc1", "collection1")
+        .await;
+
+    let snapshot = timeout(Duration::from_secs(5), async {
+        loop {
+            let snapshot = coordinator.sync_status().push_backlog;
+            if root_acked.load(Ordering::SeqCst) && snapshot.completed_total == 1 {
+                break snapshot;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("sender push did not receive an ack after selective recovery");
+
+    assert_eq!(snapshot.failed_total, 0);
+    assert!(receiver_blocks.read().contains(&root_cid));
+    assert!(receiver_blocks.read().contains(&field_cid));
+    assert!(!coordinator
+        .runtime
+        .selective_car_access
+        .allows(&receiver, &root_cid, &field_cid));
 }
 
 #[tokio::test]

--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -14,7 +14,9 @@ use multihash_codetable::{Code, MultihashDigest};
 use storage::backends::MemoryStore;
 use tokio::time::timeout;
 
-use crate::bitswap::{AccessMode, ReplicatorRegistry};
+use crate::bitswap::{
+    AccessMode, BlockAcpMeta, BlockClass, BlockClassifier, LateBoundServeAcp, ReplicatorRegistry,
+};
 use crate::error::Error;
 use crate::message::{
     BranchableSyncReply, BranchableSyncRequest, CarFetchRequest, DocSyncReply, DocSyncRequest,
@@ -30,7 +32,7 @@ use crate::sync::SyncShutdownHandle;
 use crate::topics::{DefraTopic, DOC_SYNC_TOPIC};
 use crate::transport::{MessageId, P2PTransport, PeerAddr, PeerId, TransportEvent};
 use crate::QueryId;
-use crate::ReplicatorInfo;
+use crate::{ReplicationFilter, ReplicationFilters, ReplicatorInfo};
 use async_trait::async_trait;
 use parking_lot::RwLock;
 
@@ -51,6 +53,38 @@ type TwoStreamHandler = Arc<
         + Sync,
 >;
 const BLOCK_DATA: &[u8] = b"block data";
+
+struct StaticDataClassifier {
+    collection_id: String,
+}
+
+#[async_trait]
+impl BlockClassifier for StaticDataClassifier {
+    async fn classify(&self, _cid: &Cid, _data: &[u8]) -> BlockClass {
+        BlockClass::Data(BlockAcpMeta {
+            collection_id: self.collection_id.clone(),
+            is_branchable: false,
+            policy: None,
+            doc_ids: vec!["doc1".to_string()],
+        })
+    }
+}
+
+fn filtered_replicator_registry(peer: &PeerId, collection_id: &str) -> Arc<ReplicatorRegistry> {
+    let mut filters = ReplicationFilters::new();
+    filters.insert(
+        collection_id.to_string(),
+        ReplicationFilter::new("status", serde_json::json!("ready")),
+    );
+    let registry = Arc::new(ReplicatorRegistry::new());
+    registry.set_replicator_info(ReplicatorInfo::from_raw_with_filters(
+        peer.to_string(),
+        vec![collection_id.to_string()],
+        Vec::new(),
+        filters,
+    ));
+    registry
+}
 
 fn create_test_coordinator(
     access_mode: AccessMode,
@@ -1075,14 +1109,12 @@ async fn car_fetch_controlled_mode_filters_unauthorized_data_block() {
 }
 
 #[tokio::test]
-async fn selective_car_serves_field_delta_from_active_push_dag() {
+async fn selective_car_grant_bypasses_filtered_replicator_denial() {
     use defra_core::{Block, CompositeDeltaPayload, CrdtDelta, DAGLink, LwwDeltaPayload};
 
     let peer = random_peer_id();
     let transport = NoopTransport::new();
     let transport_handle = transport.clone();
-    let local_peer_id = transport.local_peer_id().to_string();
-    let broadcaster = Broadcaster::new(transport.clone());
     let store = Arc::new(MemoryStore::new());
     let blockstore = Arc::new(DefraBlockstore::new(store, true));
 
@@ -1115,22 +1147,58 @@ async fn selective_car_serves_field_delta_from_active_push_dag() {
     let root_cid = root_block.generate_cid().unwrap();
     blockstore.put(&root_cid, &root_data).await.unwrap();
 
-    let (coordinator, _events) = create_test_coordinator_with_blockstore(TestCoordinatorParams {
-        sync_config: SyncConfig::default(),
-        request_rate_limiter: Arc::new(PeerRateLimiter::default()),
-        access_mode: AccessMode::Controlled,
-        replicators: Arc::new(ReplicatorRegistry::new()),
-        peer_state: Arc::new(PeerStateTracker::new()),
+    let replicators = filtered_replicator_registry(&peer, "collection1");
+    let (coordinator, _events) = SyncCoordinator::with_access_control_and_serve_gate(
         transport,
-        local_peer_id,
-        broadcaster,
         blockstore,
-        rate_limiter: Arc::new(PeerRateLimiter::default()),
-    });
-    let _active_push = coordinator
-        .runtime
-        .selective_car_access
-        .register(peer.clone(), [root_cid, field_cid]);
+        SyncConfig::default(),
+        AccessMode::Controlled,
+        replicators,
+        Arc::new(NoOpCollectionStorage),
+        Arc::new(crate::replicator::EqOnlyFilterMatcher),
+        Arc::new(StaticDataClassifier {
+            collection_id: "collection1".to_string(),
+        }),
+        Arc::new(LateBoundServeAcp::new()),
+    )
+    .await
+    .unwrap();
+
+    coordinator
+        .handle_transport_event(selective_car_fetch_event(
+            peer.clone(),
+            root_cid,
+            vec![field_cid],
+        ))
+        .await
+        .unwrap();
+    let responses = transport_handle.car_responses();
+    let (_roots, denied_blocks) = crate::sync::car::decode_car(&responses[0]).unwrap();
+    assert!(
+        denied_blocks.is_empty(),
+        "filtered replicators must be denied generic block reads"
+    );
+
+    let _active_push = coordinator.runtime.selective_car_access.register(
+        peer.clone(),
+        root_cid,
+        [root_cid, field_cid],
+    );
+
+    coordinator
+        .handle_transport_event(selective_car_fetch_event(
+            random_peer_id(),
+            root_cid,
+            vec![field_cid],
+        ))
+        .await
+        .unwrap();
+    let responses = transport_handle.car_responses();
+    let (_roots, unrelated_peer_blocks) = crate::sync::car::decode_car(&responses[1]).unwrap();
+    assert!(
+        unrelated_peer_blocks.is_empty(),
+        "a push grant must not authorize another peer"
+    );
 
     coordinator
         .handle_transport_event(selective_car_fetch_event(peer, root_cid, vec![field_cid]))
@@ -1138,12 +1206,12 @@ async fn selective_car_serves_field_delta_from_active_push_dag() {
         .unwrap();
 
     let responses = transport_handle.car_responses();
-    let (_roots, blocks) = crate::sync::car::decode_car(&responses[0]).unwrap();
+    let (_roots, blocks) = crate::sync::car::decode_car(&responses[2]).unwrap();
     assert_eq!(blocks, vec![(field_cid, field_data)]);
 }
 
 #[tokio::test]
-async fn active_push_recovers_missing_interior_block_and_acks() {
+async fn completed_push_allows_post_ack_selective_recovery() {
     use defra_core::{Block, CompositeDeltaPayload, CrdtDelta, DAGLink, LwwDeltaPayload};
 
     let receiver = random_peer_id();
@@ -1184,31 +1252,30 @@ async fn active_push_recovers_missing_interior_block_and_acks() {
     let root_cid = root_block.generate_cid().unwrap();
     blockstore.put(&root_cid, &root_data).await.unwrap();
 
-    let (coordinator, _events) = SyncCoordinator::with_access_control(
+    let replicators = filtered_replicator_registry(&receiver, "collection1");
+    let (coordinator, _events) = SyncCoordinator::with_access_control_and_serve_gate(
         transport.clone(),
         blockstore,
         SyncConfig::default(),
         AccessMode::Controlled,
-        Arc::new(ReplicatorRegistry::new()),
+        replicators,
         Arc::new(NoOpCollectionStorage),
         Arc::new(crate::replicator::EqOnlyFilterMatcher),
+        Arc::new(StaticDataClassifier {
+            collection_id: "collection1".to_string(),
+        }),
+        Arc::new(LateBoundServeAcp::new()),
     )
     .await
     .unwrap();
     let coordinator = Arc::new(coordinator);
-    let sender = Arc::new(std::sync::OnceLock::new());
-    sender.set(Arc::downgrade(&coordinator)).unwrap();
 
     let receiver_blocks = Arc::new(RwLock::new(std::collections::HashSet::new()));
     let root_acked = Arc::new(AtomicBool::new(false));
     transport.set_two_stream_handler(Arc::new({
-        let sender = Arc::clone(&sender);
-        let transport = transport.clone();
         let receiver_blocks = Arc::clone(&receiver_blocks);
         let root_acked = Arc::clone(&root_acked);
-        move |peer_id, request| {
-            let sender = Arc::clone(&sender);
-            let transport = transport.clone();
+        move |_peer_id, request| {
             let receiver_blocks = Arc::clone(&receiver_blocks);
             let root_acked = Arc::clone(&root_acked);
             Box::pin(async move {
@@ -1222,28 +1289,8 @@ async fn active_push_recovers_missing_interior_block_and_acks() {
                 receiver_blocks.write().insert(pushed_cid);
                 assert_eq!(pushed_cid, root_cid);
                 assert!(!receiver_blocks.read().contains(&field_cid));
-
-                let coordinator = sender.get().unwrap().upgrade().unwrap();
-                coordinator
-                    .handle_transport_event(selective_car_fetch_event(
-                        peer_id,
-                        root_cid,
-                        vec![field_cid],
-                    ))
-                    .await?;
-
-                let response = transport.car_responses().last().cloned().unwrap();
-                let (_roots, blocks) = crate::sync::car::decode_car(&response)?;
-                for (cid, _data) in blocks {
-                    receiver_blocks.write().insert(cid);
-                }
-
-                if receiver_blocks.read().contains(&field_cid) {
-                    root_acked.store(true, Ordering::SeqCst);
-                    Ok(PushLogReply::success("root-ack"))
-                } else {
-                    Ok(PushLogReply::error("root", "interior block still missing"))
-                }
+                root_acked.store(true, Ordering::SeqCst);
+                Ok(PushLogReply::success("root-ack"))
             })
         }
     }));
@@ -1262,15 +1309,31 @@ async fn active_push_recovers_missing_interior_block_and_acks() {
         }
     })
     .await
-    .expect("sender push did not receive an ack after selective recovery");
+    .expect("sender push did not complete after the receiver acked the root");
 
     assert_eq!(snapshot.failed_total, 0);
     assert!(receiver_blocks.read().contains(&root_cid));
-    assert!(receiver_blocks.read().contains(&field_cid));
-    assert!(!coordinator
+    assert!(!receiver_blocks.read().contains(&field_cid));
+    assert!(coordinator
         .runtime
         .selective_car_access
         .allows(&receiver, &root_cid, &field_cid));
+
+    coordinator
+        .handle_transport_event(selective_car_fetch_event(
+            receiver,
+            root_cid,
+            vec![field_cid],
+        ))
+        .await
+        .unwrap();
+
+    let response = transport.car_responses().last().cloned().unwrap();
+    let (_roots, blocks) = crate::sync::car::decode_car(&response).unwrap();
+    for (cid, _data) in blocks {
+        receiver_blocks.write().insert(cid);
+    }
+    assert!(receiver_blocks.read().contains(&field_cid));
 }
 
 #[tokio::test]

--- a/crates/p2p/src/sync/coordinator/constructor.rs
+++ b/crates/p2p/src/sync/coordinator/constructor.rs
@@ -180,6 +180,8 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             config.max_active_pushes_per_peer,
             max_push_tasks,
         );
+        let selective_car_access =
+            Arc::new(super::selective_car_access::SelectiveCarAccess::default());
         let rate_limit_burst = config.rate_limit_burst;
         let rate_limit_rate = config.rate_limit_rate;
         let rate_limit_backoff = config.rate_limit_backoff.clone();
@@ -216,6 +218,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 transport: transport.clone(),
                 blockstore,
                 backlog: Arc::clone(&push_backlog),
+                selective_car_access: Arc::clone(&selective_car_access),
                 failure_tx: Arc::clone(&failure_tx),
                 send_timeout: push_send_timeout,
             }),
@@ -230,6 +233,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                     failure_tx,
                     dag_fetch_limiter: DagFetchLimiter::new(max_dag_fetches),
                     push_backlog,
+                    selective_car_access,
                     rate_limiter: Arc::new(PeerRateLimiter::with_backoff_steps(
                         rate_limit_burst,
                         rate_limit_rate,

--- a/crates/p2p/src/sync/coordinator/event_handler/car.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/car.rs
@@ -15,6 +15,17 @@ fn sample_cids(cids: &[Cid]) -> Vec<String> {
     cids.iter().take(4).map(ToString::to_string).collect()
 }
 
+async fn sample_cid_presence<B: Blockstore>(
+    blockstore: &B,
+    cids: &[Cid],
+) -> Vec<(String, Option<bool>)> {
+    let mut presence = Vec::with_capacity(cids.len().min(4));
+    for cid in cids.iter().take(4) {
+        presence.push((cid.to_string(), blockstore.has(cid).await.ok()));
+    }
+    presence
+}
+
 impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     /// Handle an inbound CAR fetch request: collect the DAG and send CARv1 response.
     pub(crate) async fn handle_car_fetch_request(
@@ -51,8 +62,9 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             collect_exact_blocks(self.manager.blockstore().as_ref(), &request.wanted_cids).await?
         };
         let truncated = collected.truncated();
+        let collected_count = collected.blocks.len();
         let blocks = self
-            .filter_car_response_blocks(&peer_id, collected.blocks)
+            .filter_car_response_blocks(&peer_id, &request.root_cid, collected.blocks)
             .await;
 
         if blocks.is_empty() {
@@ -70,13 +82,19 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                     "CAR handler: no blocks found for request"
                 );
             } else {
+                let requested_presence =
+                    sample_cid_presence(self.manager.blockstore().as_ref(), &request.wanted_cids)
+                        .await;
                 tracing::warn!(
                     root_cid = %request.root_cid,
                     peer_id = %peer_id,
                     root_present = ?root_present,
                     requested_count = request.wanted_cids.len(),
+                    collected_count,
+                    filtered_count = collected_count,
                     requested_cids = ?sample_cids(&request.wanted_cids),
-                    "CAR handler: no exact blocks found for selective request"
+                    requested_presence = ?requested_presence,
+                    "CAR handler: no exact blocks served for selective request"
                 );
             }
             // Send a header-only CAR so both transports (iroh and libp2p)
@@ -141,6 +159,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     async fn filter_car_response_blocks(
         &self,
         peer_id: &PeerId,
+        root_cid: &Cid,
         blocks: Vec<(Cid, Bytes)>,
     ) -> Vec<(Cid, Bytes)> {
         if self.access.access_mode.is_open() {
@@ -153,6 +172,15 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         let mut kept = Vec::with_capacity(blocks.len());
 
         for (cid, data) in blocks {
+            if self
+                .runtime
+                .selective_car_access
+                .allows(peer_id, root_cid, &cid)
+            {
+                kept.push((cid, data));
+                continue;
+            }
+
             match self.classifier.classify(&cid, &data).await {
                 BlockClass::Allow => kept.push((cid, data)),
                 BlockClass::Deny => {

--- a/crates/p2p/src/sync/coordinator/event_handler/car.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/car.rs
@@ -66,6 +66,9 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         let blocks = self
             .filter_car_response_blocks(&peer_id, &request.root_cid, collected.blocks)
             .await;
+        let kept_count = blocks.len();
+        let filtered_count = collected_count.saturating_sub(kept_count);
+        let blockstore_miss_count = request.wanted_cids.len().saturating_sub(collected_count);
 
         if blocks.is_empty() {
             self.manager.diagnostics.record_car_no_blocks_served();
@@ -90,8 +93,10 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                     peer_id = %peer_id,
                     root_present = ?root_present,
                     requested_count = request.wanted_cids.len(),
-                    collected_count,
-                    filtered_count = collected_count,
+                    blockstore_hit_count = collected_count,
+                    blockstore_miss_count,
+                    filtered_count,
+                    kept_count,
                     requested_cids = ?sample_cids(&request.wanted_cids),
                     requested_presence = ?requested_presence,
                     "CAR handler: no exact blocks served for selective request"

--- a/crates/p2p/src/sync/coordinator/mod.rs
+++ b/crates/p2p/src/sync/coordinator/mod.rs
@@ -56,6 +56,7 @@ mod pubsub_services;
 mod push_worker;
 mod replicators;
 mod result_types;
+mod selective_car_access;
 mod subscriptions;
 
 pub use result_types::{CreateReplicatorResult, LoadReplicatorsResult};
@@ -293,6 +294,9 @@ pub(super) struct SyncRuntime<T: P2PTransport> {
     /// Bounded admission queue for outbound replicator pushes, drained by the
     /// fixed worker pool spawned at construction (#1099).
     pub(super) push_backlog: Arc<super::push_backlog::PushBacklog>,
+
+    /// Temporary per-peer CAR grants scoped to DAGs in active outbound pushes.
+    pub(super) selective_car_access: Arc<selective_car_access::SelectiveCarAccess>,
 
     /// Per-peer rate limiter for gossip dispatch (abuse ladder; drop-only).
     pub(super) rate_limiter: Arc<PeerRateLimiter>,

--- a/crates/p2p/src/sync/coordinator/push_worker.rs
+++ b/crates/p2p/src/sync/coordinator/push_worker.rs
@@ -24,6 +24,7 @@ pub(super) struct PushWorkerContext<B, T> {
     pub(super) transport: T,
     pub(super) blockstore: Arc<B>,
     pub(super) backlog: Arc<PushBacklog>,
+    pub(super) selective_car_access: Arc<super::selective_car_access::SelectiveCarAccess>,
     pub(super) failure_tx: Arc<Mutex<Option<tokio::sync::mpsc::Sender<PushFailure>>>>,
     pub(super) send_timeout: Duration,
 }
@@ -110,6 +111,9 @@ where
     } else {
         vec![(job.root_cid, job.head_block.clone())]
     };
+    let pushed_cids = job
+        .expand_dag
+        .then(|| blocks.iter().map(|(cid, _)| *cid).collect::<Vec<_>>());
 
     let mut requests: Vec<(Cid, PushLogRequest)> = Vec::with_capacity(blocks.len());
     for (block_cid, block_data) in blocks {
@@ -133,6 +137,11 @@ where
         // regenerates and re-pushes instead of silently losing the doc.
         true
     } else {
+        let _car_access = pushed_cids.map(|cids| {
+            context
+                .selective_car_access
+                .register(job.peer_id.clone(), cids)
+        });
         send_ordered_pushlogs_via_transport(
             &context.transport,
             &job.peer_id,
@@ -335,6 +344,9 @@ mod tests {
             transport,
             blockstore,
             backlog,
+            selective_car_access: Arc::new(
+                super::super::selective_car_access::SelectiveCarAccess::default(),
+            ),
             failure_tx: Arc::new(Mutex::new(Some(tx))),
             send_timeout,
         });

--- a/crates/p2p/src/sync/coordinator/push_worker.rs
+++ b/crates/p2p/src/sync/coordinator/push_worker.rs
@@ -140,7 +140,7 @@ where
         let _car_access = pushed_cids.map(|cids| {
             context
                 .selective_car_access
-                .register(job.peer_id.clone(), cids)
+                .register(job.peer_id.clone(), job.root_cid, cids)
         });
         send_ordered_pushlogs_via_transport(
             &context.transport,

--- a/crates/p2p/src/sync/coordinator/selective_car_access.rs
+++ b/crates/p2p/src/sync/coordinator/selective_car_access.rs
@@ -1,0 +1,122 @@
+//! Per-peer selective CAR grants bounded by active outbound pushes.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use cid::Cid;
+use parking_lot::Mutex;
+
+use crate::transport::PeerId;
+
+#[derive(Debug)]
+struct PushGrant {
+    cids: HashSet<Cid>,
+}
+
+#[derive(Debug, Default)]
+pub(in crate::sync) struct SelectiveCarAccess {
+    next_id: AtomicU64,
+    grants: Mutex<HashMap<PeerId, HashMap<u64, PushGrant>>>,
+}
+
+impl SelectiveCarAccess {
+    pub(super) fn register(
+        self: &Arc<Self>,
+        peer_id: PeerId,
+        pushed_cids: impl IntoIterator<Item = Cid>,
+    ) -> SelectiveCarAccessGuard {
+        let cids: HashSet<Cid> = pushed_cids.into_iter().collect();
+        let grant_id = self.next_id.fetch_add(1, Ordering::Relaxed);
+
+        self.grants
+            .lock()
+            .entry(peer_id.clone())
+            .or_default()
+            .insert(grant_id, PushGrant { cids });
+
+        SelectiveCarAccessGuard {
+            access: Arc::clone(self),
+            peer_id,
+            grant_id,
+        }
+    }
+
+    pub(super) fn allows(&self, peer_id: &PeerId, root_cid: &Cid, wanted_cid: &Cid) -> bool {
+        self.grants.lock().get(peer_id).is_some_and(|grants| {
+            grants
+                .values()
+                .any(|grant| grant.cids.contains(root_cid) && grant.cids.contains(wanted_cid))
+        })
+    }
+
+    fn remove(&self, peer_id: &PeerId, grant_id: u64) {
+        let mut grants = self.grants.lock();
+        let Some(peer_grants) = grants.get_mut(peer_id) else {
+            return;
+        };
+        peer_grants.remove(&grant_id);
+        if peer_grants.is_empty() {
+            grants.remove(peer_id);
+        }
+    }
+}
+
+pub(super) struct SelectiveCarAccessGuard {
+    access: Arc<SelectiveCarAccess>,
+    peer_id: PeerId,
+    grant_id: u64,
+}
+
+impl Drop for SelectiveCarAccessGuard {
+    fn drop(&mut self) {
+        self.access.remove(&self.peer_id, self.grant_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use multihash_codetable::{Code, MultihashDigest};
+
+    use super::*;
+
+    fn cid(label: &[u8]) -> Cid {
+        Cid::new_v1(0x71, Code::Sha2_256.digest(label))
+    }
+
+    #[test]
+    fn active_push_grants_only_its_peer_and_dag() {
+        let access = Arc::new(SelectiveCarAccess::default());
+        let peer = PeerId::new("peer-a".to_string());
+        let other_peer = PeerId::new("peer-b".to_string());
+        let root = cid(b"root");
+        let child = cid(b"child");
+        let unrelated = cid(b"unrelated");
+
+        let guard = access.register(peer.clone(), [root, child]);
+
+        assert!(access.allows(&peer, &root, &child));
+        assert!(!access.allows(&peer, &root, &unrelated));
+        assert!(!access.allows(&peer, &unrelated, &child));
+        assert!(!access.allows(&other_peer, &root, &child));
+
+        drop(guard);
+        assert!(!access.allows(&peer, &root, &child));
+    }
+
+    #[test]
+    fn overlapping_push_grants_revoke_independently() {
+        let access = Arc::new(SelectiveCarAccess::default());
+        let peer = PeerId::new("peer".to_string());
+        let root = cid(b"root");
+        let child = cid(b"child");
+
+        let first = access.register(peer.clone(), [root, child]);
+        let second = access.register(peer.clone(), [root, child]);
+        drop(first);
+        assert!(access.allows(&peer, &root, &child));
+
+        drop(second);
+        assert!(!access.allows(&peer, &root, &child));
+    }
+}

--- a/crates/p2p/src/sync/coordinator/selective_car_access.rs
+++ b/crates/p2p/src/sync/coordinator/selective_car_access.rs
@@ -1,39 +1,66 @@
-//! Per-peer selective CAR grants bounded by active outbound pushes.
+//! Per-peer selective CAR grants for outbound pushes and post-ack recovery.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use cid::Cid;
 use parking_lot::Mutex;
 
 use crate::transport::PeerId;
 
+/// Covers the receiver's worst-case bounded DAG fetch retry budget (roughly
+/// seven minutes with four providers) after it has acknowledged the PushLog.
+const POST_ACK_RECOVERY_WINDOW: Duration = Duration::from_secs(10 * 60);
+
 #[derive(Debug)]
 struct PushGrant {
+    root_cid: Cid,
     cids: HashSet<Cid>,
+    /// Active pushes have no expiry. Dropping the registration starts the
+    /// bounded post-ack recovery window instead of revoking access immediately.
+    expires_at: Option<Instant>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub(in crate::sync) struct SelectiveCarAccess {
     next_id: AtomicU64,
+    recovery_window: Duration,
     grants: Mutex<HashMap<PeerId, HashMap<u64, PushGrant>>>,
+}
+
+impl Default for SelectiveCarAccess {
+    fn default() -> Self {
+        Self {
+            next_id: AtomicU64::new(0),
+            recovery_window: POST_ACK_RECOVERY_WINDOW,
+            grants: Mutex::new(HashMap::new()),
+        }
+    }
 }
 
 impl SelectiveCarAccess {
     pub(super) fn register(
         self: &Arc<Self>,
         peer_id: PeerId,
+        root_cid: Cid,
         pushed_cids: impl IntoIterator<Item = Cid>,
     ) -> SelectiveCarAccessGuard {
-        let cids: HashSet<Cid> = pushed_cids.into_iter().collect();
+        let mut cids: HashSet<Cid> = pushed_cids.into_iter().collect();
+        cids.insert(root_cid);
         let grant_id = self.next_id.fetch_add(1, Ordering::Relaxed);
 
-        self.grants
-            .lock()
-            .entry(peer_id.clone())
-            .or_default()
-            .insert(grant_id, PushGrant { cids });
+        let mut grants = self.grants.lock();
+        Self::remove_expired(&mut grants, Instant::now());
+        grants.entry(peer_id.clone()).or_default().insert(
+            grant_id,
+            PushGrant {
+                root_cid,
+                cids,
+                expires_at: None,
+            },
+        );
 
         SelectiveCarAccessGuard {
             access: Arc::clone(self),
@@ -43,21 +70,40 @@ impl SelectiveCarAccess {
     }
 
     pub(super) fn allows(&self, peer_id: &PeerId, root_cid: &Cid, wanted_cid: &Cid) -> bool {
-        self.grants.lock().get(peer_id).is_some_and(|grants| {
-            grants
+        let mut grants = self.grants.lock();
+        Self::remove_expired(&mut grants, Instant::now());
+        grants.get(peer_id).is_some_and(|peer_grants| {
+            peer_grants
                 .values()
-                .any(|grant| grant.cids.contains(root_cid) && grant.cids.contains(wanted_cid))
+                .any(|grant| grant.root_cid == *root_cid && grant.cids.contains(wanted_cid))
         })
     }
 
-    fn remove(&self, peer_id: &PeerId, grant_id: u64) {
+    fn finish_push(&self, peer_id: &PeerId, grant_id: u64) {
         let mut grants = self.grants.lock();
-        let Some(peer_grants) = grants.get_mut(peer_id) else {
+        let Some(grant) = grants
+            .get_mut(peer_id)
+            .and_then(|peer_grants| peer_grants.get_mut(&grant_id))
+        else {
             return;
         };
-        peer_grants.remove(&grant_id);
-        if peer_grants.is_empty() {
-            grants.remove(peer_id);
+        grant.expires_at = Some(Instant::now() + self.recovery_window);
+        Self::remove_expired(&mut grants, Instant::now());
+    }
+
+    fn remove_expired(grants: &mut HashMap<PeerId, HashMap<u64, PushGrant>>, now: Instant) {
+        grants.retain(|_, peer_grants| {
+            peer_grants.retain(|_, grant| grant.expires_at.is_none_or(|expiry| expiry > now));
+            !peer_grants.is_empty()
+        });
+    }
+
+    #[cfg(test)]
+    fn with_recovery_window(recovery_window: Duration) -> Self {
+        Self {
+            next_id: AtomicU64::new(0),
+            recovery_window,
+            grants: Mutex::new(HashMap::new()),
         }
     }
 }
@@ -70,7 +116,7 @@ pub(super) struct SelectiveCarAccessGuard {
 
 impl Drop for SelectiveCarAccessGuard {
     fn drop(&mut self) {
-        self.access.remove(&self.peer_id, self.grant_id);
+        self.access.finish_push(&self.peer_id, self.grant_id);
     }
 }
 
@@ -85,7 +131,7 @@ mod tests {
     }
 
     #[test]
-    fn active_push_grants_only_its_peer_and_dag() {
+    fn completed_push_grants_post_ack_recovery_for_its_peer_and_root() {
         let access = Arc::new(SelectiveCarAccess::default());
         let peer = PeerId::new("peer-a".to_string());
         let other_peer = PeerId::new("peer-b".to_string());
@@ -93,26 +139,38 @@ mod tests {
         let child = cid(b"child");
         let unrelated = cid(b"unrelated");
 
-        let guard = access.register(peer.clone(), [root, child]);
+        let guard = access.register(peer.clone(), root, [root, child]);
+        drop(guard);
 
         assert!(access.allows(&peer, &root, &child));
         assert!(!access.allows(&peer, &root, &unrelated));
-        assert!(!access.allows(&peer, &unrelated, &child));
+        assert!(!access.allows(&peer, &child, &root));
         assert!(!access.allows(&other_peer, &root, &child));
+    }
+
+    #[test]
+    fn post_ack_grant_expires_after_recovery_window() {
+        let access = Arc::new(SelectiveCarAccess::with_recovery_window(Duration::ZERO));
+        let peer = PeerId::new("peer".to_string());
+        let root = cid(b"root");
+        let child = cid(b"child");
+
+        let guard = access.register(peer.clone(), root, [root, child]);
+        assert!(access.allows(&peer, &root, &child));
 
         drop(guard);
         assert!(!access.allows(&peer, &root, &child));
     }
 
     #[test]
-    fn overlapping_push_grants_revoke_independently() {
-        let access = Arc::new(SelectiveCarAccess::default());
+    fn overlapping_push_grants_finish_independently() {
+        let access = Arc::new(SelectiveCarAccess::with_recovery_window(Duration::ZERO));
         let peer = PeerId::new("peer".to_string());
         let root = cid(b"root");
         let child = cid(b"child");
 
-        let first = access.register(peer.clone(), [root, child]);
-        let second = access.register(peer.clone(), [root, child]);
+        let first = access.register(peer.clone(), root, [root, child]);
+        let second = access.register(peer.clone(), root, [root, child]);
         drop(first);
         assert!(access.allows(&peer, &root, &child));
 


### PR DESCRIPTION
## Summary

- grant a filtered replication peer selective-CAR access to the exact CIDs under an outbound PushLog root
- keep that grant through a bounded 10-minute post-ack recovery window so asynchronous `DagNeedsFetch` retries can complete
- require the requesting peer and CAR root to match the push job, preserving controlled-mode filtering for unrelated peers, roots, and blocks
- distinguish blockstore hits, misses, filtered blocks, and kept blocks in selective-CAR diagnostics
- add height-1..17 field/composite subset coverage plus post-ack and filtered-replicator regression tests

## Root cause

The selective lookup itself was correct: document field deltas and composite blocks are written as raw CID keys in the same blockstore namespace, and `collect_exact_blocks` retrieved the requested CIDs. In controlled mode, the CAR handler then passed those hits through the generic serve filter. Filtered replicators are deliberately denied generic block reads, so every hit was removed even when the CAR request was the recovery leg of a filter-approved PushLog. The existing warning reported the post-filter empty set as "no exact blocks found."

H1 is therefore falsified by the storage trace and the 17-height subset test. H2 is also falsified: `CarFetchRequest` and the selective-CAR encoding did not change between `63c0be62` and `a8ebb10a`, so no mixed-version compatibility path is needed.

The recovery grant is active while the outbound push is in flight. When the PushLog round-trip completes, dropping its registration starts a 10-minute recovery lease instead of revoking it immediately. That covers the receiver's documented worst-case bounded fetch retry budget (roughly seven minutes at the four-provider cap). Access remains scoped to the receiving peer, the original push-job root, and CIDs loaded as descendants of that root; expired leases are removed during subsequent registration and authorization checks.

## Validation

- `cargo test -p p2p`
- `cargo test -p integration-test --test p2p -- filtered_replication::rust_filtered_replication_excludes_nonmatching_controlled_mode --exact --nocapture --test-threads=1`
- `cargo clippy --all -- -D warnings`
- `cargo fmt --all`
- `git diff --check`

Fixes #1101
