### PR TITLE
fix(query): populate commit collection IDs

### DIFF
--- a/crates/query-plan/src/fetcher.rs
+++ b/crates/query-plan/src/fetcher.rs
@@ -182,7 +182,7 @@ pub trait DocFetcher: MaybeSendSync {
     /// # Returns
     ///
     /// Commit documents with fields: cid, height, fieldName, docID, delta,
-    /// collectionID, collectionVersionId, links, heads, signature.
+    /// collectionVersionId, links, heads, signature.
     async fn get_commits(&self, options: &CommitsQueryOptions) -> Result<Vec<Document>> {
         let _ = options;
         Err(query_types::error::QueryError::execution(

--- a/crates/query-plan/src/fetcher.rs
+++ b/crates/query-plan/src/fetcher.rs
@@ -182,7 +182,7 @@ pub trait DocFetcher: MaybeSendSync {
     /// # Returns
     ///
     /// Commit documents with fields: cid, height, fieldName, docID, delta,
-    /// collectionVersionId, links, heads, signature.
+    /// collectionID, collectionVersionId, links, heads, signature.
     async fn get_commits(&self, options: &CommitsQueryOptions) -> Result<Vec<Document>> {
         let _ = options;
         Err(query_types::error::QueryError::execution(

--- a/crates/query/src/runner/commits.rs
+++ b/crates/query/src/runner/commits.rs
@@ -368,6 +368,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         fetcher: &dyn DocFetcher,
         doc_id: &str,
         version_select: &Select,
+        collection_id: &str,
         target_cid: Option<&str>,
     ) -> Result<JsonValue> {
         use crate::fetcher::CommitsQueryOptions;
@@ -396,7 +397,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         // and render the requested fields
         let mut version_results: Vec<JsonValue> = Vec::new();
 
-        for commit in commits {
+        for mut commit in commits {
             // Filter to composite commits
             let field_name = commit
                 .get("fieldName")
@@ -406,6 +407,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                 continue;
             }
 
+            commit.set("collectionID", collection_id.to_string());
             let commit_json = self.render_commit(&commit, version_select)?;
             version_results.push(commit_json);
         }

--- a/crates/query/src/runner/commits.rs
+++ b/crates/query/src/runner/commits.rs
@@ -761,7 +761,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             > = std::collections::HashMap::new();
 
             let mut keep = Vec::with_capacity(commits.len());
-            for commit in &commits {
+            for commit in &mut commits {
                 let version_id = commit.get("collectionVersionId").and_then(|v| v.as_str());
                 let doc_id = commit.get("docID").and_then(|v| v.as_str()).unwrap_or("");
 
@@ -785,7 +785,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                     },
                 };
 
-                let allowed = match collection {
+                let allowed = match &collection {
                     // Fail closed: a commit whose collection version cannot be
                     // resolved is denied (Go errors the query here). Never allow
                     // an unresolved version through unchecked.
@@ -821,6 +821,9 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                         }
                     },
                 };
+                if let Some(collection) = collection {
+                    commit.set("collectionID", collection.collection_id.clone());
+                }
                 keep.push(allowed);
             }
             let mut keep = keep.into_iter();

--- a/crates/query/src/runner/introspection/collection.rs
+++ b/crates/query/src/runner/introspection/collection.rs
@@ -287,6 +287,7 @@ pub(super) fn build_commit_type() -> Object {
             )),
         )
         .field(null_field!("cid", TypeRef::named("String")))
+        .field(null_field!("collectionID", TypeRef::named("String")))
         .field(null_field!("collectionVersionId", TypeRef::named("String")))
         .field(null_field!("delta", TypeRef::named("String")))
         .field(null_field!("docID", TypeRef::named("String")))

--- a/crates/query/src/runner/mutation.rs
+++ b/crates/query/src/runner/mutation.rs
@@ -846,7 +846,13 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                         obj.get("_docID").and_then(|v| v.as_str()).map(String::from)
                     {
                         let version_data = self
-                            .fetch_version_data(fetcher, &doc_id, version_sel, None)
+                            .fetch_version_data(
+                                fetcher,
+                                &doc_id,
+                                version_sel,
+                                &collection.collection_id,
+                                None,
+                            )
                             .await?;
                         obj.insert(output_name.clone(), version_data);
                     }

--- a/crates/query/src/runner/version.rs
+++ b/crates/query/src/runner/version.rs
@@ -249,6 +249,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                             fetcher,
                             &doc_id_str,
                             version_select,
+                            &collection.collection_id,
                             Some(cid.as_str()),
                         )
                         .await?;
@@ -385,7 +386,13 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
 
             if let Some(doc_id_str) = doc_id {
                 let version_data = self
-                    .fetch_version_data(fetcher, &doc_id_str, version_select, None)
+                    .fetch_version_data(
+                        fetcher,
+                        &doc_id_str,
+                        version_select,
+                        &collection.collection_id,
+                        None,
+                    )
                     .await?;
                 let output_name = version_select.field.output_name();
                 doc_obj.insert(output_name.to_string(), version_data);

--- a/tools/integration-test/tests/query.rs
+++ b/tools/integration-test/tests/query.rs
@@ -1,5 +1,7 @@
 #[path = "query/commits_aggregate.rs"]
 mod commits_aggregate;
+#[path = "query/commits_collection_id.rs"]
+mod commits_collection_id;
 #[path = "query/commits_height_filter.rs"]
 mod commits_height_filter;
 #[path = "query/continuous_rollup.rs"]

--- a/tools/integration-test/tests/query/commits_collection_id.rs
+++ b/tools/integration-test/tests/query/commits_collection_id.rs
@@ -1,0 +1,110 @@
+use integration_test::TestCluster;
+use serde_json::Value;
+
+const SCHEMA: &str = "type IncidentReport { title: String status: String }";
+
+fn extract_doc_id(data: &Value) -> String {
+    data["add_IncidentReport"]
+        .as_array()
+        .and_then(|rows| rows.first())
+        .and_then(|row| row["_docID"].as_str())
+        .expect("missing _docID")
+        .to_string()
+}
+
+fn extract_collection_id(description: &Value) -> String {
+    description
+        .get("CollectionID")
+        .or_else(|| description.get("collection_id"))
+        .and_then(Value::as_str)
+        .expect("missing CollectionID")
+        .to_string()
+}
+
+fn extract_commits(data: &Value) -> &[Value] {
+    data["_commits"].as_array().expect("missing _commits array")
+}
+
+fn assert_collection_id(commits: &[Value], expected: &str) {
+    for commit in commits {
+        assert_eq!(
+            commit["collectionID"].as_str(),
+            Some(expected),
+            "unexpected collectionID for commit {}",
+            commit
+        );
+    }
+}
+
+#[tokio::test]
+async fn commits_include_collection_id_for_doc_id_and_cid_queries() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    let node = cluster.client(0);
+
+    node.schema_add(SCHEMA).expect("add schema");
+    let collection_id = extract_collection_id(
+        &node
+            .collection_describe_version("IncidentReport")
+            .expect("describe collection"),
+    );
+
+    let created = node
+        .query(
+            r#"mutation {
+                add_IncidentReport(input: {title: "Database alert", status: "open"}) {
+                    _docID
+                }
+            }"#,
+        )
+        .expect("create incident report");
+    let doc_id = extract_doc_id(&created);
+
+    node.query(&format!(
+        r#"mutation {{
+            update_IncidentReport(docID: "{doc_id}", input: {{status: "resolved"}}) {{
+                _docID
+            }}
+        }}"#,
+    ))
+    .expect("update incident report");
+
+    let by_doc_id = node
+        .query(&format!(
+            r#"query {{
+                _commits(docID: ["{doc_id}"]) {{
+                    cid
+                    collectionID
+                    fieldName
+                }}
+            }}"#,
+        ))
+        .expect("query commits by docID");
+    let doc_commits = extract_commits(&by_doc_id);
+    assert_collection_id(doc_commits, &collection_id);
+
+    let composite_cid = doc_commits
+        .iter()
+        .find(|commit| commit["fieldName"] == "_C")
+        .and_then(|commit| commit["cid"].as_str())
+        .expect("missing composite commit");
+    let field_cid = doc_commits
+        .iter()
+        .find(|commit| commit["fieldName"] == "status")
+        .and_then(|commit| commit["cid"].as_str())
+        .expect("missing field commit");
+
+    let by_cid = node
+        .query(&format!(
+            r#"query {{
+                _commits(cid: ["{composite_cid}", "{field_cid}"]) {{
+                    cid
+                    collectionID
+                    fieldName
+                }}
+            }}"#,
+        ))
+        .expect("query composite and field commits by cid");
+    let cid_commits = extract_commits(&by_cid);
+    assert_eq!(cid_commits.len(), 2, "expected both requested commits");
+    assert_collection_id(cid_commits, &collection_id);
+}

--- a/tools/integration-test/tests/query/commits_collection_id.rs
+++ b/tools/integration-test/tests/query/commits_collection_id.rs
@@ -25,7 +25,16 @@ fn extract_commits(data: &Value) -> &[Value] {
     data["_commits"].as_array().expect("missing _commits array")
 }
 
+fn extract_versions<'a>(data: &'a Value, root: &str) -> &'a [Value] {
+    data[root]
+        .as_array()
+        .and_then(|rows| rows.first())
+        .and_then(|row| row["_version"].as_array())
+        .expect("missing _version array")
+}
+
 fn assert_collection_id(commits: &[Value], expected: &str) {
+    assert!(!commits.is_empty(), "expected at least one commit");
     for commit in commits {
         assert_eq!(
             commit["collectionID"].as_str(),
@@ -37,7 +46,7 @@ fn assert_collection_id(commits: &[Value], expected: &str) {
 }
 
 #[tokio::test]
-async fn commits_include_collection_id_for_doc_id_and_cid_queries() {
+async fn commits_and_versions_include_collection_id() {
     let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
     let node = cluster.client(0);
 
@@ -59,14 +68,38 @@ async fn commits_include_collection_id_for_doc_id_and_cid_queries() {
         .expect("create incident report");
     let doc_id = extract_doc_id(&created);
 
-    node.query(&format!(
-        r#"mutation {{
+    let updated = node
+        .query(&format!(
+            r#"mutation {{
             update_IncidentReport(docID: "{doc_id}", input: {{status: "resolved"}}) {{
                 _docID
+                _version {{
+                    collectionID
+                }}
             }}
         }}"#,
-    ))
-    .expect("update incident report");
+        ))
+        .expect("update incident report");
+    assert_collection_id(
+        extract_versions(&updated, "update_IncidentReport"),
+        &collection_id,
+    );
+
+    let regular_versions = node
+        .query(&format!(
+            r#"query {{
+                IncidentReport(docID: "{doc_id}") {{
+                    _version {{
+                        collectionID
+                    }}
+                }}
+            }}"#,
+        ))
+        .expect("query versions by docID");
+    assert_collection_id(
+        extract_versions(&regular_versions, "IncidentReport"),
+        &collection_id,
+    );
 
     let by_doc_id = node
         .query(&format!(
@@ -92,6 +125,22 @@ async fn commits_include_collection_id_for_doc_id_and_cid_queries() {
         .find(|commit| commit["fieldName"] == "status")
         .and_then(|commit| commit["cid"].as_str())
         .expect("missing field commit");
+
+    let cid_versions = node
+        .query(&format!(
+            r#"query {{
+                IncidentReport(cid: "{composite_cid}") {{
+                    _version {{
+                        collectionID
+                    }}
+                }}
+            }}"#,
+        ))
+        .expect("query versions by cid");
+    assert_collection_id(
+        extract_versions(&cid_versions, "IncidentReport"),
+        &collection_id,
+    );
 
     let by_cid = node
         .query(&format!(


### PR DESCRIPTION
## Summary

- expose `collectionID` on the GraphQL `Commit` type
- populate the stable collection ID from the `CollectionVersion` already resolved for `_commits` ACP checks
- populate `_version` results from the collection already known to regular, CID time-travel, and mutation queries
- cover docID- and CID-keyed `_commits` queries plus all three `_version` entry points

## Root cause

Commit blocks provide `collectionVersionId`, and the query resolver already resolves that version to its collection for access control. The resolved collection ID was never copied into the `_commits` result, and Commit introspection omitted the field.

The `_version` renderer uses the same `Commit` GraphQL type but reads raw fetcher documents, so exposing the field also made `_version { collectionID }` selectable without populating it. Those query and mutation paths already know the stable collection ID and now pass it into the shared version renderer.

Both fixes reuse collection information already available to their resolver paths, so they add no per-row datastore lookups.

## Compatibility

`collectionID` is an intentional Rust-side GraphQL extension for #1105. The Go v1.0.0 `Commit` type exposes `collectionVersionId` but not `collectionID`, so this field is not strict Go wire parity.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all -- -D warnings`
- `cargo test --workspace --exclude integration-test --exclude ffi-test --exclude conformance`
- `cargo test -p integration-test --test query commits_collection_id -- --test-threads=1`
- `cargo test -p integration-test --test query -- --test-threads=1 --skip ::go_` (39 passed)

Fixes #1105
