### PR TITLE
fix(p2p): single-flight receive processing by CID

### DIFF
--- a/crates/p2p/src/sync/coordinator/mod.rs
+++ b/crates/p2p/src/sync/coordinator/mod.rs
@@ -135,6 +135,9 @@ pub struct SyncStatus {
     pub missing_link_retries: u64,
     pub pending_dag_resolved: u64,
     pub pending_dag_expired: u64,
+    pub single_flight_suppressed: u64,
+    pub already_merged_fast_path: u64,
+    pub pending_dag_capacity_shed: u64,
 }
 
 struct SyncShutdownState {
@@ -437,6 +440,9 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             missing_link_retries: diagnostics.missing_link_retries,
             pending_dag_resolved: diagnostics.pending_dag_resolved,
             pending_dag_expired: diagnostics.pending_dag_expired,
+            single_flight_suppressed: diagnostics.single_flight_suppressed,
+            already_merged_fast_path: diagnostics.already_merged_fast_path,
+            pending_dag_capacity_shed: diagnostics.pending_dag_capacity_shed,
         }
     }
 

--- a/crates/p2p/src/sync/manager/diagnostics.rs
+++ b/crates/p2p/src/sync/manager/diagnostics.rs
@@ -122,6 +122,9 @@ pub struct SyncDiagnostics {
     missing_link_retries: AtomicU64,
     pending_dag_resolved: AtomicU64,
     pending_dag_expired: AtomicU64,
+    single_flight_suppressed: AtomicU64,
+    already_merged_fast_path: AtomicU64,
+    pending_dag_capacity_shed: AtomicU64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -131,6 +134,9 @@ pub struct SyncDiagnosticsSnapshot {
     pub missing_link_retries: u64,
     pub pending_dag_resolved: u64,
     pub pending_dag_expired: u64,
+    pub single_flight_suppressed: u64,
+    pub already_merged_fast_path: u64,
+    pub pending_dag_capacity_shed: u64,
     /// Process-global; see [`record_gossip_decode_failure`].
     pub gossip_decode_failures: u64,
     /// Process-global recent samples captured by
@@ -146,6 +152,9 @@ impl SyncDiagnostics {
             missing_link_retries: self.missing_link_retries.load(Ordering::Relaxed),
             pending_dag_resolved: self.pending_dag_resolved.load(Ordering::Relaxed),
             pending_dag_expired: self.pending_dag_expired.load(Ordering::Relaxed),
+            single_flight_suppressed: self.single_flight_suppressed.load(Ordering::Relaxed),
+            already_merged_fast_path: self.already_merged_fast_path.load(Ordering::Relaxed),
+            pending_dag_capacity_shed: self.pending_dag_capacity_shed.load(Ordering::Relaxed),
             gossip_decode_failures: GOSSIP_DECODE_FAILURES.load(Ordering::Relaxed),
             recent_gossip_decode_failures: RECENT_GOSSIP_DECODE_FAILURES
                 .lock()
@@ -174,6 +183,21 @@ impl SyncDiagnostics {
     pub fn record_pending_dag_expired(&self) {
         self.pending_dag_expired.fetch_add(1, Ordering::Relaxed);
     }
+
+    pub fn record_single_flight_suppressed(&self) {
+        self.single_flight_suppressed
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_already_merged_fast_path(&self) {
+        self.already_merged_fast_path
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_pending_dag_capacity_shed(&self) {
+        self.pending_dag_capacity_shed
+            .fetch_add(1, Ordering::Relaxed);
+    }
 }
 
 #[cfg(test)]
@@ -189,6 +213,9 @@ mod tests {
         assert_eq!(snap.missing_link_retries, 0);
         assert_eq!(snap.pending_dag_resolved, 0);
         assert_eq!(snap.pending_dag_expired, 0);
+        assert_eq!(snap.single_flight_suppressed, 0);
+        assert_eq!(snap.already_merged_fast_path, 0);
+        assert_eq!(snap.pending_dag_capacity_shed, 0);
     }
 
     #[test]
@@ -200,6 +227,9 @@ mod tests {
         diag.record_missing_link_retry();
         diag.record_pending_dag_resolved();
         diag.record_pending_dag_expired();
+        diag.record_single_flight_suppressed();
+        diag.record_already_merged_fast_path();
+        diag.record_pending_dag_capacity_shed();
 
         let snap = diag.snapshot();
         assert_eq!(snap.car_empty_responses, 2);
@@ -207,6 +237,9 @@ mod tests {
         assert_eq!(snap.missing_link_retries, 1);
         assert_eq!(snap.pending_dag_resolved, 1);
         assert_eq!(snap.pending_dag_expired, 1);
+        assert_eq!(snap.single_flight_suppressed, 1);
+        assert_eq!(snap.already_merged_fast_path, 1);
+        assert_eq!(snap.pending_dag_capacity_shed, 1);
     }
 
     #[test]

--- a/crates/p2p/src/sync/manager/process/pending_dag.rs
+++ b/crates/p2p/src/sync/manager/process/pending_dag.rs
@@ -47,6 +47,18 @@ impl<B: Blockstore + 'static> SyncManager<B> {
         self.pending_dags.read().len()
     }
 
+    /// Return whether a root can enter the pending-DAG registry without
+    /// decoding its pushed block.
+    pub(super) fn can_admit_pending_dag(&self, root_cid: &Cid) -> bool {
+        let mut pending = self.pending_dags.write();
+        let expired = evict_expired_pending_dags(&mut pending, Instant::now());
+        for _ in expired {
+            self.diagnostics.record_pending_dag_expired();
+        }
+
+        pending.len() < self.max_pending_dags || pending.contains_key(root_cid)
+    }
+
     /// Get CIDs of all pending DAGs.
     pub fn pending_dag_cids(&self) -> Vec<Cid> {
         self.pending_dags.read().keys().copied().collect()

--- a/crates/p2p/src/sync/manager/process/pushlog.rs
+++ b/crates/p2p/src/sync/manager/process/pushlog.rs
@@ -109,78 +109,27 @@ impl<B: Blockstore + 'static> SyncManager<B> {
             "Processing pushlog"
         );
 
-        // Try to acquire exclusive processing rights for this CID
-        match self.process_queue.try_acquire(&cid).await {
-            Ok(_guard) => {
-                // We're the first - process the block
-                self.process_block_inner(
-                    &cid,
-                    msg,
+        let _guard = match self.process_queue.try_acquire_nowait(&cid) {
+            Some(guard) => guard,
+            None => {
+                self.diagnostics.record_single_flight_suppressed();
+                tracing::debug!(
+                    cid = %cid,
                     sender_peer,
-                    is_explicit_replicator,
-                    explicit_replay_authorization.clone(),
-                )
-                .await
+                    "Suppressing PushLog while the same CID is already being processed"
+                );
+                return Ok(());
             }
-            Err(rx) => {
-                // Another task is processing - wait for it
-                if rx.await.is_err() {
-                    tracing::debug!(
-                        ?cid,
-                        "First processor task was cancelled, will check merge status"
-                    );
-                }
+        };
 
-                // Now check if block is already merged
-                match self
-                    .retry_retriable_pushlog_op(&cid, "post_wait_is_merged", || async {
-                        self.blockstore
-                            .is_merged(&cid)
-                            .await
-                            .map_err(Error::from_blockstore)
-                    })
-                    .await
-                {
-                    Ok(true) => {
-                        // Already merged by the other task
-                        if self
-                            .event_tx
-                            .send(SyncEvent::BlockAlreadyMerged {
-                                cid,
-                                doc_id: msg.doc_id.clone(),
-                                collection_id: msg.collection_id.clone(),
-                                creator: msg.creator.clone(),
-                            })
-                            .await
-                            .is_err()
-                        {
-                            tracing::warn!(
-                                ?cid,
-                                "Failed to send BlockAlreadyMerged event - receiver dropped"
-                            );
-                            return Err(Error::ChannelSend);
-                        }
-                        Ok(())
-                    }
-                    Ok(false) => {
-                        // Not yet merged - we need to process it
-                        // (This can happen if the first task failed)
-                        self.process_block_inner(
-                            &cid,
-                            msg,
-                            sender_peer,
-                            is_explicit_replicator,
-                            explicit_replay_authorization.clone(),
-                        )
-                        .await
-                    }
-                    Err(e) => {
-                        self.emit_sync_error(&cid, &e).await?;
-                        Err(e)
-                    }
-                }
-            }
-        }
+        self.process_block_inner(
+            &cid,
+            msg,
+            sender_peer,
+            is_explicit_replicator,
+            explicit_replay_authorization,
+        )
+        .await
     }
 
     /// Inner block processing logic.
@@ -203,24 +152,8 @@ impl<B: Blockstore + 'static> SyncManager<B> {
             .await
         {
             Ok(true) => {
+                self.diagnostics.record_already_merged_fast_path();
                 tracing::debug!(cid = %cid, doc_id = %msg.doc_id, "Block already merged, skipping");
-                if self
-                    .event_tx
-                    .send(SyncEvent::BlockAlreadyMerged {
-                        cid: *cid,
-                        doc_id: msg.doc_id.clone(),
-                        collection_id: msg.collection_id.clone(),
-                        creator: msg.creator.clone(),
-                    })
-                    .await
-                    .is_err()
-                {
-                    tracing::warn!(
-                        ?cid,
-                        "Failed to send BlockAlreadyMerged event - receiver dropped"
-                    );
-                    return Err(Error::ChannelSend);
-                }
                 return Ok(());
             }
             Ok(false) => {
@@ -230,6 +163,21 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                 self.emit_sync_error(cid, &e).await?;
                 return Err(e);
             }
+        }
+
+        if !self.can_admit_pending_dag(cid) {
+            self.diagnostics.record_pending_dag_capacity_shed();
+            tracing::warn!(
+                cid = %cid,
+                doc_id = %msg.doc_id,
+                collection_id = %msg.collection_id,
+                source_peer = ?sender_peer,
+                max = self.max_pending_dags,
+                "Pending DAGs at capacity, shedding PushLog before block verification"
+            );
+            return Err(Error::PendingDagCapacity {
+                max: self.max_pending_dags,
+            });
         }
 
         // Verify CID matches block content before storing (finding 06-29).
@@ -376,6 +324,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                     },
                 );
                 if !inserted {
+                    self.diagnostics.record_pending_dag_capacity_shed();
                     // The block is stored but its DAG completion is not
                     // tracked. This must surface as an error: a success reply
                     // deletes the pusher's retry record, silently losing the
@@ -428,6 +377,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                     }
                 };
                 if matches!(admission, DurableAdmission::AtCapacity) {
+                    self.diagnostics.record_pending_dag_capacity_shed();
                     self.pending_dags.write().remove(cid);
                     tracing::warn!(
                         cid = %cid,
@@ -685,5 +635,184 @@ mod tests {
 
         assert!(matches!(result, Err(Error::ChannelSend)));
         assert_eq!(manager.pending_dag_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn conformance_same_cid_concurrent_announcements_are_idempotent() {
+        const ANNOUNCEMENT_COUNT: usize = 8;
+
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let peer_state = Arc::new(PeerStateTracker::new());
+        let config = SyncConfig {
+            event_buffer_size: 1,
+            ..SyncConfig::default()
+        };
+        let (manager, mut events) = SyncManager::new(blockstore, peer_state, config);
+        let manager = Arc::new(manager);
+
+        let (field_cid, _field_block) = create_lww_block("name");
+        let (root_cid, root_block) = create_composite_block("doc123", "name", field_cid);
+        let message = Arc::new(make_broadcast(
+            "doc123",
+            root_cid,
+            root_block,
+            "collection1",
+        ));
+
+        manager
+            .event_tx
+            .send(SyncEvent::SyncError {
+                cid: root_cid,
+                error: "hold event channel full".to_string(),
+            })
+            .await
+            .expect("prefill event channel");
+
+        let owner_manager = Arc::clone(&manager);
+        let owner_message = Arc::clone(&message);
+        let owner = tokio::spawn(async move {
+            owner_manager
+                .process_pushlog(&owner_message, Some("peer-0"), false, None)
+                .await
+        });
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while manager.pending_dag_count() != 1 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("owner should register the pending DAG");
+
+        let mut suppressed = Vec::new();
+        for peer in 1..ANNOUNCEMENT_COUNT {
+            let manager = Arc::clone(&manager);
+            let message = Arc::clone(&message);
+            suppressed.push(tokio::spawn(async move {
+                let peer = format!("peer-{peer}");
+                manager
+                    .process_pushlog(&message, Some(&peer), false, None)
+                    .await
+            }));
+        }
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            for task in suppressed {
+                task.await
+                    .expect("suppressed task should not panic")
+                    .expect("suppressed announcement should be accepted");
+            }
+        })
+        .await
+        .expect("same-CID announcements should exit while the owner is still in flight");
+
+        assert_eq!(
+            manager.diagnostics().snapshot().single_flight_suppressed,
+            (ANNOUNCEMENT_COUNT - 1) as u64
+        );
+        assert_eq!(manager.pending_dag_count(), 1);
+        assert_eq!(manager.process_queue.active_count(), 1);
+
+        assert!(matches!(
+            events.recv().await,
+            Some(SyncEvent::SyncError { .. })
+        ));
+        owner
+            .await
+            .expect("owner task should not panic")
+            .expect("owner should complete");
+
+        assert!(matches!(
+            events.recv().await,
+            Some(SyncEvent::DagNeedsFetch { root_cid: cid, .. }) if cid == root_cid
+        ));
+        assert_eq!(manager.pending_dag_count(), 1);
+        assert_eq!(manager.process_queue.active_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn merged_head_exits_before_block_verification_or_registration() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let peer_state = Arc::new(PeerStateTracker::new());
+        let (manager, mut events) =
+            SyncManager::new(blockstore.clone(), peer_state, SyncConfig::default());
+
+        let (cid, block) = create_lww_block("name");
+        blockstore.put(&cid, &block).await.expect("store block");
+        blockstore
+            .mark_as_merged(&cid)
+            .await
+            .expect("mark block merged");
+
+        let invalid_reannouncement =
+            make_broadcast("doc123", cid, vec![0xff; 1024 * 1024], "collection1");
+        manager
+            .process_pushlog(&invalid_reannouncement, Some("peer-1"), false, None)
+            .await
+            .expect("merged fast path should not inspect the pushed block");
+
+        assert_eq!(manager.pending_dag_count(), 0);
+        assert_eq!(manager.diagnostics().snapshot().already_merged_fast_path, 1);
+        assert!(matches!(
+            events.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+        ));
+    }
+
+    #[tokio::test]
+    async fn pending_capacity_sheds_before_block_verification() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let peer_state = Arc::new(PeerStateTracker::new());
+        let config = SyncConfig {
+            max_pending_dags: 1,
+            ..SyncConfig::default()
+        };
+        let (manager, mut events) = SyncManager::new(blockstore.clone(), peer_state, config);
+
+        let (missing_cid, _missing_block) = create_lww_block("missing");
+        let (first_cid, first_block) = create_composite_block("doc123", "name", missing_cid);
+        manager
+            .process_pushlog(
+                &make_broadcast("doc123", first_cid, first_block, "collection1"),
+                Some("peer-1"),
+                false,
+                None,
+            )
+            .await
+            .expect("fill pending DAG registry");
+        assert!(matches!(
+            events.try_recv(),
+            Ok(SyncEvent::DagNeedsFetch { root_cid, .. }) if root_cid == first_cid
+        ));
+
+        let (rejected_cid, _rejected_block) = create_lww_block("rejected");
+        let allocation_heavy_garbage = vec![0xff; 4 * 1024 * 1024];
+        let result = manager
+            .process_pushlog(
+                &make_broadcast(
+                    "doc456",
+                    rejected_cid,
+                    allocation_heavy_garbage,
+                    "collection1",
+                ),
+                Some("peer-2"),
+                false,
+                None,
+            )
+            .await;
+
+        assert!(matches!(result, Err(Error::PendingDagCapacity { max: 1 })));
+        assert_eq!(
+            manager.diagnostics().snapshot().pending_dag_capacity_shed,
+            1
+        );
+        assert!(!blockstore
+            .has(&rejected_cid)
+            .await
+            .expect("check rejected block"));
+        assert_eq!(manager.pending_dag_count(), 1);
     }
 }

--- a/crates/p2p/src/sync/queue.rs
+++ b/crates/p2p/src/sync/queue.rs
@@ -155,6 +155,22 @@ impl ProcessQueue {
         }
     }
 
+    /// Try to acquire a CID without allocating or registering a waiter.
+    ///
+    /// Returns `None` immediately when another caller owns the CID.
+    pub fn try_acquire_nowait(&self, cid: &Cid) -> Option<ProcessGuard> {
+        let mut waiters = self.inner.waiters.lock();
+        if waiters.contains_key(cid) {
+            return None;
+        }
+
+        waiters.insert(*cid, Vec::new());
+        Some(ProcessGuard {
+            cid: *cid,
+            queue: self.clone(),
+        })
+    }
+
     /// Release the CID and notify all waiters (synchronous version).
     fn release_sync(&self, cid: &Cid) {
         let mut waiters = self.inner.waiters.lock();
@@ -251,6 +267,16 @@ mod tests {
         // Second caller should get a waiter
         let result = queue.try_acquire(&cid).await;
         assert!(result.is_err(), "Second caller should wait");
+    }
+
+    #[tokio::test]
+    async fn test_nowait_second_caller_is_suppressed() {
+        let queue = ProcessQueue::new();
+        let cid = test_cid();
+
+        let _guard = queue.try_acquire_nowait(&cid).unwrap();
+
+        assert!(queue.try_acquire_nowait(&cid).is_none());
     }
 
     #[tokio::test]

--- a/crates/p2p/tests/sync_manager_tests.rs
+++ b/crates/p2p/tests/sync_manager_tests.rs
@@ -131,14 +131,11 @@ async fn test_process_pushlog_already_merged() {
         .await
         .unwrap();
 
-    // Should receive BlockAlreadyMerged event
-    let event = events.try_recv().unwrap();
-    match event {
-        SyncEvent::BlockAlreadyMerged { cid: event_cid, .. } => {
-            assert_eq!(event_cid, cid);
-        }
-        _ => panic!("Expected BlockAlreadyMerged event"),
-    }
+    assert_eq!(manager.diagnostics().snapshot().already_merged_fast_path, 1);
+    assert!(matches!(
+        events.try_recv(),
+        Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+    ));
 }
 
 #[tokio::test]
@@ -248,9 +245,7 @@ async fn test_process_pushlog_cid_mismatch_returns_error() {
 }
 
 #[tokio::test]
-async fn test_concurrent_processing_second_waiter_processes_on_first_not_merged() {
-    use std::sync::atomic::{AtomicBool, Ordering};
-
+async fn test_sequential_unmerged_reannouncement_is_processed_again() {
     let store = Arc::new(MemoryStore::new());
     let blockstore = Arc::new(DefraBlockstore::new(store, true));
     let (manager, mut events) =
@@ -260,43 +255,19 @@ async fn test_concurrent_processing_second_waiter_processes_on_first_not_merged(
     let cid = test_cid();
     let msg = create_test_broadcast(&cid);
 
-    // Flag to track if first processor completed
-    let first_done = Arc::new(AtomicBool::new(false));
-
-    // First task: acquire lock, store block, but DON'T mark as merged
-    let manager1 = manager.clone();
-    let msg1 = msg.clone();
-    let first_done1 = first_done.clone();
-    let first_task = tokio::spawn(async move {
-        manager1
-            .process_pushlog(&msg1, None, false, None)
-            .await
-            .unwrap();
-        first_done1.store(true, Ordering::SeqCst);
-    });
-
-    // Give first task time to acquire the lock
-    tokio::time::sleep(Duration::from_millis(10)).await;
-
-    // Second task: should wait for first, then also process (since not merged)
-    let manager2 = manager.clone();
-    let msg2 = msg.clone();
-    let second_task = tokio::spawn(async move {
-        manager2
-            .process_pushlog(&msg2, None, false, None)
-            .await
-            .unwrap();
-    });
-
-    // Wait for both tasks
-    first_task.await.unwrap();
-    second_task.await.unwrap();
+    manager
+        .process_pushlog(&msg, None, false, None)
+        .await
+        .unwrap();
+    manager
+        .process_pushlog(&msg, None, false, None)
+        .await
+        .unwrap();
 
     // Block should be stored
     assert!(blockstore.has(&cid).await.unwrap());
 
-    // We should get at least one BlockReceived event
-    // (could get two if second waiter also processes before checking merge status)
+    // Once the first receive has exited, its unmerged head can be retried.
     let mut received_count = 0;
     while let Ok(event) = events.try_recv() {
         match event {
@@ -305,10 +276,7 @@ async fn test_concurrent_processing_second_waiter_processes_on_first_not_merged(
             _ => {}
         }
     }
-    assert!(
-        received_count >= 1,
-        "Should have at least one BlockReceived event"
-    );
+    assert_eq!(received_count, 2);
 }
 
 #[tokio::test]
@@ -339,7 +307,7 @@ async fn test_process_pushlog_returns_error_when_receiver_dropped() {
 }
 
 #[tokio::test]
-async fn test_already_merged_returns_error_when_receiver_dropped() {
+async fn test_already_merged_fast_path_does_not_need_event_receiver() {
     let store = Arc::new(MemoryStore::new());
     let blockstore = Arc::new(DefraBlockstore::new(store, true));
     let (manager, events) =
@@ -355,15 +323,10 @@ async fn test_already_merged_returns_error_when_receiver_dropped() {
     // Drop the event receiver
     drop(events);
 
-    // Processing already-merged block should fail since we can't send event
+    // The merged lookup is terminal and does not allocate or enqueue an event.
     let result = manager.process_pushlog(&msg, None, false, None).await;
-    assert!(result.is_err());
-    match result {
-        Err(Error::ChannelSend) => {
-            // Expected - can't send BlockAlreadyMerged event
-        }
-        other => panic!("Expected ChannelSend error, got {:?}", other),
-    }
+    assert!(result.is_ok());
+    assert_eq!(manager.diagnostics().snapshot().already_merged_fast_path, 1);
 }
 
 #[tokio::test]
@@ -688,8 +651,8 @@ async fn test_process_pushlog_pending_capacity_returns_typed_error() {
         result
     );
     assert_eq!(manager.pending_dag_count(), 1, "registration was dropped");
-    // The block itself is kept (a later retry can complete without re-sending it).
-    assert!(blockstore.has(&comp_b_cid).await.unwrap());
+    // Cheap shed happens before verification, storage, and DAG decoding.
+    assert!(!blockstore.has(&comp_b_cid).await.unwrap());
 }
 
 #[tokio::test]

--- a/tools/integration-test/tests/p2p_admission.rs
+++ b/tools/integration-test/tests/p2p_admission.rs
@@ -123,6 +123,22 @@ async fn fan_in_pushlog_admission_no_silent_divergence() {
         tokio::time::sleep(Duration::from_millis(500)).await;
     }
 
+    let status: serde_json::Value =
+        reqwest::get(format!("{}/api/v0/p2p/sync/status", cluster.api_url(0)))
+            .await
+            .expect("hub sync status request")
+            .json()
+            .await
+            .expect("hub sync status json");
+    assert!(
+        status["pending_dag_capacity_shed"]
+            .as_u64()
+            .is_some_and(|count| count > 0),
+        "fan-in capacity exits were not counted: {status}"
+    );
+    assert!(status["single_flight_suppressed"].is_u64());
+    assert!(status["already_merged_fast_path"].is_u64());
+
     // M1: every success-acked document must eventually merge on the hub.
     // Overflowed pushes are nacked, kept in the pushers' retry ladders, and
     // re-pushed until the hub admits them — so completeness within the

--- a/tools/integration-test/tests/p2p_push_storm.rs
+++ b/tools/integration-test/tests/p2p_push_storm.rs
@@ -753,6 +753,9 @@ async fn outbound_push_storm_matches_fleet_shape() {
             "/push_backlog/retry_attempts_total",
             "/retry_attempts_total",
         ]),
+        "receive_single_flight_suppressed": status["single_flight_suppressed"].as_u64(),
+        "receive_already_merged_fast_path": status["already_merged_fast_path"].as_u64(),
+        "receive_pending_dag_capacity_shed": status["pending_dag_capacity_shed"].as_u64(),
     });
     println!(
         "PUSH_STORM_RESULT {}",


### PR DESCRIPTION
## Summary

- suppress overlapping PushLog announcements for the same head CID without allocating a waiter
- return immediately for already-merged heads and reject at pending-DAG capacity before block verification, storage, or DAG decoding
- expose `single_flight_suppressed`, `already_merged_fast_path`, and `pending_dag_capacity_shed` through sync diagnostics/status
- add deterministic same-CID conformance coverage and extend the fan-in/push-storm harness observability

## Root cause

The existing receive queue woke duplicate callers after the first receive task exited, but those callers continued without reacquiring the CID. Because Rust delegates the actual merge through an event, the head could still be unmerged at that point, causing every waiter to repeat storage, DAG traversal, and registration work. Pending-DAG capacity was also checked only after block verification, storage, and DAG traversal.

## Impact

Announcement floods now have one receive-path owner per CID. Overlapping duplicates, merged re-announcements, and at-capacity pushes terminate through cheap, counted exits, while sequential retries remain possible after the owner leaves.

## Validation

- `cargo test -p p2p`
- `cargo test -p integration-test --test p2p_push_storm`
- `cargo test -p integration-test --test p2p_admission -- --nocapture`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

Fixes #1115
