### PR TITLE
fix(p2p): accept subscribed gossip from outbound targets

### DIFF
--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -299,6 +299,7 @@ fn create_test_coordinator_with_blockstore_and_head_provider<B: Blockstore + 'st
             local_peer_id,
             access_mode,
             replicators,
+            gossip_direction_filtered: std::sync::atomic::AtomicU64::new(0),
         },
         subscriptions: SyncSubscriptionState {
             subscribed_collections: Arc::new(tokio::sync::RwLock::new(
@@ -1967,7 +1968,7 @@ async fn gossip_controlled_mode_rejects_mismatched_document_topic() {
 }
 
 #[tokio::test]
-async fn gossip_controlled_mode_rejects_outbound_replicator_target() {
+async fn gossip_controlled_mode_allows_subscribed_outbound_replicator_target() {
     let replicators = Arc::new(ReplicatorRegistry::new());
     let peer_state = Arc::new(PeerStateTracker::new());
     let peer = random_peer_id();
@@ -1992,10 +1993,11 @@ async fn gossip_controlled_mode_rejects_outbound_replicator_target() {
         .await;
 
     assert!(
-        matches!(&result, Err(Error::AccessDenied { .. })),
-        "outbound replicator targets must not be accepted as gossip sources, got {:?}",
+        !matches!(&result, Err(Error::AccessDenied { .. })),
+        "subscribed collections must accept gossip from outbound replicator targets, got {:?}",
         result
     );
+    assert_eq!(coordinator.sync_status().gossip_direction_filtered_total, 0);
 }
 
 #[tokio::test]
@@ -2024,7 +2026,7 @@ async fn gossip_document_topic_allows_outbound_replicator_target() {
 }
 
 #[tokio::test]
-async fn gossip_open_mode_rejects_outbound_replicator_target() {
+async fn gossip_open_mode_rejects_unsubscribed_outbound_replicator_target() {
     let replicators = Arc::new(ReplicatorRegistry::new());
     let peer_state = Arc::new(PeerStateTracker::new());
     let peer = random_peer_id();
@@ -2038,9 +2040,10 @@ async fn gossip_open_mode_rejects_outbound_replicator_target() {
 
     assert!(
         matches!(&result, Err(Error::AccessDenied { .. })),
-        "open access mode must still preserve one-way replicator gossip direction, got {:?}",
+        "unsubscribed outbound replicator targets must not become gossip sources, got {:?}",
         result
     );
+    assert_eq!(coordinator.sync_status().gossip_direction_filtered_total, 1);
 }
 
 #[tokio::test]

--- a/crates/p2p/src/sync/coordinator/constructor.rs
+++ b/crates/p2p/src/sync/coordinator/constructor.rs
@@ -1,5 +1,6 @@
 //! Constructor methods for the sync coordinator.
 
+use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -262,6 +263,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                     local_peer_id,
                     access_mode,
                     replicators,
+                    gossip_direction_filtered: AtomicU64::new(0),
                 },
                 subscriptions: SyncSubscriptionState {
                     subscribed_collections,

--- a/crates/p2p/src/sync/coordinator/event_handler/gossip.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/gossip.rs
@@ -1,5 +1,7 @@
 //! GossipSub message handling.
 
+use std::sync::atomic::Ordering;
+
 use blockstore::Blockstore;
 use cid::Cid;
 
@@ -31,12 +33,21 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         let is_open_access = self.access.access_mode.is_open();
         let is_outbound_replicator_target =
             self.is_registered_replicator(propagation_source.as_str(), &message.collection_id);
+        let is_direction_filtered = !topic_matches_document
+            && topic_matches_collection
+            && is_outbound_replicator_target
+            && !is_subscribed;
 
         if !topic_matches_document
             && (!topic_matches_collection
-                || is_outbound_replicator_target
+                || is_direction_filtered
                 || (!is_open_access && !is_subscribed))
         {
+            if is_direction_filtered {
+                self.access
+                    .gossip_direction_filtered
+                    .fetch_add(1, Ordering::Relaxed);
+            }
             tracing::warn!(
                 peer_id = %propagation_source,
                 topic = %topic,
@@ -46,7 +57,8 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 topic_matches_document,
                 is_subscribed,
                 is_outbound_replicator_target,
-                "Dropping GossipSub message outside accepted replication direction"
+                is_direction_filtered,
+                "Dropping GossipSub message outside accepted replication policy"
             );
             return Err(crate::error::Error::AccessDenied {
                 peer_id: propagation_source.to_string(),

--- a/crates/p2p/src/sync/coordinator/mod.rs
+++ b/crates/p2p/src/sync/coordinator/mod.rs
@@ -29,9 +29,9 @@
 //!   channel and skips receiver-side collection access before merge.
 //! - **Pubsub PushLog acceptance** requires collection replicator membership,
 //!   a local collection subscription, or explicit replay authorization.
-//! - **Inbound Gossip acceptance** is topic-scoped to local collection
-//!   subscriptions and rejects outbound replicator targets so one-way
-//!   replicators do not receive reverse-direction gossip from their targets.
+//! - **Inbound Gossip acceptance** treats a local collection subscription as
+//!   receive intent, regardless of outbound replicator configuration. Without
+//!   a subscription, outbound targets remain invalid gossip sources.
 //! - **Document-level ACP** remains the authoritative policy boundary for whether
 //!   replicated document content is actually mergeable/readable locally.
 //!
@@ -62,7 +62,7 @@ mod subscriptions;
 pub use result_types::{CreateReplicatorResult, LoadReplicatorsResult};
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -124,6 +124,9 @@ pub struct SyncStatus {
     pub broadcast_coalesced_total: u64,
     /// Replicator fan-outs folded before enumerating peers.
     pub push_updates_coalesced_total: u64,
+    /// Gossip messages rejected because an unsubscribed sender was configured
+    /// only as an outbound replicator target.
+    pub gossip_direction_filtered_total: u64,
     pub pending_dags: usize,
     pub pending_dag_capacity: usize,
     /// Durable pending-DAG registrations (may exceed `pending_dags`: records
@@ -351,6 +354,9 @@ pub(super) struct SyncAccessState {
 
     /// Replicator registry for access control checks.
     pub(super) replicators: Arc<ReplicatorRegistry>,
+
+    /// Gossip messages rejected by the receive-side direction guard.
+    pub(super) gossip_direction_filtered: AtomicU64,
 }
 
 /// Subscription and document head support state for the coordinator.
@@ -428,6 +434,10 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             encode_cache_entries: self.runtime.push_encode_cache.live_entries(),
             broadcast_coalesced_total: self.runtime.broadcast_coalescer.coalesced(),
             push_updates_coalesced_total: self.runtime.push_fanout_coalescer.coalesced(),
+            gossip_direction_filtered_total: self
+                .access
+                .gossip_direction_filtered
+                .load(Ordering::Relaxed),
             pending_dags: self.manager.pending_dag_count(),
             pending_dag_capacity: self.manager.max_pending_dags(),
             persisted_pending_dags: self.manager.persisted_pending_count(),

--- a/tools/integration-test/tests/acp/p2p_lifecycle.rs
+++ b/tools/integration-test/tests/acp/p2p_lifecycle.rs
@@ -359,8 +359,20 @@ async fn acp_p2p_delete_private_documents_on_different_nodes_test(cluster: TestC
     )
     .await;
 
-    assert!(query_user_names(&node0, None).is_empty());
-    assert!(query_user_names(&node1, None).is_empty());
+    poll_until(
+        || query_user_names(&node0, None).is_empty(),
+        Duration::from_secs(15),
+        Duration::from_millis(200),
+        "node0 still exposed a deleted document anonymously",
+    )
+    .await;
+    poll_until(
+        || query_user_names(&node1, None).is_empty(),
+        Duration::from_secs(15),
+        Duration::from_millis(200),
+        "node1 still exposed a deleted document anonymously",
+    )
+    .await;
 }
 
 #[tokio::test]

--- a/tools/integration-test/tests/p2p_iroh/peer/create.rs
+++ b/tools/integration-test/tests/p2p_iroh/peer/create.rs
@@ -71,9 +71,8 @@ async fn create_does_not_sync() {
 }
 
 /// Port: TestP2PCreateWithP2PCollection
-/// When collection subscription + replicator are set, docs sync one-way.
-/// Both nodes subscribe to the same gossip topic, but node0 must still reject
-/// reverse-direction gossip from its outbound replicator target.
+/// When both nodes subscribe, docs gossip symmetrically even if the explicit
+/// replicator configuration has only one outbound leg.
 #[tokio::test]
 #[serial]
 async fn create_with_p2p_collection() {
@@ -114,7 +113,8 @@ async fn create_with_p2p_collection() {
     node1
         .p2p_collection_add(&["Users"])
         .expect("collection add node1");
-    // Replicator: node0 pushes to node1 (one-way)
+    // Replicator: node0 explicitly pushes to node1. The shared subscription
+    // still expresses receive intent in both directions.
     node0
         .p2p_replicator_set(&["Users"], &addr1)
         .expect("replicator set 0→1");
@@ -127,7 +127,7 @@ async fn create_with_p2p_collection() {
         .query(r#"mutation { add_Users(input: {name: "Addo", age: 28}) { _docID } }"#)
         .expect("create Addo on node0");
 
-    // Create doc on node1 (should NOT flow back to node0)
+    // Create doc on node1; the subscription should carry it back to node0.
     node1
         .query(r#"mutation { add_Users(input: {name: "Fred", age: 31}) { _docID } }"#)
         .expect("create Fred on node1");
@@ -171,8 +171,24 @@ async fn create_with_p2p_collection() {
         "node1 should have locally-created Fred"
     );
 
-    // Verify node0 does NOT have Fred (one-way replicator)
-    tokio::time::sleep(Duration::from_secs(2)).await;
+    // Verify node0 accepts Fred from its outbound replicator target because it
+    // is locally subscribed to the collection.
+    let node0_ref = &node0;
+    poll_until(
+        || {
+            let result = node0_ref
+                .query("query { Users { name } }")
+                .unwrap_or_default();
+            result["Users"]
+                .as_array()
+                .is_some_and(|users| users.iter().any(|user| user["name"] == "Fred"))
+        },
+        Duration::from_secs(30),
+        Duration::from_millis(300),
+        "node0 should accept Fred over its subscribed collection topic",
+    )
+    .await;
+
     let node0_result = node0
         .query("query { Users { name } }")
         .expect("query node0");
@@ -183,8 +199,8 @@ async fn create_with_p2p_collection() {
         .filter_map(|u| u["name"].as_str())
         .collect();
     assert!(
-        !node0_names.contains(&"Fred"),
-        "node0 should NOT have Fred (one-way replicator), got {:?}",
+        node0_names.contains(&"Fred"),
+        "node0 should have Fred from its subscribed collection, got {:?}",
         node0_names
     );
 }


### PR DESCRIPTION
## Summary

- accept collection-topic gossip from an outbound replicator target when the local node is subscribed
- retain the direction guard for unsubscribed outbound-only targets and expose those drops as `gossip_direction_filtered_total`
- update the two-node Iroh regression to verify symmetric subscribed receive behavior
- make the adjacent ACP delete lifecycle assertion wait for replicated tombstone convergence

## Root cause

PR #938 used outbound replicator registration as a receive-side denial signal to preserve one-way Iroh replication when both peers joined the same gossip topic. In symmetric meshes, that conflated send direction with receive intent: the local node was genuinely subscribed, but messages from its configured outbound target were rejected.

This change makes a local collection subscription authoritative for receive while leaving direction meaningful for outbound sends. Topic/payload validation, Controlled-mode subscription checks, and the unsubscribed outbound-target guard remain in place.

## Impact

Subscribed symmetric/control-plane collections can propagate gossip in both directions instead of silently dropping half of the traffic and forcing recovery through missing-link fetches. Operators can observe any remaining receive-side direction drops through sync status.

## Validation

- `cargo test -p p2p` (401 unit tests plus P2P integration/doc tests pass)
- `cargo test -p integration-test --test p2p_iroh peer::create::create_with_p2p_collection -- --exact --nocapture`
- `cargo test -p integration-test --test acp p2p_lifecycle::rust_rust_acp_p2p_delete_private_documents_on_different_nodes -- --exact --nocapture`
- `cargo check --workspace --all-targets`
- `cargo clippy --all -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

A full `PATH=/tmp:$PATH cargo test` with a locally built Go binary reached the ACP integration suite with 197 passed, 1 failed, and 16 ignored. The one failure is an external Go checkout/fixture CLI mismatch: `go_acp_revoke_lifecycle` invokes `collection truncate --name`, while that Go binary reports `unknown flag: --name`.

References #1114.