### PR TITLE
fix(p2p): preserve retry for suppressed PushLogs

### DIFF
--- a/crates/p2p/src/error.rs
+++ b/crates/p2p/src/error.rs
@@ -213,6 +213,10 @@ pub enum Error {
         max: usize,
     },
 
+    /// Another receive task owns this CID and has not established recovery state yet.
+    #[error("PushLog for CID {cid} is already being processed, retry later")]
+    PushLogInFlight { cid: String },
+
     /// Request rejected because the caller is not authorized.
     #[error("unauthorized: {0}")]
     Unauthorized(String),
@@ -360,14 +364,19 @@ impl Error {
     }
 
     /// Reply text for hub-side backpressure rejections (rate limit or
-    /// pending-DAG capacity overflow), or `None` for every other error.
+    /// pending-DAG capacity overflow, or same-CID single-flight suppression),
+    /// or `None` for every other error.
     ///
     /// The pusher matches replies byte-exactly against `RATE_LIMITED_MESSAGE`
     /// (`is_rate_limited_message`) to drive its retry/backoff, so all
     /// backpressure shapes must collapse onto that one sentinel.
     pub fn backpressure_reply_message(&self) -> Option<&'static str> {
-        (self.is_rate_limited() || matches!(self, Error::PendingDagCapacity { .. }))
-            .then_some(RATE_LIMITED_MESSAGE)
+        (self.is_rate_limited()
+            || matches!(
+                self,
+                Error::PendingDagCapacity { .. } | Error::PushLogInFlight { .. }
+            ))
+        .then_some(RATE_LIMITED_MESSAGE)
     }
 }
 
@@ -491,6 +500,14 @@ mod tests {
         assert!(is_rate_limited_message(
             capacity.backpressure_reply_message().unwrap()
         ));
+
+        let in_flight = Error::PushLogInFlight {
+            cid: "bafy-head".to_string(),
+        };
+        assert_eq!(
+            in_flight.backpressure_reply_message(),
+            Some(RATE_LIMITED_MESSAGE)
+        );
 
         let rate_limited = Error::AccessDenied {
             peer_id: "peer-1".into(),

--- a/crates/p2p/src/sync/coordinator/event_handler/pushlog.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/pushlog.rs
@@ -264,3 +264,22 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn in_flight_single_flight_suppression_replies_with_backpressure() {
+        let result = Err(crate::error::Error::PushLogInFlight {
+            cid: "bafy-head".to_string(),
+        });
+
+        let reply = build_pushlog_reply("message-1", &result);
+
+        assert_eq!(
+            reply.err_message.as_deref(),
+            Some(crate::error::RATE_LIMITED_MESSAGE)
+        );
+    }
+}

--- a/crates/p2p/src/sync/manager/events.rs
+++ b/crates/p2p/src/sync/manager/events.rs
@@ -31,14 +31,6 @@ pub enum SyncEvent {
         explicit_replay_authorization: Option<ExplicitReplayAuthorization>,
     },
 
-    /// A block was already merged (received duplicate).
-    BlockAlreadyMerged {
-        cid: Cid,
-        doc_id: String,
-        collection_id: String,
-        creator: String,
-    },
-
     /// Failed to process a sync request.
     SyncError { cid: Cid, error: String },
 

--- a/crates/p2p/src/sync/manager/pending.rs
+++ b/crates/p2p/src/sync/manager/pending.rs
@@ -33,6 +33,8 @@ pub struct PendingDag {
     pub is_explicit_replicator: bool,
     /// Capability-based explicit replay authorization carried by two-stream pushes.
     pub explicit_replay_authorization: Option<ExplicitReplayAuthorization>,
+    /// Whether a success reply can rely on this entry for eventual recovery.
+    pub is_recovery_registered: bool,
     /// When this entry was inserted (for TTL eviction).
     pub inserted_at: Instant,
     /// How many times `retry_pending_dag` has been invoked for this root.

--- a/crates/p2p/src/sync/manager/process/pending_dag.rs
+++ b/crates/p2p/src/sync/manager/process/pending_dag.rs
@@ -47,6 +47,25 @@ impl<B: Blockstore + 'static> SyncManager<B> {
         self.pending_dags.read().len()
     }
 
+    pub(super) fn is_pending_dag_recovery_registered(&self, root_cid: &Cid) -> bool {
+        self.pending_dags
+            .read()
+            .get(root_cid)
+            .is_some_and(|dag| dag.is_recovery_registered)
+    }
+
+    pub(super) fn mark_pending_dag_recovery_registered(
+        &self,
+        root_cid: &Cid,
+        inserted_at: Instant,
+    ) {
+        if let Some(dag) = self.pending_dags.write().get_mut(root_cid) {
+            if dag.inserted_at == inserted_at {
+                dag.is_recovery_registered = true;
+            }
+        }
+    }
+
     /// Return whether a root can enter the pending-DAG registry without
     /// decoding its pushed block.
     pub(super) fn can_admit_pending_dag(&self, root_cid: &Cid) -> bool {
@@ -247,6 +266,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                 source_peer: Some(source_peer.clone()),
                 is_explicit_replicator: false,
                 explicit_replay_authorization: None,
+                is_recovery_registered: false,
                 inserted_at: Instant::now(),
                 attempts: 0,
                 fetch_failures: 0,
@@ -290,6 +310,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                 source_peer: Some(source_peer.clone()),
                 is_explicit_replicator: false,
                 explicit_replay_authorization: None,
+                is_recovery_registered: false,
                 inserted_at: Instant::now(),
                 attempts: 0,
                 fetch_failures: 0,
@@ -594,6 +615,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                     .explicit_replay_authorization
                     .clone()
                     .map(Into::into),
+                is_recovery_registered: true,
                 inserted_at: Instant::now(),
                 attempts: 0,
                 fetch_failures: 0,
@@ -694,6 +716,7 @@ mod tests {
             source_peer: Some("peer".to_string()),
             is_explicit_replicator: false,
             explicit_replay_authorization: None,
+            is_recovery_registered: false,
             inserted_at,
             attempts: 0,
             fetch_failures: 0,

--- a/crates/p2p/src/sync/manager/process/pushlog.rs
+++ b/crates/p2p/src/sync/manager/process/pushlog.rs
@@ -81,7 +81,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
     /// # Flow
     ///
     /// 1. Parse CID from the message
-    /// 2. Acquire process queue lock (serialize concurrent syncs for same CID)
+    /// 2. Acquire per-CID ownership or cheaply suppress a concurrent duplicate
     /// 3. Check if already merged
     /// 4. Store block in blockstore (marked as unmerged)
     /// 5. Emit BlockReceived only once the full reachable DAG is locally present,
@@ -115,10 +115,34 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                 self.diagnostics.record_single_flight_suppressed();
                 tracing::debug!(
                     cid = %cid,
-                    sender_peer,
+                    sender_peer = ?sender_peer,
                     "Suppressing PushLog while the same CID is already being processed"
                 );
-                return Ok(());
+
+                if self.is_pending_dag_recovery_registered(&cid) {
+                    return Ok(());
+                }
+
+                match self
+                    .retry_retriable_pushlog_op(&cid, "suppressed_is_merged", || async {
+                        self.blockstore
+                            .is_merged(&cid)
+                            .await
+                            .map_err(Error::from_blockstore)
+                    })
+                    .await
+                {
+                    Ok(true) => {
+                        self.diagnostics.record_already_merged_fast_path();
+                        return Ok(());
+                    }
+                    Ok(false) => {
+                        return Err(Error::PushLogInFlight {
+                            cid: cid.to_string(),
+                        });
+                    }
+                    Err(error) => return Err(error),
+                }
             }
         };
 
@@ -306,6 +330,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
             );
 
             // Track this DAG as pending (enforces TTL eviction and capacity limit).
+            let inserted_at = Instant::now();
             {
                 let inserted = self.insert_pending_dag(
                     *cid,
@@ -317,7 +342,8 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                         source_peer: sender_peer.map(str::to_owned),
                         is_explicit_replicator,
                         explicit_replay_authorization: explicit_replay_authorization.clone(),
-                        inserted_at: Instant::now(),
+                        is_recovery_registered: false,
+                        inserted_at,
                         attempts: 0,
                         fetch_failures: 0,
                         last_fetch_error: None,
@@ -352,7 +378,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
             // Durable records outlive TTL-evicted map entries, so they carry
             // their own larger cap; at the cap the obligation is refused
             // (backpressure nack) while the pusher still owns retry state.
-            if let Some(store) = self.pending_store() {
+            let has_durable_registration = if let Some(store) = self.pending_store() {
                 let durable_cap = self
                     .max_pending_dags
                     .saturating_mul(super::PERSISTED_PENDING_CAP_FACTOR);
@@ -413,7 +439,11 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                         "failed to persist pending DAG registration: {error}"
                     )));
                 }
-            }
+                self.mark_pending_dag_recovery_registered(cid, inserted_at);
+                true
+            } else {
+                false
+            };
 
             // Get providers for the missing blocks
             let providers = self.get_providers_for_cids(&missing);
@@ -444,6 +474,9 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                 // resync sweep (the pusher was nacked, so it also retries).
                 self.pending_dags.write().remove(cid);
                 return Err(Error::ChannelSend);
+            }
+            if !has_durable_registration {
+                self.mark_pending_dag_recovery_registered(cid, inserted_at);
             }
         }
 
@@ -699,9 +732,14 @@ mod tests {
 
         tokio::time::timeout(Duration::from_secs(1), async {
             for task in suppressed {
-                task.await
-                    .expect("suppressed task should not panic")
-                    .expect("suppressed announcement should be accepted");
+                let result = task.await.expect("suppressed task should not panic");
+                assert!(
+                    matches!(
+                        result,
+                        Err(Error::PushLogInFlight { ref cid }) if cid == &root_cid.to_string()
+                    ),
+                    "a duplicate must not ack before the owner establishes recovery state"
+                );
             }
         })
         .await
@@ -729,6 +767,15 @@ mod tests {
         ));
         assert_eq!(manager.pending_dag_count(), 1);
         assert_eq!(manager.process_queue.active_count(), 0);
+
+        let _guard = manager
+            .process_queue
+            .try_acquire_nowait(&root_cid)
+            .expect("simulate a later receive owner");
+        manager
+            .process_pushlog(&message, Some("peer-8"), false, None)
+            .await
+            .expect("an established pending registration can ack a duplicate");
     }
 
     #[tokio::test]

--- a/crates/p2p/src/sync/replication/handlers.rs
+++ b/crates/p2p/src/sync/replication/handlers.rs
@@ -702,18 +702,6 @@ where
             )
             .await
         }
-        SyncEvent::BlockAlreadyMerged {
-            cid,
-            doc_id,
-            collection_id,
-            creator: _,
-        } => ReplicationResult::Skipped {
-            cid,
-            doc_id,
-            collection_id,
-            reason: "already merged".to_string(),
-            terminal: true,
-        },
         SyncEvent::SyncError { cid, error } => ReplicationResult::Failed { cid, error },
         SyncEvent::DagNeedsFetch {
             root_cid,

--- a/crates/p2p/tests/sync_manager_tests.rs
+++ b/crates/p2p/tests/sync_manager_tests.rs
@@ -270,10 +270,8 @@ async fn test_sequential_unmerged_reannouncement_is_processed_again() {
     // Once the first receive has exited, its unmerged head can be retried.
     let mut received_count = 0;
     while let Ok(event) = events.try_recv() {
-        match event {
-            SyncEvent::BlockReceived { .. } => received_count += 1,
-            SyncEvent::BlockAlreadyMerged { .. } => {} // Also valid
-            _ => {}
+        if let SyncEvent::BlockReceived { .. } = event {
+            received_count += 1;
         }
     }
     assert_eq!(received_count, 2);


### PR DESCRIPTION
## Summary

- return a retriable backpressure nack when same-CID suppression happens before the owner establishes recovery state
- distinguish recovery-backed pending registrations from entries still being persisted or enqueued
- preserve cheap success acks for already-merged heads and established pending registrations
- remove the unreachable `BlockAlreadyMerged` sync event and update the receive-flow documentation/logging

## Root cause

PR #1117 suppressed concurrent same-CID PushLogs with an immediate success result. If the owner then failed before persisting or registering recovery work, the suppressed pusher could delete its retry record while the receiver held neither a merged block nor a recovery obligation.

This follow-up marks a pending entry recovery-backed only after its durable write succeeds, or after its fetch event is successfully enqueued when no durable store is installed. Earlier duplicates receive the standard rate-limited reply and retain their retry state.

## Tradeoff

The cheap capacity shed introduced in #1117 intentionally rejects before storing the pushed block. A retry therefore resends the block bytes, trading network bandwidth for bounded receiver CPU and storage work during overload.

## Validation

- `cargo test -p p2p`
- `cargo test -p integration-test --test p2p_admission -- --nocapture`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

Follow-up to #1117 and #1115.
