### PR TITLE
Resolve root-level __typename as the Query type

### DIFF
--- a/crates/query/src/runner/executor.rs
+++ b/crates/query/src/runner/executor.rs
@@ -795,4 +795,58 @@ mod tests {
             }))
         );
     }
+
+    #[tokio::test]
+    async fn root_typename_resolves_to_the_query_type() {
+        let collections = crate::parse_sdl("type Users { name: String }").expect("schema");
+        let runner = QueryRunner::new(MockFetcher::new(), collections);
+
+        let response = runner.execute(QueryRequest::new("{ __typename }")).await;
+
+        assert!(
+            !response.has_errors(),
+            "unexpected errors: {:?}",
+            response.errors
+        );
+        assert_eq!(response.data, Some(json!({ "__typename": "Query" })));
+    }
+
+    #[tokio::test]
+    async fn root_typename_is_aliasable_and_composes_with_data_fields() {
+        let collections = crate::parse_sdl("type Users { name: String }").expect("schema");
+        let fetcher = MockFetcher::new();
+        fetcher.add_doc("Users", make_users_doc("alice"));
+        let runner = QueryRunner::new(fetcher, collections);
+
+        let response = runner
+            .execute(QueryRequest::new("{ t: __typename Users { name } }"))
+            .await;
+
+        assert!(
+            !response.has_errors(),
+            "unexpected errors: {:?}",
+            response.errors
+        );
+        assert_eq!(
+            response.data,
+            Some(json!({
+                "t": "Query",
+                "Users": [{ "name": "alice" }],
+            }))
+        );
+    }
+
+    #[tokio::test]
+    async fn root_typename_resolves_with_no_collections_registered() {
+        let runner = QueryRunner::new(MockFetcher::new(), vec![]);
+
+        let response = runner.execute(QueryRequest::new("{ __typename }")).await;
+
+        assert!(
+            !response.has_errors(),
+            "unexpected errors: {:?}",
+            response.errors
+        );
+        assert_eq!(response.data, Some(json!({ "__typename": "Query" })));
+    }
 }

--- a/crates/query/src/runner/executor.rs
+++ b/crates/query/src/runner/executor.rs
@@ -849,4 +849,25 @@ mod tests {
         );
         assert_eq!(response.data, Some(json!({ "__typename": "Query" })));
     }
+
+    #[tokio::test]
+    async fn root_typename_resolves_through_the_implicit_read_txn_path() {
+        // Nodes with a transaction registry take the implicit read-txn path, which
+        // re-parses and validates against a txn-scoped provider. Probe that path too.
+        let collections = crate::parse_sdl("type Users { name: String }").expect("schema");
+        let runner = QueryRunner::with_registry(
+            MockFetcher::new(),
+            collections,
+            MockTxnRegistry::new(MockFetcher::new()),
+        );
+
+        let response = runner.execute(QueryRequest::new("{ __typename }")).await;
+
+        assert!(
+            !response.has_errors(),
+            "unexpected errors: {:?}",
+            response.errors
+        );
+        assert_eq!(response.data, Some(json!({ "__typename": "Query" })));
+    }
 }

--- a/crates/query/src/runner/query/select.rs
+++ b/crates/query/src/runner/query/select.rs
@@ -20,6 +20,12 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         fetcher: &dyn DocFetcher,
         caller_identity: Option<Did>,
     ) -> Result<JsonValue> {
+        // `__typename` on the root selection set is a meta-field, not a collection:
+        // it names the operation's root type. Answer it before resolving collections.
+        if select.collection_name == "__typename" {
+            return Ok(JsonValue::String("Query".to_string()));
+        }
+
         // Handle encrypted search queries (encrypted_<Collection>)
         if select.is_encrypted {
             return self


### PR DESCRIPTION
Fixes sourcenetwork/defra-agent#697.

`{ __typename }` — the standard GraphQL liveness probe — was parsed into a root `Select` with `collection_name == "__typename"` and fell all the way through `execute_select_internal` to `get_collection()`, which raised `collection not found: __typename`. Generic GraphQL tooling that probes a node before doing anything else got a hard error from a healthy node (38 occurrences in one empty-store window during the defra-agent#696 investigation).

`__typename` was already resolved *within* a selection set (`plan.rs`, `commits.rs`, `version.rs`); only the root case was missing. It is a meta-field naming the operation's root type, so it is now answered as `"Query"` before any collection resolution.

Handled in the data path rather than routed to the introspection engine, so it keeps composing with real data fields (`{ __typename Users { name } }`) and aliases keep working through the existing `output_name()` keying.

Scope: `__schema`/`__type` already work via the async-graphql dynamic schema. `mutation { __typename }` still returns a clean `Cannot query field "__typename" on type "Mutation".` parse error rather than `"Mutation"` — untouched here, since no client probes that way.

## Tests

Three in `runner::executor::tests`: the bare probe, an alias mixed with a data field, and the probe against a node with **zero collections registered** (the empty-store case from defra-agent#696). All three fail with the reported `collection not found: __typename` when the guard is removed.

`cargo fmt --all --check`, `cargo test -p query`, `cargo clippy -p query --all-targets`, `cargo check --workspace --all-targets` — green.