### PR TITLE
feat(p2p): receiver-authoritative pull — paced pending-DAG retry clock (#1116 stage 2)

### DIFF
--- a/crates/cli/src/commands/start/server_p2p.rs
+++ b/crates/cli/src/commands/start/server_p2p.rs
@@ -231,6 +231,15 @@ impl Node {
                 .run_pending_dag_resync(std::time::Duration::from_secs(60))
                 .await;
         });
+
+        // Receiver's re-arm loop (#1116 stage 2): dispatches due pending
+        // roots at a tight cadence. Sibling of the resync sweep above.
+        let coordinator_for_retry_clock = coordinator.clone();
+        tokio::spawn(async move {
+            coordinator_for_retry_clock
+                .run_pending_dag_retry_clock(std::time::Duration::from_secs(2))
+                .await;
+        });
         let coordinator_for_acp = coordinator.clone();
         let serve_acp_for_acp = serve_acp.clone();
         let handle_for_acp = handle.clone();
@@ -873,6 +882,15 @@ impl Node {
         tokio::spawn(async move {
             coordinator_for_restore
                 .run_pending_dag_resync(std::time::Duration::from_secs(60))
+                .await;
+        });
+
+        // Receiver's re-arm loop (#1116 stage 2): dispatches due pending
+        // roots at a tight cadence. Sibling of the resync sweep above.
+        let coordinator_for_retry_clock = coordinator.clone();
+        tokio::spawn(async move {
+            coordinator_for_retry_clock
+                .run_pending_dag_retry_clock(std::time::Duration::from_secs(2))
                 .await;
         });
         let coordinator_for_acp = coordinator.clone();

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -1442,6 +1442,15 @@ impl NodeBuilder {
                 .await;
         });
 
+        // Receiver's re-arm loop (#1116 stage 2): dispatches due pending
+        // roots at a tight cadence. Sibling of the resync sweep above.
+        let coord_for_retry_clock = coordinator.clone();
+        tokio::spawn(async move {
+            coord_for_retry_clock
+                .run_pending_dag_retry_clock(std::time::Duration::from_secs(2))
+                .await;
+        });
+
         // 10. IROH event handler (events are already TransportEvent -- no conversion needed)
         let coord_for_events = coordinator.clone();
         let event_handler_task = tokio::spawn(async move {

--- a/crates/embedded/src/node_p2p.rs
+++ b/crates/embedded/src/node_p2p.rs
@@ -165,6 +165,15 @@ where
             .run_pending_dag_resync(std::time::Duration::from_secs(60))
             .await;
     });
+
+    // Receiver's re-arm loop (#1116 stage 2): dispatches due pending roots
+    // at a tight cadence. Sibling of the resync sweep above.
+    let coordinator_for_retry_clock = coordinator.clone();
+    tokio::spawn(async move {
+        coordinator_for_retry_clock
+            .run_pending_dag_retry_clock(std::time::Duration::from_secs(2))
+            .await;
+    });
     let replication = db_merge::create_replication_stack(
         database.clone(),
         blockstore.clone(),
@@ -447,6 +456,15 @@ where
     tokio::spawn(async move {
         coordinator_for_restore
             .run_pending_dag_resync(std::time::Duration::from_secs(60))
+            .await;
+    });
+
+    // Receiver's re-arm loop (#1116 stage 2): dispatches due pending roots
+    // at a tight cadence. Sibling of the resync sweep above.
+    let coordinator_for_retry_clock = coordinator.clone();
+    tokio::spawn(async move {
+        coordinator_for_retry_clock
+            .run_pending_dag_retry_clock(std::time::Duration::from_secs(2))
             .await;
     });
     let replication = db_merge::create_replication_stack(

--- a/crates/p2p/src/sync/car.rs
+++ b/crates/p2p/src/sync/car.rs
@@ -218,6 +218,64 @@ pub async fn collect_exact_blocks<B: Blockstore>(
     Ok(outcome)
 }
 
+/// Walk the DAG rooted at `root`, collecting every reachable CID for an
+/// access grant (not the block bytes themselves).
+///
+/// Used to authorize a receiver's post-push selective-CAR recovery pull from
+/// the DAG's actual shape, independent of whatever subset of blocks the
+/// pusher happened to send in this job (root-only pushes still let the
+/// receiver recover missing ancestors/dependents via CAR). Mirrors the
+/// receiver-side `find_all_missing_links` walk by following
+/// [`extract_ipld_links`](crate::sync::manager::links::extract_ipld_links),
+/// which excludes the `encryption` link (#976): that block is never served
+/// over CAR (KMS-only, ECIES-wrapped, permission-gated), so it must never be
+/// included in a grant's explicit CID set either — `collect_exact_blocks`
+/// will happily serve any CID the grant allows.
+///
+/// Capped at `max_blocks`; absent blocks are skipped (not an error) so a
+/// partial local DAG still yields a best-effort grant.
+pub async fn collect_dag_cids<B: Blockstore>(
+    blockstore: &B,
+    root: &Cid,
+    max_blocks: usize,
+) -> Result<Vec<Cid>> {
+    let mut collected = Vec::new();
+    let mut visited = HashSet::new();
+    let mut queue = VecDeque::from([*root]);
+
+    while let Some(cid) = queue.pop_front() {
+        if !visited.insert(cid) {
+            continue;
+        }
+
+        if collected.len() >= max_blocks {
+            break;
+        }
+
+        let data = match blockstore.get(&cid).await {
+            Ok(Some(d)) => d,
+            Ok(None) => continue,
+            Err(e) => {
+                return Err(Error::BlockstoreError(format!(
+                    "failed to get block {}: {}",
+                    cid, e
+                )));
+            }
+        };
+
+        collected.push(cid);
+
+        let refs = crate::sync::manager::links::extract_ipld_links(&data).unwrap_or_default();
+        for child_cid in refs {
+            if !visited.contains(&child_cid) {
+                queue.push_back(child_cid);
+            }
+        }
+    }
+
+    Ok(collected)
+}
+
 /// Extract CID links from a DAG-CBOR block.
 fn extract_links(block_data: &[u8]) -> Vec<Cid> {
     use ipld_core::codec::Links;
@@ -586,6 +644,40 @@ mod tests {
 
         assert_eq!(collected.blocks.len(), depth);
         assert!(!collected.truncated());
+    }
+
+    #[tokio::test]
+    async fn collect_dag_cids_walks_all_reachable_and_caps() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, true);
+
+        let grandchild_data = encode_ipld(ipld!({ "kind": "grandchild" }));
+        let grandchild_cid = make_cid(&grandchild_data);
+        blockstore
+            .put(&grandchild_cid, &grandchild_data)
+            .await
+            .unwrap();
+
+        let child_data = encode_ipld(ipld!({ "child": grandchild_cid }));
+        let child_cid = make_cid(&child_data);
+        blockstore.put(&child_cid, &child_data).await.unwrap();
+
+        let root_data = encode_ipld(ipld!({ "children": [child_cid] }));
+        let root_cid = make_cid(&root_data);
+        blockstore.put(&root_cid, &root_data).await.unwrap();
+
+        let all = collect_dag_cids(&blockstore, &root_cid, CAR_MAX_BLOCKS)
+            .await
+            .unwrap();
+        let all_set: HashSet<Cid> = all.iter().copied().collect();
+        assert_eq!(
+            all_set,
+            HashSet::from([root_cid, child_cid, grandchild_cid]),
+            "expected root, child, and grandchild to be reachable"
+        );
+
+        let capped = collect_dag_cids(&blockstore, &root_cid, 2).await.unwrap();
+        assert_eq!(capped.len(), 2, "cap of 2 must yield exactly 2 CIDs");
     }
 
     #[test]

--- a/crates/p2p/src/sync/coordinator/event_handler/bitswap.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/bitswap.rs
@@ -6,7 +6,7 @@ use blockstore::Blockstore;
 
 use super::super::SyncCoordinator;
 use crate::error::Result;
-use crate::transport::{P2PTransport, PeerId};
+use crate::transport::P2PTransport;
 
 impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     async fn retry_pending_root_after_bitswap(
@@ -25,42 +25,22 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             Ok(false) => {
                 let missing = self.manager.pending_dag_missing(&root_cid);
                 if !missing.is_empty() {
-                    let mut providers: Vec<PeerId> = self
-                        .access
-                        .peer_state
-                        .connected_peers()
-                        .into_iter()
-                        .map(PeerId::new)
-                        .collect();
-                    if let Some(source) = self.manager.pending_dag_source_peer(&root_cid) {
-                        let source_transport_id = PeerId::new(source);
-                        if !providers.contains(&source_transport_id) {
-                            providers.push(source_transport_id);
-                        }
-                    }
-                    match self
-                        .runtime
-                        .transport
-                        .sync_blocks(root_cid, providers, missing)
-                        .await
+                    // Post-fetch re-issue is paced by the per-root clock:
+                    // an immediate re-fetch against the same providers is
+                    // what produced the #1112 retry storms.
+                    if self
+                        .manager
+                        .try_claim_pending_dag_dispatch(&root_cid, tokio::time::Instant::now())
                     {
-                        Ok(retry_query_id) => {
-                            self.manager.register_query(retry_query_id, root_cid);
-                            tracing::debug!(
-                                query_id = query_id.0,
-                                retry_query_id = retry_query_id.0,
-                                root_cid = %root_cid,
-                                "Started Bitswap fetch for remaining child blocks"
-                            );
+                        if let Some(dag) = self.manager.pending_dag_snapshot(&root_cid) {
+                            self.dispatch_pending_dag_fetch(root_cid, &dag, None);
                         }
-                        Err(e) => {
-                            tracing::warn!(
-                                query_id = query_id.0,
-                                root_cid = %root_cid,
-                                error = %e,
-                                "Failed to start Bitswap fetch for remaining child blocks"
-                            );
-                        }
+                    } else {
+                        tracing::debug!(
+                            query_id = query_id.0,
+                            root_cid = %root_cid,
+                            "Pending DAG not due; retry clock will re-dispatch"
+                        );
                     }
                 }
             }
@@ -215,7 +195,7 @@ mod tests {
     };
     use crate::sync::{SyncConfig, SyncCoordinator, SyncEvent};
     use crate::topics::DefraTopic;
-    use crate::transport::{MessageId, P2PTransport, PeerAddr};
+    use crate::transport::{MessageId, P2PTransport, PeerAddr, PeerId};
     use crate::{QueryId, ReplicatorInfo};
 
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -567,8 +547,93 @@ mod tests {
         assert_eq!(coordinator.manager().pending_dag_count(), 0);
     }
 
-    #[tokio::test]
-    async fn bitswap_complete_retries_only_its_registered_root() {
+    /// #1116 stage 2 (#1112): a failed post-fetch retry no longer calls the
+    /// transport inline — it must claim the per-root clock first, and only
+    /// dispatch (as a `DagNeedsFetch` event) when the claim succeeds. This
+    /// keeps a root that just registered (and so just consumed its immediate
+    /// claim) from being hammered again the instant its first fetch fails.
+    #[tokio::test(start_paused = true)]
+    async fn bitswap_complete_failure_defers_reissue_to_retry_clock() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let transport = TestTransport::new();
+        let transport_handle = transport.clone();
+        let (coordinator, mut events) =
+            SyncCoordinator::new(transport, blockstore, SyncConfig::default())
+                .await
+                .expect("coordinator");
+
+        let (field_cid, _field_block) = create_lww_block("name");
+        let (root_cid, root_block) = create_composite_block("doc123", "name", field_cid);
+
+        coordinator
+            .manager()
+            .process_pushlog(
+                &make_broadcast("doc123", root_cid, root_block, "collection1"),
+                Some("peer-1"),
+                false,
+                None,
+            )
+            .await
+            .expect("root pushlog");
+
+        // Registration consumes the root's immediate claim (#1116 stage 2);
+        // drain that event so it isn't mistaken for a post-fetch reissue.
+        match events.try_recv().expect("initial DagNeedsFetch event") {
+            SyncEvent::DagNeedsFetch {
+                root_cid: event_root,
+                ..
+            } => assert_eq!(event_root, root_cid),
+            other => panic!("expected DagNeedsFetch, got {:?}", other),
+        }
+
+        let query_id = QueryId(7);
+        coordinator.manager().register_query(query_id, root_cid);
+        coordinator
+            .handle_bitswap_complete(
+                query_id,
+                false,
+                Some("selective CAR fetch failed".to_string()),
+            )
+            .await
+            .expect("bitswap complete");
+
+        assert!(
+            events.try_recv().is_err(),
+            "root is not yet due; no reissue should be dispatched"
+        );
+        assert!(
+            transport_handle.sync_calls().is_empty(),
+            "post-fetch reissue must never call the transport inline"
+        );
+
+        // Advance past the rung reached by registration's claim
+        // (dispatches=1 -> retry_backoff(1) = 4s) and run one clock tick.
+        tokio::time::advance(std::time::Duration::from_secs(4)).await;
+        let due = coordinator
+            .manager()
+            .claim_due_pending_dag_retries(tokio::time::Instant::now());
+        assert_eq!(due.len(), 1);
+        for (due_root, dag) in &due {
+            coordinator.dispatch_pending_dag_fetch(*due_root, dag, None);
+        }
+
+        match events.try_recv().expect("clock-driven DagNeedsFetch event") {
+            SyncEvent::DagNeedsFetch {
+                root_cid: event_root,
+                ..
+            } => assert_eq!(event_root, root_cid),
+            other => panic!("expected DagNeedsFetch, got {:?}", other),
+        }
+        assert!(events.try_recv().is_err(), "clock tick dispatches once");
+        assert!(
+            transport_handle.sync_calls().is_empty(),
+            "dispatch remains event-driven, not a direct transport call"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn bitswap_complete_retries_only_its_registered_and_due_root() {
         let store = Arc::new(MemoryStore::new());
         let blockstore = Arc::new(DefraBlockstore::new(store, true));
         let transport = TestTransport::new();
@@ -608,6 +673,10 @@ mod tests {
             let _ = events.try_recv().expect("DagNeedsFetch event");
         }
 
+        // Only root1 is due; root2 stays on its registration-claimed rung so
+        // any dispatch for it would prove the wrong root was retried.
+        coordinator.manager().expedite_pending_dag_retry(&root1_cid);
+
         let query_id = QueryId(7);
         coordinator.manager().register_query(query_id, root1_cid);
         coordinator
@@ -619,17 +688,26 @@ mod tests {
             .await
             .expect("bitswap complete");
 
-        let sync_calls = transport_handle.sync_calls();
-        assert_eq!(sync_calls.len(), 1, "only one pending root should retry");
-        assert_eq!(sync_calls[0].root, root1_cid);
-        assert_eq!(sync_calls[0].missing, vec![field1_cid]);
-        assert_eq!(
-            sync_calls[0].providers,
-            vec![PeerId::new("peer-1".to_string())]
+        match events.try_recv().expect("DagNeedsFetch event for root1") {
+            SyncEvent::DagNeedsFetch {
+                root_cid: event_root,
+                ..
+            } => assert_eq!(event_root, root1_cid),
+            other => panic!("expected DagNeedsFetch, got {:?}", other),
+        }
+        assert!(
+            events.try_recv().is_err(),
+            "only the due root should be dispatched"
         );
         assert_eq!(coordinator.manager().pending_dag_attempts(&root1_cid), 1);
         assert_eq!(coordinator.manager().pending_dag_attempts(&root2_cid), 0);
 
+        // root1 just dispatched (dispatches=2 -> rung 8s): a second failure
+        // right away must not reissue again. QueryId(999) stands in for the
+        // retry query a downstream fetch consumer would have registered.
+        coordinator
+            .manager()
+            .register_query(QueryId(999), root1_cid);
         coordinator
             .handle_bitswap_complete(
                 QueryId(999),
@@ -638,22 +716,46 @@ mod tests {
             )
             .await
             .expect("registered retry bitswap complete");
-        assert_eq!(
-            transport_handle.sync_calls().len(),
-            2,
-            "retry query completion should trigger another retry"
+        assert!(
+            events.try_recv().is_err(),
+            "root1 is not due again yet; no immediate reissue"
         );
         assert_eq!(coordinator.manager().pending_dag_attempts(&root1_cid), 2);
-        assert_eq!(coordinator.manager().pending_dag_attempts(&root2_cid), 0);
+
+        // Advance past root1's second rung (dispatches=2 -> retry_backoff(2)
+        // = 8s). root2's untouched registration rung (4s) has also elapsed
+        // by now, so the clock claims both — dispatch only root1's claim to
+        // keep this assertion about root1's reissue path.
+        tokio::time::advance(std::time::Duration::from_secs(8)).await;
+        let due = coordinator
+            .manager()
+            .claim_due_pending_dag_retries(tokio::time::Instant::now());
+        assert!(
+            due.iter().any(|(cid, _)| *cid == root1_cid),
+            "root1 should be due after its second rung elapses"
+        );
+        for (due_root, dag) in due.iter().filter(|(cid, _)| *cid == root1_cid) {
+            coordinator.dispatch_pending_dag_fetch(*due_root, dag, None);
+        }
+        match events.try_recv().expect("clock-driven DagNeedsFetch event") {
+            SyncEvent::DagNeedsFetch {
+                root_cid: event_root,
+                ..
+            } => assert_eq!(event_root, root1_cid),
+            other => panic!("expected DagNeedsFetch, got {:?}", other),
+        }
 
         coordinator
             .handle_bitswap_complete(QueryId(9999), false, Some("ignored".to_string()))
             .await
             .expect("unknown query is ignored");
-        assert_eq!(
-            transport_handle.sync_calls().len(),
-            2,
+        assert!(
+            events.try_recv().is_err(),
             "unknown query should not trigger another retry"
+        );
+        assert!(
+            transport_handle.sync_calls().is_empty(),
+            "post-fetch reissue is event-driven, never a direct transport call"
         );
     }
 }

--- a/crates/p2p/src/sync/coordinator/event_handler/mod.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/mod.rs
@@ -64,48 +64,14 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         self.manager.resync_persisted_pending_dags().await;
     }
 
-    /// Re-drive pending DAGs a newly connected peer can complete: its own
-    /// prior pushes and entries whose fetches exhausted providers (#1099).
-    /// Best-effort — a full event channel leaves `fetch_failures` set, so the
-    /// next connect retries.
+    /// A newly connected peer may be able to complete pending DAGs it
+    /// provided (or ones whose fetches exhausted providers): make them
+    /// promptly due and let the retry clock dispatch, so simultaneous
+    /// connects cannot re-drive the same root more than once per tick.
     fn redrive_pending_dags_for_peer(&self, peer_id: &PeerId) {
         let peer_key = peer_id.to_string();
-        for (root_cid, dag) in self.manager.pending_dags_needing_redrive(&peer_key) {
-            let mut providers = vec![peer_key.clone()];
-            if let Some(source_peer) = dag.source_peer.clone() {
-                if source_peer != peer_key {
-                    providers.push(source_peer);
-                }
-            }
-            let missing: Vec<_> = dag.missing.iter().copied().collect();
-            tracing::debug!(
-                root_cid = %root_cid,
-                peer_id = %peer_key,
-                missing_count = missing.len(),
-                fetch_failures = dag.fetch_failures,
-                "Re-driving pending DAG fetch after peer connect"
-            );
-            if let Err(error) =
-                self.manager
-                    .event_sender()
-                    .try_send(crate::sync::SyncEvent::DagNeedsFetch {
-                        root_cid,
-                        missing,
-                        providers,
-                        doc_id: dag.doc_id.clone(),
-                        collection_id: dag.collection_id.clone(),
-                        creator: dag.creator.clone(),
-                        sender_peer: dag.source_peer.clone(),
-                        is_explicit_replicator: dag.is_explicit_replicator,
-                        explicit_replay_authorization: dag.explicit_replay_authorization.clone(),
-                    })
-            {
-                tracing::debug!(
-                    root_cid = %root_cid,
-                    error = %error,
-                    "Deferred pending DAG re-drive: event channel unavailable"
-                );
-            }
+        for (root_cid, _dag) in self.manager.pending_dags_needing_redrive(&peer_key) {
+            self.manager.expedite_pending_dag_retry(&root_cid);
         }
     }
 
@@ -483,5 +449,412 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use blockstore::DefraBlockstore;
+    use bytes::Bytes;
+    use cid::Cid;
+    use defra_core::{Block, CompositeDeltaPayload, CrdtDelta, DAGLink, LwwDeltaPayload};
+    use std::sync::Arc;
+    use storage::backends::MemoryStore;
+
+    use crate::error::Result as P2PResult;
+    use crate::message::{
+        BranchableSyncReply, BranchableSyncRequest, DocSyncReply, DocSyncRequest, PushLogBroadcast,
+        PushLogReply, PushLogRequest, PushSEArtifactsRequest,
+    };
+    use crate::sync::{SyncConfig, SyncCoordinator, SyncEvent};
+    use crate::topics::DefraTopic;
+    use crate::transport::{MessageId, PeerAddr};
+    use crate::{QueryId, ReplicatorInfo};
+
+    #[derive(Clone)]
+    struct TestTransport {
+        peer_id: PeerId,
+        pubkey: Vec<u8>,
+    }
+
+    impl TestTransport {
+        fn new() -> Self {
+            Self {
+                peer_id: PeerId::new("local-peer".to_string()),
+                pubkey: vec![1, 2, 3],
+            }
+        }
+    }
+
+    #[async_trait]
+    impl P2PTransport for TestTransport {
+        type ResponseToken = ();
+
+        fn local_peer_id(&self) -> &PeerId {
+            &self.peer_id
+        }
+
+        fn local_public_key_proto(&self) -> &[u8] {
+            &self.pubkey
+        }
+
+        fn sign(&self, _data: &[u8]) -> P2PResult<Vec<u8>> {
+            Ok(vec![0])
+        }
+
+        async fn dial(&self, _peer_id: &PeerId, _addrs: Vec<PeerAddr>) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn disconnect(&self, _peer_id: &PeerId) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn listen(&self, _addr: PeerAddr) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn connected_peers(&self) -> P2PResult<Vec<PeerId>> {
+            Ok(Vec::new())
+        }
+
+        async fn listen_addresses(&self) -> P2PResult<Vec<PeerAddr>> {
+            Ok(Vec::new())
+        }
+
+        async fn poll_until_connected(
+            &self,
+            _peer_id: &PeerId,
+            _timeout: Duration,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn peer_addresses(&self) -> P2PResult<Vec<String>> {
+            Ok(Vec::new())
+        }
+
+        async fn subscribe(&self, _topic: DefraTopic) -> P2PResult<bool> {
+            Ok(true)
+        }
+
+        async fn unsubscribe(&self, _topic: DefraTopic) -> P2PResult<bool> {
+            Ok(true)
+        }
+
+        async fn publish(
+            &self,
+            _topic: DefraTopic,
+            _msg: PushLogBroadcast,
+        ) -> P2PResult<MessageId> {
+            Ok(MessageId::new("noop".to_string()))
+        }
+
+        async fn topic_peers(&self, _topic: DefraTopic) -> P2PResult<Vec<PeerId>> {
+            Ok(Vec::new())
+        }
+
+        async fn send_pushlog_response(
+            &self,
+            _token: Self::ResponseToken,
+            _reply: PushLogReply,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_two_stream_request(
+            &self,
+            _peer_id: &PeerId,
+            _req: PushLogRequest,
+        ) -> P2PResult<PushLogReply> {
+            Ok(PushLogReply::success("noop"))
+        }
+
+        async fn send_two_stream_response(
+            &self,
+            _peer_id: &PeerId,
+            _reply: PushLogReply,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_doc_sync_request(
+            &self,
+            _peer_id: &PeerId,
+            _req: DocSyncRequest,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_doc_sync_response(
+            &self,
+            _peer_id: &PeerId,
+            _reply: DocSyncReply,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_branchable_sync_request(
+            &self,
+            _peer_id: &PeerId,
+            _req: BranchableSyncRequest,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_branchable_sync_response(
+            &self,
+            _peer_id: &PeerId,
+            _reply: BranchableSyncReply,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_car_request(&self, _peer_id: &PeerId, _root_cid: Cid) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_car_response(&self, _peer_id: &PeerId, _car_data: Vec<u8>) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_car_response_token(
+            &self,
+            _token: Self::ResponseToken,
+            _car_data: Vec<u8>,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_doc_sync_response_token(
+            &self,
+            _token: Self::ResponseToken,
+            _reply: DocSyncReply,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_branchable_sync_response_token(
+            &self,
+            _token: Self::ResponseToken,
+            _reply: BranchableSyncReply,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_se_artifacts(
+            &self,
+            _peer_id: &PeerId,
+            _req: PushSEArtifactsRequest,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn sync_blocks(
+            &self,
+            _root: Cid,
+            _providers: Vec<PeerId>,
+            _missing: Vec<Cid>,
+        ) -> P2PResult<QueryId> {
+            Ok(QueryId(999))
+        }
+
+        async fn cancel_sync(&self, _query_id: QueryId) -> P2PResult<bool> {
+            Ok(true)
+        }
+
+        async fn create_replicator(
+            &self,
+            _peer_id: &PeerId,
+            _collections: Vec<String>,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn delete_replicator(&self, _peer_id: &PeerId) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn list_replicators(&self) -> P2PResult<Vec<ReplicatorInfo>> {
+            Ok(Vec::new())
+        }
+
+        async fn get_replicator(&self, _peer_id: &PeerId) -> P2PResult<Option<ReplicatorInfo>> {
+            Ok(None)
+        }
+
+        async fn remove_replicator_collections(
+            &self,
+            _peer_id: &PeerId,
+            _collections: Vec<String>,
+        ) -> P2PResult<bool> {
+            Ok(false)
+        }
+
+        async fn shutdown(&self) -> P2PResult<()> {
+            Ok(())
+        }
+    }
+
+    fn create_lww_block(field_name: &str) -> (Cid, Vec<u8>) {
+        let block = Block::new(
+            CrdtDelta::Lww(LwwDeltaPayload {
+                doc_id: b"doc123".to_vec(),
+                field_name: field_name.to_string(),
+                priority: 1,
+                schema_version_id: "schema1".to_string(),
+                data: b"value".to_vec(),
+            }),
+            vec![],
+            vec![],
+        );
+        let bytes = block.to_dag_cbor().expect("encode lww block");
+        let cid = block.generate_cid().expect("generate lww cid");
+        (cid, bytes)
+    }
+
+    fn create_composite_block(doc_id: &str, field_name: &str, field_cid: Cid) -> (Cid, Vec<u8>) {
+        let block = Block::new(
+            CrdtDelta::Composite(CompositeDeltaPayload {
+                doc_id: doc_id.as_bytes().to_vec(),
+                schema_version_id: "schema1".to_string(),
+                priority: 1,
+                status: 1,
+            }),
+            vec![],
+            vec![DAGLink::new(field_name, field_cid)],
+        );
+        let bytes = block.to_dag_cbor().expect("encode composite block");
+        let cid = block.generate_cid().expect("generate composite cid");
+        (cid, bytes)
+    }
+
+    fn make_broadcast(
+        doc_id: &str,
+        cid: Cid,
+        block: Vec<u8>,
+        collection_id: &str,
+    ) -> PushLogBroadcast {
+        PushLogBroadcast::new(
+            doc_id.to_string(),
+            Bytes::from(cid.to_bytes()),
+            collection_id.to_string(),
+            "creator1".to_string(),
+            Bytes::from(block),
+        )
+    }
+
+    /// #1116 stage 2: a peer connect must not dispatch `DagNeedsFetch`
+    /// directly anymore — it only expedites the root's retry clock, and the
+    /// clock (a single dispatch site) performs the actual fetch. This
+    /// prevents simultaneous connects from re-driving the same root more
+    /// than once per tick.
+    #[tokio::test(start_paused = true)]
+    async fn peer_connect_expedites_and_clock_dispatches_once() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let transport = TestTransport::new();
+        let (coordinator, mut events) =
+            SyncCoordinator::new(transport, blockstore, SyncConfig::default())
+                .await
+                .expect("coordinator");
+
+        let (field_cid, _field_block) = create_lww_block("name");
+        let (root_cid, root_block) = create_composite_block("doc123", "name", field_cid);
+
+        coordinator
+            .manager()
+            .process_pushlog(
+                &make_broadcast("doc123", root_cid, root_block, "collection1"),
+                Some("peer-1"),
+                false,
+                None,
+            )
+            .await
+            .expect("root pushlog");
+
+        // Registration claims its own immediate dispatch (#1116 stage 2);
+        // drain that event and use its dispatched count as the baseline.
+        match events.try_recv().expect("initial DagNeedsFetch event") {
+            SyncEvent::DagNeedsFetch {
+                root_cid: event_root,
+                ..
+            } => assert_eq!(event_root, root_cid),
+            other => panic!("expected DagNeedsFetch, got {other:?}"),
+        }
+        let dispatched_after_registration = coordinator
+            .manager()
+            .diagnostics()
+            .snapshot()
+            .pending_dag_retry_dispatched;
+
+        // Exhausted providers so this root qualifies for redrive on any
+        // peer connect, not just its original source peer.
+        coordinator
+            .manager()
+            .record_pending_dag_fetch_failure(&root_cid, "synthetic exhaustion");
+
+        // Less than the first backoff rung (4s after one claim): not due yet.
+        tokio::time::advance(std::time::Duration::from_secs(2)).await;
+
+        // Act: a peer connects. Connect must only expedite, never dispatch.
+        coordinator
+            .handle_transport_event(TransportEvent::PeerConnected(PeerId::new(
+                "peer-2".to_string(),
+            )))
+            .await
+            .expect("peer connected handled");
+        assert!(
+            events.try_recv().is_err(),
+            "connect must expedite only, not dispatch directly"
+        );
+
+        // One clock tick: the expedited root is now due.
+        let due = coordinator
+            .manager()
+            .claim_due_pending_dag_retries(tokio::time::Instant::now());
+        assert_eq!(due.len(), 1);
+        assert_eq!(due[0].0, root_cid);
+        for (due_root, dag) in &due {
+            coordinator.dispatch_pending_dag_fetch(*due_root, dag, None);
+        }
+        match events.try_recv().expect("redrive DagNeedsFetch event") {
+            SyncEvent::DagNeedsFetch {
+                root_cid: event_root,
+                ..
+            } => assert_eq!(event_root, root_cid),
+            other => panic!("expected DagNeedsFetch, got {other:?}"),
+        }
+        assert_eq!(
+            coordinator
+                .manager()
+                .diagnostics()
+                .snapshot()
+                .pending_dag_retry_dispatched,
+            dispatched_after_registration + 1,
+            "clock tick should dispatch exactly once"
+        );
+
+        // A second tick without advancing time re-claims nothing: the claim
+        // above already re-armed the root to the next backoff rung.
+        let due_again = coordinator
+            .manager()
+            .claim_due_pending_dag_retries(tokio::time::Instant::now());
+        assert!(due_again.is_empty());
+        assert!(
+            events.try_recv().is_err(),
+            "second tick must dispatch nothing"
+        );
+        assert_eq!(
+            coordinator
+                .manager()
+                .diagnostics()
+                .snapshot()
+                .pending_dag_retry_dispatched,
+            dispatched_after_registration + 1,
+            "second tick must not add another dispatch"
+        );
     }
 }

--- a/crates/p2p/src/sync/coordinator/event_handler/mod.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/mod.rs
@@ -857,4 +857,82 @@ mod tests {
             "second tick must not add another dispatch"
         );
     }
+
+    /// #1116 stage 2: `SyncStatus` must surface the retry-clock counters and
+    /// the earliest due retry time so operators can see the clock's state
+    /// without instrumenting the manager directly.
+    #[tokio::test(start_paused = true)]
+    async fn sync_status_surfaces_pending_dag_retry_clock() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let transport = TestTransport::new();
+        let (coordinator, mut events) =
+            SyncCoordinator::new(transport, Arc::clone(&blockstore), SyncConfig::default())
+                .await
+                .expect("coordinator");
+
+        // No pending DAGs registered yet: the clock has nothing due.
+        assert_eq!(coordinator.sync_status().next_pending_retry_in_ms, None);
+
+        let (field_cid, field_block) = create_lww_block("name");
+        let (root_cid, root_block) = create_composite_block("doc123", "name", field_cid);
+
+        coordinator
+            .manager()
+            .process_pushlog(
+                &make_broadcast("doc123", root_cid, root_block, "collection1"),
+                Some("peer-1"),
+                false,
+                None,
+            )
+            .await
+            .expect("root pushlog");
+
+        // Registration claims its own immediate dispatch (#1116 stage 2).
+        match events.try_recv().expect("initial DagNeedsFetch event") {
+            SyncEvent::DagNeedsFetch {
+                root_cid: event_root,
+                ..
+            } => assert_eq!(event_root, root_cid),
+            other => panic!("expected DagNeedsFetch, got {other:?}"),
+        }
+
+        let status = coordinator.sync_status();
+        assert_eq!(status.pending_dag_retry_dispatched, 1);
+        let next_retry_ms = status
+            .next_pending_retry_in_ms
+            .expect("incomplete pending DAG must report a due time");
+        assert!(
+            next_retry_ms <= 60_000,
+            "next retry must respect the backoff cap, got {next_retry_ms}"
+        );
+
+        // A same-instant claim attempt is suppressed.
+        assert!(!coordinator
+            .manager()
+            .try_claim_pending_dag_dispatch(&root_cid, tokio::time::Instant::now()));
+        assert_eq!(coordinator.sync_status().pending_dag_retry_suppressed, 1);
+
+        // Feed the missing field block: the DAG completes and drains from
+        // the pending map, so the clock has nothing left to report.
+        blockstore
+            .put(&field_cid, &field_block)
+            .await
+            .expect("store field block");
+        let completed = coordinator
+            .manager()
+            .retry_pending_dags_waiting_on(&field_cid)
+            .await
+            .expect("retry on field arrival");
+        assert_eq!(completed, vec![root_cid]);
+        match events.try_recv().expect("DagReady event") {
+            SyncEvent::DagReady {
+                root_cid: event_root,
+                ..
+            } => assert_eq!(event_root, root_cid),
+            other => panic!("expected DagReady, got {other:?}"),
+        }
+
+        assert_eq!(coordinator.sync_status().next_pending_retry_in_ms, None);
+    }
 }

--- a/crates/p2p/src/sync/coordinator/mod.rs
+++ b/crates/p2p/src/sync/coordinator/mod.rs
@@ -138,6 +138,13 @@ pub struct SyncStatus {
     pub single_flight_suppressed: u64,
     pub already_merged_fast_path: u64,
     pub pending_dag_capacity_shed: u64,
+    /// Retry-clock ticks that dispatched a due pending-DAG fetch (#1116 stage 2).
+    pub pending_dag_retry_dispatched: u64,
+    /// Retry-clock/claim attempts that found no due entry (#1116 stage 2).
+    pub pending_dag_retry_suppressed: u64,
+    /// Milliseconds until the earliest due incomplete pending-DAG retry;
+    /// `None` when no incomplete entry is registered.
+    pub next_pending_retry_in_ms: Option<u64>,
 }
 
 struct SyncShutdownState {
@@ -443,6 +450,9 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             single_flight_suppressed: diagnostics.single_flight_suppressed,
             already_merged_fast_path: diagnostics.already_merged_fast_path,
             pending_dag_capacity_shed: diagnostics.pending_dag_capacity_shed,
+            pending_dag_retry_dispatched: diagnostics.pending_dag_retry_dispatched,
+            pending_dag_retry_suppressed: diagnostics.pending_dag_retry_suppressed,
+            next_pending_retry_in_ms: self.manager.next_pending_retry_in_ms(),
         }
     }
 

--- a/crates/p2p/src/sync/coordinator/mod.rs
+++ b/crates/p2p/src/sync/coordinator/mod.rs
@@ -80,7 +80,7 @@ use crate::transport::{P2PTransport, PeerId};
 use super::broadcaster::Broadcaster;
 use super::collection_store::P2PCollectionStorage;
 use super::head_provider::DocumentHeadProvider;
-use super::manager::SyncManager;
+use super::manager::{PendingDag, SyncManager};
 use super::peer_state::PeerStateTracker;
 use super::rate_limiter::PeerRateLimiter;
 
@@ -476,6 +476,77 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             }
             self.manager.resync_persisted_pending_dags().await;
             tokio::time::sleep(interval).await;
+        }
+    }
+
+    /// The receiver's re-arm loop (#1116 stage 2): every `interval`, claim
+    /// all due pending roots and dispatch one fetch each. This is the ONLY
+    /// scheduled re-driver; other sites (registration, peer connect,
+    /// post-fetch) either claim through the same clock or merely expedite.
+    pub async fn run_pending_dag_retry_clock(&self, interval: Duration) {
+        loop {
+            if self.runtime.shutdown.is_shutting_down() {
+                return;
+            }
+            tokio::time::sleep(interval).await;
+            let due = self
+                .manager
+                .claim_due_pending_dag_retries(tokio::time::Instant::now());
+            for (root_cid, dag) in due {
+                self.dispatch_pending_dag_fetch(root_cid, &dag, None);
+            }
+        }
+    }
+
+    /// Build the provider list for a fetch dispatch — connected peers, an
+    /// optional caller-supplied peer (e.g. a newly connected one), and the
+    /// DAG's original source, deduplicated — and emit `SyncEvent::DagNeedsFetch`.
+    /// Every dispatch site funnels through here so the wire event shape stays
+    /// uniform regardless of what triggered the dispatch.
+    fn dispatch_pending_dag_fetch(
+        &self,
+        root_cid: Cid,
+        dag: &PendingDag,
+        extra_provider: Option<&str>,
+    ) {
+        let mut providers: Vec<String> = self.access.peer_state.connected_peers();
+        if let Some(extra) = extra_provider {
+            if !providers.iter().any(|peer| peer == extra) {
+                providers.push(extra.to_string());
+            }
+        }
+        if let Some(source_peer) = dag.source_peer.clone() {
+            if !providers.contains(&source_peer) {
+                providers.push(source_peer);
+            }
+        }
+        let missing: Vec<_> = dag.missing.iter().copied().collect();
+        tracing::debug!(
+            root_cid = %root_cid,
+            missing_count = missing.len(),
+            fetch_failures = dag.fetch_failures,
+            "Dispatching pending DAG fetch"
+        );
+        if let Err(error) =
+            self.manager
+                .event_sender()
+                .try_send(crate::sync::SyncEvent::DagNeedsFetch {
+                    root_cid,
+                    missing,
+                    providers,
+                    doc_id: dag.doc_id.clone(),
+                    collection_id: dag.collection_id.clone(),
+                    creator: dag.creator.clone(),
+                    sender_peer: dag.source_peer.clone(),
+                    is_explicit_replicator: dag.is_explicit_replicator,
+                    explicit_replay_authorization: dag.explicit_replay_authorization.clone(),
+                })
+        {
+            tracing::debug!(
+                root_cid = %root_cid,
+                error = %error,
+                "Pending DAG dispatch dropped: event channel unavailable; clock re-drives later"
+            );
         }
     }
 

--- a/crates/p2p/src/sync/coordinator/mod.rs
+++ b/crates/p2p/src/sync/coordinator/mod.rs
@@ -480,9 +480,12 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     }
 
     /// The receiver's re-arm loop (#1116 stage 2): every `interval`, claim
-    /// all due pending roots and dispatch one fetch each. This is the ONLY
-    /// scheduled re-driver; other sites (registration, peer connect,
-    /// post-fetch) either claim through the same clock or merely expedite.
+    /// all due pending roots and dispatch one fetch each. This is not the
+    /// only scheduled re-driver — `run_pending_dag_resync` also re-drives
+    /// restored entries on its own 60s sweep — but every dispatch path
+    /// (registration, peer connect, post-fetch, and resync's restore) claims
+    /// through this same per-root clock before emitting `DagNeedsFetch`, so
+    /// no re-driver can double-dispatch a root this clock also claims.
     pub async fn run_pending_dag_retry_clock(&self, interval: Duration) {
         loop {
             if self.runtime.shutdown.is_shutting_down() {

--- a/crates/p2p/src/sync/coordinator/push_worker.rs
+++ b/crates/p2p/src/sync/coordinator/push_worker.rs
@@ -212,20 +212,32 @@ where
     if let Some(root_request) = root_request {
         requests.push(root_request);
     }
-    let pushed_cids = job
-        .expand_dag
-        .then(|| requests.iter().map(|(cid, _)| *cid).collect::<Vec<_>>());
-
     let send_failed = if requests.is_empty() {
         // Every block failed to sign: report so the persisted retry ladder
         // regenerates and re-pushes instead of silently losing the doc.
         true
     } else {
-        let _car_access = pushed_cids.map(|cids| {
+        // Authorize the receiver's post-ack recovery pull from the DAG
+        // itself, not from `requests` (what this job happened to push).
+        // A root-only push (`expand_dag = false`) still grants the full
+        // local DAG, decoupling recovery from payload expansion so a future
+        // removal of payload expansion (#1116 stage 3) keeps recovery
+        // working. Fall back to the pushed CIDs on a walk error: never send
+        // a push whose recovery pull we could not authorize.
+        let grant_cids = match crate::sync::car::collect_dag_cids(
+            context.blockstore.as_ref(),
+            &job.root_cid,
+            crate::sync::car::CAR_MAX_BLOCKS,
+        )
+        .await
+        {
+            Ok(cids) => cids,
+            Err(_) => requests.iter().map(|(cid, _)| *cid).collect(),
+        };
+        let _car_access =
             context
                 .selective_car_access
-                .register(job.peer_id.clone(), job.root_cid, cids)
-        });
+                .register(job.peer_id.clone(), job.root_cid, grant_cids);
         send_ordered_pushlogs_via_transport(
             &context.transport,
             &job.peer_id,
@@ -726,6 +738,75 @@ mod tests {
         assert_eq!(transport.sign_count(), 2);
         assert_eq!(transport.sent().len(), 1);
         assert_eq!(failure_rx.recv().await.unwrap().cid, root_cid.to_string());
+        backlog.job_done(&active, completion);
+        backlog.close();
+    }
+
+    /// A root-only push (`expand_dag = false`) sends just the root block, but
+    /// the selective-CAR grant must still cover the full local DAG so the
+    /// receiver's post-ack recovery pull can fetch missing dependents (#1116
+    /// stage 2): the grant is authorized from the blockstore's DAG shape, not
+    /// from the pushed payload set.
+    #[tokio::test]
+    async fn root_only_push_still_grants_full_dag_for_recovery() {
+        use defra_core::{Block, CompositeDeltaPayload, CrdtDelta, DAGLink};
+
+        let backlog = PushBacklog::new(1024, usize::MAX, 1, 1);
+        let transport = TestTransport::new(Vec::new());
+        let (context, _failure_rx) = test_context(
+            transport.clone(),
+            Arc::clone(&backlog),
+            Duration::from_secs(1),
+        );
+
+        let child_data = Bytes::from_static(b"child-block");
+        let child_cid = defra_core::block::generate_cid_from_bytes(&child_data).unwrap();
+        context
+            .blockstore
+            .put(&child_cid, &child_data)
+            .await
+            .unwrap();
+
+        let root = Block::new(
+            CrdtDelta::Composite(CompositeDeltaPayload {
+                doc_id: b"doc".to_vec(),
+                schema_version_id: "schema".to_string(),
+                priority: 1,
+                status: 1,
+            }),
+            vec![],
+            vec![DAGLink::new("child", child_cid)],
+        );
+        let root_bytes = Bytes::from(root.to_dag_cbor().unwrap());
+        let root_cid = defra_core::block::generate_cid_from_bytes(&root_bytes).unwrap();
+        context
+            .blockstore
+            .put(&root_cid, &root_bytes)
+            .await
+            .unwrap();
+
+        let peer = PeerId::new("peer".to_string());
+        let job = PushJobSpec::new(
+            peer.clone(),
+            "doc".to_string(),
+            "collection".to_string(),
+            "creator".to_string(),
+            root_cid,
+            root_bytes,
+            false,
+        );
+        assert_eq!(backlog.try_enqueue(job), EnqueueOutcome::Enqueued);
+        let active = backlog.next_job().await.unwrap();
+
+        let completion = run_push_job(&context, &active).await;
+
+        assert_eq!(completion, JobCompletion::Succeeded);
+        assert!(
+            context
+                .selective_car_access
+                .allows(&peer, &root_cid, &child_cid),
+            "root-only push must still grant the child block for receiver recovery"
+        );
         backlog.job_done(&active, completion);
         backlog.close();
     }

--- a/crates/p2p/src/sync/manager/diagnostics.rs
+++ b/crates/p2p/src/sync/manager/diagnostics.rs
@@ -125,6 +125,8 @@ pub struct SyncDiagnostics {
     single_flight_suppressed: AtomicU64,
     already_merged_fast_path: AtomicU64,
     pending_dag_capacity_shed: AtomicU64,
+    pending_dag_retry_dispatched: AtomicU64,
+    pending_dag_retry_suppressed: AtomicU64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -137,6 +139,8 @@ pub struct SyncDiagnosticsSnapshot {
     pub single_flight_suppressed: u64,
     pub already_merged_fast_path: u64,
     pub pending_dag_capacity_shed: u64,
+    pub pending_dag_retry_dispatched: u64,
+    pub pending_dag_retry_suppressed: u64,
     /// Process-global; see [`record_gossip_decode_failure`].
     pub gossip_decode_failures: u64,
     /// Process-global recent samples captured by
@@ -155,6 +159,8 @@ impl SyncDiagnostics {
             single_flight_suppressed: self.single_flight_suppressed.load(Ordering::Relaxed),
             already_merged_fast_path: self.already_merged_fast_path.load(Ordering::Relaxed),
             pending_dag_capacity_shed: self.pending_dag_capacity_shed.load(Ordering::Relaxed),
+            pending_dag_retry_dispatched: self.pending_dag_retry_dispatched.load(Ordering::Relaxed),
+            pending_dag_retry_suppressed: self.pending_dag_retry_suppressed.load(Ordering::Relaxed),
             gossip_decode_failures: GOSSIP_DECODE_FAILURES.load(Ordering::Relaxed),
             recent_gossip_decode_failures: RECENT_GOSSIP_DECODE_FAILURES
                 .lock()
@@ -198,6 +204,16 @@ impl SyncDiagnostics {
         self.pending_dag_capacity_shed
             .fetch_add(1, Ordering::Relaxed);
     }
+
+    pub fn record_pending_dag_retry_dispatched(&self) {
+        self.pending_dag_retry_dispatched
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_pending_dag_retry_suppressed(&self) {
+        self.pending_dag_retry_suppressed
+            .fetch_add(1, Ordering::Relaxed);
+    }
 }
 
 #[cfg(test)]
@@ -216,6 +232,8 @@ mod tests {
         assert_eq!(snap.single_flight_suppressed, 0);
         assert_eq!(snap.already_merged_fast_path, 0);
         assert_eq!(snap.pending_dag_capacity_shed, 0);
+        assert_eq!(snap.pending_dag_retry_dispatched, 0);
+        assert_eq!(snap.pending_dag_retry_suppressed, 0);
     }
 
     #[test]
@@ -230,6 +248,8 @@ mod tests {
         diag.record_single_flight_suppressed();
         diag.record_already_merged_fast_path();
         diag.record_pending_dag_capacity_shed();
+        diag.record_pending_dag_retry_dispatched();
+        diag.record_pending_dag_retry_suppressed();
 
         let snap = diag.snapshot();
         assert_eq!(snap.car_empty_responses, 2);
@@ -240,6 +260,8 @@ mod tests {
         assert_eq!(snap.single_flight_suppressed, 1);
         assert_eq!(snap.already_merged_fast_path, 1);
         assert_eq!(snap.pending_dag_capacity_shed, 1);
+        assert_eq!(snap.pending_dag_retry_dispatched, 1);
+        assert_eq!(snap.pending_dag_retry_suppressed, 1);
     }
 
     #[test]

--- a/crates/p2p/src/sync/manager/links.rs
+++ b/crates/p2p/src/sync/manager/links.rs
@@ -24,7 +24,7 @@ use crate::error::{Error, Result};
 /// (issue #976). The encryption block is obtained instead during merge via
 /// `decrypt_block_data` (KMS DEK fetch). Signature links are kept, matching
 /// Go's `hasAccess`, which serves signature blocks over Bitswap.
-fn extract_ipld_links(block_data: &[u8]) -> Result<Vec<Cid>> {
+pub(crate) fn extract_ipld_links(block_data: &[u8]) -> Result<Vec<Cid>> {
     use ipld_core::codec::Links;
     use serde_ipld_dagcbor::codec::DagCborCodec;
 

--- a/crates/p2p/src/sync/manager/mod.rs
+++ b/crates/p2p/src/sync/manager/mod.rs
@@ -32,4 +32,7 @@ pub use diagnostics::{
     GossipDecodeFailureSample, GossipTransport, SyncDiagnostics, SyncDiagnosticsSnapshot,
 };
 pub use events::SyncEvent;
+// Coordinator dispatch helper (#1116 stage 2) needs to name this type in its
+// signature; the `pending` module itself stays private.
+pub(crate) use pending::PendingDag;
 pub use process::SyncManager;

--- a/crates/p2p/src/sync/manager/pending.rs
+++ b/crates/p2p/src/sync/manager/pending.rs
@@ -45,4 +45,23 @@ pub struct PendingDag {
     pub fetch_failures: u32,
     /// Most recent provider-exhaustion error for this root, if any.
     pub last_fetch_error: Option<String>,
+    /// Earliest instant a fetch dispatch may be claimed for this root.
+    /// Every dispatch site must win `try_claim_pending_dag_dispatch`,
+    /// which advances this by `retry_backoff(dispatches)` — the receiver's
+    /// re-arm pacing (#1112 inbound half, #1116 stage 2).
+    pub next_retry_at: tokio::time::Instant,
+    /// Fetch dispatches claimed for this root (drives the backoff rung).
+    pub dispatches: u32,
+}
+
+/// Base delay before the first scheduled re-dispatch of a pending root.
+pub const PENDING_RETRY_BASE: Duration = Duration::from_secs(2);
+/// Ceiling for the per-root dispatch backoff.
+pub const PENDING_RETRY_CAP: Duration = Duration::from_secs(60);
+
+/// Capped exponential backoff for pending-DAG fetch dispatches: 2s, 4s,
+/// 8s, 16s, 32s, then 60s forever.
+pub fn retry_backoff(dispatches: u32) -> Duration {
+    let shifted = PENDING_RETRY_BASE.saturating_mul(1u32 << dispatches.min(5));
+    shifted.min(PENDING_RETRY_CAP)
 }

--- a/crates/p2p/src/sync/manager/process/pending_dag.rs
+++ b/crates/p2p/src/sync/manager/process/pending_dag.rs
@@ -89,6 +89,12 @@ impl<B: Blockstore + 'static> SyncManager<B> {
             .unwrap_or_default()
     }
 
+    /// Snapshot a pending DAG entry for dispatch (e.g. after a claimed
+    /// post-fetch retry, #1116 stage 2).
+    pub fn pending_dag_snapshot(&self, root_cid: &Cid) -> Option<PendingDag> {
+        self.pending_dags.read().get(root_cid).cloned()
+    }
+
     /// How many times `retry_pending_dag` has been called for this root.
     ///
     /// Returns 0 if no entry exists (either never registered or already resolved).

--- a/crates/p2p/src/sync/manager/process/pending_dag.rs
+++ b/crates/p2p/src/sync/manager/process/pending_dag.rs
@@ -216,6 +216,58 @@ impl<B: Blockstore + 'static> SyncManager<B> {
         self.pending_dags.write().remove(root_cid).is_some()
     }
 
+    /// Claim the right to dispatch a fetch for this root. Returns false when
+    /// the entry is missing, already complete, or not yet due — the caller
+    /// must then NOT emit a fetch. A successful claim advances the clock, so
+    /// concurrent dispatch sites (registration, retry clock, peer connect)
+    /// are rate-bounded by construction.
+    pub fn try_claim_pending_dag_dispatch(
+        &self,
+        root_cid: &Cid,
+        now: tokio::time::Instant,
+    ) -> bool {
+        let mut pending = self.pending_dags.write();
+        let Some(dag) = pending.get_mut(root_cid) else {
+            self.diagnostics.record_pending_dag_retry_suppressed();
+            return false;
+        };
+        if dag.missing.is_empty() || now < dag.next_retry_at {
+            self.diagnostics.record_pending_dag_retry_suppressed();
+            return false;
+        }
+        dag.dispatches = dag.dispatches.saturating_add(1);
+        dag.next_retry_at = now + super::super::pending::retry_backoff(dag.dispatches);
+        self.diagnostics.record_pending_dag_retry_dispatched();
+        true
+    }
+
+    /// Make a root promptly due (e.g. a provider just connected) without
+    /// resetting its backoff rung. The retry clock performs the dispatch.
+    pub fn expedite_pending_dag_retry(&self, root_cid: &Cid) {
+        if let Some(dag) = self.pending_dags.write().get_mut(root_cid) {
+            dag.next_retry_at = dag.next_retry_at.min(tokio::time::Instant::now());
+        }
+    }
+
+    /// Atomically claim every due incomplete entry and return snapshots for
+    /// dispatch. Used by the coordinator retry clock.
+    pub fn claim_due_pending_dag_retries(
+        &self,
+        now: tokio::time::Instant,
+    ) -> Vec<(Cid, PendingDag)> {
+        let mut pending = self.pending_dags.write();
+        let mut claimed = Vec::new();
+        for (cid, dag) in pending.iter_mut() {
+            if !dag.missing.is_empty() && now >= dag.next_retry_at {
+                dag.dispatches = dag.dispatches.saturating_add(1);
+                dag.next_retry_at = now + super::super::pending::retry_backoff(dag.dispatches);
+                self.diagnostics.record_pending_dag_retry_dispatched();
+                claimed.push((*cid, dag.clone()));
+            }
+        }
+        claimed
+    }
+
     /// Register a pending DAG for DocSync.
     ///
     /// This is called when a DocSyncReply contains head CIDs that need to be
@@ -251,6 +303,8 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                 attempts: 0,
                 fetch_failures: 0,
                 last_fetch_error: None,
+                next_retry_at: tokio::time::Instant::now(),
+                dispatches: 0,
             },
         ) {
             tracing::warn!(
@@ -294,6 +348,8 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                 attempts: 0,
                 fetch_failures: 0,
                 last_fetch_error: None,
+                next_retry_at: tokio::time::Instant::now(),
+                dispatches: 0,
             },
         ) {
             tracing::warn!(
@@ -598,6 +654,8 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                 attempts: 0,
                 fetch_failures: 0,
                 last_fetch_error: None,
+                next_retry_at: tokio::time::Instant::now(),
+                dispatches: 0,
             };
 
             if !self.insert_pending_dag(root_cid, dag.clone()) {
@@ -698,6 +756,8 @@ mod tests {
             attempts: 0,
             fetch_failures: 0,
             last_fetch_error: None,
+            next_retry_at: tokio::time::Instant::now(),
+            dispatches: 0,
         }
     }
 
@@ -766,5 +826,72 @@ mod tests {
         }
 
         assert!(manager.pending_dag_count() <= DEFAULT_MAX_PENDING_DAGS);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn claim_bumps_clock_and_suppresses_duplicates() {
+        let manager = test_manager();
+        let root = test_cid(1);
+        let mut dag = pending_dag("doc", Instant::now());
+        dag.missing.insert(test_cid(2));
+        assert!(manager.insert_pending_dag(root, dag));
+
+        let now = tokio::time::Instant::now();
+        // Fresh entry is due immediately (insert leaves next_retry_at = now).
+        assert!(manager.try_claim_pending_dag_dispatch(&root, now));
+        // Second claim in the same instant is suppressed.
+        assert!(!manager.try_claim_pending_dag_dispatch(&root, now));
+        // Becomes due again after the backoff rung reached by the first
+        // claim (dispatches=1 -> retry_backoff(1) = 4s).
+        tokio::time::advance(std::time::Duration::from_secs(4)).await;
+        assert!(manager.try_claim_pending_dag_dispatch(&root, tokio::time::Instant::now()));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn backoff_doubles_and_caps() {
+        use crate::sync::manager::pending::retry_backoff;
+        assert_eq!(retry_backoff(0), std::time::Duration::from_secs(2));
+        assert_eq!(retry_backoff(1), std::time::Duration::from_secs(4));
+        assert_eq!(retry_backoff(4), std::time::Duration::from_secs(32));
+        assert_eq!(retry_backoff(5), std::time::Duration::from_secs(60));
+        assert_eq!(retry_backoff(30), std::time::Duration::from_secs(60));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn expedite_makes_entry_due_now_without_resetting_backoff() {
+        let manager = test_manager();
+        let root = test_cid(1);
+        let mut dag = pending_dag("doc", Instant::now());
+        dag.missing.insert(test_cid(2));
+        assert!(manager.insert_pending_dag(root, dag));
+        let now = tokio::time::Instant::now();
+        assert!(manager.try_claim_pending_dag_dispatch(&root, now)); // dispatches -> 1
+        manager.expedite_pending_dag_retry(&root);
+        assert!(manager.try_claim_pending_dag_dispatch(&root, now)); // dispatches -> 2
+                                                                     // Next due time reflects dispatches=2 rung (8s), not a reset.
+        tokio::time::advance(std::time::Duration::from_secs(4)).await;
+        assert!(!manager.try_claim_pending_dag_dispatch(&root, tokio::time::Instant::now()));
+        tokio::time::advance(std::time::Duration::from_secs(4)).await;
+        assert!(manager.try_claim_pending_dag_dispatch(&root, tokio::time::Instant::now()));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn claim_due_returns_and_claims_only_due_entries_with_missing_blocks() {
+        let manager = test_manager();
+        let due = test_cid(1);
+        let complete = test_cid(3);
+        let mut dag = pending_dag("doc-due", Instant::now());
+        dag.missing.insert(test_cid(2));
+        assert!(manager.insert_pending_dag(due, dag));
+        // Entry with no missing blocks must never be dispatched.
+        assert!(manager.insert_pending_dag(complete, pending_dag("doc-done", Instant::now())));
+
+        let claimed = manager.claim_due_pending_dag_retries(tokio::time::Instant::now());
+        assert_eq!(claimed.len(), 1);
+        assert_eq!(claimed[0].0, due);
+        // Claiming consumed due-ness.
+        assert!(manager
+            .claim_due_pending_dag_retries(tokio::time::Instant::now())
+            .is_empty());
     }
 }

--- a/crates/p2p/src/sync/manager/process/pending_dag.rs
+++ b/crates/p2p/src/sync/manager/process/pending_dag.rs
@@ -47,6 +47,19 @@ impl<B: Blockstore + 'static> SyncManager<B> {
         self.pending_dags.read().len()
     }
 
+    /// Milliseconds until the earliest due incomplete pending-DAG retry, or
+    /// `None` when no incomplete entry is registered (#1116 stage 2
+    /// diagnostics: surfaces the retry clock's own state for `SyncStatus`).
+    pub fn next_pending_retry_in_ms(&self) -> Option<u64> {
+        let now = tokio::time::Instant::now();
+        self.pending_dags
+            .read()
+            .values()
+            .filter(|dag| !dag.missing.is_empty())
+            .map(|dag| dag.next_retry_at.saturating_duration_since(now).as_millis() as u64)
+            .min()
+    }
+
     /// Return whether a root can enter the pending-DAG registry without
     /// decoding its pushed block.
     pub(super) fn can_admit_pending_dag(&self, root_cid: &Cid) -> bool {

--- a/crates/p2p/src/sync/manager/process/pending_dag.rs
+++ b/crates/p2p/src/sync/manager/process/pending_dag.rs
@@ -10,7 +10,7 @@ use blockstore::Blockstore;
 
 use crate::error::{Error, Result};
 use crate::sync::manager::events::SyncEvent;
-use crate::sync::manager::links::find_all_missing_links;
+use crate::sync::manager::links::{extract_ipld_links, find_all_missing_links};
 use crate::sync::manager::pending::{PendingDag, PENDING_DAG_TTL};
 
 use super::SyncManager;
@@ -142,7 +142,13 @@ impl<B: Blockstore + 'static> SyncManager<B> {
         }
     }
 
-    /// Retry pending DAGs that were waiting on `cid`.
+    /// A block just arrived (PushLog store or Bitswap fetch). Update every
+    /// pending root waiting on it: drop it from `missing`, add the block's
+    /// own absent links to the frontier, and run the full verification walk
+    /// (`retry_pending_dag`) ONLY for roots whose frontier emptied. The full
+    /// walk per arriving block was O(DAG) per root per block — the #1112
+    /// inbound storm; the clock's periodic retry self-heals any frontier
+    /// drift this incremental pass might accumulate.
     ///
     /// This covers the explicit replay path where a composite can be registered
     /// as pending before its linked field blocks arrive via later PushLog
@@ -155,9 +161,42 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                 .filter_map(|(root_cid, dag)| dag.missing.contains(cid).then_some(*root_cid))
                 .collect()
         };
+        if waiting_roots.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // The arriving block's own links that are still absent become the
+        // new frontier for every waiting root. Computed once per block.
+        // Uses `extract_ipld_links` (not `defra_core::collect_block_links`
+        // directly) so the `encryption` link stays excluded here too — Go
+        // never serves that block over Bitswap (#976), so treating it as
+        // "absent" would strand the frontier on a CID that never arrives.
+        let mut absent_links: Vec<Cid> = Vec::new();
+        if let Ok(Some(data)) = self.blockstore.get(cid).await {
+            for link in extract_ipld_links(&data).unwrap_or_default() {
+                if !matches!(self.blockstore.has(&link).await, Ok(true)) {
+                    absent_links.push(link);
+                }
+            }
+        }
+
+        let emptied: Vec<Cid> = {
+            let mut pending = self.pending_dags.write();
+            let mut emptied = Vec::new();
+            for root_cid in &waiting_roots {
+                if let Some(dag) = pending.get_mut(root_cid) {
+                    dag.missing.remove(cid);
+                    dag.missing.extend(absent_links.iter().copied());
+                    if dag.missing.is_empty() {
+                        emptied.push(*root_cid);
+                    }
+                }
+            }
+            emptied
+        };
 
         let mut completed = Vec::new();
-        for root_cid in waiting_roots {
+        for root_cid in emptied {
             if self.retry_pending_dag(&root_cid).await? {
                 completed.push(root_cid);
             }
@@ -738,6 +777,9 @@ mod tests {
     use std::sync::Arc;
 
     use blockstore::DefraBlockstore;
+    use defra_core::{
+        Block as DefraBlock, CompositeDeltaPayload, CrdtDelta, DAGLink, LwwDeltaPayload,
+    };
     use multihash_codetable::{Code, MultihashDigest};
     use storage::backends::MemoryStore;
 
@@ -909,6 +951,107 @@ mod tests {
         assert!(manager
             .claim_due_pending_dag_retries(tokio::time::Instant::now())
             .is_empty());
+    }
+
+    fn lww_leaf(field_name: &str) -> (Cid, Vec<u8>) {
+        let block = DefraBlock::new(
+            CrdtDelta::Lww(LwwDeltaPayload {
+                doc_id: b"doc1".to_vec(),
+                field_name: field_name.to_string(),
+                priority: 1,
+                schema_version_id: "schema1".to_string(),
+                data: b"value".to_vec(),
+            }),
+            vec![],
+            vec![],
+        );
+        let bytes = block.to_dag_cbor().expect("encode lww block");
+        let cid = block.generate_cid().expect("generate lww cid");
+        (cid, bytes)
+    }
+
+    fn composite_node(link_name: &str, link_cid: Cid, priority: u64) -> (Cid, Vec<u8>) {
+        let block = DefraBlock::new(
+            CrdtDelta::Composite(CompositeDeltaPayload {
+                doc_id: b"doc1".to_vec(),
+                schema_version_id: "schema1".to_string(),
+                priority,
+                status: 1,
+            }),
+            vec![],
+            vec![DAGLink::new(link_name, link_cid)],
+        );
+        let bytes = block.to_dag_cbor().expect("encode composite block");
+        let cid = block.generate_cid().expect("generate composite cid");
+        (cid, bytes)
+    }
+
+    #[tokio::test]
+    async fn block_arrival_updates_missing_incrementally_without_full_walks() {
+        // A dropped event receiver would fail the completing `retry_pending_dag`
+        // call with `ChannelSend` before the assertions below run, so keep it
+        // alive (unlike `test_manager()`, which discards it).
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let peer_state = Arc::new(PeerStateTracker::new());
+        let (manager, mut events) = SyncManager::new(blockstore, peer_state, SyncConfig::default());
+
+        // 3-level DAG: root -> child (composite) -> grandchild (lww).
+        let (grandchild_cid, grandchild_bytes) = lww_leaf("name");
+        let (child_cid, child_bytes) = composite_node("name", grandchild_cid, 1);
+        let (root_cid, root_bytes) = composite_node("composite", child_cid, 2);
+
+        manager
+            .blockstore
+            .put(&root_cid, &root_bytes)
+            .await
+            .expect("store root");
+        manager
+            .blockstore
+            .put(&child_cid, &child_bytes)
+            .await
+            .expect("store child");
+
+        let mut dag = pending_dag("doc1", Instant::now());
+        dag.missing.insert(child_cid);
+        assert!(manager.insert_pending_dag(root_cid, dag));
+
+        // Child arrives; grandchild is still absent. This must only shrink
+        // the frontier (child -> grandchild), not run the full walk.
+        let completed = manager
+            .retry_pending_dags_waiting_on(&child_cid)
+            .await
+            .expect("retry on child arrival");
+        assert!(completed.is_empty(), "root must not complete yet");
+        assert_eq!(manager.pending_dag_missing(&root_cid), vec![grandchild_cid]);
+        assert_eq!(
+            manager.diagnostics.snapshot().missing_link_retries,
+            0,
+            "a frontier-shrinking arrival must not trigger the full verification walk"
+        );
+
+        // Grandchild arrives; the frontier empties, so the full walk runs
+        // exactly once to verify completion and the root resolves.
+        manager
+            .blockstore
+            .put(&grandchild_cid, &grandchild_bytes)
+            .await
+            .expect("store grandchild");
+        let completed = manager
+            .retry_pending_dags_waiting_on(&grandchild_cid)
+            .await
+            .expect("retry on grandchild arrival");
+        assert_eq!(completed, vec![root_cid]);
+        assert_eq!(manager.diagnostics.snapshot().missing_link_retries, 1);
+        assert_eq!(manager.pending_dag_count(), 0);
+
+        match events.try_recv().expect("DagReady event") {
+            SyncEvent::DagReady {
+                root_cid: event_root,
+                ..
+            } => assert_eq!(event_root, root_cid),
+            other => panic!("expected DagReady, got {:?}", other),
+        }
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/p2p/src/sync/manager/process/pending_dag.rs
+++ b/crates/p2p/src/sync/manager/process/pending_dag.rs
@@ -668,6 +668,16 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                 continue;
             }
 
+            // A restored entry is immediately due (`insert_pending_dag`
+            // leaves `next_retry_at = now`); claim it here so the retry
+            // clock's next tick does not also dispatch it. The `bool` is
+            // unused — the DagNeedsFetch emission below (when `missing` is
+            // non-empty) is the dispatch; when `missing` is empty the claim
+            // is a harmless no-op since `try_claim_pending_dag_dispatch`
+            // requires a non-empty `missing` set.
+            let _claimed =
+                self.try_claim_pending_dag_dispatch(&root_cid, tokio::time::Instant::now());
+
             if missing.is_empty() {
                 if let Err(error) = self.retry_pending_dag(&root_cid).await {
                     tracing::warn!(
@@ -893,5 +903,62 @@ mod tests {
         assert!(manager
             .claim_due_pending_dag_retries(tokio::time::Instant::now())
             .is_empty());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn resync_restore_consumes_retry_clock_claim_before_dispatch() {
+        use crate::sync::pending_store::{PendingDagStorage, PendingDagStore, PersistedPendingDag};
+
+        let blockstore = Arc::new(DefraBlockstore::new(Arc::new(MemoryStore::new()), true));
+        let peer_state = Arc::new(PeerStateTracker::new());
+        let (manager, mut events) = SyncManager::new(blockstore, peer_state, SyncConfig::default());
+
+        // The root's block is never put in the blockstore, so the resync
+        // sweep falls back to treating the root itself as missing and takes
+        // the DagNeedsFetch (non-empty `missing`) path.
+        let root = test_cid(1);
+        let pending_store = Arc::new(PendingDagStore::new(Arc::new(MemoryStore::new())));
+        pending_store
+            .put(
+                &root,
+                &PersistedPendingDag {
+                    doc_id: "doc".to_string(),
+                    collection_id: "collection".to_string(),
+                    creator: "creator".to_string(),
+                    source_peer: Some("peer".to_string()),
+                    is_explicit_replicator: false,
+                    explicit_replay_authorization: None,
+                },
+            )
+            .await
+            .expect("persist pending dag record");
+
+        manager.install_pending_dag_store(pending_store).await;
+
+        let restored = manager.resync_persisted_pending_dags().await;
+        assert_eq!(restored, 1);
+
+        match events
+            .try_recv()
+            .expect("DagNeedsFetch event from resync restore")
+        {
+            SyncEvent::DagNeedsFetch { root_cid, .. } => assert_eq!(root_cid, root),
+            other => panic!("expected DagNeedsFetch, got {:?}", other),
+        }
+
+        // The restore's direct DagNeedsFetch emission already consumed the
+        // immediate claim (mirrors the fresh-registration path in
+        // pushlog.rs) -- the retry clock must not also dispatch this root
+        // before the backoff rung elapses.
+        assert!(manager
+            .claim_due_pending_dag_retries(tokio::time::Instant::now())
+            .is_empty());
+
+        // Becomes due again only after the backoff rung reached by the
+        // restore's claim (dispatches=1 -> retry_backoff(1) = 4s).
+        tokio::time::advance(std::time::Duration::from_secs(4)).await;
+        let claimed = manager.claim_due_pending_dag_retries(tokio::time::Instant::now());
+        assert_eq!(claimed.len(), 1);
+        assert_eq!(claimed[0].0, root);
     }
 }

--- a/crates/p2p/src/sync/manager/process/pushlog.rs
+++ b/crates/p2p/src/sync/manager/process/pushlog.rs
@@ -321,6 +321,8 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                         attempts: 0,
                         fetch_failures: 0,
                         last_fetch_error: None,
+                        next_retry_at: tokio::time::Instant::now(),
+                        dispatches: 0,
                     },
                 );
                 if !inserted {

--- a/crates/p2p/src/sync/manager/process/pushlog.rs
+++ b/crates/p2p/src/sync/manager/process/pushlog.rs
@@ -347,6 +347,12 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                 }
             }
 
+            // A fresh registration is immediately due (`insert_pending_dag`
+            // leaves `next_retry_at = now`); claim it here so the retry
+            // clock's next tick does not also dispatch it. The `bool` is
+            // unused — the DagNeedsFetch emission below is the dispatch.
+            let _claimed = self.try_claim_pending_dag_dispatch(cid, tokio::time::Instant::now());
+
             // Persist the registration before the caller acks success: the
             // ack destroys the pusher's retry record, so an unpersisted
             // registration must fail closed as an error reply instead

--- a/tools/integration-test/tests/p2p.rs
+++ b/tools/integration-test/tests/p2p.rs
@@ -12,6 +12,8 @@ mod manage_relay;
 mod manage_relay_common;
 #[path = "p2p/management.rs"]
 mod management;
+#[path = "p2p/receiver_pull.rs"]
+mod receiver_pull;
 #[path = "p2p/replication.rs"]
 mod replication;
 #[path = "p2p/replication_advanced.rs"]

--- a/tools/integration-test/tests/p2p/README.md
+++ b/tools/integration-test/tests/p2p/README.md
@@ -12,6 +12,7 @@ cargo test -p integration-test --test p2p
 | `document.rs` | 2 | Document replication across runtimes |
 | `idempotent_replay.rs` | 3 | Idempotent reconnect/replay behavior |
 | `management.rs` | 3 | P2P collection/replicator management |
+| `receiver_pull.rs` | 1 | Paced receiver-pull convergence fence (#1116 stage 2 retry clock, storm bound) |
 | `sync.rs` | 11 | Sync protocol (document sync, versions, branchable, invalid CID) |
 | `trust_boundary.rs` | 3 | ACP enforcement at P2P trust boundaries |
 | `transports.rs` | 3 | TCP, QUIC, and WebSocket listen address coverage; Rust↔Rust QUIC/WS and Rust↔Go QUIC dialing |
@@ -20,7 +21,7 @@ cargo test -p integration-test --test p2p
 | `resilience.rs` | 9 | P2P stress tests (ignored by default) |
 | `write_contention.rs` | 9 | Concurrent write behavior across P2P topologies |
 
-**51 total tests: 40 active, 11 ignored.**
+**52 total tests: 41 active, 11 ignored.**
 
 ### Ignored
 

--- a/tools/integration-test/tests/p2p/receiver_pull.rs
+++ b/tools/integration-test/tests/p2p/receiver_pull.rs
@@ -7,6 +7,14 @@
 //! (`pending_dag_retry_dispatched`, `pending_dag_retry_suppressed`,
 //! `next_pending_retry_in_ms`).
 //!
+//! The forcing phase deliberately routes the update storm through the gossip
+//! single-head path (replicator deleted first): the outbound broadcast
+//! coalescer folds the burst so B receives head announcements whose parent
+//! chains are missing locally — exactly the pending-DAG registration and
+//! paced-fetch path this fence exists to gate. A replicator-driven storm
+//! would be vacuous: sequential pushes always deliver parents before
+//! children, so the pull path never fires.
+//!
 //! The storm assertion is the #1112 fence: before the incremental frontier,
 //! every block arrival re-walked the whole DAG from the root, so
 //! `missing_link_retries` grew with `updates * DAG-depth`. After #1112 /
@@ -22,7 +30,7 @@ const SCHEMA: &str = "type Note { title: String }";
 const UPDATE_COUNT: usize = 20;
 
 /// The pending-DAG-retry-clock subset of `/api/v0/p2p/sync/status` (#1116
-/// stage 2). Read as a typed snapshot so the two points-in-time in this test
+/// stage 2). Read as a typed snapshot so the points-in-time in this test
 /// (baseline vs. post-storm) are easy to diff.
 struct SyncStatusSnapshot {
     pending_dags: u64,
@@ -72,9 +80,31 @@ fn assert_drained_queue_has_no_next_retry(status: &SyncStatusSnapshot, when: &st
     }
 }
 
-/// 2-node cluster: B registered as A's replicator, baseline doc convergence,
-/// then a ~20-update storm on the same document. Asserts the new sync-status
-/// retry-clock fields are present and internally consistent, and that the
+async fn wait_for_title(node_b: &integration_test::DefraClient, doc_id: &str, title: &str) {
+    poll_until(
+        || {
+            let result = node_b.query("query { Note { _docID title } }").unwrap();
+            result["Note"]
+                .as_array()
+                .map(|arr| {
+                    arr.iter().any(|n| {
+                        n["_docID"].as_str() == Some(doc_id) && n["title"].as_str() == Some(title)
+                    })
+                })
+                .unwrap_or(false)
+        },
+        Duration::from_secs(30),
+        Duration::from_millis(200),
+        &format!("title {title} did not converge on B"),
+    )
+    .await;
+}
+
+/// 2-node cluster: baseline convergence through an explicit replicator, then
+/// the replicator is deleted and a ~20-update storm on the same document must
+/// converge through the gossip single-head + paced receiver-pull path alone.
+/// Asserts the new sync-status retry-clock fields are present and internally
+/// consistent, that the pull path actually fired (anti-vacuity), and that the
 /// #1112 storm fence holds: `missing_link_retries` growth stays linear in
 /// the update count instead of blowing up with DAG depth.
 #[tokio::test]
@@ -118,7 +148,9 @@ async fn receiver_pull_paced_convergence_fence() {
         .p2p_collection_add(&["Note"])
         .expect("collection add B");
 
-    // Register B as A's replicator: every Note change on A pushes to B.
+    // Register B as A's replicator for the baseline phase only: the direct
+    // push gives a deterministic starting point (B holds the v0 DAG) before
+    // the storm is forced through the gossip pull path.
     node_a
         .p2p_replicator_set(&["Note"], &addr_b)
         .expect("replicator set A -> B");
@@ -129,32 +161,23 @@ async fn receiver_pull_paced_convergence_fence() {
         .expect("create Note on A");
     let doc_id = extract_doc_id(&create, "add_Note");
 
-    let node_b_ref = &node_b;
-    let doc_id_ref = &doc_id;
-    poll_until(
-        || {
-            let result = node_b_ref.query("query { Note { _docID title } }").unwrap();
-            result["Note"]
-                .as_array()
-                .map(|arr| {
-                    arr.iter().any(|n| {
-                        n["_docID"].as_str() == Some(doc_id_ref.as_str())
-                            && n["title"].as_str() == Some("v0")
-                    })
-                })
-                .unwrap_or(false)
-        },
-        Duration::from_secs(15),
-        Duration::from_millis(200),
-        "baseline doc did not converge on B",
-    )
-    .await;
+    wait_for_title(&node_b, &doc_id, "v0").await;
 
     // --- Step 2: sync-status fields present and sane ---
     let baseline_status = fetch_sync_status(&cluster, 1).await;
     assert_drained_queue_has_no_next_retry(&baseline_status, "after baseline convergence");
 
-    // --- Step 3: storm — ~20 rapid updates to the same document ---
+    // --- Step 3: force the paced pull path ---
+    // Remove the replicator so A no longer pushes to B. B stays subscribed to
+    // the collection topic, so from here on it only learns about A's commits
+    // from gossip head announcements. Rapid same-doc updates get folded by
+    // A's outbound broadcast coalescer, so B receives heads whose parent
+    // chains it does not hold — pending-DAG registration + paced fetch is the
+    // only way it can converge.
+    node_a
+        .p2p_replicator_delete(&["Note"], Some(&addr_b))
+        .expect("replicator delete A -> B");
+
     for i in 1..=UPDATE_COUNT {
         let title = format!("v{i}");
         node_a
@@ -164,26 +187,7 @@ async fn receiver_pull_paced_convergence_fence() {
             .unwrap_or_else(|e| panic!("update {i} on A failed: {e}"));
     }
 
-    let final_title = format!("v{UPDATE_COUNT}");
-    let final_title_ref = &final_title;
-    poll_until(
-        || {
-            let result = node_b_ref.query("query { Note { _docID title } }").unwrap();
-            result["Note"]
-                .as_array()
-                .map(|arr| {
-                    arr.iter().any(|n| {
-                        n["_docID"].as_str() == Some(doc_id_ref.as_str())
-                            && n["title"].as_str() == Some(final_title_ref.as_str())
-                    })
-                })
-                .unwrap_or(false)
-        },
-        Duration::from_secs(30),
-        Duration::from_millis(200),
-        "storm updates did not converge on B",
-    )
-    .await;
+    wait_for_title(&node_b, &doc_id, &format!("v{UPDATE_COUNT}")).await;
 
     let post_storm_status = fetch_sync_status(&cluster, 1).await;
     assert_drained_queue_has_no_next_retry(&post_storm_status, "after storm convergence");
@@ -206,29 +210,51 @@ async fn receiver_pull_paced_convergence_fence() {
 
     let missing_link_growth =
         post_storm_status.missing_link_retries - baseline_status.missing_link_retries;
+    let dispatched_growth = post_storm_status.pending_dag_retry_dispatched
+        - baseline_status.pending_dag_retry_dispatched;
+
+    // Anti-vacuity (mirrors p2p_admission.rs's "hub never hit pending-DAG
+    // capacity" hard-fail): the storm must have positively exercised the
+    // paced pull path. A gossip head whose parent chain is missing forces a
+    // pending-DAG registration, and every registration's fetch is dispatched
+    // through the retry-clock claim gate, bumping
+    // `pending_dag_retry_dispatched`. Observed 6/6 local runs: growth is
+    // exactly 1 — the first post-delete gossip head registers, its dispatched
+    // fetch pulls the missing chain, and later heads then merge directly.
+    // `missing_link_retries` is NOT the mover here (0 in all observed runs):
+    // in this shape the pending entry is superseded by a later head's direct
+    // merge before its frontier empties, so the full verification walk never
+    // runs. If dispatched did not grow, B converged without ever pulling —
+    // the scenario regressed to the vacuous replicator-push shape and this
+    // fence is not testing anything.
+    assert!(
+        dispatched_growth > 0,
+        "storm converged without exercising the paced pull path \
+         (pending_dag_retry_dispatched growth = 0, missing_link_retries \
+         growth = {missing_link_growth}); the gossip-forcing scenario no \
+         longer creates pending-DAG registrations"
+    );
 
     // Bound derivation (#1112 storm fence, #1116 stage 2 incremental
-    // frontier): before #1112, a naive re-walk ran on every block arrival, so
-    // growth scaled with `updates * DAG-depth`. With the incremental
-    // frontier, a full verification walk (`record_missing_link_retry`) only
-    // fires when (a) a pending root's frontier empties on completion, or (b)
-    // the per-root retry clock re-dispatches a stalled root — at most one
-    // clock re-dispatch per completion for a healthy 2-node cluster with no
-    // induced loss. That is <= 2 full walks per update in the worst case, so
-    // growth over `UPDATE_COUNT` rapid same-doc updates should stay within
-    // `2 * UPDATE_COUNT` plus a small constant for the baseline create.
-    // Observed on this branch (3/3 local runs): growth = 0, with exactly one
-    // `pending_dag_retry_dispatched` per run — an unconstrained 2-node run
-    // has no capacity pressure, so a pushed root rarely lacks a link locally
-    // and pending-DAG registration barely triggers at all. The bound below
-    // stays at the full analytical envelope rather than an observed-x2
-    // margin: the observed value is 0, and a zero-based margin would make
-    // the assertion vacuous instead of load-bearing.
-    let bound = 2 * UPDATE_COUNT as u64 + 5;
+    // frontier): before #1112, a full verification walk ran on EVERY block
+    // arrival for every waiting root. In this scenario the dispatched fetch
+    // delivers the storm's parent chain — about 2 blocks per update
+    // (composite + field block), i.e. ~2 x UPDATE_COUNT arrivals — so a
+    // revert of the incremental frontier would push `missing_link_retries`
+    // growth to ~2 x UPDATE_COUNT (~40). With the incremental frontier, the
+    // walk only runs when a pending root's frontier empties or when the
+    // retry clock re-dispatches a stalled root: <= 2 per pending
+    // registration, and observed registrations are 1 per storm (growth = 0
+    // in 6/6 local runs, since the entry is superseded before completing).
+    // UPDATE_COUNT sits comfortably above the legitimate envelope (a few
+    // registrations x 2) while staying at half the revert signature, so it
+    // fails on the O(arrivals) regression without flaking on scheduler
+    // noise.
+    let bound = UPDATE_COUNT as u64;
     assert!(
         missing_link_growth <= bound,
         "missing_link_retries grew by {missing_link_growth} over {UPDATE_COUNT} rapid updates \
-         (bound {bound}); the incremental frontier should keep growth O(updates), not \
-         O(updates * DAG-depth) — see #1112"
+         (bound {bound}); the incremental frontier should keep growth at O(pending \
+         registrations), not O(block arrivals) — see #1112"
     );
 }

--- a/tools/integration-test/tests/p2p/receiver_pull.rs
+++ b/tools/integration-test/tests/p2p/receiver_pull.rs
@@ -1,0 +1,234 @@
+//! #1116 stage 2: paced receiver-pull convergence fence.
+//!
+//! Exercises the stage-2 receiver-side machinery against a real 2-node
+//! cluster: the per-root retry clock (post-increment ladder 4s -> 60s), the
+//! incremental pending-DAG frontier (full verification walk only when the
+//! frontier empties), and the three new `/api/v0/p2p/sync/status` fields
+//! (`pending_dag_retry_dispatched`, `pending_dag_retry_suppressed`,
+//! `next_pending_retry_in_ms`).
+//!
+//! The storm assertion is the #1112 fence: before the incremental frontier,
+//! every block arrival re-walked the whole DAG from the root, so
+//! `missing_link_retries` grew with `updates * DAG-depth`. After #1112 /
+//! stage 2, a full walk only runs when a pending root's frontier empties
+//! (once per completion) or when the retry clock re-dispatches a stalled
+//! root, so growth should track `updates` linearly, not multiplicatively.
+
+use std::time::Duration;
+
+use integration_test::{extract_doc_id, poll_until, TestCluster};
+
+const SCHEMA: &str = "type Note { title: String }";
+const UPDATE_COUNT: usize = 20;
+
+/// The pending-DAG-retry-clock subset of `/api/v0/p2p/sync/status` (#1116
+/// stage 2). Read as a typed snapshot so the two points-in-time in this test
+/// (baseline vs. post-storm) are easy to diff.
+struct SyncStatusSnapshot {
+    pending_dags: u64,
+    missing_link_retries: u64,
+    pending_dag_retry_dispatched: u64,
+    pending_dag_retry_suppressed: u64,
+    next_pending_retry_in_ms: Option<u64>,
+}
+
+async fn fetch_sync_status(cluster: &TestCluster, node: usize) -> SyncStatusSnapshot {
+    let status: serde_json::Value =
+        reqwest::get(format!("{}/api/v0/p2p/sync/status", cluster.api_url(node)))
+            .await
+            .expect("sync status request")
+            .json()
+            .await
+            .expect("sync status json");
+
+    SyncStatusSnapshot {
+        pending_dags: status["pending_dags"]
+            .as_u64()
+            .expect("pending_dags field present"),
+        missing_link_retries: status["missing_link_retries"]
+            .as_u64()
+            .expect("missing_link_retries field present"),
+        pending_dag_retry_dispatched: status["pending_dag_retry_dispatched"]
+            .as_u64()
+            .expect("pending_dag_retry_dispatched field present"),
+        pending_dag_retry_suppressed: status["pending_dag_retry_suppressed"]
+            .as_u64()
+            .expect("pending_dag_retry_suppressed field present"),
+        next_pending_retry_in_ms: status["next_pending_retry_in_ms"].as_u64(),
+    }
+}
+
+/// Assert the retry-clock invariant: once no pending-DAG entry is registered
+/// there is nothing left for the clock to schedule, so the "next due" field
+/// must report `null`, never a stale or synthesized deadline.
+fn assert_drained_queue_has_no_next_retry(status: &SyncStatusSnapshot, when: &str) {
+    if status.pending_dags == 0 {
+        assert!(
+            status.next_pending_retry_in_ms.is_none(),
+            "{when}: pending_dags == 0 but next_pending_retry_in_ms = {:?} \
+             (a drained queue must not report a pending deadline)",
+            status.next_pending_retry_in_ms
+        );
+    }
+}
+
+/// 2-node cluster: B registered as A's replicator, baseline doc convergence,
+/// then a ~20-update storm on the same document. Asserts the new sync-status
+/// retry-clock fields are present and internally consistent, and that the
+/// #1112 storm fence holds: `missing_link_retries` growth stays linear in
+/// the update count instead of blowing up with DAG depth.
+#[tokio::test]
+async fn receiver_pull_paced_convergence_fence() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(2)
+        .with_p2p()
+        .build()
+        .await
+        .expect("cluster start");
+
+    let timeout = Duration::from_secs(15);
+    cluster
+        .wait_for_log(0, "p2p_listening", timeout)
+        .await
+        .expect("node A P2P listener did not start");
+    cluster
+        .wait_for_log(1, "p2p_listening", timeout)
+        .await
+        .expect("node B P2P listener did not start");
+
+    let node_a = cluster.client(0);
+    let node_b = cluster.client(1);
+
+    node_a.schema_add(SCHEMA).expect("schema add A");
+    node_b.schema_add(SCHEMA).expect("schema add B");
+
+    let info_b = node_b.p2p_info().expect("B p2p info");
+    let addr_b = info_b
+        .as_array()
+        .and_then(|arr| arr.first())
+        .and_then(|v| v.as_str())
+        .expect("B has no P2P address")
+        .to_string();
+
+    node_a.p2p_connect(&[&addr_b]).expect("A connects to B");
+    node_a
+        .p2p_collection_add(&["Note"])
+        .expect("collection add A");
+    node_b
+        .p2p_collection_add(&["Note"])
+        .expect("collection add B");
+
+    // Register B as A's replicator: every Note change on A pushes to B.
+    node_a
+        .p2p_replicator_set(&["Note"], &addr_b)
+        .expect("replicator set A -> B");
+
+    // --- Step 1: baseline replication sanity ---
+    let create = node_a
+        .query(r#"mutation { add_Note(input: {title: "v0"}) { _docID } }"#)
+        .expect("create Note on A");
+    let doc_id = extract_doc_id(&create, "add_Note");
+
+    let node_b_ref = &node_b;
+    let doc_id_ref = &doc_id;
+    poll_until(
+        || {
+            let result = node_b_ref.query("query { Note { _docID title } }").unwrap();
+            result["Note"]
+                .as_array()
+                .map(|arr| {
+                    arr.iter().any(|n| {
+                        n["_docID"].as_str() == Some(doc_id_ref.as_str())
+                            && n["title"].as_str() == Some("v0")
+                    })
+                })
+                .unwrap_or(false)
+        },
+        Duration::from_secs(15),
+        Duration::from_millis(200),
+        "baseline doc did not converge on B",
+    )
+    .await;
+
+    // --- Step 2: sync-status fields present and sane ---
+    let baseline_status = fetch_sync_status(&cluster, 1).await;
+    assert_drained_queue_has_no_next_retry(&baseline_status, "after baseline convergence");
+
+    // --- Step 3: storm — ~20 rapid updates to the same document ---
+    for i in 1..=UPDATE_COUNT {
+        let title = format!("v{i}");
+        node_a
+            .query(&format!(
+                r#"mutation {{ update_Note(docID: "{doc_id}", input: {{title: "{title}"}}) {{ _docID }} }}"#
+            ))
+            .unwrap_or_else(|e| panic!("update {i} on A failed: {e}"));
+    }
+
+    let final_title = format!("v{UPDATE_COUNT}");
+    let final_title_ref = &final_title;
+    poll_until(
+        || {
+            let result = node_b_ref.query("query { Note { _docID title } }").unwrap();
+            result["Note"]
+                .as_array()
+                .map(|arr| {
+                    arr.iter().any(|n| {
+                        n["_docID"].as_str() == Some(doc_id_ref.as_str())
+                            && n["title"].as_str() == Some(final_title_ref.as_str())
+                    })
+                })
+                .unwrap_or(false)
+        },
+        Duration::from_secs(30),
+        Duration::from_millis(200),
+        "storm updates did not converge on B",
+    )
+    .await;
+
+    let post_storm_status = fetch_sync_status(&cluster, 1).await;
+    assert_drained_queue_has_no_next_retry(&post_storm_status, "after storm convergence");
+
+    // Per-manager diagnostic counters only ever increase within one process.
+    assert!(
+        post_storm_status.missing_link_retries >= baseline_status.missing_link_retries,
+        "missing_link_retries must be monotonic"
+    );
+    assert!(
+        post_storm_status.pending_dag_retry_dispatched
+            >= baseline_status.pending_dag_retry_dispatched,
+        "pending_dag_retry_dispatched must be monotonic"
+    );
+    assert!(
+        post_storm_status.pending_dag_retry_suppressed
+            >= baseline_status.pending_dag_retry_suppressed,
+        "pending_dag_retry_suppressed must be monotonic"
+    );
+
+    let missing_link_growth =
+        post_storm_status.missing_link_retries - baseline_status.missing_link_retries;
+
+    // Bound derivation (#1112 storm fence, #1116 stage 2 incremental
+    // frontier): before #1112, a naive re-walk ran on every block arrival, so
+    // growth scaled with `updates * DAG-depth`. With the incremental
+    // frontier, a full verification walk (`record_missing_link_retry`) only
+    // fires when (a) a pending root's frontier empties on completion, or (b)
+    // the per-root retry clock re-dispatches a stalled root — at most one
+    // clock re-dispatch per completion for a healthy 2-node cluster with no
+    // induced loss. That is <= 2 full walks per update in the worst case, so
+    // growth over `UPDATE_COUNT` rapid same-doc updates should stay within
+    // `2 * UPDATE_COUNT` plus a small constant for the baseline create.
+    // Observed on this branch (3/3 local runs): growth = 0, with exactly one
+    // `pending_dag_retry_dispatched` per run — an unconstrained 2-node run
+    // has no capacity pressure, so a pushed root rarely lacks a link locally
+    // and pending-DAG registration barely triggers at all. The bound below
+    // stays at the full analytical envelope rather than an observed-x2
+    // margin: the observed value is 0, and a zero-based margin would make
+    // the assertion vacuous instead of load-bearing.
+    let bound = 2 * UPDATE_COUNT as u64 + 5;
+    assert!(
+        missing_link_growth <= bound,
+        "missing_link_retries grew by {missing_link_growth} over {UPDATE_COUNT} rapid updates \
+         (bound {bound}); the incremental frontier should keep growth O(updates), not \
+         O(updates * DAG-depth) — see #1112"
+    );
+}


### PR DESCRIPTION
## Summary

Stage 2 of the #1116 sync-ownership convergence design (operator-approved staged plan, see the issue thread): the receiver's pending-DAG want-queue becomes a paced, self-re-arming pull loop, and every fetch dispatch is claim-gated through a per-root retry clock.

- **Per-root retry clock** on `PendingDag` (`next_retry_at` + `dispatches`, capped exponential ladder 4s→60s). Every `DagNeedsFetch` emission site must win an atomic claim that advances the clock — duplicate dispatch is structurally rate-bounded.
- **All dispatch sites routed through the clock**: fresh registration consumes its immediate claim; the new 2s `run_pending_dag_retry_clock` loop is the scheduled re-driver; durable-resync restores claim before emitting; the post-fetch re-issue is claim-gated; **peer connect only expedites** (makes entries promptly due) instead of emitting directly — no more connect-storm redrives (#1112 inbound half).
- **Incremental frontier on block arrival**: an arriving block shrinks each waiting root's missing set and contributes its own absent links; the full `find_all_missing_links` verification walk runs only when a frontier empties (was O(DAG) per root per arriving block — the 4,289-retries-in-minutes signature from defra-agent#696). The clock's periodic retries self-heal frontier drift; the full walk remains the sole completion gate.
- **Selective-CAR grants computed from a rooted DAG walk** (`collect_dag_cids`, `extract_ipld_links` semantics — the DEK block is never grantable) instead of the pushed payload set. Root-only pushes now grant full-DAG recovery; decouples grants from payload expansion so stage 3 can delete the expansion.
- **`/p2p/sync/status`** gains `pending_dag_retry_dispatched`, `pending_dag_retry_suppressed`, `next_pending_retry_in_ms`.
- **Anti-vacuity integration fence** (`p2p/receiver_pull.rs`): forces the paced pull path via gossip single-head delivery (replicator severed before the burst), hard-fails if no pending-DAG dispatch occurs, and bounds `missing_link_retries` so a revert of the incremental frontier (~2× per-update walks) trips it.

Wire format untouched. #1088 (success reply ⇒ merged-or-registered) and #1099 (durable records deleted only on merge) invariants preserved — verified in review.

## Validation

- `cargo test -p p2p` (416 lib + all test binaries), `cargo test -p integration-test --test p2p` (rust suite), `--test p2p_admission`, `--test p2p_push_storm` — green
- New fence: 12/12 runs green; `pending_dag_retry_dispatched` growth 1/1 in 6/6 instrumented runs
- `cargo clippy --all -- -D warnings`, `cargo fmt --all -- --check` clean
- Per-task spec+quality reviews plus a whole-branch review (READY TO MERGE, no Critical/Important findings)

Formal model: `SyncOwnership.tla` on `design/1116-sync-ownership` proves the obligation-conservation/single-flight/bounded-queue invariants this stage implements the receiver half of.

Follow-ups noted for stage 3: per-root in-flight fetch guard (overlap is currently rate-bounded, not deduped); walk-error grant fallback degrades to request set post-expansion-deletion; pre-existing dead `register_docsync_dag`/`register_branchable_dag` helpers.

Stage 2 of #1116. Closes #1112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)