### PR TITLE
fix(p2p): route two-stream ACKs on response tokens

### DIFF
--- a/crates/p2p/src/iroh/endpoint_commands.rs
+++ b/crates/p2p/src/iroh/endpoint_commands.rs
@@ -23,7 +23,7 @@ use super::endpoint::{
 };
 use super::endpoint_rpc::{
     close_peer_connections, handle_block_sync, handle_car_request_response, handle_fire_and_forget,
-    handle_request_response, handle_send_only, BlockSyncResources,
+    handle_request_response, handle_send_only, handle_two_stream_request, BlockSyncResources,
 };
 use super::gossip_heal;
 use super::peer_map::{endpoint_id_to_peer_id, parse_endpoint_id, PeerMap};
@@ -197,38 +197,17 @@ pub(super) async fn handle_command(
                         .lock()
                         .insert(request_message_id.clone(), reply_tx);
 
-                    if let Err(error) = handle_send_only(
+                    let result = handle_two_stream_request(
                         &endpoint,
                         &request_peer_id,
-                        protocols::ALPN_TWOSTREAM,
                         &request,
                         direct_addr,
                         &connection_cache,
-                    )
-                    .await
-                    {
-                        pending_pushlog_replies.lock().remove(&request_message_id);
-                        return Err(error);
-                    }
-
-                    match tokio::time::timeout(
-                        super::endpoint_rpc::REQUEST_RESPONSE_TIMEOUT,
                         reply_rx,
                     )
-                    .await
-                    {
-                        Ok(Ok(reply_msg)) => Ok(reply_msg),
-                        Ok(Err(_)) => {
-                            pending_pushlog_replies.lock().remove(&request_message_id);
-                            Err(crate::error::Error::Transport(
-                                "response channel closed".into(),
-                            ))
-                        }
-                        Err(_) => {
-                            pending_pushlog_replies.lock().remove(&request_message_id);
-                            Err(crate::error::Error::ResponseTimeout)
-                        }
-                    }
+                    .await;
+                    pending_pushlog_replies.lock().remove(&request_message_id);
+                    result
                 }
                 .await;
                 let _ = reply.send(result);
@@ -240,6 +219,8 @@ pub(super) async fn handle_command(
             reply_msg,
             reply,
         } => {
+            // Retained for mixed-version peers whose request did not advertise
+            // same-stream reply support.
             let direct_addr = peer_direct_addr(peer_map, &peer_id);
             let endpoint = endpoint.clone();
             let connection_cache = Arc::clone(connection_cache);

--- a/crates/p2p/src/iroh/endpoint_rpc.rs
+++ b/crates/p2p/src/iroh/endpoint_rpc.rs
@@ -4,10 +4,10 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use iroh::{Endpoint, EndpointAddr};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, warn};
 
-use crate::message::CarFetchRequest;
+use crate::message::{CarFetchRequest, PushLogReply};
 use crate::transport::{PeerId, TransportEvent};
 use crate::QueryId;
 
@@ -343,6 +343,79 @@ where
     Ok(response)
 }
 
+/// Send a two-stream PushLog request and accept either response shape.
+///
+/// Current peers reply on this request's receive stream. During a rolling
+/// upgrade, older peers may still reverse-dial `ALPN_TWOSTREAM_RESP`, which is
+/// delivered through `legacy_reply`. A failure on either path is therefore not
+/// terminal while the other path can still produce the ACK.
+pub(super) async fn handle_two_stream_request(
+    endpoint: &Endpoint,
+    peer_id: &PeerId,
+    request: &crate::message::PushLogRequest,
+    direct_addr: Option<std::net::SocketAddr>,
+    cache: &ConnectionCache,
+    legacy_reply: oneshot::Receiver<PushLogReply>,
+) -> crate::error::Result<PushLogReply> {
+    let alpn = protocols::ALPN_TWOSTREAM;
+    let connection = connect_with_cache(endpoint, peer_id, alpn, direct_addr, cache).await?;
+
+    let (mut send, mut recv) = match open_bi_with_timeout(&connection, peer_id, alpn).await {
+        Ok(streams) => streams,
+        Err(error) => {
+            evict_connection(cache, peer_id, alpn);
+            return Err(error);
+        }
+    };
+
+    if let Err(error) = protocols::write_message(&mut send, request).await {
+        evict_connection(cache, peer_id, alpn);
+        return Err(error);
+    }
+    if let Err(error) = send
+        .finish()
+        .map_err(|e| crate::error::Error::Transport(e.to_string()))
+    {
+        evict_connection(cache, peer_id, alpn);
+        return Err(error);
+    }
+
+    let wait_for_reply = async {
+        let same_stream_reply = protocols::read_message(&mut recv, protocols::MAX_MESSAGE_SIZE);
+        tokio::pin!(same_stream_reply);
+        tokio::pin!(legacy_reply);
+
+        tokio::select! {
+            result = &mut same_stream_reply => match result {
+                Ok(reply) => Ok(reply),
+                Err(same_stream_error) => match legacy_reply.await {
+                    Ok(reply) => Ok(reply),
+                    Err(_) => Err(same_stream_error),
+                },
+            },
+            result = &mut legacy_reply => match result {
+                Ok(reply) => Ok(reply),
+                Err(_) => same_stream_reply.await,
+            },
+        }
+    };
+
+    tokio::time::timeout(REQUEST_RESPONSE_TIMEOUT, wait_for_reply)
+        .await
+        .map_err(|_| {
+            warn!(
+                peer_id = %peer_id,
+                timeout_secs = REQUEST_RESPONSE_TIMEOUT.as_secs(),
+                "two-stream request timed out waiting for same-stream or legacy reply"
+            );
+            evict_connection(cache, peer_id, alpn);
+            crate::error::Error::ResponseTimeout
+        })?
+        .inspect_err(|_| {
+            evict_connection(cache, peer_id, alpn);
+        })
+}
+
 async fn send_one_way_message<T: serde::Serialize>(
     endpoint: &Endpoint,
     peer_id: &PeerId,
@@ -399,12 +472,10 @@ pub(super) async fn handle_fire_and_forget<T: serde::Serialize>(
 /// Send a one-way message, then keep the bidirectional stream alive briefly so
 /// the peer can finish reading it.
 ///
-/// The two-stream request reply arrives on a separate response ALPN, so we do
-/// not read an application reply here. But dropping the bidi stream immediately
-/// after `finish()` can cause the remote iroh reader to see
-/// `connection lost` mid-frame under burst load. Waiting for the peer to close
-/// their side (or timing out) preserves the request-stream lifetime without
-/// collapsing back to same-stream request/response semantics.
+/// This remains used for messages that do not carry an application reply on
+/// their request stream, including the legacy reverse-stream PushLog response.
+/// Waiting for the peer to close their side avoids dropping the bidi stream
+/// while the remote reader is still consuming the frame.
 pub(super) async fn handle_send_only<T: serde::Serialize>(
     endpoint: &Endpoint,
     peer_id: &PeerId,

--- a/crates/p2p/src/iroh/endpoint_streams.rs
+++ b/crates/p2p/src/iroh/endpoint_streams.rs
@@ -234,6 +234,8 @@ async fn dispatch_stream(
             }
         }
         x if x == protocols::ALPN_TWOSTREAM_RESP => {
+            // Retained so upgraded senders can receive reverse-stream ACKs
+            // from older receivers during a rolling deployment.
             let reply: PushLogReply =
                 protocols::read_message(recv, protocols::MAX_MESSAGE_SIZE).await?;
             let (sender, pending_len_after_remove) = {

--- a/crates/p2p/src/iroh/mod.rs
+++ b/crates/p2p/src/iroh/mod.rs
@@ -22,6 +22,8 @@ mod peer_map;
 mod protocols;
 mod secret_key;
 mod transport;
+#[cfg(test)]
+mod two_stream_tests;
 
 pub use addr::{
     best_shareable_public_addr, canonical_peer_id, endpoint_addr_from_parts,

--- a/crates/p2p/src/iroh/transport.rs
+++ b/crates/p2p/src/iroh/transport.rs
@@ -18,6 +18,7 @@ use crate::message::{
     PushSEArtifactsRequest, QuerySEArtifactsReply, QuerySEArtifactsRequest,
 };
 use crate::replicator::ReplicatorInfo;
+use crate::signing::sign_with_transport;
 use crate::topics::DefraTopic;
 use crate::transport::{MessageId, P2PTransport, PeerAddr, PeerId};
 use crate::QueryId;
@@ -201,8 +202,12 @@ impl P2PTransport for IrohTransport {
     async fn send_two_stream_request(
         &self,
         peer_id: &PeerId,
-        req: PushLogRequest,
+        mut req: PushLogRequest,
     ) -> Result<PushLogReply> {
+        // Advertise that this iroh sender consumes the ACK from the request
+        // stream. Re-sign because the capability is part of the wire message.
+        req.supports_same_stream_reply = true;
+        sign_with_transport(self, &mut req)?;
         self.send_command(|reply| IrohCommand::SendTwoStreamRequest {
             peer_id: peer_id.clone(),
             request: req,

--- a/crates/p2p/src/iroh/two_stream_tests.rs
+++ b/crates/p2p/src/iroh/two_stream_tests.rs
@@ -177,7 +177,7 @@ async fn two_stream_request_still_accepts_legacy_reverse_stream_reply() {
 
 #[tokio::test]
 async fn concurrent_two_stream_fan_in_replies_on_request_streams() {
-    const SENDERS: usize = 8;
+    const SENDERS: usize = 32;
 
     let mut receiver = TestNode::spawn().await;
     let mut senders = Vec::with_capacity(SENDERS);

--- a/crates/p2p/src/iroh/two_stream_tests.rs
+++ b/crates/p2p/src/iroh/two_stream_tests.rs
@@ -1,0 +1,226 @@
+use std::collections::HashSet;
+use std::net::{IpAddr, Ipv4Addr};
+use std::time::Duration;
+
+use bytes::Bytes;
+use iroh::SecretKey;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tokio::time::timeout;
+
+use super::{spawn_endpoint, IrohDiscoveryConfig, IrohEndpointConfig, IrohTransport};
+use crate::message::{PushLogReply, PushLogRequest};
+use crate::signing::sign_with_transport;
+use crate::transport::{P2PTransport, PeerId, TransportEvent};
+
+const IO_TIMEOUT: Duration = Duration::from_secs(5);
+
+struct TestNode {
+    transport: IrohTransport,
+    events: mpsc::Receiver<TransportEvent<iroh::endpoint::SendStream>>,
+    task: JoinHandle<()>,
+}
+
+impl TestNode {
+    async fn spawn() -> Self {
+        let secret_key = SecretKey::generate();
+        let config = IrohEndpointConfig {
+            secret_key: secret_key.clone(),
+            relay_mode: crate::iroh::IrohRelayModeConfig::Disabled,
+            discovery: IrohDiscoveryConfig::Disabled,
+            bind_port: None,
+            bind_addr: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+            gossip_heal: Default::default(),
+        };
+        let (command_tx, events, _replicators, task) = spawn_endpoint(config).await.unwrap();
+        Self {
+            transport: IrohTransport::new(command_tx, secret_key),
+            events,
+            task,
+        }
+    }
+
+    async fn shutdown(self) {
+        self.transport.shutdown().await.unwrap();
+        self.task.await.unwrap();
+    }
+}
+
+async fn connect(sender: &IrohTransport, receiver: &IrohTransport) {
+    sender
+        .dial(
+            receiver.local_peer_id(),
+            receiver.listen_addresses().await.unwrap(),
+        )
+        .await
+        .unwrap();
+    sender
+        .poll_until_connected(receiver.local_peer_id(), IO_TIMEOUT)
+        .await
+        .unwrap();
+    receiver
+        .poll_until_connected(sender.local_peer_id(), IO_TIMEOUT)
+        .await
+        .unwrap();
+}
+
+fn signed_request(transport: &IrohTransport, label: &str) -> PushLogRequest {
+    let mut request = PushLogRequest::new(
+        format!("doc-{label}"),
+        Bytes::from(vec![1, 2, 3]),
+        "collection1".to_string(),
+        "creator1".to_string(),
+        Bytes::from(format!("block-{label}").into_bytes()),
+    );
+    sign_with_transport(transport, &mut request).unwrap();
+    request
+}
+
+async fn next_two_stream_request(
+    events: &mut mpsc::Receiver<TransportEvent<iroh::endpoint::SendStream>>,
+) -> (PeerId, PushLogRequest, iroh::endpoint::SendStream) {
+    loop {
+        let event = timeout(IO_TIMEOUT, events.recv())
+            .await
+            .expect("timed out waiting for two-stream request")
+            .expect("iroh event channel closed");
+        if let TransportEvent::TwoStreamRequest {
+            peer_id,
+            request,
+            token: Some(token),
+            ..
+        } = event
+        {
+            return (peer_id, request, token);
+        }
+    }
+}
+
+#[tokio::test]
+async fn two_stream_request_receives_reply_on_request_stream() {
+    let sender = TestNode::spawn().await;
+    let mut receiver = TestNode::spawn().await;
+    connect(&sender.transport, &receiver.transport).await;
+
+    let request = signed_request(&sender.transport, "same-stream");
+    let message_id = request.message_id.clone();
+    let target = receiver.transport.local_peer_id().clone();
+    let sender_transport = sender.transport.clone();
+    let send_task = tokio::spawn(async move {
+        sender_transport
+            .send_two_stream_request(&target, request)
+            .await
+    });
+
+    let (peer_id, received, token) = next_two_stream_request(&mut receiver.events).await;
+    assert_eq!(peer_id, *sender.transport.local_peer_id());
+    assert_eq!(received.message_id, message_id);
+    assert!(received.supports_same_stream_reply);
+
+    let mut reply = PushLogReply::success(&message_id);
+    sign_with_transport(&receiver.transport, &mut reply).unwrap();
+    receiver
+        .transport
+        .send_pushlog_response(token, reply)
+        .await
+        .unwrap();
+
+    let received_reply = timeout(Duration::from_secs(1), send_task)
+        .await
+        .expect("same-stream two-stream reply timed out")
+        .unwrap()
+        .unwrap();
+    assert_eq!(received_reply.message_id, message_id);
+
+    sender.shutdown().await;
+    receiver.shutdown().await;
+}
+
+#[tokio::test]
+async fn two_stream_request_still_accepts_legacy_reverse_stream_reply() {
+    let sender = TestNode::spawn().await;
+    let mut receiver = TestNode::spawn().await;
+    connect(&sender.transport, &receiver.transport).await;
+
+    let request = signed_request(&sender.transport, "legacy-reply");
+    let message_id = request.message_id.clone();
+    let target = receiver.transport.local_peer_id().clone();
+    let sender_transport = sender.transport.clone();
+    let send_task = tokio::spawn(async move {
+        sender_transport
+            .send_two_stream_request(&target, request)
+            .await
+    });
+
+    let (_, received, _) = next_two_stream_request(&mut receiver.events).await;
+    assert_eq!(received.message_id, message_id);
+    assert!(received.supports_same_stream_reply);
+
+    let mut reply = PushLogReply::success(&message_id);
+    sign_with_transport(&receiver.transport, &mut reply).unwrap();
+    receiver
+        .transport
+        .send_two_stream_response(sender.transport.local_peer_id(), reply)
+        .await
+        .unwrap();
+
+    let received_reply = timeout(Duration::from_secs(1), send_task)
+        .await
+        .expect("legacy reverse-stream reply timed out")
+        .unwrap()
+        .unwrap();
+    assert_eq!(received_reply.message_id, message_id);
+
+    sender.shutdown().await;
+    receiver.shutdown().await;
+}
+
+#[tokio::test]
+async fn concurrent_two_stream_fan_in_replies_on_request_streams() {
+    const SENDERS: usize = 8;
+
+    let mut receiver = TestNode::spawn().await;
+    let mut senders = Vec::with_capacity(SENDERS);
+    for index in 0..SENDERS {
+        let sender = TestNode::spawn().await;
+        connect(&sender.transport, &receiver.transport).await;
+        let request = signed_request(&sender.transport, &format!("fan-in-{index}"));
+        let target = receiver.transport.local_peer_id().clone();
+        let sender_transport = sender.transport.clone();
+        let send_task = tokio::spawn(async move {
+            sender_transport
+                .send_two_stream_request(&target, request)
+                .await
+        });
+        senders.push((sender, send_task));
+    }
+
+    let mut peers = HashSet::with_capacity(SENDERS);
+    for _ in 0..SENDERS {
+        let (peer_id, request, token) = next_two_stream_request(&mut receiver.events).await;
+        peers.insert(peer_id);
+        assert!(request.supports_same_stream_reply);
+        let mut reply = PushLogReply::success(&request.message_id);
+        sign_with_transport(&receiver.transport, &mut reply).unwrap();
+        receiver
+            .transport
+            .send_pushlog_response(token, reply)
+            .await
+            .unwrap();
+    }
+    assert_eq!(peers.len(), SENDERS);
+
+    for (_, send_task) in &mut senders {
+        let reply = timeout(Duration::from_secs(1), send_task)
+            .await
+            .expect("fan-in two-stream reply timed out")
+            .unwrap()
+            .unwrap();
+        assert!(reply.err_message.is_none());
+    }
+
+    for (sender, _) in senders {
+        sender.shutdown().await;
+    }
+    receiver.shutdown().await;
+}

--- a/crates/p2p/src/message/pushlog.rs
+++ b/crates/p2p/src/message/pushlog.rs
@@ -8,6 +8,10 @@ use super::cbor::{nullable_bytes, optional_bytes};
 use super::traits::Message;
 use crate::protocol::MESSAGE_VERSION;
 
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
 /// PushLog request message for sending resource updates to peer nodes.
 ///
 /// This is the primary message type for CRDT synchronization between nodes.
@@ -76,6 +80,16 @@ pub struct PushLogRequest {
         default
     )]
     pub explicit_replay_capability: Option<String>,
+
+    /// Whether the sender can receive the reply on the request's bidirectional stream.
+    ///
+    /// Older iroh senders omit this field and require the legacy reverse-stream response.
+    #[serde(
+        rename = "SupportsSameStreamReply",
+        skip_serializing_if = "is_false",
+        default
+    )]
+    pub supports_same_stream_reply: bool,
 }
 
 impl PushLogRequest {
@@ -100,6 +114,7 @@ impl PushLogRequest {
             creator,
             block,
             explicit_replay_capability: None,
+            supports_same_stream_reply: false,
         }
     }
 }

--- a/crates/p2p/src/message/pushlog.rs
+++ b/crates/p2p/src/message/pushlog.rs
@@ -84,6 +84,8 @@ pub struct PushLogRequest {
     /// Whether the sender can receive the reply on the request's bidirectional stream.
     ///
     /// Older iroh senders omit this field and require the legacy reverse-stream response.
+    /// This capability is iroh-only. Never set it on libp2p: Go signature verification
+    /// re-serializes the request and would omit this unknown field.
     #[serde(
         rename = "SupportsSameStreamReply",
         skip_serializing_if = "is_false",

--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -2575,7 +2575,7 @@ async fn two_stream_reply_with_response_token_does_not_reverse_dial() {
     let peer = random_peer_id();
 
     coordinator
-        .send_two_stream_reply(&peer, PushLogReply::success("message-1"), Some(7))
+        .send_two_stream_reply(&peer, PushLogReply::success("message-1"), Some(7), true)
         .await;
 
     assert_eq!(transport.pushlog_response_tokens(), vec![7]);
@@ -2595,7 +2595,7 @@ async fn two_stream_reply_without_response_token_falls_back_to_reverse_dial() {
     let peer = random_peer_id();
 
     coordinator
-        .send_two_stream_reply(&peer, PushLogReply::success("message-1"), None)
+        .send_two_stream_reply(&peer, PushLogReply::success("message-1"), None, true)
         .await;
 
     assert!(transport.pushlog_response_tokens().is_empty());
@@ -2604,37 +2604,20 @@ async fn two_stream_reply_without_response_token_falls_back_to_reverse_dial() {
 }
 
 #[tokio::test]
-async fn two_stream_fan_in_delivers_every_ack_on_its_response_token() {
-    const SENDERS: usize = 32;
-
+async fn two_stream_reply_for_legacy_sender_falls_back_to_reverse_dial() {
     let replicators = Arc::new(ReplicatorRegistry::new());
     let peer_state = Arc::new(PeerStateTracker::new());
     let (coordinator, _events) = create_test_coordinator(AccessMode::Open, replicators, peer_state);
     let transport = coordinator.runtime.transport.clone();
+    let peer = random_peer_id();
 
-    for token in 0..SENDERS {
-        let peer = random_peer_id();
-        timeout(
-            Duration::from_secs(1),
-            coordinator.send_two_stream_reply(
-                &peer,
-                PushLogReply::success(&format!("message-{token}")),
-                Some(token),
-            ),
-        )
-        .await
-        .expect("two-stream ACK should return promptly on the inbound response token");
-    }
+    coordinator
+        .send_two_stream_reply(&peer, PushLogReply::success("message-1"), Some(7), false)
+        .await;
 
-    assert_eq!(
-        transport.pushlog_response_tokens(),
-        (0..SENDERS).collect::<Vec<_>>()
-    );
-    assert_eq!(transport.pushlog_replies().len(), SENDERS);
-    assert!(
-        transport.two_stream_replies().is_empty(),
-        "fan-in ACKs must not reverse-dial any sender"
-    );
+    assert!(transport.pushlog_response_tokens().is_empty());
+    assert!(transport.pushlog_replies().is_empty());
+    assert_eq!(transport.two_stream_replies().len(), 1);
 }
 
 #[tokio::test]

--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -417,6 +417,7 @@ struct NoopTransport {
     doc_sync_replies: Arc<RwLock<Vec<DocSyncReply>>>,
     car_responses: Arc<RwLock<Vec<Vec<u8>>>>,
     pushlog_replies: Arc<RwLock<Vec<crate::message::PushLogReply>>>,
+    pushlog_response_tokens: Arc<RwLock<Vec<usize>>>,
     two_stream_replies: Arc<RwLock<Vec<crate::message::PushLogReply>>>,
     two_stream_handler: Arc<RwLock<Option<TwoStreamHandler>>>,
     branchable_replies: Arc<RwLock<Vec<BranchableSyncReply>>>,
@@ -432,6 +433,7 @@ impl NoopTransport {
             doc_sync_replies: Arc::new(RwLock::new(Vec::new())),
             car_responses: Arc::new(RwLock::new(Vec::new())),
             pushlog_replies: Arc::new(RwLock::new(Vec::new())),
+            pushlog_response_tokens: Arc::new(RwLock::new(Vec::new())),
             two_stream_replies: Arc::new(RwLock::new(Vec::new())),
             two_stream_handler: Arc::new(RwLock::new(None)),
             branchable_replies: Arc::new(RwLock::new(Vec::new())),
@@ -448,6 +450,10 @@ impl NoopTransport {
 
     fn pushlog_replies(&self) -> Vec<crate::message::PushLogReply> {
         self.pushlog_replies.read().clone()
+    }
+
+    fn pushlog_response_tokens(&self) -> Vec<usize> {
+        self.pushlog_response_tokens.read().clone()
     }
 
     fn two_stream_replies(&self) -> Vec<crate::message::PushLogReply> {
@@ -471,7 +477,7 @@ impl NoopTransport {
 
 #[async_trait]
 impl P2PTransport for NoopTransport {
-    type ResponseToken = ();
+    type ResponseToken = usize;
 
     fn local_peer_id(&self) -> &PeerId {
         &self.peer_id
@@ -539,9 +545,10 @@ impl P2PTransport for NoopTransport {
 
     async fn send_pushlog_response(
         &self,
-        _token: Self::ResponseToken,
+        token: Self::ResponseToken,
         reply: crate::message::PushLogReply,
     ) -> crate::Result<()> {
+        self.pushlog_response_tokens.write().push(token);
         self.pushlog_replies.write().push(reply);
         Ok(())
     }
@@ -720,11 +727,11 @@ impl P2PTransport for NoopTransport {
     }
 }
 
-fn doc_sync_event(peer_id: PeerId) -> TransportEvent<()> {
+fn doc_sync_event(peer_id: PeerId) -> TransportEvent<usize> {
     doc_sync_event_with_ids(peer_id, vec!["doc1".to_string()])
 }
 
-fn doc_sync_event_with_ids(peer_id: PeerId, doc_ids: Vec<String>) -> TransportEvent<()> {
+fn doc_sync_event_with_ids(peer_id: PeerId, doc_ids: Vec<String>) -> TransportEvent<usize> {
     TransportEvent::DocSyncRequest {
         peer_id,
         request: DocSyncRequest::new(doc_ids),
@@ -732,7 +739,7 @@ fn doc_sync_event_with_ids(peer_id: PeerId, doc_ids: Vec<String>) -> TransportEv
     }
 }
 
-fn branchable_sync_event(peer_id: PeerId, collection_id: &str) -> TransportEvent<()> {
+fn branchable_sync_event(peer_id: PeerId, collection_id: &str) -> TransportEvent<usize> {
     TransportEvent::BranchableSyncRequest {
         peer_id,
         request: BranchableSyncRequest::new(collection_id.to_string()),
@@ -744,7 +751,7 @@ fn branchable_sync_reply_event(
     peer_id: PeerId,
     collection_id: &str,
     heads: Vec<Cid>,
-) -> TransportEvent<()> {
+) -> TransportEvent<usize> {
     TransportEvent::BranchableSyncReply {
         peer_id,
         reply: BranchableSyncReply::success(
@@ -786,7 +793,7 @@ fn collection_commit_request(collection_id: &str) -> PushLogRequest {
     )
 }
 
-fn collection_commit_gossip_event(peer_id: PeerId, collection_id: &str) -> TransportEvent<()> {
+fn collection_commit_gossip_event(peer_id: PeerId, collection_id: &str) -> TransportEvent<usize> {
     TransportEvent::GossipMessage {
         propagation_source: peer_id,
         message_id: MessageId::new("gossip".to_string()),
@@ -795,19 +802,23 @@ fn collection_commit_gossip_event(peer_id: PeerId, collection_id: &str) -> Trans
     }
 }
 
-fn pushlog_event(peer_id: PeerId, collection_id: &str) -> TransportEvent<()> {
+fn pushlog_event(peer_id: PeerId, collection_id: &str) -> TransportEvent<usize> {
     TransportEvent::PushLogRequest {
         peer_id,
         request: pushlog_request(collection_id),
-        token: (),
+        token: 0,
     }
 }
 
-fn gossip_event(peer_id: PeerId, collection_id: &str) -> TransportEvent<()> {
+fn gossip_event(peer_id: PeerId, collection_id: &str) -> TransportEvent<usize> {
     gossip_event_on_topic(peer_id, collection_id, collection_id)
 }
 
-fn gossip_event_on_topic(peer_id: PeerId, topic: &str, collection_id: &str) -> TransportEvent<()> {
+fn gossip_event_on_topic(
+    peer_id: PeerId,
+    topic: &str,
+    collection_id: &str,
+) -> TransportEvent<usize> {
     TransportEvent::GossipMessage {
         propagation_source: peer_id,
         message_id: MessageId::new("gossip".to_string()),
@@ -816,7 +827,7 @@ fn gossip_event_on_topic(peer_id: PeerId, topic: &str, collection_id: &str) -> T
     }
 }
 
-fn car_fetch_event(peer_id: PeerId, root_cid: Cid) -> TransportEvent<()> {
+fn car_fetch_event(peer_id: PeerId, root_cid: Cid) -> TransportEvent<usize> {
     TransportEvent::CarFetchRequest {
         peer_id,
         request: CarFetchRequest::full_dag(root_cid),
@@ -828,7 +839,7 @@ fn selective_car_fetch_event(
     peer_id: PeerId,
     root_cid: Cid,
     wanted_cids: Vec<Cid>,
-) -> TransportEvent<()> {
+) -> TransportEvent<usize> {
     TransportEvent::CarFetchRequest {
         peer_id,
         request: CarFetchRequest::selective_blocks(root_cid, wanted_cids),
@@ -855,7 +866,7 @@ fn two_stream_event(
     peer_id: PeerId,
     collection_id: &str,
     is_explicit_replicator: bool,
-) -> TransportEvent<()> {
+) -> TransportEvent<usize> {
     TransportEvent::TwoStreamRequest {
         peer_id,
         request: pushlog_request(collection_id),
@@ -2466,7 +2477,7 @@ async fn pushlog_request_at_pending_capacity_replies_at_capacity_nack() {
         .handle_transport_event(TransportEvent::PushLogRequest {
             peer_id: peer.clone(),
             request: pushlog_request_with_missing_link("collection1", "docA"),
-            token: (),
+            token: 0,
         })
         .await
         .unwrap();
@@ -2480,7 +2491,7 @@ async fn pushlog_request_at_pending_capacity_replies_at_capacity_nack() {
         .handle_transport_event(TransportEvent::PushLogRequest {
             peer_id: peer.clone(),
             request: pushlog_request_with_missing_link("collection1", "docB"),
-            token: (),
+            token: 0,
         })
         .await;
     assert!(
@@ -2552,6 +2563,77 @@ async fn two_stream_at_pending_capacity_replies_at_capacity_nack() {
         reply.err_message.as_deref(),
         Some(crate::error::AT_CAPACITY_MESSAGE),
         "capacity overflow must nack with the byte-exact capacity sentinel, never success"
+    );
+}
+
+#[tokio::test]
+async fn two_stream_reply_with_response_token_does_not_reverse_dial() {
+    let replicators = Arc::new(ReplicatorRegistry::new());
+    let peer_state = Arc::new(PeerStateTracker::new());
+    let (coordinator, _events) = create_test_coordinator(AccessMode::Open, replicators, peer_state);
+    let transport = coordinator.runtime.transport.clone();
+    let peer = random_peer_id();
+
+    coordinator
+        .send_two_stream_reply(&peer, PushLogReply::success("message-1"), Some(7))
+        .await;
+
+    assert_eq!(transport.pushlog_response_tokens(), vec![7]);
+    assert_eq!(transport.pushlog_replies().len(), 1);
+    assert!(
+        transport.two_stream_replies().is_empty(),
+        "a response token must avoid a fresh reverse-dial"
+    );
+}
+
+#[tokio::test]
+async fn two_stream_reply_without_response_token_falls_back_to_reverse_dial() {
+    let replicators = Arc::new(ReplicatorRegistry::new());
+    let peer_state = Arc::new(PeerStateTracker::new());
+    let (coordinator, _events) = create_test_coordinator(AccessMode::Open, replicators, peer_state);
+    let transport = coordinator.runtime.transport.clone();
+    let peer = random_peer_id();
+
+    coordinator
+        .send_two_stream_reply(&peer, PushLogReply::success("message-1"), None)
+        .await;
+
+    assert!(transport.pushlog_response_tokens().is_empty());
+    assert!(transport.pushlog_replies().is_empty());
+    assert_eq!(transport.two_stream_replies().len(), 1);
+}
+
+#[tokio::test]
+async fn two_stream_fan_in_delivers_every_ack_on_its_response_token() {
+    const SENDERS: usize = 32;
+
+    let replicators = Arc::new(ReplicatorRegistry::new());
+    let peer_state = Arc::new(PeerStateTracker::new());
+    let (coordinator, _events) = create_test_coordinator(AccessMode::Open, replicators, peer_state);
+    let transport = coordinator.runtime.transport.clone();
+
+    for token in 0..SENDERS {
+        let peer = random_peer_id();
+        timeout(
+            Duration::from_secs(1),
+            coordinator.send_two_stream_reply(
+                &peer,
+                PushLogReply::success(&format!("message-{token}")),
+                Some(token),
+            ),
+        )
+        .await
+        .expect("two-stream ACK should return promptly on the inbound response token");
+    }
+
+    assert_eq!(
+        transport.pushlog_response_tokens(),
+        (0..SENDERS).collect::<Vec<_>>()
+    );
+    assert_eq!(transport.pushlog_replies().len(), SENDERS);
+    assert!(
+        transport.two_stream_replies().is_empty(),
+        "fan-in ACKs must not reverse-dial any sender"
     );
 }
 

--- a/crates/p2p/src/sync/coordinator/event_handler/mod.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/mod.rs
@@ -164,6 +164,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         peer_id: &PeerId,
         message_id: &str,
         token: Option<T::ResponseToken>,
+        supports_same_stream_reply: bool,
         error: Error,
     ) -> Error {
         let mut reply = PushLogReply::error(message_id, RATE_LIMITED_MESSAGE);
@@ -172,7 +173,8 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         if let Err(sign_err) = sign_with_transport(&self.runtime.transport, &mut reply) {
             tracing::debug!(error = %sign_err, "Failed to sign two-stream backpressure nack");
         }
-        self.send_two_stream_reply(peer_id, reply, token).await;
+        self.send_two_stream_reply(peer_id, reply, token, supports_same_stream_reply)
+            .await;
         error
     }
 
@@ -334,13 +336,20 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 is_explicit_replicator,
                 explicit_replay_authorization,
             } => {
+                let supports_same_stream_reply = request.supports_same_stream_reply;
                 if let Err(error) = self.check_rate_limit(
                     &self.runtime.request_rate_limiter,
                     &peer_id,
                     "TwoStreamRequest",
                 ) {
                     return Err(self
-                        .reject_rate_limited_two_stream(&peer_id, &request.message_id, token, error)
+                        .reject_rate_limited_two_stream(
+                            &peer_id,
+                            &request.message_id,
+                            token,
+                            supports_same_stream_reply,
+                            error,
+                        )
                         .await);
                 }
                 self.handle_two_stream_request(

--- a/crates/p2p/src/sync/coordinator/event_handler/pushlog.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/pushlog.rs
@@ -167,6 +167,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         is_explicit_replicator: bool,
         explicit_replay_authorization: Option<ExplicitReplayAuthorization>,
     ) -> Result<()> {
+        let supports_same_stream_reply = request.supports_same_stream_reply;
         tracing::debug!(
             peer_id = %peer_id,
             doc_id = %request.doc_id,
@@ -199,7 +200,8 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 if let Err(sign_err) = sign_with_transport(&self.runtime.transport, &mut reply) {
                     tracing::error!(error = %sign_err, "Failed to sign invalid CID response");
                 }
-                self.send_two_stream_reply(&peer_id, reply, token).await;
+                self.send_two_stream_reply(&peer_id, reply, token, supports_same_stream_reply)
+                    .await;
                 return Err(crate::error::Error::InvalidCid(error_msg));
             }
         };
@@ -228,24 +230,33 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             return Err(e);
         }
 
-        self.send_two_stream_reply(&peer_id, reply, token).await;
+        self.send_two_stream_reply(&peer_id, reply, token, supports_same_stream_reply)
+            .await;
 
         process_result
     }
 
-    /// Send a two-stream reply using the response token if available,
-    /// falling back to the transport's send_two_stream_response.
+    /// Send a two-stream reply on the request stream when the sender advertised
+    /// support, falling back to the legacy reverse-stream response otherwise.
     pub(in crate::sync::coordinator) async fn send_two_stream_reply(
         &self,
         peer_id: &PeerId,
         reply: PushLogReply,
         token: Option<T::ResponseToken>,
+        supports_same_stream_reply: bool,
     ) {
-        let send_result = if let Some(token) = token {
-            self.runtime
-                .transport
-                .send_pushlog_response(token, reply)
-                .await
+        let send_result = if supports_same_stream_reply {
+            if let Some(token) = token {
+                self.runtime
+                    .transport
+                    .send_pushlog_response(token, reply)
+                    .await
+            } else {
+                self.runtime
+                    .transport
+                    .send_two_stream_response(peer_id, reply)
+                    .await
+            }
         } else {
             self.runtime
                 .transport

--- a/crates/p2p/src/sync/coordinator/event_handler/pushlog.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/pushlog.rs
@@ -239,13 +239,19 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         &self,
         peer_id: &PeerId,
         reply: PushLogReply,
-        _token: Option<T::ResponseToken>,
+        token: Option<T::ResponseToken>,
     ) {
-        let send_result = self
-            .runtime
-            .transport
-            .send_two_stream_response(peer_id, reply)
-            .await;
+        let send_result = if let Some(token) = token {
+            self.runtime
+                .transport
+                .send_pushlog_response(token, reply)
+                .await
+        } else {
+            self.runtime
+                .transport
+                .send_two_stream_response(peer_id, reply)
+                .await
+        };
 
         if let Err(e) = send_result {
             if e.is_connection_like() {

--- a/crates/p2p/tests/message_tests.rs
+++ b/crates/p2p/tests/message_tests.rs
@@ -43,6 +43,40 @@ fn test_pushlog_request_serialization() {
     assert_eq!(decoded.collection_id, "collection1");
     assert_eq!(decoded.creator, "creator1");
     assert_eq!(decoded.block, vec![5, 6, 7, 8]);
+    assert!(!decoded.supports_same_stream_reply);
+}
+
+#[test]
+fn test_pushlog_request_same_stream_reply_capability_is_backward_compatible() {
+    let mut request = PushLogRequest::new(
+        "doc123".to_string(),
+        Bytes::from(vec![1, 2, 3, 4]),
+        "collection1".to_string(),
+        "creator1".to_string(),
+        Bytes::from(vec![5, 6, 7, 8]),
+    );
+
+    let encoded = encode_with_ciborium(&request);
+    let value: ciborium::Value = decode_with_ciborium(&encoded);
+    let ciborium::Value::Map(map) = value else {
+        panic!("Expected CBOR map");
+    };
+    assert!(
+        !has_text_key(&map, "SupportsSameStreamReply"),
+        "false capability should be omitted for older peers"
+    );
+    let decoded: PushLogRequest = decode_with_ciborium(&encoded);
+    assert!(!decoded.supports_same_stream_reply);
+
+    request.supports_same_stream_reply = true;
+    let encoded = encode_with_ciborium(&request);
+    let value: ciborium::Value = decode_with_ciborium(&encoded);
+    let ciborium::Value::Map(map) = value else {
+        panic!("Expected CBOR map");
+    };
+    assert!(has_text_key(&map, "SupportsSameStreamReply"));
+    let decoded: PushLogRequest = decode_with_ciborium(&encoded);
+    assert!(decoded.supports_same_stream_reply);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- route capable Iroh two-stream PushLog ACKs over the already-open request stream instead of reverse-dialing a new response stream
- advertise same-stream reply support on `PushLogRequest`, re-sign the request, and have the Iroh sender accept either the same-stream ACK or the legacy `ALPN_TWOSTREAM_RESP` ACK
- keep reverse-stream replies for requests that omit the capability or do not carry a response token
- replace the sequential mock fan-in case with real Iroh endpoint round-trip, legacy fallback, and concurrent 32-sender fan-in coverage

## Root cause

`send_two_stream_reply` accepted an optional response token but ignored it, so every ACK opened a fresh response stream back to the sender by peer ID. Under hub fan-in, those reverse-dials produced 30-second sender-side failures and compounded return-path load.

The receiver cannot switch paths alone: the Iroh sender previously used `handle_send_only`, discarded data from the request receive stream, and waited exclusively for the reverse response ALPN. This change updates both sides of the protocol.

## Mixed-version compatibility

The rollout is capability-negotiated through the optional `SupportsSameStreamReply` request field:

- old sender -> new receiver: the field is absent and defaults to false, so the receiver uses the legacy reverse response stream
- new sender -> old receiver: the new sender races the request stream against the retained pending-reply/response-ALPN path, so the old reverse-stream ACK is still accepted
- new sender -> new receiver: the receiver writes the ACK on the request token and the sender consumes it directly
- libp2p/Go-compatible traffic: requests do not advertise the Iroh capability and continue using the existing reverse-stream path

`ALPN_TWOSTREAM_RESP` dispatch and `SendTwoStreamResponse` intentionally remain reachable for mixed-version and compatibility traffic.

## Validation

- real Iroh same-stream request/ACK round trip
- real Iroh sender accepting a legacy reverse-stream ACK
- real concurrent fan-in from 32 Iroh endpoints to one receiver
- `cargo test -p integration-test --test p2p_iroh` (230 passed)
- `cargo test -p p2p -p defra-p2p-adapter`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

Fixes #1127