### PR TITLE
fix(p2p): quarantine terminal merge failures — dead-letter for the pending-DAG ledger (#1128)

### DIFF
--- a/crates/cli/src/commands/start/server_p2p.rs
+++ b/crates/cli/src/commands/start/server_p2p.rs
@@ -357,6 +357,20 @@ impl Node {
                     p2p::sync::ReplicationResult::MergedButNotMarked { cid, error } => {
                         error!(cid = %cid, error = %error, "Block merged but failed to mark");
                     }
+                    p2p::sync::ReplicationResult::Quarantined {
+                        cid,
+                        doc_id,
+                        collection_id,
+                        reason,
+                    } => {
+                        tracing::warn!(
+                            cid = %cid,
+                            doc_id = %doc_id,
+                            collection_id = %collection_id,
+                            reason = %reason,
+                            "Block quarantined: merge deterministically rejected, will not be re-driven locally"
+                        );
+                    }
                     _ => {}
                 },
             )

--- a/crates/db-merge/src/merge_handler/batch.rs
+++ b/crates/db-merge/src/merge_handler/batch.rs
@@ -225,6 +225,17 @@ impl<S: Store + 'static, B: blockstore::Blockstore + Send + Sync + 'static> DbMe
                     )
                     .await
                 {
+                    // A Rejected outcome (unique-index violation) surfaces AFTER
+                    // persist_merged_document has staged the doc's field data in
+                    // the SHARED batch txn, and the shared txn cannot roll back a
+                    // single block. Treat it as batch-poisoning: discard the whole
+                    // attempt and let the caller fall back to per-block processing,
+                    // whose per-CID txn discards cleanly and re-yields the clean
+                    // Rejected outcome (partial `results` are dropped with the Err).
+                    Ok(MergeOutcome::Rejected { reason }) => {
+                        batch_error = Some(MergeError::UniqueConstraintViolation(reason));
+                        break;
+                    }
                     Ok(outcome) => results.push(Ok(outcome)),
                     Err(e) => {
                         batch_error = Some(e);

--- a/crates/db-merge/src/merge_handler/composite.rs
+++ b/crates/db-merge/src/merge_handler/composite.rs
@@ -267,11 +267,16 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                 .await
             {
                 Ok(Some(outcome)) => Ok(Some(outcome)),
-                Ok(None) => {
-                    self.persist_merged_document(&mut datastore, &context, &mut state)
-                        .await?;
-                    Ok(None)
-                }
+                Ok(None) => match self
+                    .persist_merged_document(&mut datastore, &context, &mut state)
+                    .await
+                {
+                    Ok(()) => Ok(None),
+                    Err(MergeError::UniqueConstraintViolation(reason)) => {
+                        Ok(Some(MergeOutcome::rejected(reason)))
+                    }
+                    Err(e) => Err(e),
+                },
                 Err(MergeError::ImmutableFieldChanged(reason)) => {
                     Ok(Some(MergeOutcome::terminal_skip(reason)))
                 }
@@ -570,11 +575,16 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                 .await
             {
                 Ok(Some(outcome)) => Ok(Some(outcome)),
-                Ok(None) => {
-                    self.persist_merged_document(&mut datastore, &context, &mut state)
-                        .await?;
-                    Ok(None)
-                }
+                Ok(None) => match self
+                    .persist_merged_document(&mut datastore, &context, &mut state)
+                    .await
+                {
+                    Ok(()) => Ok(None),
+                    Err(MergeError::UniqueConstraintViolation(reason)) => {
+                        Ok(Some(MergeOutcome::rejected(reason)))
+                    }
+                    Err(e) => Err(e),
+                },
                 Err(MergeError::ImmutableFieldChanged(reason)) => {
                     Ok(Some(MergeOutcome::terminal_skip(reason)))
                 }

--- a/crates/db-merge/src/merge_handler/composite.rs
+++ b/crates/db-merge/src/merge_handler/composite.rs
@@ -567,9 +567,15 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
             let mut datastore = datastore.clone();
 
             // process_linked_field_blocks validates @immutable fields BEFORE
-            // persisting any field, so a rejected composite leaves no partial write
-            // in the shared batch txn. A change is a deterministic content
-            // rejection: skip terminally, not retry.
+            // persisting any field, so an immutable rejection leaves no partial
+            // write in the shared batch txn and can terminally skip in place.
+            // A unique-index rejection is different: it is detected AFTER
+            // persist_merged_document has staged the doc in the shared txn,
+            // which cannot roll back a single block — so its Rejected outcome
+            // must poison the whole batch attempt. try_batch_merge discards
+            // the txn and falls back to per-block processing, where the
+            // standalone path's per-CID txn discards cleanly. Both are
+            // deterministic content rejections, not retries.
             match self
                 .process_linked_field_blocks(&mut datastore, headstore, &context, &mut state)
                 .await

--- a/crates/db-merge/src/merge_handler/composite_persist.rs
+++ b/crates/db-merge/src/merge_handler/composite_persist.rs
@@ -110,6 +110,17 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                     }
                 };
                 if let Err(e) = index_result {
+                    // The merge variants above already resolve the common live
+                    // unique-conflict case deterministically without erroring.
+                    // What still surfaces `UniqueConstraintViolation` here are
+                    // the degenerate arms (non-Unique index type mismatch,
+                    // empty collection_id, `conflicting_doc_id` returning
+                    // None) — internal index-state inconsistency, not a
+                    // transient storage failure. Classify and reject rather
+                    // than retrying forever.
+                    if is_unique_constraint_violation(&e) {
+                        return Err(MergeError::UniqueConstraintViolation(e.to_string()));
+                    }
                     let message = if context.mode.is_standalone() {
                         "Failed to update indexes after merge"
                     } else {
@@ -217,5 +228,36 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
         }
 
         Ok(())
+    }
+}
+
+/// True if `e` represents a deterministic unique-index rejection rather than a
+/// transient storage failure during merge-time index maintenance. Only this
+/// case should be converted into `MergeOutcome::Rejected`; every other
+/// `db_index::Error` must keep surfacing as `Err` so transient failures retry.
+fn is_unique_constraint_violation(e: &db::index_manager::Error) -> bool {
+    matches!(e, db::index_manager::Error::Storage(se) if se.is_unique_constraint_violation())
+}
+
+#[cfg(test)]
+mod classify_tests {
+    use super::is_unique_constraint_violation;
+
+    #[test]
+    fn unique_constraint_violation_is_classified() {
+        let e = db::index_manager::Error::Storage(storage::Error::UniqueConstraintViolation);
+        assert!(is_unique_constraint_violation(&e));
+    }
+
+    #[test]
+    fn non_unique_storage_error_is_not_classified() {
+        let e = db::index_manager::Error::Storage(storage::Error::Other("disk full".to_string()));
+        assert!(!is_unique_constraint_violation(&e));
+    }
+
+    #[test]
+    fn non_storage_index_error_is_not_classified() {
+        let e = db::index_manager::Error::Other("index misconfigured".to_string());
+        assert!(!is_unique_constraint_violation(&e));
     }
 }

--- a/crates/db-merge/src/merge_handler/error.rs
+++ b/crates/db-merge/src/merge_handler/error.rs
@@ -28,6 +28,13 @@ pub enum MergeError {
     #[error("immutable field rejected: {0}")]
     ImmutableFieldChanged(String),
 
+    /// A merge would violate a unique-index constraint. Like
+    /// `ImmutableFieldChanged`, this is a deterministic rejection of the
+    /// block's content (the same document content will violate the same
+    /// constraint on every replay), not a transient failure.
+    #[error("unique constraint violation during merge: {0}")]
+    UniqueConstraintViolation(String),
+
     /// Database error.
     #[error("database error: {0}")]
     Database(#[from] db::error::Error),

--- a/crates/db-merge/src/merge_handler/mod.rs
+++ b/crates/db-merge/src/merge_handler/mod.rs
@@ -3100,19 +3100,35 @@ mod tests {
         (handler, blockstore)
     }
 
-    /// #1128: a replicated composite merge that trips a unique-index
-    /// constraint must classify as `MergeOutcome::Rejected`, not an opaque
-    /// `Err`. `Err` never reaches the durable pending-DAG deletion path, so
-    /// the resync sweep re-drives the same doomed root forever.
+    /// #1128 composed with #1126: a replicated composite merge that trips a
+    /// LIVE twin unique-index conflict (two distinct, both-alive documents
+    /// racing the same unique value) no longer classifies as
+    /// `MergeOutcome::Rejected`. #1126's merge-path index maintenance
+    /// (`on_document_create_merge`/`on_document_update_merge`) resolves this
+    /// deterministically — smallest docID wins the index entry — instead of
+    /// erroring, because a CRDT merge cannot preserve cross-replica
+    /// uniqueness and failing here wedged the document's forward history in
+    /// permanent retry on both replicas (#1111). Both documents persist;
+    /// the classification seam in `composite_persist.rs` remains as
+    /// defense-in-depth for the degenerate arms that `on_document_*_merge`
+    /// still errors on (see
+    /// `remote_composite_merge_with_corrupted_unique_index_entry_is_rejected`
+    /// below).
     #[tokio::test]
-    async fn remote_composite_merge_with_unique_index_violation_is_rejected_not_err() {
+    async fn remote_composite_merge_with_unique_index_twin_conflict_merges_via_canonical_pick() {
         let (handler, blockstore) = make_handler_with_unique_index_schema().await;
+        let collection = handler
+            .db
+            .find_collection_by_id("col-sessions")
+            .unwrap()
+            .expect("sessions collection should exist");
 
         // Doc A: first writer of session_id="dup-session" — merges cleanly.
         let mut doc_a = Document::new();
         doc_a.set("name", NormalValue::String("Alice".to_string()));
         doc_a.set("session_id", NormalValue::String("dup-session".to_string()));
         doc_a.generate_and_set_doc_id().unwrap();
+        let doc_a_id = doc_a.id().unwrap().clone();
         let result_a = db_blocks::build_blocks_from_document(&doc_a, "v1", &blockstore)
             .await
             .unwrap();
@@ -3130,12 +3146,14 @@ mod tests {
         assert_eq!(outcome_a, MergeOutcome::Merged);
 
         // Doc B: distinct document content (different name => different doc_id
-        // and CID), but the SAME session_id — a genuine cross-document unique
-        // violation, exactly what a replicated push can carry.
+        // and CID), but the SAME session_id — a genuine cross-document live
+        // unique conflict, exactly what a replicated push can carry. #1126
+        // converges this instead of rejecting it.
         let mut doc_b = Document::new();
         doc_b.set("name", NormalValue::String("Bob".to_string()));
         doc_b.set("session_id", NormalValue::String("dup-session".to_string()));
         doc_b.generate_and_set_doc_id().unwrap();
+        let doc_b_id = doc_b.id().unwrap().clone();
         let result_b = db_blocks::build_blocks_from_document(&doc_b, "v1", &blockstore)
             .await
             .unwrap();
@@ -3150,7 +3168,71 @@ mod tests {
             .handle_block(&result_b.cid, &result_b.block, metadata_b)
             .await;
 
-        match outcome_b {
+        assert!(
+            matches!(outcome_b, Ok(MergeOutcome::Merged)),
+            "a live twin unique conflict on a replicated merge must converge via \
+             #1126's canonical pick, not classify as Rejected: {:?}",
+            outcome_b
+        );
+
+        // Both documents persist — the CRDT merge never drops data, even
+        // though only the deterministic winner keeps the index entry.
+        assert!(
+            read_session_doc(&handler, &collection, &doc_a_id)
+                .await
+                .is_some(),
+            "doc A must remain readable after the twin conflict converges"
+        );
+        assert!(
+            read_session_doc(&handler, &collection, &doc_b_id)
+                .await
+                .is_some(),
+            "doc B must remain readable after the twin conflict converges"
+        );
+    }
+
+    /// #1128 composed with #1126: #1126's merge-path resolution heals the
+    /// common live-twin case (above), but its degenerate arms — reached when
+    /// `UniqueIndex::conflicting_doc_id` cannot identify a holder for a key
+    /// it just observed as present — still propagate
+    /// `storage::corekv::Error::UniqueConstraintViolation` unchanged. That is
+    /// internal index-state inconsistency (damaged data), not a live
+    /// conflict a deterministic pick can resolve, so it must still classify
+    /// as `MergeOutcome::Rejected` rather than retrying forever. This drives
+    /// that arm through the real stack — corrupting a unique-index entry to
+    /// an empty value (key present, so `save()` still detects a violation;
+    /// value empty, so `conflicting_doc_id()` reports no holder) — rather
+    /// than only asserting the classification predicate in isolation.
+    #[tokio::test]
+    async fn remote_composite_merge_with_corrupted_unique_index_entry_is_rejected() {
+        let (handler, blockstore) = make_handler_with_unique_index_schema().await;
+        let collection = handler
+            .db
+            .find_collection_by_id("col-sessions")
+            .unwrap()
+            .expect("sessions collection should exist");
+
+        corrupt_unique_index_entry(&handler, &collection, "dup-session").await;
+
+        let mut doc = Document::new();
+        doc.set("name", NormalValue::String("Alice".to_string()));
+        doc.set("session_id", NormalValue::String("dup-session".to_string()));
+        doc.generate_and_set_doc_id().unwrap();
+        let result = db_blocks::build_blocks_from_document(&doc, "v1", &blockstore)
+            .await
+            .unwrap();
+        let metadata = BlockMetadata::normal(
+            &result.doc_id,
+            "col-sessions",
+            "did:key:z6MkrSessionA",
+            None,
+            false,
+        );
+        let outcome = handler
+            .handle_block(&result.cid, &result.block, metadata)
+            .await;
+
+        match outcome {
             Ok(MergeOutcome::Rejected { reason }) => {
                 assert!(
                     !reason.is_empty(),
@@ -3158,23 +3240,20 @@ mod tests {
                 );
             }
             other => panic!(
-                "unique-index violation on a replicated merge must classify as \
-                 Ok(MergeOutcome::Rejected), not {:?}",
+                "a corrupted unique-index entry (degenerate arm, #1126 cannot heal) \
+                 must classify as Ok(MergeOutcome::Rejected), not {:?}",
                 other
             ),
         }
     }
 
-    // Transient contrast: only a typed `storage::Error::UniqueConstraintViolation`
-    // is converted to `MergeOutcome::Rejected`. Any other `db_index::Error`
-    // (including other storage failures) must keep surfacing as `Err` so the
-    // caller retries — matching pre-existing behavior for non-deterministic
-    // failures. That discrimination is a pure function of the error value
-    // (independent of collection/store state), so it is covered directly at
-    // the classification seam: see `composite_persist::classify_tests`
+    // The pure discrimination between a deterministic unique violation and
+    // any other `db_index::Error` (including other storage failures, which
+    // must keep surfacing as `Err` so the caller retries) is independent of
+    // collection/store state, so it is additionally covered directly at the
+    // classification seam: see `composite_persist::classify_tests`
     // (`non_unique_storage_error_is_not_classified`,
-    // `non_storage_index_error_is_not_classified`) rather than re-derived
-    // here through a second full store fixture.
+    // `non_storage_index_error_is_not_classified`).
 
     async fn build_session_merge_block(
         blockstore: &Arc<DefraBlockstore<MemoryStore>>,
@@ -3220,12 +3299,54 @@ mod tests {
         doc
     }
 
+    /// Corrupt the `idx_session_id_unique` unique index (id=1, see
+    /// `make_handler_with_unique_index_schema`) with an entry whose key is
+    /// present but whose value is empty. `UniqueIndex::save()` treats
+    /// key-presence alone as a violation regardless of value content, while
+    /// `conflicting_doc_id()` only reports a holder for a non-empty value —
+    /// so a merge that targets `session_id` afterward trips the degenerate
+    /// arm in `save_healing_stale_unique`/`save_resolving_unique_conflict`
+    /// (#1126) that #1128's classification seam still converts to
+    /// `MergeOutcome::Rejected`, rather than the live-twin case #1126 now
+    /// resolves deterministically.
+    async fn corrupt_unique_index_entry(
+        handler: &DbMergeHandler<MemoryStore, DefraBlockstore<MemoryStore>>,
+        collection: &Collection,
+        session_id: &str,
+    ) {
+        let short_id = collection.resolved_root_id();
+        let corrupted_key = storage::keys::IndexDataStoreKey::new(
+            short_id,
+            1,
+            vec![storage::keys::IndexedField::new(
+                NormalValue::String(session_id.to_string()),
+                false,
+            )],
+        )
+        .try_bytes()
+        .unwrap();
+        let write_txn = handler.db.new_txn(false).await.unwrap();
+        {
+            let datastore = write_txn.datastore().unwrap();
+            datastore.set(&corrupted_key, &[]).await.unwrap();
+        }
+        write_txn.commit().await.unwrap();
+    }
+
     /// Batch path of the #1128 classification: a unique-index violation is
     /// detected AFTER `persist_merged_document` has staged the doc's field
     /// data in the SHARED batch txn, so a `Rejected` outcome must poison the
     /// whole batch attempt (discard + per-block fallback). The rejected doc's
     /// raw field data must NOT be committed (it would be queryable but
     /// un-indexed), while the valid sibling in the same batch still merges.
+    ///
+    /// #1128 composed with #1126: a live twin (two documents racing the same
+    /// value) no longer rejects — it merges via #1126's canonical pick (see
+    /// `remote_composite_merge_with_unique_index_twin_conflict_merges_via_canonical_pick`).
+    /// The poison/fallback mechanics this test guards are independent of
+    /// *why* a block rejects, so the violating block here is manufactured
+    /// via the still-live degenerate arm (a corrupted, holder-less unique
+    /// index entry) rather than a twin conflict.
     #[tokio::test]
     async fn batch_merge_rejects_unique_violation_without_partial_write() {
         let (handler, blockstore) = make_handler_with_unique_index_schema().await;
@@ -3235,17 +3356,13 @@ mod tests {
             .unwrap()
             .expect("sessions collection should exist");
 
-        // Doc A commits first (separate merge), owning session_id="dup-session".
-        let (block_a, _doc_a_id) =
-            build_session_merge_block(&blockstore, "Alice", "dup-session").await;
-        let results_a = handler.handle_block_batch(&[block_a]).await;
-        assert!(matches!(results_a[0], Ok(MergeOutcome::Merged)));
+        corrupt_unique_index_entry(&handler, &collection, "ghost-session").await;
 
-        // Batch: [valid sibling, violating duplicate].
+        // Batch: [valid sibling, violating block targeting the corrupted entry].
         let (block_valid, valid_id) =
             build_session_merge_block(&blockstore, "Carol", "other-session").await;
         let (block_violating, violating_id) =
-            build_session_merge_block(&blockstore, "Bob", "dup-session").await;
+            build_session_merge_block(&blockstore, "Bob", "ghost-session").await;
 
         let results = handler
             .handle_block_batch(&[block_valid, block_violating])
@@ -3280,6 +3397,11 @@ mod tests {
     /// block comes FIRST, so the batch attempt is poisoned before the valid
     /// sibling is processed. The fallback must still merge the sibling and
     /// keep result order aligned with the input blocks.
+    ///
+    /// #1128 composed with #1126: as above, the violating block is
+    /// manufactured via the still-live degenerate arm (corrupted,
+    /// holder-less unique index entry) since a live twin now merges instead
+    /// of rejecting.
     #[tokio::test]
     async fn batch_merge_unique_violation_first_still_merges_valid_sibling() {
         let (handler, blockstore) = make_handler_with_unique_index_schema().await;
@@ -3289,14 +3411,11 @@ mod tests {
             .unwrap()
             .expect("sessions collection should exist");
 
-        let (block_a, _doc_a_id) =
-            build_session_merge_block(&blockstore, "Alice", "dup-session").await;
-        let results_a = handler.handle_block_batch(&[block_a]).await;
-        assert!(matches!(results_a[0], Ok(MergeOutcome::Merged)));
+        corrupt_unique_index_entry(&handler, &collection, "ghost-session").await;
 
-        // Batch: [violating duplicate, valid sibling].
+        // Batch: [violating block targeting the corrupted entry, valid sibling].
         let (block_violating, violating_id) =
-            build_session_merge_block(&blockstore, "Bob", "dup-session").await;
+            build_session_merge_block(&blockstore, "Bob", "ghost-session").await;
         let (block_valid, valid_id) =
             build_session_merge_block(&blockstore, "Carol", "other-session").await;
 

--- a/crates/db-merge/src/merge_handler/mod.rs
+++ b/crates/db-merge/src/merge_handler/mod.rs
@@ -3062,4 +3062,117 @@ mod tests {
         let out = handler.decrypt_block_data(&data, None, None).await.unwrap();
         assert_eq!(out, data);
     }
+
+    async fn make_handler_with_unique_index_schema() -> (
+        DbMergeHandler<MemoryStore, DefraBlockstore<MemoryStore>>,
+        Arc<DefraBlockstore<MemoryStore>>,
+    ) {
+        let store = Arc::new(MemoryStore::new());
+        let db = Arc::new(DB::from_arc(store.clone()).unwrap());
+
+        db.create_collection(
+            CollectionVersion::new(
+                "Sessions",
+                "v1",
+                "col-sessions",
+                vec![
+                    FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                    FieldDescription::new("2", "name", FieldKind::string()),
+                    FieldDescription::new("3", "session_id", FieldKind::string()),
+                ],
+            )
+            .with_index(schema::IndexDescription {
+                name: "idx_session_id_unique".to_string(),
+                id: 1,
+                fields: vec![schema::IndexedFieldDescription {
+                    name: "session_id".to_string(),
+                    descending: false,
+                }],
+                unique: true,
+                auto_generated: false,
+            }),
+        )
+        .await
+        .unwrap();
+
+        let blockstore = Arc::new(DefraBlockstore::new(store, false));
+        let handler = DbMergeHandler::new(db, blockstore.clone());
+        (handler, blockstore)
+    }
+
+    /// #1128: a replicated composite merge that trips a unique-index
+    /// constraint must classify as `MergeOutcome::Rejected`, not an opaque
+    /// `Err`. `Err` never reaches the durable pending-DAG deletion path, so
+    /// the resync sweep re-drives the same doomed root forever.
+    #[tokio::test]
+    async fn remote_composite_merge_with_unique_index_violation_is_rejected_not_err() {
+        let (handler, blockstore) = make_handler_with_unique_index_schema().await;
+
+        // Doc A: first writer of session_id="dup-session" — merges cleanly.
+        let mut doc_a = Document::new();
+        doc_a.set("name", NormalValue::String("Alice".to_string()));
+        doc_a.set("session_id", NormalValue::String("dup-session".to_string()));
+        doc_a.generate_and_set_doc_id().unwrap();
+        let result_a = db_blocks::build_blocks_from_document(&doc_a, "v1", &blockstore)
+            .await
+            .unwrap();
+        let metadata_a = BlockMetadata::normal(
+            &result_a.doc_id,
+            "col-sessions",
+            "did:key:z6MkrSessionA",
+            None,
+            false,
+        );
+        let outcome_a = handler
+            .handle_block(&result_a.cid, &result_a.block, metadata_a)
+            .await
+            .expect("first writer of the unique value should merge");
+        assert_eq!(outcome_a, MergeOutcome::Merged);
+
+        // Doc B: distinct document content (different name => different doc_id
+        // and CID), but the SAME session_id — a genuine cross-document unique
+        // violation, exactly what a replicated push can carry.
+        let mut doc_b = Document::new();
+        doc_b.set("name", NormalValue::String("Bob".to_string()));
+        doc_b.set("session_id", NormalValue::String("dup-session".to_string()));
+        doc_b.generate_and_set_doc_id().unwrap();
+        let result_b = db_blocks::build_blocks_from_document(&doc_b, "v1", &blockstore)
+            .await
+            .unwrap();
+        let metadata_b = BlockMetadata::normal(
+            &result_b.doc_id,
+            "col-sessions",
+            "did:key:z6MkrSessionB",
+            None,
+            false,
+        );
+        let outcome_b = handler
+            .handle_block(&result_b.cid, &result_b.block, metadata_b)
+            .await;
+
+        match outcome_b {
+            Ok(MergeOutcome::Rejected { reason }) => {
+                assert!(
+                    !reason.is_empty(),
+                    "rejection reason should carry the typed violation detail"
+                );
+            }
+            other => panic!(
+                "unique-index violation on a replicated merge must classify as \
+                 Ok(MergeOutcome::Rejected), not {:?}",
+                other
+            ),
+        }
+    }
+
+    // Transient contrast: only a typed `storage::Error::UniqueConstraintViolation`
+    // is converted to `MergeOutcome::Rejected`. Any other `db_index::Error`
+    // (including other storage failures) must keep surfacing as `Err` so the
+    // caller retries — matching pre-existing behavior for non-deterministic
+    // failures. That discrimination is a pure function of the error value
+    // (independent of collection/store state), so it is covered directly at
+    // the classification seam: see `composite_persist::classify_tests`
+    // (`non_unique_storage_error_is_not_classified`,
+    // `non_storage_index_error_is_not_classified`) rather than re-derived
+    // here through a second full store fixture.
 }

--- a/crates/db-merge/src/merge_handler/mod.rs
+++ b/crates/db-merge/src/merge_handler/mod.rs
@@ -3198,11 +3198,11 @@ mod tests {
     /// `storage::corekv::Error::UniqueConstraintViolation` unchanged. That is
     /// internal index-state inconsistency (damaged data), not a live
     /// conflict a deterministic pick can resolve, so it must still classify
-    /// as `MergeOutcome::Rejected` rather than retrying forever. This drives
-    /// that arm through the real stack — corrupting a unique-index entry to
-    /// an empty value (key present, so `save()` still detects a violation;
-    /// value empty, so `conflicting_doc_id()` reports no holder) — rather
-    /// than only asserting the classification predicate in isolation.
+    /// as `MergeOutcome::Rejected` rather than retrying forever. This test
+    /// exercises the code path end-to-end (the merge disposition is real
+    /// production code), but the precondition (key-present/value-empty unique
+    /// entry) is synthetic corruption not producible by current write paths;
+    /// the test proves the seam exists, not that the state occurs in production.
     #[tokio::test]
     async fn remote_composite_merge_with_corrupted_unique_index_entry_is_rejected() {
         let (handler, blockstore) = make_handler_with_unique_index_schema().await;

--- a/crates/db-merge/src/merge_handler/mod.rs
+++ b/crates/db-merge/src/merge_handler/mod.rs
@@ -3175,4 +3175,156 @@ mod tests {
     // (`non_unique_storage_error_is_not_classified`,
     // `non_storage_index_error_is_not_classified`) rather than re-derived
     // here through a second full store fixture.
+
+    async fn build_session_merge_block(
+        blockstore: &Arc<DefraBlockstore<MemoryStore>>,
+        name: &str,
+        session_id: &str,
+    ) -> (MergeBlock, DocID) {
+        let mut doc = Document::new();
+        doc.set("name", NormalValue::String(name.to_string()));
+        doc.set("session_id", NormalValue::String(session_id.to_string()));
+        doc.generate_and_set_doc_id().unwrap();
+        let doc_id = doc.id().unwrap().clone();
+        let result = db_blocks::build_blocks_from_document(&doc, "v1", blockstore)
+            .await
+            .unwrap();
+        let merge_block = MergeBlock {
+            cid: result.cid,
+            block_data: bytes::Bytes::from(result.block),
+            doc_id: result.doc_id,
+            collection_id: "col-sessions".to_string(),
+            creator: format!("did:key:z6MkrSession{name}"),
+            sender_peer: Some("peer1".to_string()),
+            is_explicit_replicator: false,
+            explicit_replay_authorization: None,
+            verified_creator: None,
+        };
+        (merge_block, doc_id)
+    }
+
+    async fn read_session_doc(
+        handler: &DbMergeHandler<MemoryStore, DefraBlockstore<MemoryStore>>,
+        collection: &Collection,
+        doc_id: &DocID,
+    ) -> Option<Document> {
+        let txn = handler.db.new_txn(true).await.unwrap();
+        let doc = {
+            let datastore = txn.datastore().unwrap();
+            collection
+                .get_with_datastore(&datastore, doc_id)
+                .await
+                .unwrap()
+        };
+        txn.force_discard().unwrap();
+        doc
+    }
+
+    /// Batch path of the #1128 classification: a unique-index violation is
+    /// detected AFTER `persist_merged_document` has staged the doc's field
+    /// data in the SHARED batch txn, so a `Rejected` outcome must poison the
+    /// whole batch attempt (discard + per-block fallback). The rejected doc's
+    /// raw field data must NOT be committed (it would be queryable but
+    /// un-indexed), while the valid sibling in the same batch still merges.
+    #[tokio::test]
+    async fn batch_merge_rejects_unique_violation_without_partial_write() {
+        let (handler, blockstore) = make_handler_with_unique_index_schema().await;
+        let collection = handler
+            .db
+            .find_collection_by_id("col-sessions")
+            .unwrap()
+            .expect("sessions collection should exist");
+
+        // Doc A commits first (separate merge), owning session_id="dup-session".
+        let (block_a, _doc_a_id) =
+            build_session_merge_block(&blockstore, "Alice", "dup-session").await;
+        let results_a = handler.handle_block_batch(&[block_a]).await;
+        assert!(matches!(results_a[0], Ok(MergeOutcome::Merged)));
+
+        // Batch: [valid sibling, violating duplicate].
+        let (block_valid, valid_id) =
+            build_session_merge_block(&blockstore, "Carol", "other-session").await;
+        let (block_violating, violating_id) =
+            build_session_merge_block(&blockstore, "Bob", "dup-session").await;
+
+        let results = handler
+            .handle_block_batch(&[block_valid, block_violating])
+            .await;
+        assert!(
+            matches!(results[0], Ok(MergeOutcome::Merged)),
+            "valid sibling block must merge, got {:?}",
+            results[0]
+        );
+        assert!(
+            matches!(results[1], Ok(MergeOutcome::Rejected { .. })),
+            "unique-violating batch block must classify as Rejected, got {:?}",
+            results[1]
+        );
+
+        // No partial write: the rejected doc's field data must not be readable.
+        assert!(
+            read_session_doc(&handler, &collection, &violating_id)
+                .await
+                .is_none(),
+            "rejected doc's field data must NOT survive the batch txn"
+        );
+        assert!(
+            read_session_doc(&handler, &collection, &valid_id)
+                .await
+                .is_some(),
+            "valid sibling must be committed"
+        );
+    }
+
+    /// Ordering contrast for the poison-then-fallback flow: the violating
+    /// block comes FIRST, so the batch attempt is poisoned before the valid
+    /// sibling is processed. The fallback must still merge the sibling and
+    /// keep result order aligned with the input blocks.
+    #[tokio::test]
+    async fn batch_merge_unique_violation_first_still_merges_valid_sibling() {
+        let (handler, blockstore) = make_handler_with_unique_index_schema().await;
+        let collection = handler
+            .db
+            .find_collection_by_id("col-sessions")
+            .unwrap()
+            .expect("sessions collection should exist");
+
+        let (block_a, _doc_a_id) =
+            build_session_merge_block(&blockstore, "Alice", "dup-session").await;
+        let results_a = handler.handle_block_batch(&[block_a]).await;
+        assert!(matches!(results_a[0], Ok(MergeOutcome::Merged)));
+
+        // Batch: [violating duplicate, valid sibling].
+        let (block_violating, violating_id) =
+            build_session_merge_block(&blockstore, "Bob", "dup-session").await;
+        let (block_valid, valid_id) =
+            build_session_merge_block(&blockstore, "Carol", "other-session").await;
+
+        let results = handler
+            .handle_block_batch(&[block_violating, block_valid])
+            .await;
+        assert!(
+            matches!(results[0], Ok(MergeOutcome::Rejected { .. })),
+            "unique-violating batch block must classify as Rejected, got {:?}",
+            results[0]
+        );
+        assert!(
+            matches!(results[1], Ok(MergeOutcome::Merged)),
+            "valid sibling after a poisoning rejection must still merge, got {:?}",
+            results[1]
+        );
+
+        assert!(
+            read_session_doc(&handler, &collection, &violating_id)
+                .await
+                .is_none(),
+            "rejected doc's field data must NOT survive the batch txn"
+        );
+        assert!(
+            read_session_doc(&handler, &collection, &valid_id)
+                .await
+                .is_some(),
+            "valid sibling must be committed"
+        );
+    }
 }

--- a/crates/embedded/src/node_tasks.rs
+++ b/crates/embedded/src/node_tasks.rs
@@ -407,6 +407,28 @@ where
                     }
                     tracing::debug!(cid = %cid, reason = %reason, "replication loop skipped block");
                 }
+                ReplicationResult::Quarantined {
+                    cid,
+                    doc_id,
+                    collection_id,
+                    reason,
+                } => {
+                    tracing::warn!(
+                        cid = %cid,
+                        doc_id = %doc_id,
+                        collection_id = %collection_id,
+                        reason = %reason,
+                        "Block quarantined: merge deterministically rejected, will not be re-driven locally"
+                    );
+                    event_bus.publish(events::Message::pending_dag_quarantined(
+                        events::PendingDagQuarantinedData {
+                            cid: *cid,
+                            doc_id: doc_id.clone(),
+                            collection_id: collection_id.clone(),
+                            reason: reason.clone(),
+                        },
+                    ));
+                }
                 _ => {}
             },
         )

--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -25,6 +25,9 @@ pub enum EventName {
     AcpHeightAdvanced,
     /// ACP light client invalidated cached entries after a root change.
     AcpCacheInvalidated,
+    /// A pending-DAG root was quarantined after a deterministic merge
+    /// rejection (#1128) — the operator-facing forensics signal.
+    PendingDagQuarantined,
 }
 
 impl EventName {
@@ -49,6 +52,7 @@ impl std::fmt::Display for EventName {
             EventName::SEArtifactReceived => write!(f, "se-artifact-received"),
             EventName::AcpHeightAdvanced => write!(f, "acp-height-advanced"),
             EventName::AcpCacheInvalidated => write!(f, "acp-cache-invalidated"),
+            EventName::PendingDagQuarantined => write!(f, "pending-dag-quarantined"),
         }
     }
 }
@@ -84,6 +88,25 @@ pub struct TopicPeerEventData {
 pub struct SEArtifactReceivedData {
     /// Document ID the artifact is for.
     pub doc_id: String,
+}
+
+/// Pending-DAG quarantine event data (#1128).
+///
+/// Emitted when a pending-DAG root is quarantined after a deterministic
+/// merge rejection: the block is left unmerged and will not be re-driven
+/// locally. This is distinct from `MergeComplete` — the document did NOT
+/// merge — so fleet alerting can distinguish "caught up" from "stuck
+/// forever on bad content" without misreading a quarantine as a success.
+#[derive(Debug, Clone)]
+pub struct PendingDagQuarantinedData {
+    /// CID of the quarantined root block.
+    pub cid: Cid,
+    /// Document ID, if known.
+    pub doc_id: String,
+    /// Collection ID, if known.
+    pub collection_id: String,
+    /// Human-readable rejection reason (e.g. unique-index violation).
+    pub reason: String,
 }
 
 /// ACP light client height advancement event data.
@@ -199,6 +222,8 @@ pub enum MessageData {
     AcpHeightAdvanced(AcpHeightAdvancedData),
     /// ACP light client cache invalidated after a root change.
     AcpCacheInvalidated(AcpCacheInvalidatedData),
+    /// Pending-DAG root quarantined after a deterministic merge rejection.
+    PendingDagQuarantined(PendingDagQuarantinedData),
 }
 
 impl Message {
@@ -266,6 +291,14 @@ impl Message {
         }
     }
 
+    /// Create a new PendingDagQuarantined message.
+    pub fn pending_dag_quarantined(data: PendingDagQuarantinedData) -> Self {
+        Self {
+            name: EventName::PendingDagQuarantined,
+            data: MessageData::PendingDagQuarantined(data),
+        }
+    }
+
     /// Get the SEArtifactReceivedData if this is an SEArtifactReceived message.
     pub fn as_se_artifact_received(&self) -> Option<&SEArtifactReceivedData> {
         match &self.data {
@@ -310,6 +343,14 @@ impl Message {
     pub fn as_acp_cache_invalidated(&self) -> Option<&AcpCacheInvalidatedData> {
         match &self.data {
             MessageData::AcpCacheInvalidated(d) => Some(d),
+            _ => None,
+        }
+    }
+
+    /// Get the PendingDagQuarantinedData if this is a PendingDagQuarantined message.
+    pub fn as_pending_dag_quarantined(&self) -> Option<&PendingDagQuarantinedData> {
+        match &self.data {
+            MessageData::PendingDagQuarantined(d) => Some(d),
             _ => None,
         }
     }
@@ -358,5 +399,25 @@ mod tests {
         assert_eq!(mc_msg.name, EventName::MergeComplete);
         assert!(mc_msg.as_merge_complete().is_some());
         assert_eq!(mc_msg.as_merge_complete().unwrap().doc_id, "doc-789");
+    }
+
+    #[test]
+    fn test_pending_dag_quarantined_message() {
+        let data = PendingDagQuarantinedData {
+            cid: Cid::default(),
+            doc_id: "doc-1".to_string(),
+            collection_id: "col-1".to_string(),
+            reason: "unique constraint violation".to_string(),
+        };
+
+        let msg = Message::pending_dag_quarantined(data);
+        assert_eq!(msg.name, EventName::PendingDagQuarantined);
+        assert!(msg.as_merge_complete().is_none());
+        let quarantined = msg
+            .as_pending_dag_quarantined()
+            .expect("message should carry PendingDagQuarantinedData");
+        assert_eq!(quarantined.doc_id, "doc-1");
+        assert_eq!(quarantined.collection_id, "col-1");
+        assert_eq!(quarantined.reason, "unique constraint violation");
     }
 }

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -35,7 +35,7 @@ pub use bus::Bus;
 pub use channel_bus::{ChannelBus, ChannelBusConfig};
 pub use event::{
     AcpCacheInvalidatedData, AcpHeightAdvancedData, EventName, MergeCompleteData, Message,
-    SEArtifactReceivedData, TopicPeerEventData, Update,
+    PendingDagQuarantinedData, SEArtifactReceivedData, TopicPeerEventData, Update,
 };
 pub use noop_bus::NoOpBus;
 pub use subscription::Subscription;

--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -2927,3 +2927,24 @@ async fn request_intake_uses_paced_limiter_separate_from_gossip_ladder() {
         push_result
     );
 }
+
+#[tokio::test]
+async fn sync_status_surfaces_quarantine_counters() {
+    let replicators = Arc::new(ReplicatorRegistry::new());
+    let peer_state = Arc::new(PeerStateTracker::new());
+    let (coordinator, _events) = create_test_coordinator(AccessMode::Open, replicators, peer_state);
+
+    let before = coordinator.sync_status();
+    assert_eq!(before.pending_dag_terminal_quarantined, 0);
+    assert_eq!(before.quarantined_pending_dags, 0);
+
+    let root = cid_for(b"sync-status-quarantine-root");
+    coordinator
+        .manager
+        .quarantine_pending_dag(&root, "unique constraint violation")
+        .await;
+
+    let after = coordinator.sync_status();
+    assert_eq!(after.pending_dag_terminal_quarantined, 1);
+    assert_eq!(after.quarantined_pending_dags, 1);
+}

--- a/crates/p2p/src/sync/coordinator/mod.rs
+++ b/crates/p2p/src/sync/coordinator/mod.rs
@@ -148,6 +148,11 @@ pub struct SyncStatus {
     /// Milliseconds until the earliest due incomplete pending-DAG retry;
     /// `None` when no incomplete entry is registered.
     pub next_pending_retry_in_ms: Option<u64>,
+    /// Pending-DAG roots quarantined after a deterministic merge rejection
+    /// (#1128); see `SyncManager::quarantine_pending_dag`.
+    pub pending_dag_terminal_quarantined: u64,
+    /// Current gauge of quarantined pending-DAG roots (#1128).
+    pub quarantined_pending_dags: usize,
 }
 
 struct SyncShutdownState {
@@ -463,6 +468,8 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             pending_dag_retry_dispatched: diagnostics.pending_dag_retry_dispatched,
             pending_dag_retry_suppressed: diagnostics.pending_dag_retry_suppressed,
             next_pending_retry_in_ms: self.manager.next_pending_retry_in_ms(),
+            pending_dag_terminal_quarantined: diagnostics.pending_dag_terminal_quarantined,
+            quarantined_pending_dags: self.manager.quarantined_pending_count(),
         }
     }
 

--- a/crates/p2p/src/sync/coordinator/subscriptions.rs
+++ b/crates/p2p/src/sync/coordinator/subscriptions.rs
@@ -172,6 +172,11 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         self.manager.mark_batch_as_merged(cids).await
     }
 
+    /// Quarantine a terminally-rejected pending-DAG root (#1128).
+    pub async fn quarantine_pending_dag(&self, root_cid: &Cid, reason: &str) {
+        self.manager.quarantine_pending_dag(root_cid, reason).await
+    }
+
     /// Check if a block is merged.
     pub async fn is_merged(&self, cid: &Cid) -> Result<bool> {
         self.manager.is_merged(cid).await

--- a/crates/p2p/src/sync/manager/diagnostics.rs
+++ b/crates/p2p/src/sync/manager/diagnostics.rs
@@ -127,6 +127,7 @@ pub struct SyncDiagnostics {
     pending_dag_capacity_shed: AtomicU64,
     pending_dag_retry_dispatched: AtomicU64,
     pending_dag_retry_suppressed: AtomicU64,
+    pending_dag_terminal_quarantined: AtomicU64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -141,6 +142,9 @@ pub struct SyncDiagnosticsSnapshot {
     pub pending_dag_capacity_shed: u64,
     pub pending_dag_retry_dispatched: u64,
     pub pending_dag_retry_suppressed: u64,
+    /// Pending-DAG registrations moved to quarantine after a deterministic
+    /// merge rejection (#1128). See `SyncManager::quarantine_pending_dag`.
+    pub pending_dag_terminal_quarantined: u64,
     /// Process-global; see [`record_gossip_decode_failure`].
     pub gossip_decode_failures: u64,
     /// Process-global recent samples captured by
@@ -161,6 +165,9 @@ impl SyncDiagnostics {
             pending_dag_capacity_shed: self.pending_dag_capacity_shed.load(Ordering::Relaxed),
             pending_dag_retry_dispatched: self.pending_dag_retry_dispatched.load(Ordering::Relaxed),
             pending_dag_retry_suppressed: self.pending_dag_retry_suppressed.load(Ordering::Relaxed),
+            pending_dag_terminal_quarantined: self
+                .pending_dag_terminal_quarantined
+                .load(Ordering::Relaxed),
             gossip_decode_failures: GOSSIP_DECODE_FAILURES.load(Ordering::Relaxed),
             recent_gossip_decode_failures: RECENT_GOSSIP_DECODE_FAILURES
                 .lock()
@@ -214,6 +221,11 @@ impl SyncDiagnostics {
         self.pending_dag_retry_suppressed
             .fetch_add(1, Ordering::Relaxed);
     }
+
+    pub fn record_pending_dag_terminal_quarantined(&self) {
+        self.pending_dag_terminal_quarantined
+            .fetch_add(1, Ordering::Relaxed);
+    }
 }
 
 #[cfg(test)]
@@ -234,6 +246,7 @@ mod tests {
         assert_eq!(snap.pending_dag_capacity_shed, 0);
         assert_eq!(snap.pending_dag_retry_dispatched, 0);
         assert_eq!(snap.pending_dag_retry_suppressed, 0);
+        assert_eq!(snap.pending_dag_terminal_quarantined, 0);
     }
 
     #[test]
@@ -250,6 +263,7 @@ mod tests {
         diag.record_pending_dag_capacity_shed();
         diag.record_pending_dag_retry_dispatched();
         diag.record_pending_dag_retry_suppressed();
+        diag.record_pending_dag_terminal_quarantined();
 
         let snap = diag.snapshot();
         assert_eq!(snap.car_empty_responses, 2);
@@ -262,6 +276,7 @@ mod tests {
         assert_eq!(snap.pending_dag_capacity_shed, 1);
         assert_eq!(snap.pending_dag_retry_dispatched, 1);
         assert_eq!(snap.pending_dag_retry_suppressed, 1);
+        assert_eq!(snap.pending_dag_terminal_quarantined, 1);
     }
 
     #[test]

--- a/crates/p2p/src/sync/manager/process/mod.rs
+++ b/crates/p2p/src/sync/manager/process/mod.rs
@@ -105,6 +105,14 @@ pub struct SyncManager<B: Blockstore> {
     /// Resync invocation counter; every Nth sweep skips the steady-state
     /// early-exit so store/set desyncs from rare races self-heal.
     pub(super) pending_resync_tick: std::sync::atomic::AtomicUsize,
+
+    /// Gauge of currently quarantined pending-DAG roots (#1128). Hydrated
+    /// from `load_quarantined().len()` when the store is installed and
+    /// bumped on each `quarantine_pending_dag` call, rather than rescanning
+    /// the store on every read — quarantine is rare (deterministic content
+    /// rejection) but `quarantined_pending_count()` may be polled by status
+    /// endpoints far more often than that.
+    pub(super) quarantined_pending_count: std::sync::atomic::AtomicUsize,
 }
 
 /// Every Nth resync is a forced full sweep (see `pending_resync_tick`).
@@ -149,6 +157,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
             persisted_roots: Arc::new(RwLock::new(std::collections::HashSet::new())),
             pending_resync_in_flight: std::sync::atomic::AtomicBool::new(false),
             pending_resync_tick: std::sync::atomic::AtomicUsize::new(0),
+            quarantined_pending_count: std::sync::atomic::AtomicUsize::new(0),
         };
 
         (manager, event_rx)
@@ -166,7 +175,9 @@ impl<B: Blockstore + 'static> SyncManager<B> {
     ///
     /// A successful terminal merge is the point where a durable pending
     /// registration has discharged its recovery obligation (#1099): only
-    /// here (and never at DagReady emission, TTL eviction, or clear) is the
+    /// here or by quarantine (#1128, `quarantine_pending_dag` — a
+    /// deterministic content rejection that will never succeed on replay)
+    /// — and never at DagReady emission, TTL eviction, or clear — is the
     /// persisted record deleted.
     pub async fn mark_as_merged(&self, cid: &Cid) -> crate::error::Result<()> {
         self.blockstore
@@ -275,6 +286,24 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                 );
             }
         }
+        match store.load_quarantined().await {
+            Ok(records) => {
+                self.quarantined_pending_count
+                    .store(records.len(), std::sync::atomic::Ordering::Relaxed);
+            }
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    "Failed to hydrate quarantined pending DAG gauge; count is 0 until the next quarantine"
+                );
+            }
+        }
+    }
+
+    /// Number of pending-DAG roots currently quarantined (#1128).
+    pub fn quarantined_pending_count(&self) -> usize {
+        self.quarantined_pending_count
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     pub(super) fn pending_store(

--- a/crates/p2p/src/sync/manager/process/pending_dag.rs
+++ b/crates/p2p/src/sync/manager/process/pending_dag.rs
@@ -1462,6 +1462,10 @@ mod tests {
             .install_pending_dag_store(pending_store.clone())
             .await;
 
+        // Pins the restart-hydration property the e2e composition fence no
+        // longer covers: the in-memory gauge is rebuilt from load_quarantined.
+        assert_eq!(manager.quarantined_pending_count(), 1);
+
         let restored = manager.resync_persisted_pending_dags().await;
 
         assert_eq!(restored, 0, "a quarantined root must not be re-registered");

--- a/crates/p2p/src/sync/manager/process/pending_dag.rs
+++ b/crates/p2p/src/sync/manager/process/pending_dag.rs
@@ -838,7 +838,22 @@ impl<B: Blockstore + 'static> SyncManager<B> {
     pub async fn quarantine_pending_dag(&self, root_cid: &Cid, reason: &str) {
         let entry = self.build_quarantine_entry(root_cid, reason).await;
 
+        // Checked BEFORE the write: a remote re-push of an already-rejected
+        // root re-runs this function (repeat rejection is the expected,
+        // sender-paced retry — not a bug), and the gauge below counts
+        // distinct quarantined *roots*, not quarantine *occurrences*.
+        // Without this check a repeat rejection would drift the gauge above
+        // the true record count until the next restart's
+        // `install_pending_dag_store` hydration silently corrects it. The
+        // occurrence-level diagnostic counter
+        // (`pending_dag_terminal_quarantined`, below) is deliberately NOT
+        // deduped the same way — it exists to count every rejection event
+        // for alerting, gauge or no.
+        let mut already_quarantined = false;
+
         if let Some(store) = self.pending_store() {
+            already_quarantined = matches!(store.is_quarantined(root_cid).await, Ok(true));
+
             if let Err(error) = store.quarantine(root_cid, &entry).await {
                 tracing::error!(
                     root_cid = %root_cid,
@@ -866,8 +881,10 @@ impl<B: Blockstore + 'static> SyncManager<B> {
         }
 
         self.pending_dags.write().remove(root_cid);
-        self.quarantined_pending_count
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        if !already_quarantined {
+            self.quarantined_pending_count
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
         self.diagnostics.record_pending_dag_terminal_quarantined();
 
         tracing::warn!(
@@ -1297,6 +1314,84 @@ mod tests {
             1
         );
         assert_eq!(manager.quarantined_pending_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn quarantine_pending_dag_dedupes_gauge_on_repeat_rejection() {
+        use crate::sync::pending_store::{PendingDagStorage, PendingDagStore, PersistedPendingDag};
+
+        let blockstore = Arc::new(DefraBlockstore::new(Arc::new(MemoryStore::new()), true));
+        let peer_state = Arc::new(PeerStateTracker::new());
+        let (manager, _events) = SyncManager::new(blockstore, peer_state, SyncConfig::default());
+
+        let root = test_cid(1);
+        let pending_store = Arc::new(PendingDagStore::new(Arc::new(MemoryStore::new())));
+        pending_store
+            .put(
+                &root,
+                &PersistedPendingDag {
+                    doc_id: "doc".to_string(),
+                    collection_id: "collection".to_string(),
+                    creator: "creator".to_string(),
+                    source_peer: Some("peer".to_string()),
+                    is_explicit_replicator: false,
+                    explicit_replay_authorization: None,
+                },
+            )
+            .await
+            .expect("persist live pending dag record");
+
+        manager
+            .install_pending_dag_store(pending_store.clone())
+            .await;
+
+        assert!(manager.insert_pending_dag(root, pending_dag("doc", Instant::now())));
+
+        // First rejection: quarantines the root, gauge and counter both move
+        // to 1.
+        manager
+            .quarantine_pending_dag(&root, "unique constraint violation")
+            .await;
+        assert_eq!(manager.quarantined_pending_count(), 1);
+        assert_eq!(
+            manager
+                .diagnostics
+                .snapshot()
+                .pending_dag_terminal_quarantined,
+            1
+        );
+
+        // Second rejection of the SAME root (e.g. a sender-paced re-push
+        // after the first rejection re-hits the same deterministic
+        // classification): the occurrence counter keeps counting, but the
+        // gauge must NOT double-count a root that was already quarantined —
+        // it tracks distinct quarantined roots, not quarantine events.
+        manager
+            .quarantine_pending_dag(&root, "unique constraint violation")
+            .await;
+        assert_eq!(
+            manager
+                .diagnostics
+                .snapshot()
+                .pending_dag_terminal_quarantined,
+            2,
+            "the occurrence-level diagnostic counter must count every rejection"
+        );
+        assert_eq!(
+            manager.quarantined_pending_count(),
+            1,
+            "the gauge must not drift above the true number of quarantined roots on repeat rejection"
+        );
+
+        let quarantined = pending_store
+            .load_quarantined()
+            .await
+            .expect("load quarantined records");
+        assert_eq!(
+            quarantined.len(),
+            1,
+            "the store itself must hold exactly one quarantine record for this root"
+        );
     }
 
     #[tokio::test]

--- a/crates/p2p/src/sync/manager/process/pending_dag.rs
+++ b/crates/p2p/src/sync/manager/process/pending_dag.rs
@@ -12,6 +12,7 @@ use crate::error::{Error, Result};
 use crate::sync::manager::events::SyncEvent;
 use crate::sync::manager::links::{extract_ipld_links, find_all_missing_links};
 use crate::sync::manager::pending::{PendingDag, PENDING_DAG_TTL};
+use crate::sync::pending_store::{PersistedPendingDag, PersistedQuarantinedDag};
 
 use super::SyncManager;
 
@@ -804,6 +805,127 @@ impl<B: Blockstore + 'static> SyncManager<B> {
         }
         restored
     }
+
+    /// Quarantine a terminally-rejected pending-DAG root (#1128).
+    ///
+    /// `MergeOutcome::Rejected` means the merge failed on the block's
+    /// *content* (e.g. a unique-index violation) rather than transiently:
+    /// replaying it will fail identically every time. Unlike a successful
+    /// merge, the block is deliberately left unmerged — a remote re-push can
+    /// still retry (sender-paced) and re-quarantine on repeat rejection —
+    /// but local re-drive (retry clock, resync sweep) must stop.
+    ///
+    /// Sequencing is load-bearing: the quarantine record is written to the
+    /// durable store BEFORE the live `/p2p/pending_dag/` record is deleted.
+    /// A crash in the window between the two leaves BOTH records on disk
+    /// rather than losing the live one; Task 4's resync sweep consults
+    /// `is_quarantined` before re-registering a leftover live record, so the
+    /// crash window self-heals instead of re-driving (or silently losing) a
+    /// merge that is now known to fail forever.
+    pub async fn quarantine_pending_dag(&self, root_cid: &Cid, reason: &str) {
+        let entry = self.build_quarantine_entry(root_cid, reason).await;
+
+        if let Some(store) = self.pending_store() {
+            if let Err(error) = store.quarantine(root_cid, &entry).await {
+                tracing::error!(
+                    root_cid = %root_cid,
+                    error = %error,
+                    "Failed to write quarantine record; leaving the live pending-DAG registration in place for retry"
+                );
+                return;
+            }
+
+            if let Err(error) = store.remove(root_cid).await {
+                tracing::warn!(
+                    root_cid = %root_cid,
+                    error = %error,
+                    "Failed to delete live pending-DAG record after quarantine; the next resync sweep will self-heal"
+                );
+            }
+            self.persisted_roots.write().remove(root_cid);
+        }
+
+        self.pending_dags.write().remove(root_cid);
+        self.quarantined_pending_count
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        self.diagnostics.record_pending_dag_terminal_quarantined();
+
+        tracing::warn!(
+            root_cid = %root_cid,
+            doc_id = %entry.record.doc_id,
+            collection_id = %entry.record.collection_id,
+            reason = %reason,
+            "Pending DAG quarantined: merge deterministically rejected, will not be re-driven locally"
+        );
+    }
+
+    /// Build the quarantine record for `root_cid`, preferring the most
+    /// complete provenance available so quarantine never fails for lack of
+    /// it: the live durable record if one exists, else the in-memory
+    /// `PendingDag` entry, else an empty-provenance record as a last resort.
+    async fn build_quarantine_entry(
+        &self,
+        root_cid: &Cid,
+        reason: &str,
+    ) -> PersistedQuarantinedDag {
+        let record = match self.load_live_durable_record(root_cid).await {
+            Some(record) => record,
+            None => self
+                .pending_dags
+                .read()
+                .get(root_cid)
+                .map(|dag| PersistedPendingDag {
+                    doc_id: dag.doc_id.clone(),
+                    collection_id: dag.collection_id.clone(),
+                    creator: dag.creator.clone(),
+                    source_peer: dag.source_peer.clone(),
+                    is_explicit_replicator: dag.is_explicit_replicator,
+                    explicit_replay_authorization: dag
+                        .explicit_replay_authorization
+                        .as_ref()
+                        .map(Into::into),
+                })
+                .unwrap_or_else(|| PersistedPendingDag {
+                    doc_id: String::new(),
+                    collection_id: String::new(),
+                    creator: String::new(),
+                    source_peer: None,
+                    is_explicit_replicator: false,
+                    explicit_replay_authorization: None,
+                }),
+        };
+
+        PersistedQuarantinedDag {
+            record,
+            reason: reason.to_string(),
+            quarantined_at_unix_secs: PersistedQuarantinedDag::now_unix_secs(),
+        }
+    }
+
+    /// Look up the live durable record for `root_cid`, if any. The store has
+    /// no by-CID lookup (only `load_all`/prefix scan), so this pays an O(n)
+    /// scan of the live keyspace — acceptable because quarantine only fires
+    /// on a deterministic content rejection, not the hot merge path.
+    async fn load_live_durable_record(&self, root_cid: &Cid) -> Option<PersistedPendingDag> {
+        if !self.persisted_roots.read().contains(root_cid) {
+            return None;
+        }
+        let store = self.pending_store()?;
+        match store.load_all().await {
+            Ok(records) => records
+                .into_iter()
+                .find(|(cid, _)| cid == root_cid)
+                .map(|(_, record)| record),
+            Err(error) => {
+                tracing::warn!(
+                    root_cid = %root_cid,
+                    error = %error,
+                    "Failed to load durable pending DAG records while building quarantine entry"
+                );
+                None
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1088,6 +1210,97 @@ mod tests {
             } => assert_eq!(event_root, root_cid),
             other => panic!("expected DagReady, got {:?}", other),
         }
+    }
+
+    #[tokio::test]
+    async fn quarantine_pending_dag_moves_live_record_and_clears_in_memory_entry() {
+        use crate::sync::pending_store::{PendingDagStorage, PendingDagStore, PersistedPendingDag};
+
+        let blockstore = Arc::new(DefraBlockstore::new(Arc::new(MemoryStore::new()), true));
+        let peer_state = Arc::new(PeerStateTracker::new());
+        let (manager, _events) = SyncManager::new(blockstore, peer_state, SyncConfig::default());
+
+        let root = test_cid(1);
+        let pending_store = Arc::new(PendingDagStore::new(Arc::new(MemoryStore::new())));
+        pending_store
+            .put(
+                &root,
+                &PersistedPendingDag {
+                    doc_id: "doc".to_string(),
+                    collection_id: "collection".to_string(),
+                    creator: "creator".to_string(),
+                    source_peer: Some("peer".to_string()),
+                    is_explicit_replicator: false,
+                    explicit_replay_authorization: None,
+                },
+            )
+            .await
+            .expect("persist live pending dag record");
+
+        // Hydrates persisted_roots from the store (put must happen first, see
+        // install_pending_dag_store's hydration-at-install contract).
+        manager
+            .install_pending_dag_store(pending_store.clone())
+            .await;
+
+        assert!(manager.insert_pending_dag(root, pending_dag("doc", Instant::now())));
+        assert_eq!(manager.pending_dag_count(), 1);
+
+        manager
+            .quarantine_pending_dag(&root, "unique constraint violation")
+            .await;
+
+        let quarantined = pending_store
+            .load_quarantined()
+            .await
+            .expect("load quarantined records");
+        assert_eq!(quarantined.len(), 1);
+        assert_eq!(quarantined[0].0, root);
+        assert_eq!(quarantined[0].1.reason, "unique constraint violation");
+        assert_eq!(quarantined[0].1.record.doc_id, "doc");
+
+        assert!(
+            pending_store.load_all().await.unwrap().is_empty(),
+            "live durable record must be removed once quarantined"
+        );
+        assert_eq!(
+            manager.pending_dag_count(),
+            0,
+            "in-memory entry must be cleared on quarantine"
+        );
+        assert_eq!(manager.persisted_pending_count(), 0);
+        assert_eq!(
+            manager
+                .diagnostics
+                .snapshot()
+                .pending_dag_terminal_quarantined,
+            1
+        );
+        assert_eq!(manager.quarantined_pending_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn quarantine_pending_dag_synthesizes_record_when_no_durable_record_exists() {
+        let manager = test_manager();
+        let root = test_cid(1);
+
+        assert!(manager.insert_pending_dag(root, pending_dag("doc-in-memory", Instant::now())));
+
+        // No pending store installed at all: quarantine must still succeed
+        // (never fail for lack of provenance) and clear the in-memory entry.
+        manager
+            .quarantine_pending_dag(&root, "unique constraint violation")
+            .await;
+
+        assert_eq!(manager.pending_dag_count(), 0);
+        assert_eq!(
+            manager
+                .diagnostics
+                .snapshot()
+                .pending_dag_terminal_quarantined,
+            1
+        );
+        assert_eq!(manager.quarantined_pending_count(), 1);
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/p2p/src/sync/manager/process/pending_dag.rs
+++ b/crates/p2p/src/sync/manager/process/pending_dag.rs
@@ -709,6 +709,19 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                 continue;
             }
 
+            // A quarantined root's live record is a leftover, not a
+            // recovery obligation. Steady state never reaches this branch
+            // (quarantine_pending_dag's own delete already removed the live
+            // record before this sweep ran); it only fires for the crash
+            // window between that write and delete (steps (2)->(3)). Either
+            // way the quarantine record is authoritative, so clean up the
+            // leftover instead of re-registering a root that will only be
+            // rejected again.
+            if matches!(store.is_quarantined(&root_cid).await, Ok(true)) {
+                self.remove_persisted_pending(&root_cid).await;
+                continue;
+            }
+
             let missing: Vec<Cid> = match self.blockstore.get(&root_cid).await {
                 Ok(Some(data)) => {
                     match find_all_missing_links(self.blockstore.as_ref(), &data).await {
@@ -842,6 +855,13 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                     "Failed to delete live pending-DAG record after quarantine; the next resync sweep will self-heal"
                 );
             }
+            // Unconditional, unlike `remove_persisted_pending`'s only-on-Ok
+            // drop: the quarantine write above (not the live-record delete)
+            // is this root's discharge point, so it must stop counting
+            // against the durable admission cap even if `store.remove` just
+            // failed above. The live record may still be on disk, but the
+            // resync sweep's `is_quarantined` check (Task 4) cleans up that
+            // leftover independently of this in-memory set.
             self.persisted_roots.write().remove(root_cid);
         }
 
@@ -1301,6 +1321,77 @@ mod tests {
             1
         );
         assert_eq!(manager.quarantined_pending_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn resync_deletes_live_leftover_of_quarantined_root_without_redriving() {
+        use crate::sync::pending_store::{
+            PendingDagStorage, PendingDagStore, PersistedPendingDag, PersistedQuarantinedDag,
+        };
+
+        let blockstore = Arc::new(DefraBlockstore::new(Arc::new(MemoryStore::new()), true));
+        let peer_state = Arc::new(PeerStateTracker::new());
+        let (manager, mut events) = SyncManager::new(blockstore, peer_state, SyncConfig::default());
+
+        let root = test_cid(1);
+        let pending_store = Arc::new(PendingDagStore::new(Arc::new(MemoryStore::new())));
+        let record = PersistedPendingDag {
+            doc_id: "doc".to_string(),
+            collection_id: "collection".to_string(),
+            creator: "creator".to_string(),
+            source_peer: Some("peer".to_string()),
+            is_explicit_replicator: false,
+            explicit_replay_authorization: None,
+        };
+
+        // Simulate the crash window inside `quarantine_pending_dag` between
+        // writing the quarantine record and deleting the live one: both
+        // records exist on disk simultaneously.
+        pending_store
+            .put(&root, &record)
+            .await
+            .expect("persist live leftover record");
+        pending_store
+            .quarantine(
+                &root,
+                &PersistedQuarantinedDag {
+                    record: record.clone(),
+                    reason: "unique constraint violation".to_string(),
+                    quarantined_at_unix_secs: PersistedQuarantinedDag::now_unix_secs(),
+                },
+            )
+            .await
+            .expect("persist quarantine record");
+
+        manager
+            .install_pending_dag_store(pending_store.clone())
+            .await;
+
+        let restored = manager.resync_persisted_pending_dags().await;
+
+        assert_eq!(restored, 0, "a quarantined root must not be re-registered");
+        assert_eq!(
+            manager.pending_dag_count(),
+            0,
+            "in-memory pending map must stay empty for a quarantined root"
+        );
+        assert!(
+            pending_store.load_all().await.unwrap().is_empty(),
+            "the resync sweep must delete the live leftover record"
+        );
+        assert!(
+            pending_store
+                .load_quarantined()
+                .await
+                .unwrap()
+                .iter()
+                .any(|(cid, _)| *cid == root),
+            "the quarantine record itself must survive the sweep"
+        );
+        assert!(
+            events.try_recv().is_err(),
+            "no DagNeedsFetch/DagReady must be emitted for a quarantined root"
+        );
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/p2p/src/sync/merge.rs
+++ b/crates/p2p/src/sync/merge.rs
@@ -86,6 +86,14 @@ pub enum MergeOutcome {
         /// unmerged so the block can be retried after policy/state changes.
         terminal: bool,
     },
+    /// Block was deterministically rejected on its content (e.g. a unique-index
+    /// violation): it will never succeed on replay. Unlike a terminal skip, the
+    /// receiver does not discharge the block as merged — it quarantines it
+    /// instead, so local re-drive stops while a remote re-push can still retry.
+    Rejected {
+        /// Human-readable reason for the rejection.
+        reason: String,
+    },
 }
 
 impl MergeOutcome {
@@ -105,6 +113,15 @@ impl MergeOutcome {
         }
     }
 
+    /// Create a rejected outcome: a deterministic content rejection that will
+    /// never succeed on replay. The receiver quarantines rather than
+    /// discharging the block as merged.
+    pub fn rejected(reason: impl Into<String>) -> Self {
+        Self::Rejected {
+            reason: reason.into(),
+        }
+    }
+
     /// Returns true if this outcome indicates the block was merged.
     pub fn is_merged(&self) -> bool {
         matches!(self, Self::Merged)
@@ -113,6 +130,11 @@ impl MergeOutcome {
     /// Returns true if this outcome indicates the block was skipped.
     pub fn is_skipped(&self) -> bool {
         matches!(self, Self::Skipped { .. })
+    }
+
+    /// Returns true if this outcome indicates the block was deterministically rejected.
+    pub fn is_rejected(&self) -> bool {
+        matches!(self, Self::Rejected { .. })
     }
 
     /// Returns true if this outcome is a terminal skip.
@@ -316,6 +338,7 @@ pub trait MergeHandler: Send + Sync {
     ///
     /// * `Ok(MergeOutcome::Merged)` - Block was merged successfully
     /// * `Ok(MergeOutcome::Skipped { reason })` - Block was skipped
+    /// * `Ok(MergeOutcome::Rejected { reason })` - Block was deterministically rejected
     /// * `Err(e)` - Merge failed
     async fn handle_block(
         &self,

--- a/crates/p2p/src/sync/merge.rs
+++ b/crates/p2p/src/sync/merge.rs
@@ -86,10 +86,15 @@ pub enum MergeOutcome {
         /// unmerged so the block can be retried after policy/state changes.
         terminal: bool,
     },
-    /// Block was deterministically rejected on its content (e.g. a unique-index
-    /// violation): it will never succeed on replay. Unlike a terminal skip, the
-    /// receiver does not discharge the block as merged — it quarantines it
-    /// instead, so local re-drive stops while a remote re-push can still retry.
+    /// Block was deterministically rejected on its content: it will never
+    /// succeed on replay. Not every unique-index conflict qualifies — a live
+    /// conflict between two alive documents resolves deterministically at
+    /// merge time instead (smallest docID wins) and converges rather than
+    /// rejecting. This variant is for the cases that resolution can't heal
+    /// (e.g. internal index-state inconsistency) and any other content-level
+    /// rejection. Unlike a terminal skip, the receiver does not discharge the
+    /// block as merged — it quarantines it instead, so local re-drive stops
+    /// while a remote re-push can still retry.
     Rejected {
         /// Human-readable reason for the rejection.
         reason: String,

--- a/crates/p2p/src/sync/mod.rs
+++ b/crates/p2p/src/sync/mod.rs
@@ -51,7 +51,8 @@ pub use manager::{
 pub use merge::{BlockMetadata, MergeBlock, MergeHandler, MergeOutcome, RecoveredBlockMetadata};
 pub use peer_state::{PeerStateTracker, PeerStats};
 pub use pending_store::{
-    PendingDagStorage, PendingDagStore, PersistedPendingDag, PersistedReplayAuthorization,
+    PendingDagStorage, PendingDagStore, PersistedPendingDag, PersistedQuarantinedDag,
+    PersistedReplayAuthorization,
 };
 pub use push_backlog::{
     CidRetrySnapshot, EnqueueOutcome, PeerBacklogSnapshot, PushBacklog, PushBacklogSnapshot,

--- a/crates/p2p/src/sync/pending_store.rs
+++ b/crates/p2p/src/sync/pending_store.rs
@@ -6,9 +6,11 @@
 //! the ack and Bitswap completion silently loses the document (modeled in
 //! `proofs/tla/PendingDagRestart.tla`). Installing a store makes each
 //! push-originated registration durable: it is written before the success
-//! reply, deleted only when the root is successfully marked merged (never at
-//! DagReady emission, TTL eviction, or clear), and re-driven at startup and
-//! by the periodic resync sweep via `resync_persisted_pending_dags`.
+//! reply, deleted only when the root is successfully marked merged or
+//! quarantined (#1128 — a deterministic content rejection that will never
+//! succeed on replay; never at DagReady emission, TTL eviction, or clear),
+//! and re-driven at startup and by the periodic resync sweep via
+//! `resync_persisted_pending_dags`.
 //!
 //! Pull-originated registrations (DocSync/BranchableSync) are not persisted —
 //! no remote retry state is destroyed by their acks, so restart loss is

--- a/crates/p2p/src/sync/pending_store.rs
+++ b/crates/p2p/src/sync/pending_store.rs
@@ -18,8 +18,9 @@ use async_trait::async_trait;
 use cid::Cid;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 use storage::corekv::{IterOptions, Key, Store};
-use storage::keys::systemstore::P2PPendingDagKey;
+use storage::keys::systemstore::{P2PPendingDagKey, P2PQuarantinedDagKey};
 use storage::stores::Systemstore;
 
 use crate::error::{Error, Result};
@@ -84,12 +85,49 @@ impl PersistedPendingDag {
     }
 }
 
+/// A pending-DAG record whose merge failed deterministically (e.g. a unique-index
+/// rejection): moved out of the live keyspace, retained for forensics and counted,
+/// and never re-driven by the resync sweep.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PersistedQuarantinedDag {
+    pub record: PersistedPendingDag,
+    pub reason: String,
+    pub quarantined_at_unix_secs: u64,
+}
+
+impl PersistedQuarantinedDag {
+    pub fn to_bytes(&self) -> Result<Vec<u8>> {
+        serde_cbor::to_vec(self).map_err(|e| Error::Storage(e.to_string()))
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
+        serde_cbor::from_slice(bytes).map_err(|e| Error::Storage(e.to_string()))
+    }
+
+    /// Current wall-clock time as Unix seconds, for stamping `quarantined_at_unix_secs`.
+    pub fn now_unix_secs() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0)
+    }
+}
+
 /// Durable KV backing for push-originated pending-DAG registrations.
 #[async_trait]
 pub trait PendingDagStorage: Send + Sync {
     async fn put(&self, root_cid: &Cid, record: &PersistedPendingDag) -> Result<()>;
     async fn remove(&self, root_cid: &Cid) -> Result<()>;
     async fn load_all(&self) -> Result<Vec<(Cid, PersistedPendingDag)>>;
+
+    /// Move a terminally-rejected root into the quarantine keyspace. The caller
+    /// is responsible for deleting the live `/p2p/pending_dag/` record (write
+    /// quarantine first, delete live second, so a crash mid-transition leaves
+    /// a re-drivable live record rather than a silently lost one).
+    async fn quarantine(&self, root_cid: &Cid, entry: &PersistedQuarantinedDag) -> Result<()>;
+    async fn is_quarantined(&self, root_cid: &Cid) -> Result<bool>;
+    async fn load_quarantined(&self) -> Result<Vec<(Cid, PersistedQuarantinedDag)>>;
+    async fn remove_quarantined(&self, root_cid: &Cid) -> Result<()>;
 }
 
 /// `PendingDagStorage` over the systemstore keyspace (`/p2p/pending_dag/`).
@@ -180,6 +218,95 @@ impl<S: Store + 'static> PendingDagStorage for PendingDagStore<S> {
             .map_err(|e| Error::Storage(e.to_string()))?;
         Ok(records)
     }
+
+    async fn quarantine(&self, root_cid: &Cid, entry: &PersistedQuarantinedDag) -> Result<()> {
+        let key = P2PQuarantinedDagKey::new(root_cid.to_string());
+        let value = entry.to_bytes()?;
+        let mut txn = self
+            .systemstore
+            .new_txn(false)
+            .await
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        txn.set(&key.bytes(), &value)
+            .await
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        txn.commit()
+            .await
+            .map_err(|e| Error::Storage(e.to_string()))
+    }
+
+    async fn is_quarantined(&self, root_cid: &Cid) -> Result<bool> {
+        let key = P2PQuarantinedDagKey::new(root_cid.to_string());
+        let txn = self
+            .systemstore
+            .new_txn(true)
+            .await
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        let value = txn
+            .get(&key.bytes())
+            .await
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        Ok(value.is_some())
+    }
+
+    async fn load_quarantined(&self) -> Result<Vec<(Cid, PersistedQuarantinedDag)>> {
+        let txn = self
+            .systemstore
+            .new_txn(true)
+            .await
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        let opts =
+            IterOptions::new().with_prefix(P2PQuarantinedDagKey::p2p_quarantined_dag_prefix());
+        let mut iter = txn
+            .iterator(opts)
+            .await
+            .map_err(|e| Error::Storage(e.to_string()))?;
+
+        let mut records = Vec::new();
+        while let Some(pair) = iter
+            .next()
+            .await
+            .map_err(|e| Error::Storage(e.to_string()))?
+        {
+            let key_str = String::from_utf8_lossy(&pair.key);
+            let Some(cid_str) = key_str.strip_prefix("/p2p/quarantined_dag/") else {
+                continue;
+            };
+            let Ok(root_cid) = cid_str.parse::<Cid>() else {
+                tracing::warn!(key = %key_str, "Skipping quarantined DAG with invalid CID key");
+                continue;
+            };
+            match PersistedQuarantinedDag::from_bytes(&pair.value) {
+                Ok(record) => records.push((root_cid, record)),
+                Err(error) => {
+                    tracing::warn!(
+                        root_cid = %root_cid,
+                        error = %error,
+                        "Skipping undecodable quarantined DAG record"
+                    );
+                }
+            }
+        }
+        iter.close()
+            .await
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        Ok(records)
+    }
+
+    async fn remove_quarantined(&self, root_cid: &Cid) -> Result<()> {
+        let key = P2PQuarantinedDagKey::new(root_cid.to_string());
+        let mut txn = self
+            .systemstore
+            .new_txn(false)
+            .await
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        txn.delete(&key.bytes())
+            .await
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        txn.commit()
+            .await
+            .map_err(|e| Error::Storage(e.to_string()))
+    }
 }
 
 #[cfg(test)]
@@ -243,5 +370,65 @@ mod tests {
         let loaded = store.load_all().await.unwrap();
         assert_eq!(loaded.len(), 1);
         assert_eq!(loaded[0].1.doc_id, "doc-new");
+    }
+
+    fn quarantined(doc: &str, reason: &str) -> PersistedQuarantinedDag {
+        PersistedQuarantinedDag {
+            record: record(doc),
+            reason: reason.to_string(),
+            quarantined_at_unix_secs: 1_700_000_000,
+        }
+    }
+
+    #[tokio::test]
+    async fn quarantine_load_remove_roundtrip() {
+        let store = PendingDagStore::new(Arc::new(MemoryStore::new()));
+        let root = cid(b"a");
+
+        assert!(!store.is_quarantined(&root).await.unwrap());
+
+        let entry = quarantined("doc-a", "unique constraint violation");
+        store.quarantine(&root, &entry).await.unwrap();
+
+        assert!(store.is_quarantined(&root).await.unwrap());
+
+        let loaded = store.load_quarantined().await.unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].0, root);
+        assert_eq!(loaded[0].1, entry);
+
+        store.remove_quarantined(&root).await.unwrap();
+        assert!(!store.is_quarantined(&root).await.unwrap());
+        assert!(store.load_quarantined().await.unwrap().is_empty());
+
+        // Removing an absent record is a no-op, not an error.
+        store.remove_quarantined(&root).await.unwrap();
+    }
+
+    /// The quarantine keyspace is deliberately outside `/p2p/pending_dag/`:
+    /// the live resync sweep's prefix scan (`load_all`) must never observe a
+    /// quarantined root, or it would re-drive a merge known to fail every time.
+    #[tokio::test]
+    async fn quarantined_root_is_absent_from_live_load_all() {
+        let store = PendingDagStore::new(Arc::new(MemoryStore::new()));
+        let live_root = cid(b"live");
+        let quarantined_root = cid(b"quarantined");
+
+        store.put(&live_root, &record("doc-live")).await.unwrap();
+        store
+            .quarantine(
+                &quarantined_root,
+                &quarantined("doc-quarantined", "unique constraint violation"),
+            )
+            .await
+            .unwrap();
+
+        let live = store.load_all().await.unwrap();
+        assert_eq!(live.len(), 1);
+        assert_eq!(live[0].0, live_root);
+
+        let quarantined_records = store.load_quarantined().await.unwrap();
+        assert_eq!(quarantined_records.len(), 1);
+        assert_eq!(quarantined_records[0].0, quarantined_root);
     }
 }

--- a/crates/p2p/src/sync/replication/handlers.rs
+++ b/crates/p2p/src/sync/replication/handlers.rs
@@ -350,6 +350,26 @@ where
                 terminal,
             }
         }
+        Ok(MergeOutcome::Rejected { reason }) => {
+            // Temporary shim: quarantine disposition lands separately (#1128).
+            // Treated as non-terminal so the block stays live and retryable
+            // until quarantine wiring exists, keeping behavior safe standalone.
+            tracing::warn!(
+                cid = %cid,
+                doc_id = %doc_id_for_result,
+                collection_id = %collection_id_for_result,
+                reason = %reason,
+                "merge rejected (deterministic content rejection); treating as retryable skip pending quarantine wiring"
+            );
+
+            ReplicationResult::Skipped {
+                cid,
+                doc_id: doc_id_for_result,
+                collection_id: collection_id_for_result,
+                reason,
+                terminal: false,
+            }
+        }
         Err(e) => ReplicationResult::Failed {
             cid,
             error: e.to_string(),
@@ -567,6 +587,26 @@ where
                     collection_id: block.collection_id.clone(),
                     reason,
                     terminal,
+                });
+            }
+            Ok(MergeOutcome::Rejected { reason }) => {
+                // Temporary shim: quarantine disposition lands separately (#1128).
+                // Not added to merged_cids, so the block stays live and retryable
+                // until quarantine wiring exists.
+                tracing::warn!(
+                    cid = %block.cid,
+                    doc_id = %block.doc_id,
+                    collection_id = %block.collection_id,
+                    reason = %reason,
+                    "merge rejected (deterministic content rejection); treating as retryable skip pending quarantine wiring"
+                );
+
+                results.push(ReplicationResult::Skipped {
+                    cid: block.cid,
+                    doc_id: block.doc_id.clone(),
+                    collection_id: block.collection_id.clone(),
+                    reason,
+                    terminal: false,
                 });
             }
             Err(e) => {

--- a/crates/p2p/src/sync/replication/handlers.rs
+++ b/crates/p2p/src/sync/replication/handlers.rs
@@ -351,23 +351,13 @@ where
             }
         }
         Ok(MergeOutcome::Rejected { reason }) => {
-            // Temporary shim: quarantine disposition lands separately (#1128).
-            // Treated as non-terminal so the block stays live and retryable
-            // until quarantine wiring exists, keeping behavior safe standalone.
-            tracing::warn!(
-                cid = %cid,
-                doc_id = %doc_id_for_result,
-                collection_id = %collection_id_for_result,
-                reason = %reason,
-                "merge rejected (deterministic content rejection); treating as retryable skip pending quarantine wiring"
-            );
+            coordinator.quarantine_pending_dag(&cid, &reason).await;
 
-            ReplicationResult::Skipped {
+            ReplicationResult::Quarantined {
                 cid,
                 doc_id: doc_id_for_result,
                 collection_id: collection_id_for_result,
                 reason,
-                terminal: false,
             }
         }
         Err(e) => ReplicationResult::Failed {
@@ -590,23 +580,17 @@ where
                 });
             }
             Ok(MergeOutcome::Rejected { reason }) => {
-                // Temporary shim: quarantine disposition lands separately (#1128).
-                // Not added to merged_cids, so the block stays live and retryable
-                // until quarantine wiring exists.
-                tracing::warn!(
-                    cid = %block.cid,
-                    doc_id = %block.doc_id,
-                    collection_id = %block.collection_id,
-                    reason = %reason,
-                    "merge rejected (deterministic content rejection); treating as retryable skip pending quarantine wiring"
-                );
+                // Deliberately NOT added to merged_cids: quarantine leaves
+                // the block unmerged (see `quarantine_pending_dag`).
+                coordinator
+                    .quarantine_pending_dag(&block.cid, &reason)
+                    .await;
 
-                results.push(ReplicationResult::Skipped {
+                results.push(ReplicationResult::Quarantined {
                     cid: block.cid,
                     doc_id: block.doc_id.clone(),
                     collection_id: block.collection_id.clone(),
                     reason,
-                    terminal: false,
                 });
             }
             Err(e) => {

--- a/crates/p2p/src/sync/replication/loop_runner.rs
+++ b/crates/p2p/src/sync/replication/loop_runner.rs
@@ -105,6 +105,24 @@ impl ReplicationLoop {
                     ReplicationResult::Skipped { cid, reason, .. } => {
                         tracing::debug!(cid = %cid, reason = %reason, "Block skipped");
                     }
+                    ReplicationResult::Quarantined {
+                        cid,
+                        doc_id,
+                        collection_id,
+                        reason,
+                    } => {
+                        // Non-fatal: local re-drive has stopped for this
+                        // root, but the loop keeps processing other events.
+                        // This line is the operator's forensics pointer —
+                        // the record now lives under /p2p/quarantined_dag/.
+                        tracing::warn!(
+                            cid = %cid,
+                            doc_id = %doc_id,
+                            collection_id = %collection_id,
+                            reason = %reason,
+                            "Block quarantined: merge deterministically rejected, will not be re-driven locally"
+                        );
+                    }
                     ReplicationResult::Failed { cid, error } => {
                         tracing::error!(cid = %cid, error = %error, "Block merge failed");
                         if !config.continue_on_error {

--- a/crates/p2p/src/sync/replication/mod.rs
+++ b/crates/p2p/src/sync/replication/mod.rs
@@ -631,6 +631,33 @@ mod tests {
         }
     }
 
+    /// Merge handler that always returns a deterministic content rejection.
+    struct RejectingMergeHandler {
+        reason: String,
+    }
+
+    impl RejectingMergeHandler {
+        fn new(reason: &str) -> Self {
+            Self {
+                reason: reason.to_string(),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl MergeHandler for RejectingMergeHandler {
+        type Error = TestError;
+
+        async fn handle_block(
+            &self,
+            _cid: &Cid,
+            _block_data: &[u8],
+            _metadata: BlockMetadata<'_>,
+        ) -> Result<MergeOutcome, Self::Error> {
+            Ok(MergeOutcome::rejected(self.reason.clone()))
+        }
+    }
+
     #[async_trait]
     impl MergeHandler for RetryThenMergeHandler {
         type Error = TestError;
@@ -1049,6 +1076,148 @@ mod tests {
         assert!(
             blockstore.is_merged(&cid).await.unwrap(),
             "successful replay should mark the CID as merged"
+        );
+    }
+
+    /// Seed a coordinator whose manager has a durable pending-DAG store
+    /// installed and a live registration for `cid`, mirroring a push-driven
+    /// registration awaiting merge.
+    async fn coordinator_with_live_pending_dag(
+        blockstore: Arc<DefraBlockstore<MemoryStore>>,
+        cid: Cid,
+    ) -> (
+        crate::sync::coordinator::SyncCoordinator<DefraBlockstore<MemoryStore>, NoopTransport>,
+        Arc<crate::sync::pending_store::PendingDagStore<MemoryStore>>,
+    ) {
+        use crate::sync::pending_store::PendingDagStorage;
+
+        let (coordinator, _events) =
+            crate::sync::coordinator::SyncCoordinator::with_access_control(
+                NoopTransport::new(),
+                blockstore,
+                crate::sync::SyncConfig::default(),
+                AccessMode::Open,
+                Arc::new(crate::ReplicatorRegistry::new()),
+                Arc::new(crate::sync::collection_store::NoOpCollectionStorage),
+                Arc::new(EqOnlyFilterMatcher),
+            )
+            .await
+            .unwrap();
+
+        let pending_store = Arc::new(crate::sync::pending_store::PendingDagStore::new(Arc::new(
+            MemoryStore::new(),
+        )));
+        pending_store
+            .put(
+                &cid,
+                &crate::sync::pending_store::PersistedPendingDag {
+                    doc_id: "doc1".to_string(),
+                    collection_id: "col1".to_string(),
+                    creator: "peer1".to_string(),
+                    source_peer: Some("sender1".to_string()),
+                    is_explicit_replicator: true,
+                    explicit_replay_authorization: None,
+                },
+            )
+            .await
+            .expect("persist live pending dag record");
+
+        // install_pending_dag_store hydrates persisted_roots from the store
+        // at install time, so the record must already be `put` above.
+        coordinator
+            .manager()
+            .install_pending_dag_store(pending_store.clone())
+            .await;
+
+        (coordinator, pending_store)
+    }
+
+    #[tokio::test]
+    async fn test_rejected_merge_quarantines_and_leaves_block_unmerged() {
+        use crate::sync::pending_store::PendingDagStorage;
+
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let cid = test_cid();
+        blockstore.put(&cid, b"test data").await.unwrap();
+
+        let (coordinator, pending_store) =
+            coordinator_with_live_pending_dag(blockstore.clone(), cid).await;
+
+        let handler = RejectingMergeHandler::new("unique constraint violation");
+        let result = handle_block_received(
+            &coordinator,
+            &handler,
+            &ReplicationConfig::default(),
+            cid,
+            BlockMetadata::normal("doc1", "col1", "peer1", Some("sender1"), true),
+        )
+        .await;
+
+        match result {
+            ReplicationResult::Quarantined {
+                cid: result_cid,
+                reason,
+                ..
+            } => {
+                assert_eq!(result_cid, cid);
+                assert_eq!(reason, "unique constraint violation");
+            }
+            other => panic!("expected Quarantined, got {:?}", other),
+        }
+
+        assert!(
+            !blockstore.is_merged(&cid).await.unwrap(),
+            "quarantine must not mark the block merged (mark_as_merged must not run)"
+        );
+        assert!(
+            pending_store.is_quarantined(&cid).await.unwrap(),
+            "quarantine store must be populated"
+        );
+        assert!(
+            pending_store.load_all().await.unwrap().is_empty(),
+            "live durable record must be removed after quarantine"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_transient_merge_error_stays_failed_and_does_not_quarantine() {
+        use crate::sync::pending_store::PendingDagStorage;
+
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let cid = test_cid();
+        blockstore.put(&cid, b"test data").await.unwrap();
+
+        let (coordinator, pending_store) =
+            coordinator_with_live_pending_dag(blockstore.clone(), cid).await;
+
+        let handler = TestMergeHandler::new(false, false); // handle_block returns Err
+        let result = handle_block_received(
+            &coordinator,
+            &handler,
+            &ReplicationConfig::default(),
+            cid,
+            BlockMetadata::normal("doc1", "col1", "peer1", Some("sender1"), true),
+        )
+        .await;
+
+        match result {
+            ReplicationResult::Failed {
+                cid: result_cid, ..
+            } => assert_eq!(result_cid, cid),
+            other => panic!("expected Failed, got {:?}", other),
+        }
+
+        assert!(!blockstore.is_merged(&cid).await.unwrap());
+        assert!(
+            !pending_store.is_quarantined(&cid).await.unwrap(),
+            "a transient failure must not quarantine the root"
+        );
+        assert_eq!(
+            pending_store.load_all().await.unwrap().len(),
+            1,
+            "durable record must remain live after a transient failure"
         );
     }
 

--- a/crates/p2p/src/sync/replication/mod.rs
+++ b/crates/p2p/src/sync/replication/mod.rs
@@ -726,6 +726,7 @@ mod tests {
         batch_calls: AtomicUsize,
         batch_block_count: AtomicUsize,
         fail_at_index: Option<usize>,
+        reject_at_index: Option<(usize, String)>,
     }
 
     impl BatchTestHandler {
@@ -735,6 +736,7 @@ mod tests {
                 batch_calls: AtomicUsize::new(0),
                 batch_block_count: AtomicUsize::new(0),
                 fail_at_index: None,
+                reject_at_index: None,
             }
         }
 
@@ -744,6 +746,20 @@ mod tests {
                 batch_calls: AtomicUsize::new(0),
                 batch_block_count: AtomicUsize::new(0),
                 fail_at_index: Some(index),
+                reject_at_index: None,
+            }
+        }
+
+        /// Returns `MergeOutcome::Rejected` for the block at `index`, leaving
+        /// every other block in the batch a normal merge — exercises that a
+        /// batch-mixed Rejected outcome does not stop siblings from merging.
+        fn with_rejection_at(index: usize, reason: &str) -> Self {
+            Self {
+                per_block_calls: AtomicUsize::new(0),
+                batch_calls: AtomicUsize::new(0),
+                batch_block_count: AtomicUsize::new(0),
+                fail_at_index: None,
+                reject_at_index: Some((index, reason.to_string())),
             }
         }
 
@@ -832,6 +848,12 @@ mod tests {
                 .map(|(i, _block)| {
                     if self.fail_at_index == Some(i) {
                         Err(TestError("batch block failed".to_string()))
+                    } else if let Some((reject_index, reason)) = &self.reject_at_index {
+                        if *reject_index == i {
+                            Ok(MergeOutcome::rejected(reason.clone()))
+                        } else {
+                            Ok(MergeOutcome::Merged)
+                        }
                     } else {
                         Ok(MergeOutcome::Merged)
                     }
@@ -1218,6 +1240,91 @@ mod tests {
             pending_store.load_all().await.unwrap().len(),
             1,
             "durable record must remain live after a transient failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_batch_rejected_block_not_marked_merged_while_sibling_merges() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let rejected_cid = make_cid(b"batch-reject");
+        let merged_cid = make_cid(b"batch-merge");
+        blockstore
+            .put(&rejected_cid, b"batch-reject")
+            .await
+            .unwrap();
+        blockstore.put(&merged_cid, b"batch-merge").await.unwrap();
+
+        let (coordinator, _events) =
+            crate::sync::coordinator::SyncCoordinator::with_access_control(
+                NoopTransport::new(),
+                blockstore.clone(),
+                crate::sync::SyncConfig::default(),
+                AccessMode::Open,
+                Arc::new(crate::ReplicatorRegistry::new()),
+                Arc::new(crate::sync::collection_store::NoOpCollectionStorage),
+                Arc::new(EqOnlyFilterMatcher),
+            )
+            .await
+            .unwrap();
+
+        let events = vec![
+            SyncEvent::BlockReceived {
+                cid: rejected_cid,
+                doc_id: "doc-reject".to_string(),
+                collection_id: "col1".to_string(),
+                creator: "peer1".to_string(),
+                sender_peer: None,
+                is_explicit_replicator: false,
+                explicit_replay_authorization: None,
+            },
+            SyncEvent::BlockReceived {
+                cid: merged_cid,
+                doc_id: "doc-merge".to_string(),
+                collection_id: "col1".to_string(),
+                creator: "peer1".to_string(),
+                sender_peer: None,
+                is_explicit_replicator: false,
+                explicit_replay_authorization: None,
+            },
+        ];
+        let handler = BatchTestHandler::with_rejection_at(0, "unique constraint violation");
+
+        let results = process_merge_batch(
+            &coordinator,
+            events,
+            &handler,
+            &ReplicationConfig::default(),
+        )
+        .await;
+
+        assert_eq!(results.len(), 2);
+        match &results[0] {
+            ReplicationResult::Quarantined {
+                cid: result_cid,
+                reason,
+                ..
+            } => {
+                assert_eq!(*result_cid, rejected_cid);
+                assert_eq!(reason, "unique constraint violation");
+            }
+            other => panic!(
+                "expected Quarantined for the rejected block, got {:?}",
+                other
+            ),
+        }
+        assert!(matches!(
+            &results[1],
+            ReplicationResult::Merged { cid, .. } if *cid == merged_cid
+        ));
+
+        assert!(
+            !blockstore.is_merged(&rejected_cid).await.unwrap(),
+            "a Rejected block in a batch must not be marked merged, even though a sibling merged in the same call"
+        );
+        assert!(
+            blockstore.is_merged(&merged_cid).await.unwrap(),
+            "the sibling block must still merge normally"
         );
     }
 

--- a/crates/p2p/src/sync/replication/recovery.rs
+++ b/crates/p2p/src/sync/replication/recovery.rs
@@ -108,6 +108,24 @@ where
                     "Block merged during recovery but broadcast failed (expected - recovery mode)"
                 );
             }
+            ReplicationResult::Quarantined {
+                cid,
+                doc_id,
+                collection_id,
+                reason,
+            } => {
+                // Quarantine resolves the recovery obligation just like a
+                // merge or terminal skip: the block will not be retried
+                // locally again, so it counts as handled, not failed.
+                success_count += 1;
+                tracing::warn!(
+                    cid = %cid,
+                    doc_id = %doc_id,
+                    collection_id = %collection_id,
+                    reason = %reason,
+                    "Block quarantined during recovery: merge deterministically rejected"
+                );
+            }
             ReplicationResult::Failed { cid, error } => {
                 failure_count += 1;
                 tracing::error!(

--- a/crates/p2p/src/sync/replication/result.rs
+++ b/crates/p2p/src/sync/replication/result.rs
@@ -29,6 +29,17 @@ pub enum ReplicationResult {
         reason: String,
         terminal: bool,
     },
+    /// Block was deterministically rejected on its content and has been
+    /// quarantined (#1128): durably retained for forensics, counted, and no
+    /// longer re-driven by local retry (a remote re-push may still repeat
+    /// the rejection independently). See `MergeOutcome::Rejected` and
+    /// `SyncManager::quarantine_pending_dag`.
+    Quarantined {
+        cid: Cid,
+        doc_id: String,
+        collection_id: String,
+        reason: String,
+    },
     /// Merge failed
     Failed { cid: Cid, error: String },
     /// Merge succeeded but failed to mark as merged (will be reprocessed on restart)

--- a/crates/p2p/tests/sync_manager_tests.rs
+++ b/crates/p2p/tests/sync_manager_tests.rs
@@ -686,7 +686,9 @@ mod pending_persistence {
 
     use super::*;
     use async_trait::async_trait;
-    use p2p::sync::{PendingDagStorage, PendingDagStore, PersistedPendingDag};
+    use p2p::sync::{
+        PendingDagStorage, PendingDagStore, PersistedPendingDag, PersistedQuarantinedDag,
+    };
 
     async fn manager_with_store(
         store: Arc<MemoryStore>,
@@ -1223,6 +1225,24 @@ mod pending_persistence {
         }
         async fn load_all(&self) -> p2p::error::Result<Vec<(Cid, PersistedPendingDag)>> {
             Ok(Vec::new())
+        }
+        async fn quarantine(
+            &self,
+            _root_cid: &Cid,
+            _entry: &PersistedQuarantinedDag,
+        ) -> p2p::error::Result<()> {
+            Err(Error::Storage("disk full".to_string()))
+        }
+        async fn is_quarantined(&self, _root_cid: &Cid) -> p2p::error::Result<bool> {
+            Ok(false)
+        }
+        async fn load_quarantined(
+            &self,
+        ) -> p2p::error::Result<Vec<(Cid, PersistedQuarantinedDag)>> {
+            Ok(Vec::new())
+        }
+        async fn remove_quarantined(&self, _root_cid: &Cid) -> p2p::error::Result<()> {
+            Ok(())
         }
     }
 

--- a/crates/storage/src/keys/mod.rs
+++ b/crates/storage/src/keys/mod.rs
@@ -67,7 +67,7 @@ pub use peerstore::{
 pub use systemstore::{
     CollectionID, CollectionIDSequenceKey, CollectionKey, CollectionNameKey, CollectionVersionKey,
     FieldID, FieldIDSequenceKey, IndexIDSequenceKey, NodeACPKey, P2PCollectionKey, P2PDocumentKey,
-    P2PPendingDagKey,
+    P2PPendingDagKey, P2PQuarantinedDagKey,
 };
 pub use utils::{InstanceType, SEPARATOR};
 

--- a/crates/storage/src/keys/systemstore.rs
+++ b/crates/storage/src/keys/systemstore.rs
@@ -338,6 +338,45 @@ impl Key for P2PPendingDagKey {
     }
 }
 
+/// P2PQuarantinedDagKey: Terminally-rejected pending-DAG record, retained for forensics
+///
+/// Deliberately a distinct prefix from `/p2p/pending_dag/` (not a subpath of it):
+/// the live-record resync sweep prefix-scans `/p2p/pending_dag/` via `load_all` and
+/// must never observe a quarantined root, or it would re-drive a merge that is
+/// known to fail deterministically on every replay.
+///
+/// Structure: /p2p/quarantined_dag/[RootCID]
+/// Example: /p2p/quarantined_dag/bafyreib2rxk3rybk3aobmv5cjuql3bm2twh4jo5uxgf5kpqrsgxbyqx54
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct P2PQuarantinedDagKey {
+    /// Root CID of the quarantined DAG (canonical string form)
+    pub root_cid: String,
+}
+
+impl P2PQuarantinedDagKey {
+    /// Create a new P2PQuarantinedDagKey
+    pub fn new(root_cid: impl Into<String>) -> Self {
+        Self {
+            root_cid: root_cid.into(),
+        }
+    }
+
+    /// Create a prefix for all quarantined pending-DAG records
+    pub fn p2p_quarantined_dag_prefix() -> Vec<u8> {
+        b"/p2p/quarantined_dag/".to_vec()
+    }
+}
+
+impl Key for P2PQuarantinedDagKey {
+    fn bytes(&self) -> Vec<u8> {
+        format!("/p2p/quarantined_dag/{}", self.root_cid).into_bytes()
+    }
+
+    fn to_string(&self) -> String {
+        format!("/p2p/quarantined_dag/{}", self.root_cid)
+    }
+}
+
 /// LensConfigKey: Stores a serialized LensConfig for persistence across restarts.
 ///
 /// Structure: /lens/config/[TransformID]
@@ -527,6 +566,21 @@ mod tests {
             "/p2p/document/bae123456789abcdef0123456789abcdef012345"
         );
         assert_eq!(key.bytes(), key.to_string().as_bytes());
+    }
+
+    #[test]
+    fn test_p2p_quarantined_dag_key() {
+        let key =
+            P2PQuarantinedDagKey::new("bafyreib2rxk3rybk3aobmv5cjuql3bm2twh4jo5uxgf5kpqrsgxbyqx54");
+        assert_eq!(
+            key.to_string(),
+            "/p2p/quarantined_dag/bafyreib2rxk3rybk3aobmv5cjuql3bm2twh4jo5uxgf5kpqrsgxbyqx54"
+        );
+        assert_eq!(key.bytes(), key.to_string().as_bytes());
+        assert_eq!(
+            P2PQuarantinedDagKey::p2p_quarantined_dag_prefix(),
+            b"/p2p/quarantined_dag/".to_vec()
+        );
     }
 
     #[test]

--- a/proofs/tla/MC_PendingDagQuarantine_Green.cfg
+++ b/proofs/tla/MC_PendingDagQuarantine_Green.cfg
@@ -1,0 +1,16 @@
+\* GREEN (#1128 fix): a deterministic content rejection is quarantined
+\* durably and never re-driven; a transient failure leaves the root
+\* registered for another sweep. No doc is ever silently dropped from the
+\* ledger, and - with poison rejection and sound success fair - every sound
+\* doc eventually merges and every poison doc eventually quarantines.
+SPECIFICATION FairSpec
+CHECK_DEADLOCK TRUE
+CONSTANTS
+  SoundDocs      = {s1}
+  PoisonDocs     = {p1}
+  MaxAttempts    = 3
+  QuarantineMode = "Quarantine"
+INVARIANT INV_TypeOK
+INVARIANT INV_NoSilentDrop
+PROPERTY LIVE_SoundEventuallyMerged
+PROPERTY LIVE_PoisonQuiesces

--- a/proofs/tla/MC_PendingDagQuarantine_Red_OvereagerQuarantine.cfg
+++ b/proofs/tla/MC_PendingDagQuarantine_Red_OvereagerQuarantine.cfg
@@ -1,0 +1,19 @@
+\* RED 2 (the forbidden overcorrection): a sound doc's transient failure is
+\* quarantined as if it were a deterministic content rejection, so a doc
+\* that would have merged on retry never gets the chance -
+\* LIVE_SoundEventuallyMerged never closes. INV_NoSilentDrop still holds:
+\* the doc is accounted for (quarantined), just wrongly disposed of - a
+\* liveness bug, not a safety one. Poison handling is unaffected by this
+\* knob, so LIVE_PoisonQuiesces is not checked here (it still holds; this
+\* config's counterexample is attributable to sound-doc overcorrection
+\* alone).
+SPECIFICATION FairSpec
+CHECK_DEADLOCK TRUE
+CONSTANTS
+  SoundDocs      = {s1}
+  PoisonDocs     = {p1}
+  MaxAttempts    = 3
+  QuarantineMode = "QuarantineTransient"
+INVARIANT INV_TypeOK
+INVARIANT INV_NoSilentDrop
+PROPERTY LIVE_SoundEventuallyMerged

--- a/proofs/tla/MC_PendingDagQuarantine_Red_RetryForever.cfg
+++ b/proofs/tla/MC_PendingDagQuarantine_Red_RetryForever.cfg
@@ -1,0 +1,17 @@
+\* RED 1 (today's bug): a deterministic content rejection is treated as a
+\* retryable skip, so the poison root is swept forever and never
+\* quarantines - LIVE_PoisonQuiesces never closes, even under fair
+\* scheduling (the saturating attempts counter keeps the state space finite
+\* while the sweep loop that witnesses the bug stays reachable).
+\* INV_NoSilentDrop still holds: the doc is never lost, it is just never
+\* disposed of - a liveness bug, not a safety one.
+SPECIFICATION FairSpec
+CHECK_DEADLOCK TRUE
+CONSTANTS
+  SoundDocs      = {s1}
+  PoisonDocs     = {p1}
+  MaxAttempts    = 3
+  QuarantineMode = "RetryForever"
+INVARIANT INV_TypeOK
+INVARIANT INV_NoSilentDrop
+PROPERTY LIVE_PoisonQuiesces

--- a/proofs/tla/PendingDagQuarantine.tla
+++ b/proofs/tla/PendingDagQuarantine.tla
@@ -1,0 +1,181 @@
+---- MODULE PendingDagQuarantine ----
+\* Terminal-failure disposition for pending-DAG roots (#1128), companion to
+\* PendingDagRestart.tla (does a registration SURVIVE a hub restart?) and
+\* SyncOwnership.tla (who OWNS a registration's completion). Those models ask
+\* whether a registration survives; this one asks what happens when its
+\* merge is retried and DETERMINISTICALLY REJECTED on the block's own
+\* content (e.g. a unique-index violation) rather than failing transiently.
+\* Abstracts crates/db-merge/src/merge_handler/composite.rs
+\* (UniqueConstraintViolation -> MergeOutcome::Rejected, composite.rs:261-284;
+\* MergeOutcome::Rejected itself at crates/p2p/src/sync/merge.rs:89-97),
+\* crates/p2p/src/sync/replication/handlers.rs (Ok(MergeOutcome::Rejected)
+\* -> quarantine_pending_dag, handlers.rs:353-362) and
+\* crates/p2p/src/sync/manager/process/pending_dag.rs
+\* (quarantine_pending_dag's write-quarantine-record-BEFORE-delete-live-record
+\* ordering, pending_dag.rs:838-880, and the resync sweep's is_quarantined
+\* skip that keeps a quarantined root out of re-registration,
+\* pending_dag.rs:712-723).
+\*
+\* THE MECHANISM: a registered pending-DAG root is re-driven by a sweep
+\* (retry clock, resync, peer reconnect - the trigger is irrelevant here).
+\* The re-drive's merge attempt has three possible content-determined
+\* outcomes: MERGED (success), a transient failure that leaves the root
+\* registered for another sweep, or a deterministic REJECTION. Poison docs
+\* (model: a doc whose content will never merge, e.g. a unique-index
+\* collision with data already committed) are rejected on every attempt.
+\* Sound docs merge, possibly after one transient hiccup first (network
+\* blip, lock contention - anything NOT a function of the block's content).
+\*
+\* One knob, three settings - each isolates one way to get the disposition
+\* wrong:
+\*   QuarantineMode = "Quarantine"          - Rejected -> durable quarantine
+\*                     record, root never re-driven again; a transient
+\*                     failure leaves the root registered (retried). [GREEN]
+\*                   = "RetryForever"        - today's bug: Rejected is
+\*                     treated as a retryable skip, so the doomed root is
+\*                     swept forever. [RED 1]
+\*                   = "QuarantineTransient" - the forbidden overcorrection:
+\*                     a SOUND doc's transient failure ALSO quarantines it,
+\*                     so a doc that would have merged on retry never gets
+\*                     the chance. [RED 2]
+\*
+\* Abstractions: as in PendingDagRestart, the sweep trigger (retry clock
+\* tick, resync sweep, peer reconnect) is irrelevant - only the content-
+\* determined outcome matters. "Registered" collapses PendingDagRestart's
+\* in-memory/durable distinction (that durability question is already
+\* fenced there); here every registered root is assumed durable and this
+\* model owns only the terminal-vs-retryable disposition. One optional
+\* transient failure per sound doc, before it succeeds, is enough to give
+\* QuarantineTransient something to bite without needing an unbounded retry
+\* ladder. attempts is a saturating counter (capped at MaxAttempts) rather
+\* than an unbounded one: RetryForever's bug is "sweeps forever, never
+\* disposes" - saturating keeps the state space finite while the
+\* never-disposes behavior still shows up as an infinite sweep loop under
+\* fairness (LIVE_PoisonQuiesces never closes).
+EXTENDS Naturals, FiniteSets
+
+CONSTANTS
+  SoundDocs,     \* docs that merge (possibly after one transient hiccup)
+  PoisonDocs,    \* docs whose content is deterministically rejected, always
+  MaxAttempts,   \* saturating cap on the attempts counter (state-space bound)
+  QuarantineMode \* "Quarantine" | "RetryForever" | "QuarantineTransient"
+
+Docs == SoundDocs \cup PoisonDocs
+
+ASSUME SoundDocs # {} /\ PoisonDocs # {} /\ SoundDocs \cap PoisonDocs = {}
+ASSUME MaxAttempts \in Nat /\ MaxAttempts >= 1
+ASSUME QuarantineMode \in {"Quarantine", "RetryForever", "QuarantineTransient"}
+
+Status == {"registered", "quarantined", "merged"}
+
+VARIABLES
+  status,       \* [Docs -> Status]
+  attempts,     \* [Docs -> 0..MaxAttempts] - saturating sweep counter
+  transientDone \* [SoundDocs -> BOOLEAN] - has this doc already used its one
+                \* optional transient failure?
+
+vars == <<status, attempts, transientDone>>
+
+TypeOK ==
+  /\ status \in [Docs -> Status]
+  /\ attempts \in [Docs -> 0..MaxAttempts]
+  /\ transientDone \in [SoundDocs -> BOOLEAN]
+
+Init ==
+  /\ status = [d \in Docs |-> "registered"]
+  /\ attempts = [d \in Docs |-> 0]
+  /\ transientDone = [s \in SoundDocs |-> FALSE]
+
+Bumped(d) == IF attempts[d] < MaxAttempts THEN attempts[d] + 1 ELSE attempts[d]
+
+\* A poison doc's sweep is always a rejection (composite.rs:261-284: the
+\* unique-index check is a function of already-committed data, not of retry
+\* timing - every replay reaches the same verdict). Quarantine and
+\* QuarantineTransient both dispose it correctly (handlers.rs:353-362 ->
+\* pending_dag.rs:838-880); RetryForever leaves it registered forever -
+\* the #1128 bug this model exists to catch.
+SweepPoisonReject(p) ==
+  /\ p \in PoisonDocs
+  /\ status[p] = "registered"
+  /\ attempts' = [attempts EXCEPT ![p] = Bumped(p)]
+  /\ status' = [status EXCEPT ![p] =
+       IF QuarantineMode = "RetryForever" THEN "registered" ELSE "quarantined"]
+  /\ UNCHANGED transientDone
+
+\* A sound doc's one optional transient failure (network blip, lock
+\* contention - NOT a function of content, unlike SweepPoisonReject).
+\* QuarantineTransient's mistake: it cannot tell this apart from a real
+\* content rejection and quarantines anyway, stranding a doc that would
+\* have merged. Quarantine and RetryForever both correctly leave it
+\* registered for the next sweep, which - transientDone now TRUE - must
+\* succeed (SweepSoundTransientFail can never fire twice for the same doc).
+SweepSoundTransientFail(s) ==
+  /\ s \in SoundDocs
+  /\ status[s] = "registered"
+  /\ ~transientDone[s]
+  /\ attempts' = [attempts EXCEPT ![s] = Bumped(s)]
+  /\ transientDone' = [transientDone EXCEPT ![s] = TRUE]
+  /\ status' = [status EXCEPT ![s] =
+       IF QuarantineMode = "QuarantineTransient" THEN "quarantined" ELSE "registered"]
+
+\* A sound doc's sweep succeeds - enabled every sweep, not gated on the one
+\* optional transient failure having already happened (a doc may merge on
+\* its very first attempt).
+SweepSoundSucceed(s) ==
+  /\ s \in SoundDocs
+  /\ status[s] = "registered"
+  /\ attempts' = [attempts EXCEPT ![s] = Bumped(s)]
+  /\ status' = [status EXCEPT ![s] = "merged"]
+  /\ UNCHANGED transientDone
+
+\* Every doc disposed (merged or quarantined): stutter so TLC does not flag
+\* deadlock on a finished schedule. Under RetryForever a poison doc never
+\* reaches this state - SweepPoisonReject stays enabled forever instead,
+\* which is exactly the bug LIVE_PoisonQuiesces is built to catch.
+Done == \A d \in Docs : status[d] \in {"quarantined", "merged"}
+Terminating == Done /\ UNCHANGED vars
+
+Next ==
+  \/ \E p \in PoisonDocs : SweepPoisonReject(p)
+  \/ \E s \in SoundDocs : SweepSoundTransientFail(s) \/ SweepSoundSucceed(s)
+
+Spec == Init /\ [][Next \/ Terminating]_vars
+
+\* Weak fairness on the DISPOSITIVE action per doc only - a sound doc's
+\* optional transient failure is never required to fire (it is optional by
+\* construction: a doc may go straight to merged). This is the minimal
+\* fairness under which GREEN's two liveness properties are real: without
+\* WF(SweepPoisonReject) a fair trace could simply never sweep a poison doc;
+\* without WF(SweepSoundSucceed) a fair trace could dwell forever between a
+\* transient failure and the guaranteed-success sweep that follows it
+\* (verified: the no-fairness probe on the GREEN config fails both
+\* liveness properties - see the DESIGN doc's anti-vacuity note).
+FairSpec ==
+  Spec
+  /\ \A p \in PoisonDocs : WF_vars(SweepPoisonReject(p))
+  /\ \A s \in SoundDocs : WF_vars(SweepSoundSucceed(s))
+
+INV_TypeOK == TypeOK
+
+\* THE #1128 LEDGER INVARIANT: every doc is registered, quarantined, or
+\* merged - never a fourth, untracked state. Holds by construction in every
+\* config (status \in [Docs -> Status] already enforces it); stated because
+\* it is the property the quarantine record exists to preserve at the
+\* granularity that matters - a deterministically-failing merge stays
+\* accounted for. Neither RED config loses a doc from the ledger; they get
+\* the DISPOSITION wrong (a liveness failure), not the accounting.
+INV_NoSilentDrop == \A d \in Docs : status[d] \in {"registered", "quarantined", "merged"}
+
+\* Liveness (GREEN, under FairSpec): every sound doc eventually merges and
+\* stays merged. Violated by QuarantineTransient (RED 2): a doc quarantined
+\* on its transient failure never merges - <>[] never closes.
+LIVE_SoundEventuallyMerged == <>[](\A s \in SoundDocs : status[s] = "merged")
+
+\* Liveness (GREEN, under FairSpec): every poison doc eventually quarantines
+\* and stays quarantined - the #1128 fix's headline promise: a
+\* deterministically failing merge is disposed of, not retried indefinitely.
+\* Violated by RetryForever (RED 1): SweepPoisonReject stays enabled and
+\* keeps firing (attempts saturated at MaxAttempts closes the state space)
+\* without status ever reaching "quarantined" - the loop IS the bug.
+LIVE_PoisonQuiesces == <>[](\A p \in PoisonDocs : status[p] = "quarantined")
+====

--- a/proofs/tla/PendingDagQuarantine_DESIGN.md
+++ b/proofs/tla/PendingDagQuarantine_DESIGN.md
@@ -1,0 +1,114 @@
+# PendingDagQuarantine — terminal-failure disposition for pending-DAG roots (TLA+ design)
+
+Models the disposition of a pending-DAG root once its merge is retried and comes back
+**deterministically rejected** on the block's own content (e.g. a unique-index
+violation), for issue **#1128**. Companion to `PendingDagRestart.tla` (does a
+registration *survive* a hub restart?) and `SyncOwnership.tla` (who *owns* a
+registration's completion) — both ask about the registration's lifecycle; this model
+asks what happens to it once a retry comes back with a verdict that will never change.
+
+> **Status: the RED 1 config is current-main behavior.** `MergeOutcome::Rejected` was
+> treated as a retryable skip, so a root whose merge fails on content (not timing) is
+> swept forever by the retry clock and the resync sweep. The GREEN config quarantines
+> it durably instead — write-first ordering so a crash mid-disposition self-heals
+> instead of losing the quarantine. RED 2 is the fix's own failure mode to avoid:
+> over-eager quarantine of a doc that only failed *transiently*.
+
+## Mechanism
+
+A registered pending-DAG root is re-driven by a sweep (retry clock, resync, peer
+reconnect — the trigger is irrelevant, as in `PendingDagRestart`). **Poison** docs (a
+doc whose content will never merge, e.g. a unique-index collision with data already
+committed) are rejected on every attempt —
+`crates/db-merge/src/merge_handler/composite.rs:261-284` converts
+`MergeError::UniqueConstraintViolation` into `MergeOutcome::Rejected` (defined at
+`crates/p2p/src/sync/merge.rs:89-97`), which
+`crates/p2p/src/sync/replication/handlers.rs:353-362` routes to
+`SyncManager::quarantine_pending_dag`. **Sound** docs merge, possibly after one
+transient hiccup first (network blip, lock contention — not a function of content).
+
+`quarantine_pending_dag` (`crates/p2p/src/sync/manager/process/pending_dag.rs:838-880`)
+writes the durable quarantine record **before** deleting the live
+`/p2p/pending_dag/` record, so a crash in that window leaves both records on disk
+rather than losing the live one; the resync sweep's `is_quarantined` check
+(`pending_dag.rs:712-723`) treats a leftover live record for an already-quarantined
+root as cleanup, not a recovery obligation — the crash window self-heals instead of
+re-driving a merge now known to fail forever.
+
+One knob, three settings — each isolates one way to get the disposition wrong:
+
+| Knob | GREEN | RED 1 | RED 2 |
+|------|-------|-------|-------|
+| `QuarantineMode` | `"Quarantine"` — `Rejected` quarantines durably; a transient failure leaves the root registered | `"RetryForever"` — today's bug: `Rejected` is treated as a retryable skip | `"QuarantineTransient"` — the forbidden overcorrection: a *sound* doc's transient failure also quarantines it |
+
+## Properties
+
+- `INV_NoSilentDrop` — **every doc is registered, quarantined, or merged.** Holds by
+  construction in all three configs; stated because it is the property the quarantine
+  record exists to preserve at the granularity that matters. Neither RED config loses a
+  doc from the ledger — they get the *disposition* wrong (a liveness failure), not the
+  accounting (a safety failure).
+- `LIVE_SoundEventuallyMerged` (GREEN, under `FairSpec`) — every sound doc eventually
+  merges and stays merged. Violated by `QuarantineTransient` (RED 2, 3 steps: transient
+  failure quarantines the doc before it ever gets a chance to retry).
+- `LIVE_PoisonQuiesces` (GREEN, under `FairSpec`) — every poison doc eventually
+  quarantines and stays quarantined — the #1128 fix's headline promise: a
+  deterministically failing merge is disposed of, not retried indefinitely. Violated by
+  `RetryForever` (RED 1): the counterexample is a genuine infinite sweep loop, not a
+  starvation artifact — `attempts` saturating at `MaxAttempts` keeps the state space
+  finite while the loop (never reaching `"quarantined"`) still witnesses the bug.
+
+Each RED checks `INV_TypeOK` + `INV_NoSilentDrop` (both hold everywhere) plus only the
+one liveness property it violates, so failures stay attributable.
+
+## Abstractions
+
+- As in `PendingDagRestart`, the sweep trigger (retry clock tick, resync sweep, peer
+  reconnect) is irrelevant — only the content-determined outcome matters.
+- `"registered"` collapses `PendingDagRestart`'s in-memory/durable distinction — that
+  durability question is already fenced there; this model owns only the
+  terminal-vs-retryable disposition and assumes every registered root is durable.
+- One optional transient failure per sound doc, before it succeeds, is enough to give
+  `QuarantineTransient` something to bite without needing an unbounded retry ladder —
+  `SweepSoundTransientFail` can fire at most once per doc (guarded by `transientDone`).
+- `attempts` is a **saturating** counter capped at `MaxAttempts` rather than an
+  unbounded one. `RetryForever`'s bug is "sweeps forever, never disposes"; saturating
+  keeps the state space finite (TLC needs a complete, closed graph to check `<>[]`)
+  while the never-disposes behavior still shows up as an infinite sweep loop under
+  fairness — the loop *is* the counterexample TLC reports.
+- Fairness is minimal: `WF(SweepPoisonReject(p))` and `WF(SweepSoundSucceed(s))` only.
+  Sound docs' optional transient failure is never required to fire — it is optional by
+  construction (a doc may merge on its first attempt). This is deliberately the
+  smallest fairness under which GREEN's two liveness properties are real (see
+  Anti-vacuity below), matching `SyncOwnership`'s "minimal fairness that makes the green
+  liveness real" convention.
+
+## Anti-vacuity
+
+Re-running the GREEN config with `SPECIFICATION Spec` (no fairness) in place of
+`FairSpec` fails `LIVE_SoundEventuallyMerged`: TLC finds a 3-state counterexample where
+the sound doc's `SweepSoundTransientFail` fires once and then the trace stutters
+forever, and flags the standard warning that the counterexample is an artifact of
+missing fairness. This confirms the liveness properties have teeth — they are not
+vacuously true from `Init`, and `FairSpec`'s two `WF` clauses are load-bearing.
+
+## Configs
+
+| Config | Knob | Verdict | Meaning |
+|--------|------|---------|---------|
+| `MC_PendingDagQuarantine_Green.cfg` | `QuarantineMode="Quarantine"` | GREEN | rejection quarantines durably, transient failure retries: no silent drop, all docs eventually disposed correctly (8 states, complete space) |
+| `MC_PendingDagQuarantine_Red_RetryForever.cfg` | `QuarantineMode="RetryForever"` | RED | current main: poison root swept forever, `LIVE_PoisonQuiesces` violated (16 states) |
+| `MC_PendingDagQuarantine_Red_OvereagerQuarantine.cfg` | `QuarantineMode="QuarantineTransient"` | RED | forbidden overcorrection: sound doc's transient failure quarantines it, `LIVE_SoundEventuallyMerged` violated (6 states) |
+
+## Conformance fence
+
+The Rust-side fence: `pending_dag.rs`'s
+`quarantine_pending_dag_moves_live_record_and_clears_in_memory_entry` and
+`quarantine_pending_dag_synthesizes_record_when_no_durable_record_exists` cover the
+write-then-delete ordering and the never-fails-for-lack-of-provenance guarantee this
+model assumes as `SweepPoisonReject`'s single atomic transition;
+`resync_deletes_live_leftover_of_quarantined_root_without_redriving` exercises the
+crash-window leftover the `is_quarantined` check exists to clean up without
+re-registering. `crates/p2p/src/sync/replication/mod.rs`'s `Rejected`-in-a-batch
+regression test is the sibling fence for the batch-merge path feeding the same
+disposition.

--- a/proofs/tla/PendingDagQuarantine_DESIGN.md
+++ b/proofs/tla/PendingDagQuarantine_DESIGN.md
@@ -7,7 +7,7 @@ registration *survive* a hub restart?) and `SyncOwnership.tla` (who *owns* a
 registration's completion) — both ask about the registration's lifecycle; this model
 asks what happens to it once a retry comes back with a verdict that will never change.
 
-> **Status: RED 1 models the pre-#1126 wedge, not current-main's dominant path.**
+> **Status: RED 1 models the pre-#1128 bug, not current-main's dominant path.**
 > `MergeOutcome::Rejected` was treated as a retryable skip, so a root whose merge fails
 > on content (not timing) was swept forever by the retry clock and the resync sweep.
 > That was current-main behavior when this model was written; #1126 (merged afterward)
@@ -108,7 +108,7 @@ vacuously true from `Init`, and `FairSpec`'s two `WF` clauses are load-bearing.
 | Config | Knob | Verdict | Meaning |
 |--------|------|---------|---------|
 | `MC_PendingDagQuarantine_Green.cfg` | `QuarantineMode="Quarantine"` | GREEN | rejection quarantines durably, transient failure retries: no silent drop, all docs eventually disposed correctly (8 states, complete space) |
-| `MC_PendingDagQuarantine_Red_RetryForever.cfg` | `QuarantineMode="RetryForever"` | RED | pre-#1126 wedge, still live for any unclassified `Rejected` producer (today: #1126's degenerate arms): poison root swept forever, `LIVE_PoisonQuiesces` violated (16 states) |
+| `MC_PendingDagQuarantine_Red_RetryForever.cfg` | `QuarantineMode="RetryForever"` | RED | pre-#1128 bug, still live for any unclassified `Rejected` producer (today: #1126's degenerate arms): poison root swept forever, `LIVE_PoisonQuiesces` violated (16 states) |
 | `MC_PendingDagQuarantine_Red_OvereagerQuarantine.cfg` | `QuarantineMode="QuarantineTransient"` | RED | forbidden overcorrection: sound doc's transient failure quarantines it, `LIVE_SoundEventuallyMerged` violated (6 states) |
 
 ## Conformance fence

--- a/proofs/tla/PendingDagQuarantine_DESIGN.md
+++ b/proofs/tla/PendingDagQuarantine_DESIGN.md
@@ -7,19 +7,30 @@ registration *survive* a hub restart?) and `SyncOwnership.tla` (who *owns* a
 registration's completion) — both ask about the registration's lifecycle; this model
 asks what happens to it once a retry comes back with a verdict that will never change.
 
-> **Status: the RED 1 config is current-main behavior.** `MergeOutcome::Rejected` was
-> treated as a retryable skip, so a root whose merge fails on content (not timing) is
-> swept forever by the retry clock and the resync sweep. The GREEN config quarantines
-> it durably instead — write-first ordering so a crash mid-disposition self-heals
-> instead of losing the quarantine. RED 2 is the fix's own failure mode to avoid:
-> over-eager quarantine of a doc that only failed *transiently*.
+> **Status: RED 1 models the pre-#1126 wedge, not current-main's dominant path.**
+> `MergeOutcome::Rejected` was treated as a retryable skip, so a root whose merge fails
+> on content (not timing) was swept forever by the retry clock and the resync sweep.
+> That was current-main behavior when this model was written; #1126 (merged afterward)
+> changed the *dominant* producer of that rejection: a live unique-index conflict between
+> two alive documents (the common "twin" case) now resolves deterministically at merge
+> time — smallest docID wins — and converges instead of rejecting at all. RED 1 still
+> describes exactly what happens to whatever a `Rejected` outcome DOES still get produced
+> from — today, the degenerate arms #1126's merge-path resolution can't heal (internal
+> index-state inconsistency, e.g. a corrupted index entry with no identifiable holder),
+> and any future deterministic-rejection producer this classification seam is extended to
+> cover. The GREEN config quarantines it durably instead — write-first ordering so a crash
+> mid-disposition self-heals instead of losing the quarantine. RED 2 is the fix's own
+> failure mode to avoid: over-eager quarantine of a doc that only failed *transiently*.
 
 ## Mechanism
 
 A registered pending-DAG root is re-driven by a sweep (retry clock, resync, peer
 reconnect — the trigger is irrelevant, as in `PendingDagRestart`). **Poison** docs (a
-doc whose content will never merge, e.g. a unique-index collision with data already
-committed) are rejected on every attempt —
+doc whose content will never merge — since #1126, this means the merge-path unique-index
+resolution's degenerate arms: internal index-state inconsistency such as a corrupted
+entry with no identifiable holder, not a live conflict between two alive documents,
+which #1126 now resolves deterministically instead of rejecting) are rejected on every
+attempt —
 `crates/db-merge/src/merge_handler/composite.rs:261-284` converts
 `MergeError::UniqueConstraintViolation` into `MergeOutcome::Rejected` (defined at
 `crates/p2p/src/sync/merge.rs:89-97`), which
@@ -39,7 +50,7 @@ One knob, three settings — each isolates one way to get the disposition wrong:
 
 | Knob | GREEN | RED 1 | RED 2 |
 |------|-------|-------|-------|
-| `QuarantineMode` | `"Quarantine"` — `Rejected` quarantines durably; a transient failure leaves the root registered | `"RetryForever"` — today's bug: `Rejected` is treated as a retryable skip | `"QuarantineTransient"` — the forbidden overcorrection: a *sound* doc's transient failure also quarantines it |
+| `QuarantineMode` | `"Quarantine"` — `Rejected` quarantines durably; a transient failure leaves the root registered | `"RetryForever"` — the pre-#1128 bug: `Rejected` is treated as a retryable skip | `"QuarantineTransient"` — the forbidden overcorrection: a *sound* doc's transient failure also quarantines it |
 
 ## Properties
 
@@ -97,7 +108,7 @@ vacuously true from `Init`, and `FairSpec`'s two `WF` clauses are load-bearing.
 | Config | Knob | Verdict | Meaning |
 |--------|------|---------|---------|
 | `MC_PendingDagQuarantine_Green.cfg` | `QuarantineMode="Quarantine"` | GREEN | rejection quarantines durably, transient failure retries: no silent drop, all docs eventually disposed correctly (8 states, complete space) |
-| `MC_PendingDagQuarantine_Red_RetryForever.cfg` | `QuarantineMode="RetryForever"` | RED | current main: poison root swept forever, `LIVE_PoisonQuiesces` violated (16 states) |
+| `MC_PendingDagQuarantine_Red_RetryForever.cfg` | `QuarantineMode="RetryForever"` | RED | pre-#1126 wedge, still live for any unclassified `Rejected` producer (today: #1126's degenerate arms): poison root swept forever, `LIVE_PoisonQuiesces` violated (16 states) |
 | `MC_PendingDagQuarantine_Red_OvereagerQuarantine.cfg` | `QuarantineMode="QuarantineTransient"` | RED | forbidden overcorrection: sound doc's transient failure quarantines it, `LIVE_SoundEventuallyMerged` violated (6 states) |
 
 ## Conformance fence

--- a/proofs/tla/run-all.sh
+++ b/proofs/tla/run-all.sh
@@ -101,6 +101,9 @@ RUNS=(
   "MC_DeferredAcp_Red_OwnerBypass.cfg MC_DeferredAcp_Red_OwnerBypass.tla RED" # projection grants what committed state denies
   "MC_DeferredAcp_Red_RollbackHooks.cfg MC_DeferredAcp_Red_RollbackHooks.tla RED" # rollback leaves hooks applied (not a no-op)
   "MC_DeferredAcp_Red_SharedOverlay.cfg MC_DeferredAcp_Red_SharedOverlay.tla RED" # one txn observes another's uncommitted projection
+  "MC_PendingDagQuarantine_Green.cfg PendingDagQuarantine.tla GREEN" # #1128: deterministic rejection quarantines durably; sound docs merge, poison docs quarantine
+  "MC_PendingDagQuarantine_Red_RetryForever.cfg PendingDagQuarantine.tla RED" # current main: Rejected treated as retryable skip -> poison root swept forever (LIVE_PoisonQuiesces)
+  "MC_PendingDagQuarantine_Red_OvereagerQuarantine.cfg PendingDagQuarantine.tla RED" # forbidden overcorrection: sound doc's transient failure also quarantines it (LIVE_SoundEventuallyMerged)
 )
 
 fails=0; n=0
@@ -109,7 +112,7 @@ for row in "${RUNS[@]}"; do
   n=$((n+1))
   out=$(./tools/tlc -metadir "states/run$n" -config "$cfg" "$mod" 2>&1)
   if echo "$out" | grep -q "No error has been found"; then got=GREEN
-  elif echo "$out" | grep -qE "is violated|properties were violated|Deadlock reached|Deadlock"; then got=RED
+  elif echo "$out" | grep -qE "is violated|was violated|properties were violated|Deadlock reached|Deadlock"; then got=RED
   else got=ERROR; fi
   rm -rf "states/run$n"
   if [ "$got" = "$want" ]; then printf "  ok   %-6s %-34s %s\n" "$got" "$cfg" "$mod"

--- a/proofs/tla/run-all.sh
+++ b/proofs/tla/run-all.sh
@@ -102,7 +102,7 @@ RUNS=(
   "MC_DeferredAcp_Red_RollbackHooks.cfg MC_DeferredAcp_Red_RollbackHooks.tla RED" # rollback leaves hooks applied (not a no-op)
   "MC_DeferredAcp_Red_SharedOverlay.cfg MC_DeferredAcp_Red_SharedOverlay.tla RED" # one txn observes another's uncommitted projection
   "MC_PendingDagQuarantine_Green.cfg PendingDagQuarantine.tla GREEN" # #1128: deterministic rejection quarantines durably; sound docs merge, poison docs quarantine
-  "MC_PendingDagQuarantine_Red_RetryForever.cfg PendingDagQuarantine.tla RED" # current main: Rejected treated as retryable skip -> poison root swept forever (LIVE_PoisonQuiesces)
+  "MC_PendingDagQuarantine_Red_RetryForever.cfg PendingDagQuarantine.tla RED" # pre-#1128 wedge, still live for any unclassified Rejected producer: Rejected treated as retryable skip -> poison root swept forever (LIVE_PoisonQuiesces)
   "MC_PendingDagQuarantine_Red_OvereagerQuarantine.cfg PendingDagQuarantine.tla RED" # forbidden overcorrection: sound doc's transient failure also quarantines it (LIVE_SoundEventuallyMerged)
 )
 

--- a/tools/integration-test/tests/p2p.rs
+++ b/tools/integration-test/tests/p2p.rs
@@ -12,6 +12,8 @@ mod manage_relay;
 mod manage_relay_common;
 #[path = "p2p/management.rs"]
 mod management;
+#[path = "p2p/quarantine.rs"]
+mod quarantine;
 #[path = "p2p/receiver_pull.rs"]
 mod receiver_pull;
 #[path = "p2p/replication.rs"]

--- a/tools/integration-test/tests/p2p/README.md
+++ b/tools/integration-test/tests/p2p/README.md
@@ -12,7 +12,7 @@ cargo test -p integration-test --test p2p
 | `document.rs` | 2 | Document replication across runtimes |
 | `idempotent_replay.rs` | 3 | Idempotent reconnect/replay behavior |
 | `management.rs` | 3 | P2P collection/replicator management |
-| `quarantine.rs` | 1 | Terminal-failure quarantine e2e fence: fleet-mirroring fan-in + hub restart durability (#1128) |
+| `quarantine.rs` | 1 | #1126 x #1128 composition fence: canonical-pick convergence under fan-in with the quarantine guard staying silent, across a hub restart |
 | `receiver_pull.rs` | 1 | Paced receiver-pull convergence fence (#1116 stage 2 retry clock, storm bound) |
 | `sync.rs` | 11 | Sync protocol (document sync, versions, branchable, invalid CID) |
 | `trust_boundary.rs` | 3 | ACP enforcement at P2P trust boundaries |

--- a/tools/integration-test/tests/p2p/README.md
+++ b/tools/integration-test/tests/p2p/README.md
@@ -12,6 +12,7 @@ cargo test -p integration-test --test p2p
 | `document.rs` | 2 | Document replication across runtimes |
 | `idempotent_replay.rs` | 3 | Idempotent reconnect/replay behavior |
 | `management.rs` | 3 | P2P collection/replicator management |
+| `quarantine.rs` | 1 | Terminal-failure quarantine e2e fence: fleet-mirroring fan-in + hub restart durability (#1128) |
 | `receiver_pull.rs` | 1 | Paced receiver-pull convergence fence (#1116 stage 2 retry clock, storm bound) |
 | `sync.rs` | 11 | Sync protocol (document sync, versions, branchable, invalid CID) |
 | `trust_boundary.rs` | 3 | ACP enforcement at P2P trust boundaries |
@@ -21,7 +22,7 @@ cargo test -p integration-test --test p2p
 | `resilience.rs` | 9 | P2P stress tests (ignored by default) |
 | `write_contention.rs` | 9 | Concurrent write behavior across P2P topologies |
 
-**52 total tests: 41 active, 11 ignored.**
+**53 total tests: 42 active, 11 ignored.**
 
 ### Ignored
 

--- a/tools/integration-test/tests/p2p/quarantine.rs
+++ b/tools/integration-test/tests/p2p/quarantine.rs
@@ -1,46 +1,70 @@
-//! #1128 end-to-end fence: terminal-failure quarantine under fleet-mirroring
-//! conditions.
+//! #1126 x #1128 composition fence: canonical-pick convergence with the
+//! quarantine guard staying silent.
 //!
-//! Mirrors the shape of the 2026-07-14 fleet incident (hub "Amy" held 6 stuck
-//! heads: docs whose unique `session_id` index rejected an incoming twin,
-//! re-driven by the 60s resync sweep forever) rather than a minimal repro:
-//! a 3-node fan-in (hub B, spokes A and C) with a UNIQUE index, a genuine
-//! content collision under concurrent *sound* traffic, and a hub restart that
-//! exercises the same resync path the incident's 60s sweep used, on a fast
-//! reconnect-triggered timescale instead of waiting out the real interval.
+//! Mirrors the shape of the 2026-07-14 fleet incident (hub "Amy" held 6
+//! stuck heads: docs whose unique `session_id` index rejected an incoming
+//! twin, re-driven by the 60s resync sweep forever) rather than a minimal
+//! repro — 3-node fan-in (hub B, spokes A and C), a UNIQUE index, a genuine
+//! content collision under concurrent *sound* traffic, and a hub restart —
+//! but proves the POST-#1126 outcome, not the pre-#1126 one.
 //!
-//! Phase 1 (conflict under concurrent sound traffic): B locally owns a
-//! `session_id` value under its own unique index. Spoke A pushes a twin
-//! document with the identical value over gossip (so the rejection runs
-//! through the real pending-DAG -> DagReady -> merge path, not a bundled
-//! push that might never touch the live queue) while spoke C concurrently
-//! fans in several unrelated, sound documents via a replicator. Asserts the
-//! twin is quarantined (counted + durably recorded), sound traffic is
-//! unharmed by the poisoned neighbor, and the live `pending_dags` queue
-//! drains to 0 while the quarantine gauge does not — the load-bearing
-//! contrast with the pre-fix behavior, where the rejected root would stay
-//! stuck in the live retry queue forever.
+//! #1126 changed what a live twin unique-index conflict does on the merge
+//! path: instead of rejecting (the incident's trigger), it now resolves
+//! deterministically — both documents persist, and the lexicographically
+//! smallest docID owns the unique index entry (the losing document stays
+//! fully readable by scan queries, just not by the index). #1128's
+//! quarantine mechanism is trigger-agnostic: it only acts on whatever
+//! `MergeOutcome::Rejected` the classification seam still produces. Composed
+//! together, the question this fence answers is: does #1126's canonical
+//! pick actually convergence through the real fan-in/gossip/merge stack
+//! (not just the db-merge unit level), and does #1128's guard stay quiet
+//! while it does — i.e. does the fleet incident's *signature* (a stuck head,
+//! re-driven forever, `pending_dag_terminal_quarantined` climbing) stay dead
+//! under the healed semantics, with no false-positive quarantine of a
+//! conflict that now resolves cleanly?
 //!
-//! Phase 2 (durability across restart): continuous unrelated writes from A
-//! travel the same missing-link path until B holds a live registration, then
-//! A is frozen mid-fetch (SIGSTOP) so a genuine durable pending-DAG record
-//! exists when B is hard-killed and respawned on its own rootdir. On
-//! reconnect, `handle_peer_connected` triggers
-//! `resync_persisted_pending_dags`, which must (a) restore the genuine
-//! frozen registrations and drive them to a real merge (anti-vacuity: the
-//! restore log fires AND both pending gauges drain to 0) while (b) NOT
-//! re-registering the quarantined root — proven by the fresh process's
-//! `pending_dag_terminal_quarantined` counter staying at 0 across a bounded
-//! window and through the recovery drain, since any re-registration would
-//! re-attempt the merge and re-hit the same deterministic rejection.
+//! Quarantine's OWN producer-level proof — that a `Rejected` outcome (today:
+//! only the degenerate arms `IndexManager::conflicting_doc_id` can't
+//! identify a holder for) still gets quarantined and never re-driven — lives
+//! in the crate tests, not here: `crates/db-merge/src/merge_handler/mod.rs`
+//! (`remote_composite_merge_with_corrupted_unique_index_entry_is_rejected`)
+//! for the degenerate-arm classification, and
+//! `crates/p2p/src/sync/manager/process/pending_dag.rs`
+//! (`quarantine_pending_dag_*`, `resync_deletes_live_leftover_of_quarantined_root_*`)
+//! for the disposition/suppression mechanics. Post-#1126, no public-API path
+//! in this integration harness can manufacture a genuine `Rejected` outcome
+//! any more (the live-twin trigger that could is exactly what #1126 healed),
+//! so an e2e fence asserting quarantine's OWN behavior would have no way to
+//! trigger it without reaching into internals the harness cannot touch —
+//! this fence instead proves the two changes compose correctly at the
+//! system level, which is the property only an e2e test can check.
+//!
+//! Phase 1 (composed convergence under concurrent sound traffic): B locally
+//! owns a `session_id` value under its own unique index. Spoke A pushes a
+//! twin document with the identical value over gossip (so it runs through
+//! the real pending-DAG -> DagReady -> merge path, not a bundled push that
+//! might never touch the live queue) while spoke C concurrently fans in
+//! several unrelated, sound documents via a replicator. Asserts: both
+//! twins persist (docID-level presence — canonical pick never drops data);
+//! the unique-index lookup on the shared value converges to exactly the
+//! lexicographically-smaller docID (computed independently in the test);
+//! sound traffic is unharmed by the colliding neighbor; the quarantine
+//! guard never fires (`pending_dag_terminal_quarantined == 0`,
+//! `quarantined_pending_dags == 0`); and the live `pending_dags` queue
+//! still drains to 0 — no wedge, the incident-class signature stays dead.
+//!
+//! Phase 2 (restart durability of composed state): B is hard-killed
+//! (SIGKILL) and respawned on its own rootdir. Asserts the composed state
+//! (both twins present, indexed lookup still resolving to the same winner)
+//! and the silent guard (`pending_dag_terminal_quarantined == 0`,
+//! `quarantined_pending_dags == 0`) both survive the restart, and that
+//! ordinary post-restart sound traffic from A and C still converges.
 //!
 //! Run with `DEFRA_E2E_KEEP=1` to retain node directories (including
 //! `logs/stdout.log` per node under `target/e2e/`) for post-mortem when a run
 //! fails — the harness normally cleans them up on success.
 
 use std::collections::HashSet;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use integration_test::{extract_doc_id, extract_p2p_addr, poll_until, TestCluster};
@@ -53,19 +77,9 @@ const SPOKE_C: usize = 2;
 const CONFLICT_VALUE: &str = "conflict-v1";
 const SOUND_DOC_COUNT: usize = 5;
 
-fn signal(pid: u32, signal: &str) {
-    let status = std::process::Command::new("kill")
-        .arg(signal)
-        .arg(pid.to_string())
-        .status()
-        .expect("spawn kill");
-    assert!(status.success(), "kill {signal} {pid} failed");
-}
-
 /// The quarantine-relevant subset of `/api/v0/p2p/sync/status` (#1128).
 struct SyncStatusSnapshot {
     pending_dags: usize,
-    persisted_pending_dags: usize,
     pending_dag_terminal_quarantined: u64,
     quarantined_pending_dags: usize,
 }
@@ -82,10 +96,6 @@ async fn fetch_sync_status(cluster: &TestCluster, node: usize) -> SyncStatusSnap
         pending_dags: status["pending_dags"]
             .as_u64()
             .expect("pending_dags field present") as usize,
-        persisted_pending_dags: status["persisted_pending_dags"]
-            .as_u64()
-            .expect("persisted_pending_dags field present")
-            as usize,
         pending_dag_terminal_quarantined: status["pending_dag_terminal_quarantined"]
             .as_u64()
             .expect("pending_dag_terminal_quarantined field present"),
@@ -96,33 +106,51 @@ async fn fetch_sync_status(cluster: &TestCluster, node: usize) -> SyncStatusSnap
     }
 }
 
+/// Every `_docID` currently present in the `Session` collection.
+///
+/// Deliberately panics (rather than defaulting to an empty set) on a query
+/// error or an unexpected response shape: a transient failure here must
+/// fail the test loudly, not silently masquerade as "no documents present"
+/// and let a retention assertion downstream pass vacuously against an
+/// empty snapshot (review finding, #1128 task 8).
 fn doc_ids_present(client: &integration_test::DefraClient) -> HashSet<String> {
     let result = client
         .query("query { Session { _docID } }")
-        .unwrap_or_default();
+        .expect("Session _docID query failed");
     result["Session"]
         .as_array()
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v["_docID"].as_str().map(str::to_string))
-                .collect()
+        .unwrap_or_else(|| {
+            panic!("Session _docID query did not return an array; full response: {result}")
         })
-        .unwrap_or_default()
+        .iter()
+        .filter_map(|v| v["_docID"].as_str().map(str::to_string))
+        .collect()
 }
 
-fn hub_log_path(cluster: &TestCluster) -> std::path::PathBuf {
-    cluster.nodes[HUB]
-        .rootdir
-        .parent()
-        .expect("hub rootdir has a parent")
-        .join("logs/stdout.log")
+/// docIDs returned by an indexed lookup on `session_id`, driving the same
+/// error-loudly contract as [`doc_ids_present`].
+fn indexed_session_lookup(client: &integration_test::DefraClient, value: &str) -> Vec<String> {
+    let result = client
+        .query(&format!(
+            r#"query {{ Session(filter: {{session_id: {{_eq: "{value}"}}}}) {{ _docID }} }}"#
+        ))
+        .expect("indexed session_id lookup query failed");
+    result["Session"]
+        .as_array()
+        .unwrap_or_else(|| {
+            panic!("indexed session_id lookup did not return an array; full response: {result}")
+        })
+        .iter()
+        .filter_map(|v| v["_docID"].as_str().map(str::to_string))
+        .collect()
 }
 
-/// 3-node fan-in (hub B, spokes A and C), a real unique-index collision under
-/// concurrent sound traffic, then a hub restart that must not re-drive the
-/// quarantined twin while still recovering a genuinely in-flight registration.
+/// 3-node fan-in (hub B, spokes A and C): a real unique-index collision
+/// under concurrent sound traffic converges via #1126's canonical pick
+/// without #1128's quarantine guard misfiring, and both properties survive
+/// a hub restart.
 #[tokio::test]
-async fn quarantine_survives_fan_in_and_hub_restart() {
+async fn canonical_pick_converges_and_quarantine_guard_stays_silent() {
     let mut cluster = TestCluster::builder()
         .rust_nodes(3)
         .with_node_store(HUB, "redb")
@@ -152,13 +180,13 @@ async fn quarantine_survives_fan_in_and_hub_restart() {
     node_a.p2p_connect(&[&addr_b]).expect("A connects to B");
     node_c.p2p_connect(&[&addr_b]).expect("C connects to B");
 
-    // Subscribe every node to the collection topic: A's twin push (and,
-    // later, its frozen post-restart document) deliberately travels the
-    // gossip head-announcement path rather than a bundled replicator push, so
-    // the receiver must register a pending-DAG entry and Bitswap-fetch the
-    // missing field block — the same mechanism the real incident's stuck
-    // heads went through, and the only way `pending_dags` genuinely carries
-    // the rejected root before quarantine removes it.
+    // Subscribe every node to the collection topic: A's twin push travels
+    // the gossip head-announcement path rather than a bundled replicator
+    // push, so the receiver must register a pending-DAG entry and
+    // Bitswap-fetch the missing field block — the same mechanism the real
+    // incident's stuck heads went through, and the only way the merge
+    // genuinely runs through the pending-DAG -> DagReady path instead of a
+    // bundled push that might never touch it.
     node_b
         .p2p_collection_add(&["Session"])
         .expect("B subscribe");
@@ -170,18 +198,19 @@ async fn quarantine_survives_fan_in_and_hub_restart() {
         .expect("C subscribe");
 
     // C fans in via an explicit replicator: deterministic, fast convergence
-    // for the "sound traffic unharmed by the poison neighbor" assertion,
+    // for the "sound traffic unharmed by the colliding neighbor" assertion,
     // independent of the gossip mechanism forcing A's twin through the
     // pending-DAG path.
     node_c
         .p2p_replicator_set(&["Session"], &addr_b)
         .expect("replicator C -> B");
 
-    // --- Phase 1: conflict under concurrent sound traffic ---
+    // --- Phase 1: composed convergence under concurrent sound traffic ---
 
     // B's unique index is created before any data lands, then B writes its
-    // own local doc under the value it owns — the "pre-fix-era twin" setup:
-    // a hub that already holds v under an active unique index.
+    // own local doc under the value it owns — the same setup that, pre
+    // #1126, produced the incident's twin rejection; post #1126 it instead
+    // sets up a genuine live conflict for the canonical pick to resolve.
     node_b
         .index_create(
             "Session",
@@ -232,323 +261,235 @@ async fn quarantine_survives_fan_in_and_hub_restart() {
         "C never produced its sound-doc load"
     );
 
-    // Anti-vacuity: the scenario must have produced a deterministic merge
-    // rejection, not just eventual quiescence.
-    let quarantine_deadline = Instant::now() + Duration::from_secs(30);
+    // The deterministic winner per #1126: the lexicographically smaller
+    // docID (computed here independently of production code, mirroring
+    // `IndexManager::save_resolving_unique_conflict`'s `doc_id <
+    // holder.as_str()` comparison in
+    // crates/db-index/src/index_manager/mod.rs). Arrival order does not
+    // matter — the pick is a pure function of the two docIDs.
+    let winner_doc_id = if x_doc_id < y_doc_id {
+        x_doc_id.clone()
+    } else {
+        y_doc_id.clone()
+    };
+    eprintln!(
+        "[compose fence] phase 1: X={x_doc_id}, Y={y_doc_id}, computed winner={winner_doc_id}"
+    );
+
+    // Composed convergence, polled together: BOTH twins present at the
+    // docID level (the positive evidence that a genuine collision
+    // occurred and that the CRDT merge never dropped data — anti-vacuity:
+    // if Y never shows up, the scenario never exercised the collision at
+    // all), C's sound docs all converge, and the unique-index lookup on
+    // the shared value resolves to exactly the computed winner (not zero,
+    // not both — exactly one).
+    let convergence_deadline = Instant::now() + Duration::from_secs(30);
     loop {
-        let status = fetch_sync_status(&cluster, HUB).await;
-        if status.pending_dag_terminal_quarantined >= 1 && status.quarantined_pending_dags >= 1 {
+        let present = doc_ids_present(&node_b);
+        let indexed = indexed_session_lookup(&node_b, CONFLICT_VALUE);
+        let x_present = present.contains(&x_doc_id);
+        let y_present = present.contains(&y_doc_id);
+        let sound_converged = sound_doc_ids.iter().all(|id| present.contains(id));
+        let index_converged = indexed == [winner_doc_id.clone()];
+
+        if x_present && y_present && sound_converged && index_converged {
             eprintln!(
-                "[quarantine e2e] phase 1: twin rejected+quarantined \
-                 (pending_dag_terminal_quarantined={}, quarantined_pending_dags={}, \
-                 pending_dags={})",
-                status.pending_dag_terminal_quarantined,
-                status.quarantined_pending_dags,
-                status.pending_dags
+                "[compose fence] phase 1 converged: both twins present, {} sound docs converged, \
+                 indexed lookup for {CONFLICT_VALUE} returns exactly the winner {winner_doc_id}",
+                sound_doc_ids.len()
             );
             break;
         }
-        assert!(
-            Instant::now() < quarantine_deadline,
-            "the scenario did not produce a deterministic merge rejection: B never quarantined \
-             the twin session_id={CONFLICT_VALUE} push (pending_dag_terminal_quarantined={}, \
-             quarantined_pending_dags={})",
-            status.pending_dag_terminal_quarantined,
-            status.quarantined_pending_dags
-        );
+
+        if Instant::now() >= convergence_deadline {
+            assert!(
+                y_present,
+                "anti-vacuity failure: twin Y ({y_doc_id}) never arrived on B — the scenario did \
+                 not exercise the unique-index collision at all, so this run proves nothing about \
+                 #1126 x #1128 composition"
+            );
+            assert!(
+                x_present,
+                "hub's own locally-created doc X ({x_doc_id}) is missing from B"
+            );
+            assert!(
+                sound_converged,
+                "C's sound docs did not all converge on B while the twin collision was resolving"
+            );
+            assert!(
+                index_converged,
+                "unique-index lookup for {CONFLICT_VALUE} did not converge to exactly the \
+                 computed winner {winner_doc_id}: got {indexed:?} — #1126's canonical pick did \
+                 not converge through the real fan-in/gossip/merge stack"
+            );
+            unreachable!(
+                "all convergence sub-conditions individually passed but the loop still timed out"
+            );
+        }
         tokio::time::sleep(Duration::from_millis(200)).await;
     }
 
-    // The load-bearing realism: sound traffic is unharmed by the poisoned
-    // neighbor. All of C's docs converge on B while the rejection is (or was
-    // just) being handled.
-    poll_until(
-        || {
-            let present = doc_ids_present(&node_b);
-            sound_doc_ids.iter().all(|id| present.contains(id))
-        },
-        Duration::from_secs(30),
-        Duration::from_millis(200),
-        "C's sound docs did not all converge on B while the twin rejection was in flight",
-    )
-    .await;
+    // The quarantine guard must stay silent: a live twin conflict resolves
+    // via #1126's canonical pick now, not via rejection, so #1128's
+    // mechanism must never fire for it. `pending_dag_terminal_quarantined`
+    // is a monotonic per-process counter, so a single read after
+    // convergence is equivalent to it never having moved throughout.
+    let status = fetch_sync_status(&cluster, HUB).await;
+    assert_eq!(
+        status.pending_dag_terminal_quarantined, 0,
+        "quarantine guard misfired: {} deterministic rejection(s) counted for a live twin \
+         conflict that should have converged via #1126's canonical pick instead of rejecting",
+        status.pending_dag_terminal_quarantined
+    );
+    assert_eq!(
+        status.quarantined_pending_dags, 0,
+        "quarantine guard misfired: {} root(s) quarantined for a live twin conflict that should \
+         have converged via #1126's canonical pick instead of rejecting",
+        status.quarantined_pending_dags
+    );
 
-    // The quarantined root must leave the live retry queue permanently — the
-    // exact contrast with the pre-fix incident, where it would stay stuck in
-    // `pending_dags`, re-driven by the periodic sweep forever.
+    // The incident-class signature stays dead: the live retry queue must
+    // still drain to 0 (no wedge), with the quarantine guard remaining
+    // silent throughout the drain.
     let drain_deadline = Instant::now() + Duration::from_secs(30);
     loop {
         let status = fetch_sync_status(&cluster, HUB).await;
         if status.pending_dags == 0 {
-            assert!(
-                status.quarantined_pending_dags >= 1,
-                "pending_dags drained to 0 but quarantined_pending_dags also dropped to {} \
-                 (the quarantine gauge must persist once a root is quarantined)",
-                status.quarantined_pending_dags
+            assert_eq!(
+                status.pending_dag_terminal_quarantined, 0,
+                "quarantine guard misfired while draining the live pending-DAG queue"
+            );
+            assert_eq!(
+                status.quarantined_pending_dags, 0,
+                "quarantine guard misfired while draining the live pending-DAG queue"
             );
             break;
         }
         assert!(
             Instant::now() < drain_deadline,
-            "B's live pending_dags gauge never drained to 0 ({} still pending) — a quarantined \
-             root must leave the live retry queue instead of being re-driven",
+            "B's live pending_dags gauge never drained to 0 ({} still pending) — the incident's \
+             stuck-head signature is back",
             status.pending_dags
         );
         tokio::time::sleep(Duration::from_millis(200)).await;
     }
 
-    // Data-level confirmation: the rejected twin never lands, and the hub's
-    // own value survives the conflicting spoke push unchanged.
+    // Data-level confirmation: both documents are fully readable via a
+    // non-indexed scan (canonical pick never drops data), and each retains
+    // its own content.
     let rows = node_b
         .query("query { Session { _docID session_id note } }")
         .expect("query B Session")["Session"]
         .as_array()
         .cloned()
         .unwrap_or_default();
-    assert!(
-        !rows
-            .iter()
-            .any(|r| r["_docID"].as_str() == Some(y_doc_id.as_str())),
-        "rejected twin doc Y ({y_doc_id}) must never merge onto B's Session collection"
-    );
     let x_row = rows
         .iter()
         .find(|r| r["_docID"].as_str() == Some(x_doc_id.as_str()))
-        .expect("hub's own doc X missing from its own collection");
-    assert_eq!(
-        x_row["note"].as_str(),
-        Some("hub-owned"),
-        "hub's locally-owned value must survive the conflicting spoke push unchanged"
-    );
+        .expect("hub's own doc X missing from a full scan of its own collection");
+    assert_eq!(x_row["note"].as_str(), Some("hub-owned"));
+    let y_row = rows
+        .iter()
+        .find(|r| r["_docID"].as_str() == Some(y_doc_id.as_str()))
+        .expect("twin doc Y missing from a full scan — canonical pick must not drop data");
+    assert_eq!(y_row["note"].as_str(), Some("spoke-twin"));
 
-    // --- Phase 2: durability across restart ---
+    // --- Phase 2: restart durability of composed state ---
 
-    let quarantined_before = fetch_sync_status(&cluster, HUB)
-        .await
-        .quarantined_pending_dags;
-    assert!(
-        quarantined_before >= 1,
-        "phase 1 must leave a quarantined root behind"
-    );
-
-    // Force a genuine, still-open pending-DAG registration to exist at kill
-    // time. A single fresh document races the freeze — Bitswap can resolve
-    // the missing field block before the SIGSTOP even lands, as observed
-    // empirically (single-shot attempts never landed). Instead, drive
-    // continuous head-only load from A over the same missing-link gossip
-    // mechanism proven above for Y, so at least one registration is reliably
-    // mid-flight whenever the poll samples it (mirrors
-    // p2p_admission_restart.rs's continuous-writer-then-freeze technique,
-    // adapted from replicator pushes to gossip-forced ones).
-    let a_pid = cluster.nodes[SPOKE_A].process.id().expect("A pid");
-    let node_a = cluster.client(SPOKE_A);
-    let stop_writer = Arc::new(AtomicBool::new(false));
-    let w_doc_ids = Arc::new(Mutex::new(Vec::<String>::new()));
-    let writer_handle = {
-        let client = cluster.client(SPOKE_A);
-        let stop = Arc::clone(&stop_writer);
-        let doc_ids = Arc::clone(&w_doc_ids);
-        std::thread::spawn(move || {
-            let mut n = 0usize;
-            while !stop.load(Ordering::Relaxed) {
-                n += 1;
-                let mutation = format!(
-                    r#"mutation {{ add_Session(input: {{session_id: "post-restart-w-{n}", note: "v0"}}) {{ _docID }} }}"#
-                );
-                if let Ok(create) = client.query(&mutation) {
-                    doc_ids
-                        .lock()
-                        .unwrap()
-                        .push(extract_doc_id(&create, "add_Session"));
-                }
-                std::thread::sleep(Duration::from_millis(10));
-            }
-        })
-    };
-
-    let freeze_deadline = Instant::now() + Duration::from_secs(60);
-    loop {
-        assert!(
-            Instant::now() < freeze_deadline,
-            "hub never showed a live pending-DAG registration under continuous gossip-forced \
-             load from A; without one, restarting B would prove nothing about restoring real \
-             (not synthetic) durable state"
-        );
-        if fetch_sync_status(&cluster, HUB).await.pending_dags == 0 {
-            tokio::time::sleep(Duration::from_millis(50)).await;
-            continue;
-        }
-        signal(a_pid, "-STOP");
-        // Let any in-flight fetch settle: whatever can still resolve,
-        // resolves now (mirrors p2p_admission_restart.rs's freeze window).
-        tokio::time::sleep(Duration::from_millis(500)).await;
-        if fetch_sync_status(&cluster, HUB).await.pending_dags >= 1 {
-            break;
-        }
-        signal(a_pid, "-CONT");
-    }
-
-    // Anti-vacuity input: a durable record must exist before the kill, or
-    // the restore log below would have nothing genuine to restore.
-    let pre_kill_status = fetch_sync_status(&cluster, HUB).await;
-    assert!(
-        pre_kill_status.persisted_pending_dags >= 1,
-        "no durable pending-DAG record existed before the kill (persisted_pending_dags={}) — \
-         the restart would prove nothing about the resync path",
-        pre_kill_status.persisted_pending_dags
-    );
-    eprintln!(
-        "[quarantine e2e] phase 2 pre-kill: pending_dags={}, persisted_pending_dags={}, \
-         quarantined_pending_dags={}",
-        pre_kill_status.pending_dags,
-        pre_kill_status.persisted_pending_dags,
-        pre_kill_status.quarantined_pending_dags
-    );
-
-    // Snapshot B's merged documents right before the kill: everything B held
-    // must survive the restart on its redb rootdir.
+    // Pre-kill snapshot: everything B holds right now must survive the
+    // restart on its redb rootdir. Asserting it contains the known IDs
+    // (rather than trusting an unchecked snapshot) is the fix for the
+    // review finding: `doc_ids_present` used to swallow query errors into
+    // an empty set, which would let the post-restart retention assertion
+    // below pass vacuously against an empty "nothing lost" comparison if
+    // this snapshot silently came back empty. `doc_ids_present` itself now
+    // panics loudly on a query error (see its definition); this assertion
+    // is the second line of defense, failing loudly if the snapshot came
+    // back incomplete for any other reason.
     let pre_kill_docs = doc_ids_present(&node_b);
+    let pre_kill_missing: Vec<&str> = std::iter::once(x_doc_id.as_str())
+        .chain(std::iter::once(y_doc_id.as_str()))
+        .chain(sound_doc_ids.iter().map(String::as_str))
+        .filter(|id| !pre_kill_docs.contains(*id))
+        .collect();
+    assert!(
+        pre_kill_missing.is_empty(),
+        "pre-kill snapshot is missing known documents {pre_kill_missing:?} out of {} total docs \
+         present — doc_ids_present must never silently return an incomplete set",
+        pre_kill_docs.len()
+    );
 
     cluster.nodes[HUB].process.kill();
-    stop_writer.store(true, Ordering::Relaxed);
-
     cluster
         .restart_node(HUB, Duration::from_secs(60))
         .await
         .expect("restart hub on its rootdir");
 
-    signal(a_pid, "-CONT");
-    writer_handle.join().expect("A writer thread panicked");
-    let w_doc_ids = Arc::try_unwrap(w_doc_ids)
-        .expect("writer joined")
-        .into_inner()
-        .unwrap();
-    assert!(
-        !w_doc_ids.is_empty(),
-        "A's writer thread never produced load"
-    );
-
     node_a.p2p_connect(&[&addr_b]).expect("A reconnect to B");
     node_c.p2p_connect(&[&addr_b]).expect("C reconnect to B");
 
-    // Anti-vacuity for the restart itself: the resync path must have
-    // demonstrably run and done real work (mirrors p2p_admission.rs's
-    // "hub never hit capacity" pattern — grep an emitted-only-when-true log
-    // line instead of trusting quiescence).
-    let hub_log = hub_log_path(&cluster);
-    let restore_deadline = Instant::now() + Duration::from_secs(30);
-    loop {
-        let log = std::fs::read_to_string(&hub_log).unwrap_or_default();
-        if log.contains("restored persisted pending DAG registrations") {
-            break;
-        }
-        assert!(
-            Instant::now() < restore_deadline,
-            "resync path demonstrably never ran after hub restart+reconnect: \"restored \
-             persisted pending DAG registrations\" never logged (persisted_pending_dags was {} \
-             before the kill, so there was genuine work for it to restore)",
-            pre_kill_status.persisted_pending_dags
-        );
-        tokio::time::sleep(Duration::from_millis(250)).await;
-    }
-
-    // The quarantine gauge must survive the restart via hydration from
-    // `load_quarantined()`, not just in-memory bookkeeping that a fresh
-    // process would reset to 0.
-    let post_restart_status = fetch_sync_status(&cluster, HUB).await;
-    assert!(
-        post_restart_status.quarantined_pending_dags >= quarantined_before,
-        "quarantined_pending_dags did not survive the restart: was {quarantined_before} before \
-         the kill, {} after restart (must hydrate from load_quarantined at startup)",
-        post_restart_status.quarantined_pending_dags
-    );
-    eprintln!(
-        "[quarantine e2e] phase 2 post-restart: quarantined_pending_dags={} (was \
-         {quarantined_before} pre-kill), pending_dags={}, persisted_pending_dags={}, \
-         fresh-process pending_dag_terminal_quarantined={}",
-        post_restart_status.quarantined_pending_dags,
-        post_restart_status.pending_dags,
-        post_restart_status.persisted_pending_dags,
-        post_restart_status.pending_dag_terminal_quarantined
-    );
-
-    // The quarantined root must NOT be re-registered and re-driven. Because
-    // `pending_dag_terminal_quarantined` is a fresh-process counter (reset to
-    // 0 by the restart, unlike the durable gauge above), any re-registration
-    // of the quarantined root would attempt to re-merge it, re-hit the same
-    // deterministic rejection, and tick this counter off 0 — over a window
-    // spanning several 2s retry-clock ticks.
-    let flat_window_deadline = Instant::now() + Duration::from_secs(10);
-    while Instant::now() < flat_window_deadline {
-        let status = fetch_sync_status(&cluster, HUB).await;
-        assert_eq!(
-            status.pending_dag_terminal_quarantined, 0,
-            "the quarantined twin was re-registered and re-rejected after restart (fresh-process \
-             pending_dag_terminal_quarantined moved off 0) — suppression did not hold across \
-             restart+reconnect"
-        );
-        tokio::time::sleep(Duration::from_millis(500)).await;
-    }
-
-    // The restored registrations must actually RESOLVE, not just restore:
-    // both pending gauges drain to 0 once B re-fetches the frozen roots'
-    // missing blocks from the reconnected A. Combined with the fresh-process
-    // quarantine counter staying 0 (checked above and re-checked below), a
-    // drained durable gauge proves every restored root exited through a
-    // successful merge — the only other counted exit is quarantine.
-    //
-    // Note deliberately NOT asserted: that every document A's writer created
-    // lands on B. A's docs travel by gossip, which is best-effort — an
-    // announcement published while B was dead (or before A re-established
-    // the connection) carries no re-delivery obligation. The durable
-    // recovery contract covers exactly the roots B had *registered*, and
-    // that is what the gauge drain verifies. (C's docs below are different:
-    // its replicator has a persistent retry ladder, so full convergence IS
-    // its contract.) This poll runs before C's post-restart pushes so fresh
-    // registrations from C cannot hold the gauges up.
-    let drain_recovery_deadline = Instant::now() + Duration::from_secs(45);
-    loop {
-        let status = fetch_sync_status(&cluster, HUB).await;
-        if status.pending_dags == 0 && status.persisted_pending_dags == 0 {
-            break;
-        }
-        assert!(
-            Instant::now() < drain_recovery_deadline,
-            "restored pending-DAG registrations never resolved after restart+reconnect \
-             (pending_dags={}, persisted_pending_dags={}; {} durable records existed pre-kill)",
-            status.pending_dags,
-            status.persisted_pending_dags,
-            pre_kill_status.persisted_pending_dags
-        );
-        tokio::time::sleep(Duration::from_millis(200)).await;
-    }
-
-    // Post-restart sound traffic from C (replicator path, persistent retry
-    // ladder) still converges on the restarted hub.
-    let post_restart_c_1 = node_c
-        .query(r#"mutation { add_Session(input: {session_id: "post-restart-c-1", note: "c-sound"}) { _docID } }"#)
-        .expect("create post-restart doc on C");
-    let post_restart_c_1_id = extract_doc_id(&post_restart_c_1, "add_Session");
-    let post_restart_c_2 = node_c
-        .query(r#"mutation { add_Session(input: {session_id: "post-restart-c-2", note: "c-sound"}) { _docID } }"#)
-        .expect("create post-restart doc on C");
-    let post_restart_c_2_id = extract_doc_id(&post_restart_c_2, "add_Session");
-
     let node_b_after = cluster.client(HUB);
+
+    // Composed state survives the restart: both twins still present, and
+    // the indexed lookup still resolves to the same winner (docIDs are
+    // immutable, so recomputing the pick from a fresh index on restart is
+    // identical to before the kill).
     poll_until(
         || {
             let present = doc_ids_present(&node_b_after);
-            present.contains(&post_restart_c_1_id) && present.contains(&post_restart_c_2_id)
+            let indexed = indexed_session_lookup(&node_b_after, CONFLICT_VALUE);
+            present.contains(&x_doc_id)
+                && present.contains(&y_doc_id)
+                && indexed == [winner_doc_id.clone()]
         },
-        Duration::from_secs(30),
+        Duration::from_secs(45),
         Duration::from_millis(200),
-        "post-restart sound traffic from C did not converge on B after reconnect",
+        "composed state (both twins present + indexed winner) did not survive hub restart+reconnect",
     )
     .await;
 
-    // Final state: everything B held pre-kill survived the restart, the
-    // quarantined twin stays gone (durable, not just in-memory), and the
-    // recovery drain above did not exit through a fresh quarantine.
+    // The silent guard survives the restart too: the durable gauge
+    // hydrates from `load_quarantined()` at startup (0 in, 0 out — nothing
+    // was ever quarantined), and the fresh process's occurrence counter
+    // starts at 0 and must stay there.
+    let post_restart_status = fetch_sync_status(&cluster, HUB).await;
+    assert_eq!(
+        post_restart_status.pending_dag_terminal_quarantined, 0,
+        "quarantine guard misfired after restart: fresh-process pending_dag_terminal_quarantined \
+         moved off 0 for a conflict that should stay resolved via canonical pick"
+    );
+    assert_eq!(
+        post_restart_status.quarantined_pending_dags, 0,
+        "quarantine guard misfired after restart: {} root(s) quarantined",
+        post_restart_status.quarantined_pending_dags
+    );
+
+    // Post-restart sound traffic from both A (gossip) and C (replicator)
+    // still converges on the restarted hub. Unlike traffic racing the
+    // kill/freeze window, these are ordinary live-network writes issued
+    // after reconnection completes, so best-effort gossip delivery is not
+    // a concern here.
+    let post_restart_a = node_a
+        .query(r#"mutation { add_Session(input: {session_id: "post-restart-a", note: "a-sound"}) { _docID } }"#)
+        .expect("create post-restart doc on A");
+    let post_restart_a_id = extract_doc_id(&post_restart_a, "add_Session");
+    let post_restart_c = node_c
+        .query(r#"mutation { add_Session(input: {session_id: "post-restart-c", note: "c-sound"}) { _docID } }"#)
+        .expect("create post-restart doc on C");
+    let post_restart_c_id = extract_doc_id(&post_restart_c, "add_Session");
+
+    poll_until(
+        || {
+            let present = doc_ids_present(&node_b_after);
+            present.contains(&post_restart_a_id) && present.contains(&post_restart_c_id)
+        },
+        Duration::from_secs(30),
+        Duration::from_millis(200),
+        "post-restart sound traffic from A and C did not converge on B after reconnect",
+    )
+    .await;
+
+    // Final retention: everything B held pre-kill survived the restart.
     let present_final = doc_ids_present(&node_b_after);
     let lost: Vec<&String> = pre_kill_docs
         .iter()
@@ -556,32 +497,19 @@ async fn quarantine_survives_fan_in_and_hub_restart() {
         .collect();
     assert!(
         lost.is_empty(),
-        "{} of {} documents merged before the kill are missing after restart: {:?}",
+        "{} of {} documents present before the kill are missing after restart: {:?}",
         lost.len(),
         pre_kill_docs.len(),
         lost
     );
-    assert!(
-        !present_final.contains(&y_doc_id),
-        "quarantined twin Y reappeared on B after restart — quarantine must be durable"
-    );
+
     let final_status = fetch_sync_status(&cluster, HUB).await;
-    assert_eq!(
-        final_status.pending_dag_terminal_quarantined, 0,
-        "recovery drained through a fresh quarantine, not through merges"
-    );
-    assert!(
-        final_status.quarantined_pending_dags >= quarantined_before,
-        "durable quarantine gauge decayed by the end of the run: {} < {quarantined_before}",
-        final_status.quarantined_pending_dags
-    );
+    assert_eq!(final_status.pending_dag_terminal_quarantined, 0);
+    assert_eq!(final_status.quarantined_pending_dags, 0);
     eprintln!(
-        "[quarantine e2e] final: quarantined_pending_dags={}, fresh-process \
-         pending_dag_terminal_quarantined={}, pending_dags={}, docs on B={} \
-         ({} pre-kill docs all retained, twin absent)",
-        final_status.quarantined_pending_dags,
-        final_status.pending_dag_terminal_quarantined,
-        final_status.pending_dags,
+        "[compose fence] final: winner={winner_doc_id}, docs on B={} ({} pre-kill docs all \
+         retained, both twins present), quarantine guard silent throughout \
+         (pending_dag_terminal_quarantined=0, quarantined_pending_dags=0)",
         present_final.len(),
         pre_kill_docs.len()
     );

--- a/tools/integration-test/tests/p2p/quarantine.rs
+++ b/tools/integration-test/tests/p2p/quarantine.rs
@@ -1,0 +1,588 @@
+//! #1128 end-to-end fence: terminal-failure quarantine under fleet-mirroring
+//! conditions.
+//!
+//! Mirrors the shape of the 2026-07-14 fleet incident (hub "Amy" held 6 stuck
+//! heads: docs whose unique `session_id` index rejected an incoming twin,
+//! re-driven by the 60s resync sweep forever) rather than a minimal repro:
+//! a 3-node fan-in (hub B, spokes A and C) with a UNIQUE index, a genuine
+//! content collision under concurrent *sound* traffic, and a hub restart that
+//! exercises the same resync path the incident's 60s sweep used, on a fast
+//! reconnect-triggered timescale instead of waiting out the real interval.
+//!
+//! Phase 1 (conflict under concurrent sound traffic): B locally owns a
+//! `session_id` value under its own unique index. Spoke A pushes a twin
+//! document with the identical value over gossip (so the rejection runs
+//! through the real pending-DAG -> DagReady -> merge path, not a bundled
+//! push that might never touch the live queue) while spoke C concurrently
+//! fans in several unrelated, sound documents via a replicator. Asserts the
+//! twin is quarantined (counted + durably recorded), sound traffic is
+//! unharmed by the poisoned neighbor, and the live `pending_dags` queue
+//! drains to 0 while the quarantine gauge does not — the load-bearing
+//! contrast with the pre-fix behavior, where the rejected root would stay
+//! stuck in the live retry queue forever.
+//!
+//! Phase 2 (durability across restart): continuous unrelated writes from A
+//! travel the same missing-link path until B holds a live registration, then
+//! A is frozen mid-fetch (SIGSTOP) so a genuine durable pending-DAG record
+//! exists when B is hard-killed and respawned on its own rootdir. On
+//! reconnect, `handle_peer_connected` triggers
+//! `resync_persisted_pending_dags`, which must (a) restore the genuine
+//! frozen registrations and drive them to a real merge (anti-vacuity: the
+//! restore log fires AND both pending gauges drain to 0) while (b) NOT
+//! re-registering the quarantined root — proven by the fresh process's
+//! `pending_dag_terminal_quarantined` counter staying at 0 across a bounded
+//! window and through the recovery drain, since any re-registration would
+//! re-attempt the merge and re-hit the same deterministic rejection.
+//!
+//! Run with `DEFRA_E2E_KEEP=1` to retain node directories (including
+//! `logs/stdout.log` per node under `target/e2e/`) for post-mortem when a run
+//! fails — the harness normally cleans them up on success.
+
+use std::collections::HashSet;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use integration_test::{extract_doc_id, extract_p2p_addr, poll_until, TestCluster};
+use serde_json::Value;
+
+const SCHEMA: &str = "type Session { session_id: String  note: String }";
+const HUB: usize = 0;
+const SPOKE_A: usize = 1;
+const SPOKE_C: usize = 2;
+const CONFLICT_VALUE: &str = "conflict-v1";
+const SOUND_DOC_COUNT: usize = 5;
+
+fn signal(pid: u32, signal: &str) {
+    let status = std::process::Command::new("kill")
+        .arg(signal)
+        .arg(pid.to_string())
+        .status()
+        .expect("spawn kill");
+    assert!(status.success(), "kill {signal} {pid} failed");
+}
+
+/// The quarantine-relevant subset of `/api/v0/p2p/sync/status` (#1128).
+struct SyncStatusSnapshot {
+    pending_dags: usize,
+    persisted_pending_dags: usize,
+    pending_dag_terminal_quarantined: u64,
+    quarantined_pending_dags: usize,
+}
+
+async fn fetch_sync_status(cluster: &TestCluster, node: usize) -> SyncStatusSnapshot {
+    let status: Value = reqwest::get(format!("{}/api/v0/p2p/sync/status", cluster.api_url(node)))
+        .await
+        .expect("sync status request")
+        .json()
+        .await
+        .expect("sync status json");
+
+    SyncStatusSnapshot {
+        pending_dags: status["pending_dags"]
+            .as_u64()
+            .expect("pending_dags field present") as usize,
+        persisted_pending_dags: status["persisted_pending_dags"]
+            .as_u64()
+            .expect("persisted_pending_dags field present")
+            as usize,
+        pending_dag_terminal_quarantined: status["pending_dag_terminal_quarantined"]
+            .as_u64()
+            .expect("pending_dag_terminal_quarantined field present"),
+        quarantined_pending_dags: status["quarantined_pending_dags"]
+            .as_u64()
+            .expect("quarantined_pending_dags field present")
+            as usize,
+    }
+}
+
+fn doc_ids_present(client: &integration_test::DefraClient) -> HashSet<String> {
+    let result = client
+        .query("query { Session { _docID } }")
+        .unwrap_or_default();
+    result["Session"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v["_docID"].as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn hub_log_path(cluster: &TestCluster) -> std::path::PathBuf {
+    cluster.nodes[HUB]
+        .rootdir
+        .parent()
+        .expect("hub rootdir has a parent")
+        .join("logs/stdout.log")
+}
+
+/// 3-node fan-in (hub B, spokes A and C), a real unique-index collision under
+/// concurrent sound traffic, then a hub restart that must not re-drive the
+/// quarantined twin while still recovering a genuinely in-flight registration.
+#[tokio::test]
+async fn quarantine_survives_fan_in_and_hub_restart() {
+    let mut cluster = TestCluster::builder()
+        .rust_nodes(3)
+        .with_node_store(HUB, "redb")
+        .with_keyring()
+        .with_p2p()
+        .build()
+        .await
+        .expect("cluster start");
+
+    let startup_timeout = Duration::from_secs(30);
+    for node in [HUB, SPOKE_A, SPOKE_C] {
+        cluster
+            .wait_for_log(node, "p2p_listening", startup_timeout)
+            .await
+            .unwrap_or_else(|e| panic!("node{node} P2P listener did not start: {e}"));
+    }
+
+    let node_b = cluster.client(HUB);
+    let node_a = cluster.client(SPOKE_A);
+    let node_c = cluster.client(SPOKE_C);
+
+    node_b.schema_add(SCHEMA).expect("schema add B");
+    node_a.schema_add(SCHEMA).expect("schema add A");
+    node_c.schema_add(SCHEMA).expect("schema add C");
+
+    let addr_b = extract_p2p_addr(&cluster, HUB);
+    node_a.p2p_connect(&[&addr_b]).expect("A connects to B");
+    node_c.p2p_connect(&[&addr_b]).expect("C connects to B");
+
+    // Subscribe every node to the collection topic: A's twin push (and,
+    // later, its frozen post-restart document) deliberately travels the
+    // gossip head-announcement path rather than a bundled replicator push, so
+    // the receiver must register a pending-DAG entry and Bitswap-fetch the
+    // missing field block — the same mechanism the real incident's stuck
+    // heads went through, and the only way `pending_dags` genuinely carries
+    // the rejected root before quarantine removes it.
+    node_b
+        .p2p_collection_add(&["Session"])
+        .expect("B subscribe");
+    node_a
+        .p2p_collection_add(&["Session"])
+        .expect("A subscribe");
+    node_c
+        .p2p_collection_add(&["Session"])
+        .expect("C subscribe");
+
+    // C fans in via an explicit replicator: deterministic, fast convergence
+    // for the "sound traffic unharmed by the poison neighbor" assertion,
+    // independent of the gossip mechanism forcing A's twin through the
+    // pending-DAG path.
+    node_c
+        .p2p_replicator_set(&["Session"], &addr_b)
+        .expect("replicator C -> B");
+
+    // --- Phase 1: conflict under concurrent sound traffic ---
+
+    // B's unique index is created before any data lands, then B writes its
+    // own local doc under the value it owns — the "pre-fix-era twin" setup:
+    // a hub that already holds v under an active unique index.
+    node_b
+        .index_create(
+            "Session",
+            &["session_id"],
+            Some("idx_session_id_unique"),
+            true,
+        )
+        .expect("create unique index on B");
+    let x_create = node_b
+        .query(&format!(
+            r#"mutation {{ add_Session(input: {{session_id: "{CONFLICT_VALUE}", note: "hub-owned"}}) {{ _docID }} }}"#
+        ))
+        .expect("create X on B");
+    let x_doc_id = extract_doc_id(&x_create, "add_Session");
+
+    // A pushes a twin with the identical value; concurrently C fans in
+    // several sound documents with distinct values. Real race, not a
+    // sequenced repro: both threads fire at the same time.
+    let (y_doc_id, sound_doc_ids) = std::thread::scope(|scope| {
+        let y_handle = scope.spawn(|| {
+            let create = node_a
+                .query(&format!(
+                    r#"mutation {{ add_Session(input: {{session_id: "{CONFLICT_VALUE}", note: "spoke-twin"}}) {{ _docID }} }}"#
+                ))
+                .expect("create Y on A");
+            extract_doc_id(&create, "add_Session")
+        });
+        let c_handle = scope.spawn(|| {
+            (0..SOUND_DOC_COUNT)
+                .map(|i| {
+                    let create = node_c
+                        .query(&format!(
+                            r#"mutation {{ add_Session(input: {{session_id: "sound-{i}", note: "c-sound"}}) {{ _docID }} }}"#
+                        ))
+                        .expect("create sound doc on C");
+                    extract_doc_id(&create, "add_Session")
+                })
+                .collect::<Vec<String>>()
+        });
+        (
+            y_handle.join().expect("A thread panicked"),
+            c_handle.join().expect("C thread panicked"),
+        )
+    });
+    assert_eq!(
+        sound_doc_ids.len(),
+        SOUND_DOC_COUNT,
+        "C never produced its sound-doc load"
+    );
+
+    // Anti-vacuity: the scenario must have produced a deterministic merge
+    // rejection, not just eventual quiescence.
+    let quarantine_deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let status = fetch_sync_status(&cluster, HUB).await;
+        if status.pending_dag_terminal_quarantined >= 1 && status.quarantined_pending_dags >= 1 {
+            eprintln!(
+                "[quarantine e2e] phase 1: twin rejected+quarantined \
+                 (pending_dag_terminal_quarantined={}, quarantined_pending_dags={}, \
+                 pending_dags={})",
+                status.pending_dag_terminal_quarantined,
+                status.quarantined_pending_dags,
+                status.pending_dags
+            );
+            break;
+        }
+        assert!(
+            Instant::now() < quarantine_deadline,
+            "the scenario did not produce a deterministic merge rejection: B never quarantined \
+             the twin session_id={CONFLICT_VALUE} push (pending_dag_terminal_quarantined={}, \
+             quarantined_pending_dags={})",
+            status.pending_dag_terminal_quarantined,
+            status.quarantined_pending_dags
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    // The load-bearing realism: sound traffic is unharmed by the poisoned
+    // neighbor. All of C's docs converge on B while the rejection is (or was
+    // just) being handled.
+    poll_until(
+        || {
+            let present = doc_ids_present(&node_b);
+            sound_doc_ids.iter().all(|id| present.contains(id))
+        },
+        Duration::from_secs(30),
+        Duration::from_millis(200),
+        "C's sound docs did not all converge on B while the twin rejection was in flight",
+    )
+    .await;
+
+    // The quarantined root must leave the live retry queue permanently — the
+    // exact contrast with the pre-fix incident, where it would stay stuck in
+    // `pending_dags`, re-driven by the periodic sweep forever.
+    let drain_deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let status = fetch_sync_status(&cluster, HUB).await;
+        if status.pending_dags == 0 {
+            assert!(
+                status.quarantined_pending_dags >= 1,
+                "pending_dags drained to 0 but quarantined_pending_dags also dropped to {} \
+                 (the quarantine gauge must persist once a root is quarantined)",
+                status.quarantined_pending_dags
+            );
+            break;
+        }
+        assert!(
+            Instant::now() < drain_deadline,
+            "B's live pending_dags gauge never drained to 0 ({} still pending) — a quarantined \
+             root must leave the live retry queue instead of being re-driven",
+            status.pending_dags
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    // Data-level confirmation: the rejected twin never lands, and the hub's
+    // own value survives the conflicting spoke push unchanged.
+    let rows = node_b
+        .query("query { Session { _docID session_id note } }")
+        .expect("query B Session")["Session"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        !rows
+            .iter()
+            .any(|r| r["_docID"].as_str() == Some(y_doc_id.as_str())),
+        "rejected twin doc Y ({y_doc_id}) must never merge onto B's Session collection"
+    );
+    let x_row = rows
+        .iter()
+        .find(|r| r["_docID"].as_str() == Some(x_doc_id.as_str()))
+        .expect("hub's own doc X missing from its own collection");
+    assert_eq!(
+        x_row["note"].as_str(),
+        Some("hub-owned"),
+        "hub's locally-owned value must survive the conflicting spoke push unchanged"
+    );
+
+    // --- Phase 2: durability across restart ---
+
+    let quarantined_before = fetch_sync_status(&cluster, HUB)
+        .await
+        .quarantined_pending_dags;
+    assert!(
+        quarantined_before >= 1,
+        "phase 1 must leave a quarantined root behind"
+    );
+
+    // Force a genuine, still-open pending-DAG registration to exist at kill
+    // time. A single fresh document races the freeze — Bitswap can resolve
+    // the missing field block before the SIGSTOP even lands, as observed
+    // empirically (single-shot attempts never landed). Instead, drive
+    // continuous head-only load from A over the same missing-link gossip
+    // mechanism proven above for Y, so at least one registration is reliably
+    // mid-flight whenever the poll samples it (mirrors
+    // p2p_admission_restart.rs's continuous-writer-then-freeze technique,
+    // adapted from replicator pushes to gossip-forced ones).
+    let a_pid = cluster.nodes[SPOKE_A].process.id().expect("A pid");
+    let node_a = cluster.client(SPOKE_A);
+    let stop_writer = Arc::new(AtomicBool::new(false));
+    let w_doc_ids = Arc::new(Mutex::new(Vec::<String>::new()));
+    let writer_handle = {
+        let client = cluster.client(SPOKE_A);
+        let stop = Arc::clone(&stop_writer);
+        let doc_ids = Arc::clone(&w_doc_ids);
+        std::thread::spawn(move || {
+            let mut n = 0usize;
+            while !stop.load(Ordering::Relaxed) {
+                n += 1;
+                let mutation = format!(
+                    r#"mutation {{ add_Session(input: {{session_id: "post-restart-w-{n}", note: "v0"}}) {{ _docID }} }}"#
+                );
+                if let Ok(create) = client.query(&mutation) {
+                    doc_ids
+                        .lock()
+                        .unwrap()
+                        .push(extract_doc_id(&create, "add_Session"));
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+        })
+    };
+
+    let freeze_deadline = Instant::now() + Duration::from_secs(60);
+    loop {
+        assert!(
+            Instant::now() < freeze_deadline,
+            "hub never showed a live pending-DAG registration under continuous gossip-forced \
+             load from A; without one, restarting B would prove nothing about restoring real \
+             (not synthetic) durable state"
+        );
+        if fetch_sync_status(&cluster, HUB).await.pending_dags == 0 {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            continue;
+        }
+        signal(a_pid, "-STOP");
+        // Let any in-flight fetch settle: whatever can still resolve,
+        // resolves now (mirrors p2p_admission_restart.rs's freeze window).
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        if fetch_sync_status(&cluster, HUB).await.pending_dags >= 1 {
+            break;
+        }
+        signal(a_pid, "-CONT");
+    }
+
+    // Anti-vacuity input: a durable record must exist before the kill, or
+    // the restore log below would have nothing genuine to restore.
+    let pre_kill_status = fetch_sync_status(&cluster, HUB).await;
+    assert!(
+        pre_kill_status.persisted_pending_dags >= 1,
+        "no durable pending-DAG record existed before the kill (persisted_pending_dags={}) — \
+         the restart would prove nothing about the resync path",
+        pre_kill_status.persisted_pending_dags
+    );
+    eprintln!(
+        "[quarantine e2e] phase 2 pre-kill: pending_dags={}, persisted_pending_dags={}, \
+         quarantined_pending_dags={}",
+        pre_kill_status.pending_dags,
+        pre_kill_status.persisted_pending_dags,
+        pre_kill_status.quarantined_pending_dags
+    );
+
+    // Snapshot B's merged documents right before the kill: everything B held
+    // must survive the restart on its redb rootdir.
+    let pre_kill_docs = doc_ids_present(&node_b);
+
+    cluster.nodes[HUB].process.kill();
+    stop_writer.store(true, Ordering::Relaxed);
+
+    cluster
+        .restart_node(HUB, Duration::from_secs(60))
+        .await
+        .expect("restart hub on its rootdir");
+
+    signal(a_pid, "-CONT");
+    writer_handle.join().expect("A writer thread panicked");
+    let w_doc_ids = Arc::try_unwrap(w_doc_ids)
+        .expect("writer joined")
+        .into_inner()
+        .unwrap();
+    assert!(
+        !w_doc_ids.is_empty(),
+        "A's writer thread never produced load"
+    );
+
+    node_a.p2p_connect(&[&addr_b]).expect("A reconnect to B");
+    node_c.p2p_connect(&[&addr_b]).expect("C reconnect to B");
+
+    // Anti-vacuity for the restart itself: the resync path must have
+    // demonstrably run and done real work (mirrors p2p_admission.rs's
+    // "hub never hit capacity" pattern — grep an emitted-only-when-true log
+    // line instead of trusting quiescence).
+    let hub_log = hub_log_path(&cluster);
+    let restore_deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let log = std::fs::read_to_string(&hub_log).unwrap_or_default();
+        if log.contains("restored persisted pending DAG registrations") {
+            break;
+        }
+        assert!(
+            Instant::now() < restore_deadline,
+            "resync path demonstrably never ran after hub restart+reconnect: \"restored \
+             persisted pending DAG registrations\" never logged (persisted_pending_dags was {} \
+             before the kill, so there was genuine work for it to restore)",
+            pre_kill_status.persisted_pending_dags
+        );
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+
+    // The quarantine gauge must survive the restart via hydration from
+    // `load_quarantined()`, not just in-memory bookkeeping that a fresh
+    // process would reset to 0.
+    let post_restart_status = fetch_sync_status(&cluster, HUB).await;
+    assert!(
+        post_restart_status.quarantined_pending_dags >= quarantined_before,
+        "quarantined_pending_dags did not survive the restart: was {quarantined_before} before \
+         the kill, {} after restart (must hydrate from load_quarantined at startup)",
+        post_restart_status.quarantined_pending_dags
+    );
+    eprintln!(
+        "[quarantine e2e] phase 2 post-restart: quarantined_pending_dags={} (was \
+         {quarantined_before} pre-kill), pending_dags={}, persisted_pending_dags={}, \
+         fresh-process pending_dag_terminal_quarantined={}",
+        post_restart_status.quarantined_pending_dags,
+        post_restart_status.pending_dags,
+        post_restart_status.persisted_pending_dags,
+        post_restart_status.pending_dag_terminal_quarantined
+    );
+
+    // The quarantined root must NOT be re-registered and re-driven. Because
+    // `pending_dag_terminal_quarantined` is a fresh-process counter (reset to
+    // 0 by the restart, unlike the durable gauge above), any re-registration
+    // of the quarantined root would attempt to re-merge it, re-hit the same
+    // deterministic rejection, and tick this counter off 0 — over a window
+    // spanning several 2s retry-clock ticks.
+    let flat_window_deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < flat_window_deadline {
+        let status = fetch_sync_status(&cluster, HUB).await;
+        assert_eq!(
+            status.pending_dag_terminal_quarantined, 0,
+            "the quarantined twin was re-registered and re-rejected after restart (fresh-process \
+             pending_dag_terminal_quarantined moved off 0) — suppression did not hold across \
+             restart+reconnect"
+        );
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+
+    // The restored registrations must actually RESOLVE, not just restore:
+    // both pending gauges drain to 0 once B re-fetches the frozen roots'
+    // missing blocks from the reconnected A. Combined with the fresh-process
+    // quarantine counter staying 0 (checked above and re-checked below), a
+    // drained durable gauge proves every restored root exited through a
+    // successful merge — the only other counted exit is quarantine.
+    //
+    // Note deliberately NOT asserted: that every document A's writer created
+    // lands on B. A's docs travel by gossip, which is best-effort — an
+    // announcement published while B was dead (or before A re-established
+    // the connection) carries no re-delivery obligation. The durable
+    // recovery contract covers exactly the roots B had *registered*, and
+    // that is what the gauge drain verifies. (C's docs below are different:
+    // its replicator has a persistent retry ladder, so full convergence IS
+    // its contract.) This poll runs before C's post-restart pushes so fresh
+    // registrations from C cannot hold the gauges up.
+    let drain_recovery_deadline = Instant::now() + Duration::from_secs(45);
+    loop {
+        let status = fetch_sync_status(&cluster, HUB).await;
+        if status.pending_dags == 0 && status.persisted_pending_dags == 0 {
+            break;
+        }
+        assert!(
+            Instant::now() < drain_recovery_deadline,
+            "restored pending-DAG registrations never resolved after restart+reconnect \
+             (pending_dags={}, persisted_pending_dags={}; {} durable records existed pre-kill)",
+            status.pending_dags,
+            status.persisted_pending_dags,
+            pre_kill_status.persisted_pending_dags
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    // Post-restart sound traffic from C (replicator path, persistent retry
+    // ladder) still converges on the restarted hub.
+    let post_restart_c_1 = node_c
+        .query(r#"mutation { add_Session(input: {session_id: "post-restart-c-1", note: "c-sound"}) { _docID } }"#)
+        .expect("create post-restart doc on C");
+    let post_restart_c_1_id = extract_doc_id(&post_restart_c_1, "add_Session");
+    let post_restart_c_2 = node_c
+        .query(r#"mutation { add_Session(input: {session_id: "post-restart-c-2", note: "c-sound"}) { _docID } }"#)
+        .expect("create post-restart doc on C");
+    let post_restart_c_2_id = extract_doc_id(&post_restart_c_2, "add_Session");
+
+    let node_b_after = cluster.client(HUB);
+    poll_until(
+        || {
+            let present = doc_ids_present(&node_b_after);
+            present.contains(&post_restart_c_1_id) && present.contains(&post_restart_c_2_id)
+        },
+        Duration::from_secs(30),
+        Duration::from_millis(200),
+        "post-restart sound traffic from C did not converge on B after reconnect",
+    )
+    .await;
+
+    // Final state: everything B held pre-kill survived the restart, the
+    // quarantined twin stays gone (durable, not just in-memory), and the
+    // recovery drain above did not exit through a fresh quarantine.
+    let present_final = doc_ids_present(&node_b_after);
+    let lost: Vec<&String> = pre_kill_docs
+        .iter()
+        .filter(|id| !present_final.contains(id.as_str()))
+        .collect();
+    assert!(
+        lost.is_empty(),
+        "{} of {} documents merged before the kill are missing after restart: {:?}",
+        lost.len(),
+        pre_kill_docs.len(),
+        lost
+    );
+    assert!(
+        !present_final.contains(&y_doc_id),
+        "quarantined twin Y reappeared on B after restart — quarantine must be durable"
+    );
+    let final_status = fetch_sync_status(&cluster, HUB).await;
+    assert_eq!(
+        final_status.pending_dag_terminal_quarantined, 0,
+        "recovery drained through a fresh quarantine, not through merges"
+    );
+    assert!(
+        final_status.quarantined_pending_dags >= quarantined_before,
+        "durable quarantine gauge decayed by the end of the run: {} < {quarantined_before}",
+        final_status.quarantined_pending_dags
+    );
+    eprintln!(
+        "[quarantine e2e] final: quarantined_pending_dags={}, fresh-process \
+         pending_dag_terminal_quarantined={}, pending_dags={}, docs on B={} \
+         ({} pre-kill docs all retained, twin absent)",
+        final_status.quarantined_pending_dags,
+        final_status.pending_dag_terminal_quarantined,
+        final_status.pending_dags,
+        present_final.len(),
+        pre_kill_docs.len()
+    );
+}


### PR DESCRIPTION
## Summary

Terminal-failure quarantine for the pending-DAG ledger (#1128, from the 2026-07-14 fleet rollout: 6 stuck heads on the hub re-driven by the resync sweep every ~60s forever), **composed with #1126's canonical-pick unique-index semantics** which merged mid-flight and removed the common trigger.

- **Classification**: the typed `storage::Error::UniqueConstraintViolation` is preserved through db-merge (`MergeError::UniqueConstraintViolation`) and converted to a new `MergeOutcome::Rejected { reason }` at the same boundary where `ImmutableFieldChanged` becomes `terminal_skip`. Post-#1126 the common twin case converges instead of rejecting; the seam remains as defense-in-depth for #1126's still-live degenerate arms (index-state inconsistency) and any future deterministic rejection. In batch mode a rejection **poisons the shared txn** (force_discard + per-block fallback) — without this, the rejected doc's staged field data would commit (review-caught partial-write leak).
- **Disposition**: `Rejected` → `SyncManager::quarantine_pending_dag`: durable record moved to a distinct `/p2p/quarantined_dag/` keyspace (quarantine written first, live record deleted second — the crash window self-heals via resync), in-memory entry cleared, `pending_dag_terminal_quarantined` counter + `quarantined_pending_dags` gauge (deduped per root) in `/api/v0/p2p/sync/status`, new `PendingDagQuarantined` embedded event-bus kind for fleet alerting. Blocks are deliberately NOT marked merged: local re-drive stops; a remote re-push may retry (sender-paced) and re-quarantines.
- **Suppression**: the resync sweep skips quarantined roots and cleans up live leftovers. Transient failures (missing blocks, peer down) keep retrying exactly as before — never quarantined.
- **TLA model** `PendingDagQuarantine` (green + retry-forever red + overeager-quarantine red, TLC-verified twice independently). Includes a deliberate side-fix to `run-all.sh`'s verdict regex: single-property temporal violations print "was violated", which the old oracle regex missed — `MC_PushBacklog_Red_NoPeerCap` was silently misclassified before this.
- **E2E composition fence** (`p2p/quarantine.rs`): 3-node fan-in, hub-owned unique value vs concurrent spoke twin + sound traffic, SIGKILL restart — asserts #1126's canonical pick converges through the real stack (both docs persist, indexed lookup returns exactly the lexicographically-smallest docID, computed in-test), the quarantine guard stays silent on the healed path, and the composed state survives restart. Anti-vacuity hard-fails throughout. 4 clean runs (4–8s).

## Go reference (divergence, deliberate and documented)

Code-verified against Go v1.0.0 (`3de01484`): **Go wedges on this class.** The unique-index save is a bare existence check inside the same txn as the CRDT merge — on conflict the entire merge rolls back; the replicator path retries the identical deterministic failure forever at a 32-minute cadence, and one wedged doc **head-of-line-blocks every other doc queued to that replicator peer** (`retryReplicator` aborts the batch on first failure); gossip/pull paths log once and silently drop. Zero upstream test coverage for unique+P2P. Both #1126 (converge) and this PR (quarantine what still rejects) are deliberate improvements over Go; upstream report recommended.

## Validation

- Per-task spec+quality reviews on all 8 tasks (review loops caught and fixed: batch-txn partial-write leak, swallowed `Quarantined` variant in cli/embedded callbacks, gauge drift on repeat rejection, an initially-lost restart-hydration assertion) + two whole-branch reviews (final verdict READY TO MERGE)
- `cargo test -p p2p` (434 lib + all binaries), `-p db-merge` (94), integration `--test p2p` rust suite, `p2p_admission`, `p2p_push_storm`, TLC 3/3 configs, clippy `--all -D warnings`, fmt — all green
- Related: #1132 (pre-existing filtered_replication parallel-load flake, filed during this work)

Fixes #1128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Correction (2026-07-15, see #1134):** the Go-reference paragraph above overstates the retry behavior. On current Go `develop` (`68eafac2`), a response-check bug in `message.Send` (checks the request's `GetErrMessage` instead of the response's) makes the sender treat the rejected merge as **success** — it deletes the retry record and reports the replicator active. The actual Go signature is **silent terminal divergence**, not retry-forever/head-of-line blocking (that is what *would* happen if the response error propagated). Characterization test: `jackzampolin/defradb@8b961abe`. Parity probe pinning the cross-implementation divergence: #1134.
