### PR TITLE
fix(storage): prevent successful Redb writes from disappearing

### DIFF
--- a/crates/storage/src/backends/redb/group_commit.rs
+++ b/crates/storage/src/backends/redb/group_commit.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use parking_lot::Mutex;
 use redb::Database;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot, RwLock as AsyncRwLock};
 
 use super::config::DurabilityMode;
 use super::KV_TABLE;
@@ -41,9 +41,16 @@ impl GroupCommitBuffer {
         db: Arc<Database>,
         durability: DurabilityMode,
         conflict_tracker: Arc<ConflictTracker>,
+        commit_gate: Arc<AsyncRwLock<()>>,
     ) -> Self {
         let (tx, rx) = mpsc::unbounded_channel();
-        let flush_handle = tokio::spawn(flush_loop(rx, db, durability, conflict_tracker));
+        let flush_handle = tokio::spawn(flush_loop(
+            rx,
+            db,
+            durability,
+            conflict_tracker,
+            commit_gate,
+        ));
         Self {
             sender: Mutex::new(Some(tx)),
             flush_handle: Mutex::new(Some(flush_handle)),
@@ -85,6 +92,7 @@ async fn flush_loop(
     db: Arc<Database>,
     durability: DurabilityMode,
     conflict_tracker: Arc<ConflictTracker>,
+    commit_gate: Arc<AsyncRwLock<()>>,
 ) {
     loop {
         // Block until at least one commit arrives
@@ -102,39 +110,43 @@ async fn flush_loop(
             }
         }
 
-        // Check conflicts and partition into passing/failing commits.
-        // This is done inside the flush loop so version tracking is atomic
-        // with the actual data write.
-        let mut passed = Vec::with_capacity(batch.len());
-        let mut failed: Vec<(PendingCommit, Error)> = Vec::new();
+        let (passed, failed, result) = {
+            // Keep version publication and the Redb flush indivisible to new snapshots.
+            let _commit_guard = commit_gate.write().await;
+            let mut passed = Vec::with_capacity(batch.len());
+            let mut failed: Vec<(PendingCommit, Error)> = Vec::new();
 
-        for commit in batch {
-            match conflict_tracker.check_and_record(
-                commit.read_version,
-                commit.changes.keys(),
-                &commit.read_set,
-            ) {
-                Ok(()) => passed.push(commit),
-                Err(e) => failed.push((commit, e)),
+            for commit in batch {
+                match conflict_tracker.check_and_record(
+                    commit.read_version,
+                    commit.changes.keys(),
+                    &commit.read_set,
+                ) {
+                    Ok(()) => passed.push(commit),
+                    Err(e) => failed.push((commit, e)),
+                }
             }
-        }
 
-        // Notify failed commits immediately
+            let result = if passed.is_empty() {
+                None
+            } else {
+                Some(flush_batch(&db, &passed, durability))
+            };
+            (passed, failed, result)
+        };
+
         for (commit, err) in failed {
             CallbackManager::execute_callbacks(commit.on_error);
             CallbackManager::execute_async_callbacks(commit.on_error_async).await;
             let _ = commit.result_tx.send(Err(err));
         }
 
-        if passed.is_empty() {
+        let Some(result) = result else {
             continue;
-        }
+        };
 
         let batch_size = passed.len();
         let total_changes: usize = passed.iter().map(|c| c.changes.len()).sum();
-
-        // Flush all non-conflicting commits in one redb write transaction
-        let result = flush_batch(&db, &passed, durability);
 
         if let Err(ref e) = result {
             tracing::error!(

--- a/crates/storage/src/backends/redb/store.rs
+++ b/crates/storage/src/backends/redb/store.rs
@@ -33,6 +33,8 @@ pub struct RedbStore {
     db_path: std::path::PathBuf,
     /// Conflict tracker for write-write conflict detection
     conflict_tracker: Arc<ConflictTracker>,
+    /// Keeps transaction snapshots aligned with committed conflict versions.
+    commit_gate: Arc<tokio::sync::RwLock<()>>,
     /// Durability mode for write transactions
     durability: DurabilityMode,
     /// Group commit buffer for coalescing write transactions
@@ -146,6 +148,7 @@ impl RedbStore {
 
         let db = Arc::new(db);
         let conflict_tracker = Arc::new(ConflictTracker::new());
+        let commit_gate = Arc::new(tokio::sync::RwLock::new(()));
 
         // Create group commit buffer if a tokio runtime is available.
         // This coalesces multiple transaction commits into single redb writes.
@@ -154,6 +157,7 @@ impl RedbStore {
                 Arc::clone(&db),
                 opts.durability(),
                 Arc::clone(&conflict_tracker),
+                Arc::clone(&commit_gate),
             ))
         });
 
@@ -164,6 +168,7 @@ impl RedbStore {
             close_timeout: opts.close_timeout(),
             db_path,
             conflict_tracker,
+            commit_gate,
             durability: opts.durability(),
             group_commit,
         })
@@ -301,11 +306,13 @@ impl Store for RedbStore {
         }
         let mut guard = NewTxnGuard(&self.active_txn_count, false);
 
-        // Record version before taking snapshot for conflict detection
-        let read_version = self.conflict_tracker.current_version();
-
-        // Use redb's MVCC ReadTransaction for snapshot isolation (O(1) creation)
-        let read_txn = self.db.begin_read()?;
+        let (read_version, read_txn) = {
+            // Pair the conflict version and Redb snapshot without a commit between them.
+            let _commit_guard = self.commit_gate.read().await;
+            let read_version = self.conflict_tracker.current_version();
+            let read_txn = self.db.begin_read()?;
+            (read_version, read_txn)
+        };
 
         // Defuse the guard - transaction will manage its own count via its Drop impl
         guard.1 = true;
@@ -314,6 +321,7 @@ impl Store for RedbStore {
             db: Arc::clone(&self.db),
             active_txn_count: Arc::clone(&self.active_txn_count),
             conflict_tracker: Arc::clone(&self.conflict_tracker),
+            commit_gate: Arc::clone(&self.commit_gate),
             read_version,
             read_txn,
             pending: Mutex::new(BTreeMap::new()),

--- a/crates/storage/src/backends/redb/tests/stress.rs
+++ b/crates/storage/src/backends/redb/tests/stress.rs
@@ -122,6 +122,45 @@ async fn test_redb_high_contention_100_concurrent_txns() {
     );
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_redb_concurrent_read_modify_write_preserves_every_commit() {
+    let temp_dir = TempDir::new().unwrap();
+    let store = std::sync::Arc::new(RedbStore::open(temp_dir.path().join("test.redb")).unwrap());
+
+    let mut txn = store.new_txn(false).await.unwrap();
+    txn.set(b"counter", &0u64.to_be_bytes()).await.unwrap();
+    txn.commit().await.unwrap();
+
+    let mut handles = Vec::new();
+    for _ in 0..20 {
+        let store = store.clone();
+        handles.push(tokio::spawn(async move {
+            loop {
+                let mut txn = store.new_txn(false).await.unwrap();
+                let value = txn.get(b"counter").await.unwrap().unwrap();
+                let current = u64::from_be_bytes(value.try_into().unwrap());
+                txn.set(b"counter", &(current + 1).to_be_bytes())
+                    .await
+                    .unwrap();
+
+                match txn.commit().await {
+                    Ok(()) => return,
+                    Err(crate::corekv::Error::TxnConflict) => continue,
+                    Err(error) => panic!("unexpected error: {error}"),
+                }
+            }
+        }));
+    }
+
+    for handle in handles {
+        handle.await.unwrap();
+    }
+
+    let txn = store.new_txn(true).await.unwrap();
+    let value = txn.get(b"counter").await.unwrap().unwrap();
+    assert_eq!(u64::from_be_bytes(value.try_into().unwrap()), 20);
+}
+
 #[tokio::test]
 async fn test_redb_close_during_concurrent_transaction_creation() {
     use std::sync::atomic::{AtomicUsize, Ordering};

--- a/crates/storage/src/backends/redb/tests/stress.rs
+++ b/crates/storage/src/backends/redb/tests/stress.rs
@@ -131,14 +131,22 @@ async fn test_redb_concurrent_read_modify_write_preserves_every_commit() {
     txn.set(b"counter", &0u64.to_be_bytes()).await.unwrap();
     txn.commit().await.unwrap();
 
-    let mut handles = Vec::new();
-    for _ in 0..20 {
+    let writer_count = 20;
+    let first_snapshot_barrier = std::sync::Arc::new(tokio::sync::Barrier::new(writer_count));
+    let mut handles = Vec::with_capacity(writer_count);
+    for _ in 0..writer_count {
         let store = store.clone();
+        let first_snapshot_barrier = std::sync::Arc::clone(&first_snapshot_barrier);
         handles.push(tokio::spawn(async move {
+            let mut first_attempt = true;
             loop {
                 let mut txn = store.new_txn(false).await.unwrap();
                 let value = txn.get(b"counter").await.unwrap().unwrap();
                 let current = u64::from_be_bytes(value.try_into().unwrap());
+                if first_attempt {
+                    first_snapshot_barrier.wait().await;
+                    first_attempt = false;
+                }
                 txn.set(b"counter", &(current + 1).to_be_bytes())
                     .await
                     .unwrap();
@@ -158,7 +166,10 @@ async fn test_redb_concurrent_read_modify_write_preserves_every_commit() {
 
     let txn = store.new_txn(true).await.unwrap();
     let value = txn.get(b"counter").await.unwrap().unwrap();
-    assert_eq!(u64::from_be_bytes(value.try_into().unwrap()), 20);
+    assert_eq!(
+        u64::from_be_bytes(value.try_into().unwrap()),
+        writer_count as u64
+    );
 }
 
 #[tokio::test]

--- a/crates/storage/src/backends/redb/transaction.rs
+++ b/crates/storage/src/backends/redb/transaction.rs
@@ -38,6 +38,9 @@ pub(crate) struct RedbTxn {
     /// Conflict tracker for write-write conflict detection
     pub(crate) conflict_tracker: Arc<ConflictTracker>,
 
+    /// Keeps transaction snapshots aligned with committed conflict versions.
+    pub(crate) commit_gate: Arc<tokio::sync::RwLock<()>>,
+
     /// Version at which this transaction's snapshot was taken
     pub(crate) read_version: u64,
 
@@ -351,24 +354,20 @@ impl Txn for RedbTxn {
                     .map_err(|_| Error::Other("group commit result channel dropped".into()))?;
             }
 
-            // Direct commit path: check conflicts eagerly
-            if let Err(e) =
-                self.conflict_tracker
-                    .check_and_record(self.read_version, pending.keys(), &read_set)
-            {
-                CallbackManager::execute_callbacks(self.callbacks.take_error());
-                CallbackManager::execute_async_callbacks(self.callbacks.take_error_async()).await;
-                return Err(e);
-            }
-
             // Move blocking redb operations to a blocking thread so we don't
             // starve tokio worker threads while waiting for the exclusive write lock.
             let db = self.db.clone();
+            let conflict_tracker = self.conflict_tracker.clone();
+            let commit_gate = self.commit_gate.clone();
+            let read_version = self.read_version;
             let durability = self.durability;
             let error_callbacks = self.callbacks.take_error();
             let error_async_callbacks = self.callbacks.take_error_async();
 
             let write_result = tokio::task::spawn_blocking(move || -> Result<()> {
+                let _commit_guard = commit_gate.blocking_write();
+                conflict_tracker.check_and_record(read_version, pending.keys(), &read_set)?;
+
                 let mut write_txn = db.begin_write().map_err(|e| {
                     tracing::error!(error = %e, pending_changes = pending.len(),
                         "Failed to begin write transaction during commit");


### PR DESCRIPTION
Fixes #1138. Unblocks the next `defra-agent` release from pinning current DefraDB `main`.

## Root cause

The Redb conflict tracker published an accepted transaction version before the corresponding Redb write was physically committed. In the group-commit path, a conflicting transaction could be notified and retry while the winning batch was still being flushed.

That retry could pair two different points in time:

- a conflict read-version that already included the winner;
- a Redb snapshot that did not yet contain the winner.

Because the winner was no longer newer than the retry read-version, the conflict tracker accepted the stale retry. During concurrent document creates, that retry could read the old `/seq/doc` value, reuse the same short ID, and replace mappings written by a create that had already returned success.

## What changed

- Added a shared async read/write gate between Redb snapshot creation and commit publication.
- New transactions take a shared guard only while pairing the conflict version with the Redb snapshot, so unrelated snapshots can still be opened concurrently.
- Group and direct commits take the exclusive guard across both conflict-version publication and the physical Redb commit.
- Conflicting group commits are notified only after the winning batch is visible, so immediate retries cannot observe a stale snapshot.
- Added a deterministic 20-writer read/modify/write regression. On the old code every writer returned success but only 10 increments remained; the fixed path retains all 20.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test -p storage --features redb` (412 passed, 1 ignored; all storage integration tests passed)
- [x] `cargo test --workspace --exclude integration-test --quiet`