### PR TITLE
feat(acp): add bulk relationship endpoints (#1032)

### DIFF
--- a/crates/http/src/handlers/acp.rs
+++ b/crates/http/src/handlers/acp.rs
@@ -142,6 +142,46 @@ pub struct DocRelationshipResponse {
     pub existed_already: bool,
 }
 
+fn validate_add_doc_relationship(body: &DocRelationshipRequest) -> Result<(), HttpError> {
+    if body.collection.is_empty() {
+        return Err(HttpError::BadRequest(
+            "collection name can't be empty".into(),
+        ));
+    }
+    if body.target_actor.is_empty() || body.doc_id.is_empty() || body.relation.is_empty() {
+        return Err(HttpError::BadRequest(
+            "missing a required argument needed to add doc actor relationship.".into(),
+        ));
+    }
+    if body.relation == "owner" {
+        return Err(HttpError::BadRequest(
+            "OPERATION_FORBIDDEN: cannot add owner relation".into(),
+        ));
+    }
+    Ok(())
+}
+
+async fn apply_add_doc_relationship(
+    doc_acp: &dyn crate::router::DocumentAcpOperations,
+    requestor: &identity::Did,
+    body: &DocRelationshipRequest,
+) -> Result<DocRelationshipResponse, HttpError> {
+    let is_new = doc_acp
+        .add_doc_relationship(
+            requestor,
+            &body.target_actor,
+            &body.collection,
+            &body.doc_id,
+            &body.relation,
+        )
+        .await
+        .map_err(http_error_from_backend_message)?;
+
+    Ok(DocRelationshipResponse {
+        existed_already: !is_new,
+    })
+}
+
 /// Request body for document ACP decision preview operations.
 #[derive(Debug, Clone, Deserialize)]
 pub struct DocDecisionRequest {
@@ -233,39 +273,41 @@ pub async fn add_doc_relationship(
         .did()
         .ok_or_else(|| HttpError::BadRequest("identity required for document ACP".into()))?;
 
-    if body.collection.is_empty() {
-        return Err(HttpError::BadRequest(
-            "collection name can't be empty".into(),
-        ));
-    }
-    if body.target_actor.is_empty() || body.doc_id.is_empty() || body.relation.is_empty() {
-        return Err(HttpError::BadRequest(
-            "missing a required argument needed to add doc actor relationship.".into(),
-        ));
-    }
+    validate_add_doc_relationship(&body)?;
+    let doc_acp = state.require_doc_acp()?;
+    Ok(Json(
+        apply_add_doc_relationship(doc_acp.as_ref(), requestor, &body).await?,
+    ))
+}
 
-    if body.relation == "owner" {
-        return Err(HttpError::BadRequest(
-            "OPERATION_FORBIDDEN: cannot add owner relation".into(),
-        ));
+/// Add multiple document ACP relationships in one request.
+///
+/// POST /api/v0/acp/document/relationships
+///
+/// The request and response arrays have matching order. All entries are validated
+/// before the first write. A backend error stops processing without rolling back
+/// earlier entries.
+pub async fn add_doc_relationships(
+    State(state): State<AppState>,
+    identity: ExtractIdentity,
+    Json(bodies): Json<Vec<DocRelationshipRequest>>,
+) -> Result<Json<Vec<DocRelationshipResponse>>, HttpError> {
+    require_permission(&state, &identity, NodePermission::DacRelationAdd).await?;
+
+    let requestor = identity
+        .did()
+        .ok_or_else(|| HttpError::BadRequest("identity required for document ACP".into()))?;
+
+    for body in &bodies {
+        validate_add_doc_relationship(body)?;
     }
 
     let doc_acp = state.require_doc_acp()?;
-
-    let is_new = doc_acp
-        .add_doc_relationship(
-            requestor,
-            &body.target_actor,
-            &body.collection,
-            &body.doc_id,
-            &body.relation,
-        )
-        .await
-        .map_err(http_error_from_backend_message)?;
-
-    Ok(Json(DocRelationshipResponse {
-        existed_already: !is_new,
-    }))
+    let mut results = Vec::with_capacity(bodies.len());
+    for body in &bodies {
+        results.push(apply_add_doc_relationship(doc_acp.as_ref(), requestor, body).await?);
+    }
+    Ok(Json(results))
 }
 
 /// Remove a document ACP relationship.
@@ -322,6 +364,19 @@ pub async fn remove_doc_relationship(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mock::{MockDocumentAcpOperations, MockQueryExecutor};
+    use crate::router::{AppStateBuilder, DocumentAcpOperations};
+    use query::executor::QueryExecutor;
+    use std::sync::Arc;
+
+    fn doc_relationship(relation: &str, target_actor: &str) -> DocRelationshipRequest {
+        DocRelationshipRequest {
+            collection: "Users".into(),
+            doc_id: "bae-123".into(),
+            relation: relation.into(),
+            target_actor: target_actor.into(),
+        }
+    }
 
     #[test]
     fn test_add_policy_response_serialize() {
@@ -399,5 +454,44 @@ mod tests {
             parse_doc_permission("admin"),
             Err(HttpError::BadRequest(_))
         ));
+    }
+
+    #[tokio::test]
+    async fn add_doc_relationships_validates_every_item_before_writing() {
+        let doc_acp = Arc::new(MockDocumentAcpOperations::new());
+        let state =
+            AppStateBuilder::new(Arc::new(MockQueryExecutor::new()) as Arc<dyn QueryExecutor>)
+                .with_doc_acp(Arc::clone(&doc_acp) as Arc<dyn DocumentAcpOperations>)
+                .build();
+        let requestor = identity::Did::new("did:key:requestor").unwrap();
+        let identity = ExtractIdentity::from_did(Some(requestor));
+
+        let result = add_doc_relationships(
+            State(state.clone()),
+            identity.clone(),
+            Json(vec![
+                doc_relationship("reader", "did:key:first"),
+                doc_relationship("owner", "did:key:second"),
+            ]),
+        )
+        .await;
+
+        assert!(matches!(result, Err(HttpError::BadRequest(_))));
+        assert_eq!(doc_acp.add_count(), 0);
+
+        let Json(results) = add_doc_relationships(
+            State(state),
+            identity,
+            Json(vec![
+                doc_relationship("reader", "did:key:first"),
+                doc_relationship("writer", "did:key:second"),
+            ]),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(results.len(), 2);
+        assert!(results.iter().all(|result| !result.existed_already));
+        assert_eq!(doc_acp.add_count(), 2);
     }
 }

--- a/crates/http/src/handlers/nac.rs
+++ b/crates/http/src/handlers/nac.rs
@@ -35,6 +35,41 @@ pub struct GoNacRelationshipRequest {
     pub target_actor: String,
 }
 
+#[derive(Debug, serde::Serialize)]
+pub struct GoNacRelationshipResponse {
+    pub added: bool,
+}
+
+fn validate_add_relationship(body: &GoNacRelationshipRequest) -> Result<identity::Did, HttpError> {
+    if !is_valid_nac_relation(&body.relation) || body.relation == "owner" {
+        return Err(HttpError::BadRequest(
+            "relation not in resource".to_string(),
+        ));
+    }
+    if body.target_actor.is_empty() {
+        return Err(HttpError::BadRequest("actor must be a valid did".into()));
+    }
+    identity::Did::new(&body.target_actor)
+        .map_err(|e| HttpError::BadRequest(format!("invalid TargetActor DID: {}", e)))
+}
+
+async fn apply_add_relationship(
+    nac: &dyn crate::router::NodeAcpOperations,
+    requestor: &identity::Did,
+    target: &identity::Did,
+    relation: &str,
+) -> Result<GoNacRelationshipResponse, HttpError> {
+    let added = nac
+        .add_relationship(requestor, target, relation)
+        .await
+        .map_err(|e| {
+            let normalized = normalize_auth_error(e, "add-nac-relation");
+            tracing::warn!(error = %normalized, "NAC add_relationship operation failed");
+            http_error_from_backend_message(normalized)
+        })?;
+    Ok(GoNacRelationshipResponse { added })
+}
+
 /// Request body for enabling NAC (Go-compatible format).
 #[derive(Debug, serde::Deserialize)]
 pub struct EnableNacRequest {
@@ -234,31 +269,40 @@ pub async fn go_add_relationship(
         HttpError::Forbidden("authentication required to add relationship".into())
     })?;
 
-    // Validate relation name against NAC policy (matches FFI ordering: after auth, before target)
-    if !is_valid_nac_relation(&body.relation) || body.relation == "owner" {
-        return Err(HttpError::BadRequest(
-            "relation not in resource".to_string(),
-        ));
+    let target = validate_add_relationship(&body)?;
+    let result = apply_add_relationship(nac.as_ref(), &requestor, &target, &body.relation).await?;
+
+    Ok(Json(result).into_response())
+}
+
+/// POST /api/v0/acp/node/relationships
+///
+/// Add multiple NAC relationships in one request. The response array matches
+/// request order, and every entry is validated before writes begin. A backend
+/// error stops processing without rolling back earlier entries.
+pub async fn go_add_relationships(
+    State(state): State<AppState>,
+    identity: ExtractIdentity,
+    Json(bodies): Json<Vec<GoNacRelationshipRequest>>,
+) -> Result<Json<Vec<GoNacRelationshipResponse>>, HttpError> {
+    require_permission(&state, &identity, NodePermission::NacRelationAdd).await?;
+
+    let nac = state.require_nac()?;
+    let requestor = identity.did().cloned().ok_or_else(|| {
+        HttpError::Forbidden("authentication required to add relationship".into())
+    })?;
+
+    let targets = bodies
+        .iter()
+        .map(validate_add_relationship)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut results = Vec::with_capacity(bodies.len());
+    for (body, target) in bodies.iter().zip(&targets) {
+        results
+            .push(apply_add_relationship(nac.as_ref(), &requestor, target, &body.relation).await?);
     }
-
-    if body.target_actor.is_empty() {
-        return Err(HttpError::BadRequest("actor must be a valid did".into()));
-    }
-
-    // Parse target DID
-    let target = identity::Did::new(&body.target_actor)
-        .map_err(|e| HttpError::BadRequest(format!("invalid TargetActor DID: {}", e)))?;
-
-    let added = nac
-        .add_relationship(&requestor, &target, &body.relation)
-        .await
-        .map_err(|e| {
-            let normalized = normalize_auth_error(e, "add-nac-relation");
-            tracing::warn!(error = %normalized, "NAC add_relationship operation failed");
-            http_error_from_backend_message(normalized)
-        })?;
-
-    Ok(Json(serde_json::json!({"added": added})).into_response())
+    Ok(Json(results))
 }
 
 /// DELETE /api/v0/acp/node/relationship (Go-compatible)
@@ -354,4 +398,64 @@ pub async fn re_enable(
     })?;
 
     Ok(Json(()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mock::{MockNodeAcpOperations, MockQueryExecutor};
+    use crate::router::{AppStateBuilder, NodeAcpOperations};
+    use query::executor::QueryExecutor;
+    use std::sync::Arc;
+
+    fn relationship(relation: &str, target_actor: &str) -> GoNacRelationshipRequest {
+        GoNacRelationshipRequest {
+            relation: relation.into(),
+            target_actor: target_actor.into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn add_relationships_prevalidates_and_returns_ordered_results() {
+        let requestor = identity::Did::new("did:key:requestor").unwrap();
+        let target = identity::Did::new("did:key:target").unwrap();
+        let nac = Arc::new(MockNodeAcpOperations::enabled_with_owner(requestor.clone()));
+        let state =
+            AppStateBuilder::new(Arc::new(MockQueryExecutor::new()) as Arc<dyn QueryExecutor>)
+                .with_nac(Arc::clone(&nac) as Arc<dyn NodeAcpOperations>)
+                .build();
+        let identity = ExtractIdentity::from_did(Some(requestor));
+
+        let result = go_add_relationships(
+            State(state.clone()),
+            identity.clone(),
+            Json(vec![
+                relationship("admin", target.as_str()),
+                relationship("owner", "did:key:other"),
+            ]),
+        )
+        .await;
+
+        assert!(matches!(result, Err(HttpError::BadRequest(_))));
+        assert!(!nac.is_admin(&target).await.unwrap());
+
+        let Json(results) = go_add_relationships(
+            State(state),
+            identity,
+            Json(vec![
+                relationship("admin", target.as_str()),
+                relationship("admin", target.as_str()),
+            ]),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            results
+                .iter()
+                .map(|result| result.added)
+                .collect::<Vec<_>>(),
+            vec![true, false]
+        );
+    }
 }

--- a/crates/http/src/mock/doc_acp.rs
+++ b/crates/http/src/mock/doc_acp.rs
@@ -2,6 +2,10 @@
 
 use async_trait::async_trait;
 use identity::Did;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
 
 use crate::router::DocumentAcpOperations;
 
@@ -9,15 +13,27 @@ use crate::router::DocumentAcpOperations;
 #[derive(Debug, Clone)]
 pub struct MockDocumentAcpOperations {
     allowed: bool,
+    add_count: Arc<AtomicUsize>,
 }
 
 impl MockDocumentAcpOperations {
     pub fn new() -> Self {
-        Self { allowed: true }
+        Self {
+            allowed: true,
+            add_count: Arc::new(AtomicUsize::new(0)),
+        }
     }
 
     pub fn with_allowed(allowed: bool) -> Self {
-        Self { allowed }
+        Self {
+            allowed,
+            add_count: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    /// Return the number of attempted relationship additions.
+    pub fn add_count(&self) -> usize {
+        self.add_count.load(Ordering::Relaxed)
     }
 }
 
@@ -48,6 +64,7 @@ impl DocumentAcpOperations for MockDocumentAcpOperations {
         _doc_id: &str,
         _relation: &str,
     ) -> Result<bool, String> {
+        self.add_count.fetch_add(1, Ordering::Relaxed);
         Ok(true)
     }
 

--- a/crates/http/src/route_permissions.rs
+++ b/crates/http/src/route_permissions.rs
@@ -193,6 +193,9 @@ pub fn route_permission(path: &str, method: &Method) -> RoutePermission {
             Method::DELETE => RoutePermission::Required(NodePermission::DacRelationDelete),
             _ => RoutePermission::Required(NodePermission::DacRelationAdd),
         },
+        "/api/v0/acp/document/relationships" => {
+            RoutePermission::Required(NodePermission::DacRelationAdd)
+        }
 
         // =====================================================================
         // ACP Node (NAC via Go-compatible /acp/node/* routes)
@@ -204,6 +207,9 @@ pub fn route_permission(path: &str, method: &Method) -> RoutePermission {
             Method::DELETE => RoutePermission::Required(NodePermission::NacRelationDelete),
             _ => RoutePermission::Required(NodePermission::NacRelationAdd),
         },
+        "/api/v0/acp/node/relationships" => {
+            RoutePermission::Required(NodePermission::NacRelationAdd)
+        }
         "/api/v0/acp/node/disable" => RoutePermission::Dynamic,
         "/api/v0/acp/node/re-enable" => RoutePermission::Dynamic,
 
@@ -528,6 +534,11 @@ mod tests {
                 Method::DELETE,
                 RoutePermission::Required(NodePermission::DacRelationDelete),
             ),
+            (
+                "/api/v0/acp/document/relationships",
+                Method::POST,
+                RoutePermission::Required(NodePermission::DacRelationAdd),
+            ),
             // ACP Node
             (
                 "/api/v0/acp/node/status",
@@ -538,6 +549,11 @@ mod tests {
                 "/api/v0/acp/node/enable",
                 Method::POST,
                 RoutePermission::Dynamic,
+            ),
+            (
+                "/api/v0/acp/node/relationships",
+                Method::POST,
+                RoutePermission::Required(NodePermission::NacRelationAdd),
             ),
             (
                 "/api/v0/acp/node/disable",

--- a/crates/http/src/route_permissions_tests.rs
+++ b/crates/http/src/route_permissions_tests.rs
@@ -389,6 +389,11 @@ mod tests {
                 Method::DELETE,
                 RoutePermission::Required(NodePermission::DacRelationDelete),
             ),
+            (
+                "/api/v0/acp/document/relationships",
+                Method::POST,
+                RoutePermission::Required(NodePermission::DacRelationAdd),
+            ),
             // ACP Node
             (
                 "/api/v0/acp/node/status",
@@ -399,6 +404,11 @@ mod tests {
                 "/api/v0/acp/node/enable",
                 Method::POST,
                 RoutePermission::Dynamic,
+            ),
+            (
+                "/api/v0/acp/node/relationships",
+                Method::POST,
+                RoutePermission::Required(NodePermission::NacRelationAdd),
             ),
             (
                 "/api/v0/acp/node/disable",

--- a/crates/http/src/router/routes.rs
+++ b/crates/http/src/router/routes.rs
@@ -162,6 +162,10 @@ pub fn create_router_with_state(state: AppState) -> Router {
             post(handlers::acp::add_doc_relationship),
         )
         .route(
+            "/document/relationships",
+            post(handlers::acp::add_doc_relationships),
+        )
+        .route(
             "/document/relationship",
             delete(handlers::acp::remove_doc_relationship),
         );
@@ -211,6 +215,7 @@ pub fn create_router_with_state(state: AppState) -> Router {
         .route("/status", get(handlers::nac::get_status))
         .route("/enable", post(handlers::nac::enable))
         .route("/relationship", post(handlers::nac::go_add_relationship))
+        .route("/relationships", post(handlers::nac::go_add_relationships))
         .route(
             "/relationship",
             delete(handlers::nac::go_remove_relationship),


### PR DESCRIPTION
Fixes #1032.

Fleet seeding currently sends one HTTP request per ACP relationship. A realistic 100-200 relationship fleet therefore spends most of its setup time on serial request overhead, even though document and schema writes already have batching paths.

## What changed

- Added `POST /api/v0|v1/acp/document/relationships` for bulk document ACP relationships.
- Added `POST /api/v0|v1/acp/node/relationships` for bulk node ACP relationships.
- Both endpoints accept a JSON array using the existing singular request shape and return an ordered array using the existing per-item result shape.
- The full request is validated before the first relationship is written, so an invalid later entry cannot leave an otherwise-valid prefix applied.
- The existing singular handlers now reuse the same validation and write helpers; their paths, request formats, response formats, permissions, and behavior remain unchanged.
- Both new routes are mapped to the existing `DacRelationAdd` / `NacRelationAdd` permissions for global auth enforcement.

## Batch semantics

This collapses N HTTP round-trips to one without adding a second ACP persistence abstraction. Relationships are still applied through the existing backend operations in request order. If a backend operation fails, processing stops and earlier successful writes are not rolled back; that limitation is documented explicitly rather than implying transactional behavior the stores do not provide.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p defra-http --all-targets -- -D warnings`
- `cargo test -p defra-http` - 91 unit tests and 15 identity-extractor integration tests passed; 1 doc-test ignored

Regression coverage verifies full-batch prevalidation before writes, ordered NAC results, duplicate relationship results, and route permission mappings.