### PR TITLE
perf(p2p): index pending DAG waiters by missing CID (#1088 W3)

### DIFF
--- a/crates/p2p/src/sync/manager/pending.rs
+++ b/crates/p2p/src/sync/manager/pending.rs
@@ -1,6 +1,7 @@
 //! Pending DAG tracking for Bitswap synchronization.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+use std::ops::Deref;
 use std::time::{Duration, Instant};
 
 use cid::Cid;
@@ -54,6 +55,125 @@ pub struct PendingDag {
     pub next_retry_at: tokio::time::Instant,
     /// Fetch dispatches claimed for this root (drives the backoff rung).
     pub dispatches: u32,
+}
+
+/// Pending roots and the reverse index used to route arriving blocks only to
+/// roots that are waiting for them.
+#[derive(Debug, Default)]
+pub(super) struct PendingDagRegistry {
+    roots: HashMap<Cid, PendingDag>,
+    waiters: HashMap<Cid, HashSet<Cid>>,
+}
+
+impl Deref for PendingDagRegistry {
+    type Target = HashMap<Cid, PendingDag>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.roots
+    }
+}
+
+impl PendingDagRegistry {
+    pub(super) fn get_mut(&mut self, root_cid: &Cid) -> Option<&mut PendingDag> {
+        self.roots.get_mut(root_cid)
+    }
+
+    pub(super) fn iter_mut(&mut self) -> impl Iterator<Item = (&Cid, &mut PendingDag)> {
+        self.roots.iter_mut()
+    }
+
+    pub(super) fn insert(&mut self, root_cid: Cid, dag: PendingDag) -> Option<PendingDag> {
+        let previous = self.remove(&root_cid);
+        for missing_cid in &dag.missing {
+            self.waiters
+                .entry(*missing_cid)
+                .or_default()
+                .insert(root_cid);
+        }
+        self.roots.insert(root_cid, dag);
+        previous
+    }
+
+    pub(super) fn remove(&mut self, root_cid: &Cid) -> Option<PendingDag> {
+        let dag = self.roots.remove(root_cid)?;
+        for missing_cid in &dag.missing {
+            self.remove_waiter(missing_cid, root_cid);
+        }
+        Some(dag)
+    }
+
+    pub(super) fn replace_missing(&mut self, root_cid: &Cid, missing: HashSet<Cid>) -> bool {
+        let Some(previous) = self.roots.get(root_cid).map(|dag| dag.missing.clone()) else {
+            return false;
+        };
+
+        for missing_cid in previous.difference(&missing) {
+            self.remove_waiter(missing_cid, root_cid);
+        }
+        for missing_cid in missing.difference(&previous) {
+            self.waiters
+                .entry(*missing_cid)
+                .or_default()
+                .insert(*root_cid);
+        }
+        self.roots
+            .get_mut(root_cid)
+            .expect("root checked above")
+            .missing = missing;
+        true
+    }
+
+    pub(super) fn waiting_roots(&self, missing_cid: &Cid) -> Vec<Cid> {
+        self.waiters
+            .get(missing_cid)
+            .map(|roots| roots.iter().copied().collect())
+            .unwrap_or_default()
+    }
+
+    pub(super) fn has_waiters(&self, missing_cid: &Cid) -> bool {
+        self.waiters.contains_key(missing_cid)
+    }
+
+    pub(super) fn advance_waiters(
+        &mut self,
+        received_cid: &Cid,
+        newly_missing: &[Cid],
+    ) -> Vec<Cid> {
+        let waiting_roots = self.waiters.remove(received_cid).unwrap_or_default();
+        let mut emptied = Vec::new();
+
+        for root_cid in waiting_roots {
+            let Some(dag) = self.roots.get_mut(&root_cid) else {
+                continue;
+            };
+            if !dag.missing.remove(received_cid) {
+                continue;
+            }
+            for missing_cid in newly_missing {
+                if dag.missing.insert(*missing_cid) {
+                    self.waiters
+                        .entry(*missing_cid)
+                        .or_default()
+                        .insert(root_cid);
+                }
+            }
+            if dag.missing.is_empty() {
+                emptied.push(root_cid);
+            }
+        }
+
+        emptied
+    }
+
+    fn remove_waiter(&mut self, missing_cid: &Cid, root_cid: &Cid) {
+        let remove_entry = self.waiters.get_mut(missing_cid).is_some_and(|roots| {
+            roots.remove(root_cid);
+            roots.is_empty()
+        });
+        if remove_entry {
+            self.waiters.remove(missing_cid);
+        }
+    }
 }
 
 /// Base delay before the first scheduled re-dispatch of a pending root.

--- a/crates/p2p/src/sync/manager/process/bitswap.rs
+++ b/crates/p2p/src/sync/manager/process/bitswap.rs
@@ -167,17 +167,12 @@ impl<B: Blockstore + 'static> SyncManager<B> {
             "Stored Bitswap block in blockstore"
         );
 
-        // Check if any pending DAGs can now proceed
-        // This is done by checking which pending DAGs were waiting for this CID
-        let pending = self.pending_dags.read().clone();
-        for (root_cid, pending_info) in pending {
-            if pending_info.missing.contains(cid) {
-                tracing::debug!(
-                    root_cid = %root_cid,
-                    received_cid = %cid,
-                    "Pending DAG received a missing block - will check completeness"
-                );
-            }
+        for root_cid in self.pending_dags.read().waiting_roots(cid) {
+            tracing::debug!(
+                root_cid = %root_cid,
+                received_cid = %cid,
+                "Pending DAG received a missing block - will check completeness"
+            );
         }
 
         Ok(true)

--- a/crates/p2p/src/sync/manager/process/mod.rs
+++ b/crates/p2p/src/sync/manager/process/mod.rs
@@ -31,7 +31,7 @@ use super::super::queue::ProcessQueue;
 use super::config::SyncConfig;
 use super::diagnostics::SyncDiagnostics;
 use super::events::SyncEvent;
-use super::pending::PendingDag;
+use super::pending::PendingDagRegistry;
 
 /// Manager for P2P block synchronization.
 ///
@@ -75,9 +75,9 @@ pub struct SyncManager<B: Blockstore> {
     /// Peer state tracker for finding providers
     pub(super) peer_state: Arc<PeerStateTracker>,
 
-    /// Pending DAGs waiting for Bitswap to complete.
-    /// Maps root CID → pending DAG metadata.
-    pub(super) pending_dags: Arc<RwLock<HashMap<Cid, PendingDag>>>,
+    /// Pending DAGs waiting for Bitswap to complete, indexed by root and each
+    /// missing CID.
+    pub(super) pending_dags: Arc<RwLock<PendingDagRegistry>>,
 
     /// Maps Bitswap QueryId → root CID for tracking completions.
     pub(super) query_to_root: Arc<RwLock<HashMap<QueryId, Cid>>>,
@@ -147,7 +147,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
             process_queue: ProcessQueue::new(),
             event_tx,
             peer_state,
-            pending_dags: Arc::new(RwLock::new(HashMap::new())),
+            pending_dags: Arc::new(RwLock::new(PendingDagRegistry::default())),
             query_to_root: Arc::new(RwLock::new(HashMap::new())),
             diagnostics: Arc::new(SyncDiagnostics::default()),
             // A zero cap would reject every missing-link push forever

--- a/crates/p2p/src/sync/manager/process/pending_dag.rs
+++ b/crates/p2p/src/sync/manager/process/pending_dag.rs
@@ -1,6 +1,6 @@
 //! Pending DAG registration and retry logic.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -26,7 +26,7 @@ pub struct PendingDagFetchFailure {
 }
 
 fn evict_expired_pending_dags(
-    pending: &mut HashMap<Cid, PendingDag>,
+    pending: &mut crate::sync::manager::pending::PendingDagRegistry,
     now: Instant,
 ) -> Vec<(Cid, PendingDag)> {
     let expired: Vec<_> = pending
@@ -187,14 +187,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
     /// as pending before its linked field blocks arrive via later PushLog
     /// requests rather than Bitswap.
     pub async fn retry_pending_dags_waiting_on(&self, cid: &Cid) -> Result<Vec<Cid>> {
-        let waiting_roots: Vec<Cid> = {
-            let pending = self.pending_dags.read();
-            pending
-                .iter()
-                .filter_map(|(root_cid, dag)| dag.missing.contains(cid).then_some(*root_cid))
-                .collect()
-        };
-        if waiting_roots.is_empty() {
+        if !self.pending_dags.read().has_waiters(cid) {
             return Ok(Vec::new());
         }
 
@@ -213,20 +206,10 @@ impl<B: Blockstore + 'static> SyncManager<B> {
             }
         }
 
-        let emptied: Vec<Cid> = {
-            let mut pending = self.pending_dags.write();
-            let mut emptied = Vec::new();
-            for root_cid in &waiting_roots {
-                if let Some(dag) = pending.get_mut(root_cid) {
-                    dag.missing.remove(cid);
-                    dag.missing.extend(absent_links.iter().copied());
-                    if dag.missing.is_empty() {
-                        emptied.push(*root_cid);
-                    }
-                }
-            }
-            emptied
-        };
+        let emptied = self
+            .pending_dags
+            .write()
+            .advance_waiters(cid, &absent_links);
 
         let mut completed = Vec::new();
         for root_cid in emptied {
@@ -273,8 +256,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
         if dag.inserted_at != inserted_at {
             return false;
         }
-        dag.missing = missing;
-        true
+        pending.replace_missing(root_cid, missing)
     }
 
     fn take_pending_dag_if_current(
@@ -1037,6 +1019,68 @@ mod tests {
                 .get(&root)
                 .map(|dag| dag.doc_id.as_str()),
             Some("replacement")
+        );
+    }
+
+    #[test]
+    fn pending_dag_reverse_index_tracks_frontier_lifecycle() {
+        let manager = test_manager();
+        let root_a = test_cid(0);
+        let root_b = test_cid(1);
+        let shared = test_cid(2);
+        let other = test_cid(3);
+        let next = test_cid(4);
+
+        let mut dag_a = pending_dag("a", Instant::now());
+        dag_a.missing.insert(shared);
+        let mut dag_b = pending_dag("b", Instant::now());
+        dag_b.missing.extend([shared, other]);
+        assert!(manager.insert_pending_dag(root_a, dag_a));
+        assert!(manager.insert_pending_dag(root_b, dag_b));
+
+        let waiting: HashSet<_> = manager
+            .pending_dags
+            .read()
+            .waiting_roots(&shared)
+            .into_iter()
+            .collect();
+        assert_eq!(waiting, [root_a, root_b].into_iter().collect());
+
+        assert!(manager
+            .pending_dags
+            .write()
+            .advance_waiters(&shared, &[next])
+            .is_empty());
+        assert!(manager
+            .pending_dags
+            .read()
+            .waiting_roots(&shared)
+            .is_empty());
+        assert_eq!(
+            manager
+                .pending_dags
+                .read()
+                .waiting_roots(&next)
+                .into_iter()
+                .collect::<HashSet<_>>(),
+            [root_a, root_b].into_iter().collect()
+        );
+
+        assert!(manager.update_pending_dag_missing_if_current(
+            &root_a,
+            manager.pending_dag_snapshot(&root_a).unwrap().inserted_at,
+            [other].into_iter().collect(),
+        ));
+        assert_eq!(
+            manager.pending_dags.read().waiting_roots(&next).as_slice(),
+            &[root_b]
+        );
+
+        assert!(manager.clear_pending_dag(&root_b));
+        assert!(manager.pending_dags.read().waiting_roots(&next).is_empty());
+        assert_eq!(
+            manager.pending_dags.read().waiting_roots(&other).as_slice(),
+            &[root_a]
         );
     }
 


### PR DESCRIPTION
Implements **W3** of #1088. The remaining W2 per-source-peer quota work stays open.

## Problem

Every received block calls `retry_pending_dags_waiting_on`. The existing implementation linearly scans the entire pending-DAG map to discover which roots contain that CID in their missing frontier. At the configured 1,000-root cap, high fan-in therefore pays O(all pending roots) discovery work for every arriving block, including blocks with no waiters.

The paced retry work already made frontier advancement incremental and limited full DAG verification to roots whose frontier becomes empty. This PR removes the remaining global discovery scan.

## What changed

- Added a `PendingDagRegistry` that owns both the root map and a reverse `missing CID -> waiting roots` index under one lock.
- Insert, replacement, missing-frontier updates, expiry, completion, failure cleanup, resync, and quarantine all update the reverse index through the same registry operations.
- Block arrival now performs a direct missing-CID lookup and advances only the roots actually waiting for that block.
- Blocks with no waiters return before blockstore link decoding.
- Bitswap progress logging uses the same lookup instead of cloning and scanning the full pending map.

Waiter discovery is now proportional to the roots waiting for the received CID, rather than total hub pending depth. There are no wire, persistence-format, retry-policy, or acknowledgement changes.

## Regression coverage

The new lifecycle test registers multiple roots sharing and not sharing missing CIDs, advances the shared frontier, replaces one root frontier, and removes another root. It verifies that old index entries disappear and new entries point only to the correct live roots.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p p2p --all-targets -- -D warnings`
- `cargo test -p p2p` - full crate unit and integration suites green; only tests requiring a pre-running Go node and documented examples remain ignored
