### PR TITLE
fix(query): align @default directive with Go v1

### DIFF
--- a/crates/query-parse/src/sdl_parse/directives.rs
+++ b/crates/query-parse/src/sdl_parse/directives.rs
@@ -38,10 +38,7 @@ pub fn known_directive_arguments(directive_name: &str) -> &'static [&'static str
         "crdt" => &["type"],
         "index" => &["name", "unique", "direction", "fields", "includes"],
         "relation" => &["name"],
-        "default" => &[
-            "string", "value", "bool", "int", "float", "float32", "float64", "dateTime", "json",
-            "blob",
-        ],
+        "default" => &["value"],
         "constraints" => &["size"],
         "materialized" => &["if"],
         "downsample" => &["interval", "timeField", "retention"],
@@ -138,8 +135,6 @@ pub struct ParsedDirectives {
     pub relation_name: Option<String>,
     /// Default value from @default directive
     pub default_value: Option<serde_json::Value>,
-    /// The argument name used in @default (e.g., "int", "bool", "string")
-    pub default_arg_name: Option<String>,
     /// Array size constraint from @constraints directive
     pub size_constraint: Option<usize>,
     /// Whether this field has an encrypted index for searchable encryption

--- a/crates/query-parse/src/sdl_parse/fields.rs
+++ b/crates/query-parse/src/sdl_parse/fields.rs
@@ -26,7 +26,8 @@ use super::warnings::{DirectiveLocation, ParseWarning};
 impl<'a> SdlParser<'a> {
     pub(super) fn parse_field(&mut self, field: &Field<'_, String>) -> Result<ParsedField> {
         let field_type = parse_graphql_type(&field.field_type);
-        let directives = self.parse_field_directives(&field.directives, &field.name)?;
+        let directives =
+            self.parse_field_directives(&field.directives, &field.name, &field_type.base_type)?;
 
         Ok(ParsedField {
             name: field.name.clone(),
@@ -39,6 +40,7 @@ impl<'a> SdlParser<'a> {
         &mut self,
         directives: &[Directive<'_, String>],
         field_name: &str,
+        field_type: &str,
     ) -> Result<ParsedDirectives> {
         let mut result = ParsedDirectives::default();
         let type_name = self.current_type.clone().unwrap_or_default();
@@ -57,10 +59,8 @@ impl<'a> SdlParser<'a> {
                 "index" => result.index = Some(self.parse_index_directive(directive, field_name)?),
                 "relation" => result.relation_name = get_directive_string(directive, "name"),
                 "default" => {
-                    let arg_name = directive.arguments.first().map(|(n, _)| n.clone());
                     result.default_value =
-                        Some(self.parse_default_directive(directive, field_name)?);
-                    result.default_arg_name = arg_name;
+                        Some(self.parse_default_directive(directive, field_name, field_type)?);
                 }
                 "constraints" => {
                     if let Some(size) =
@@ -511,8 +511,9 @@ impl<'a> SdlParser<'a> {
         &self,
         directive: &Directive<'_, String>,
         field_name: &str,
+        field_type: &str,
     ) -> Result<serde_json::Value> {
-        // Go supports: string, bool, int, float, float32, float64, dateTime, json, blob
+        // Match Go's supported scalar field types for @default(value:).
         let Some((name, value)) = directive.arguments.first() else {
             return Err(QueryError::parse(
                 "@default directive requires a value argument",
@@ -527,25 +528,34 @@ impl<'a> SdlParser<'a> {
             )));
         }
 
-        match name.as_str() {
-            "string" | "value" => match value {
-                graphql_parser::schema::Value::String(s) => Ok(serde_json::Value::String(s.clone())),
+        if name != "value" {
+            return Err(QueryError::parse(format!(
+                "unknown @default argument '{}'. Valid argument is: value",
+                name
+            )));
+        }
+
+        match field_type {
+            "String" => match value {
+                graphql_parser::schema::Value::String(s) => {
+                    Ok(serde_json::Value::String(s.clone()))
+                }
                 other => Err(default_type_error(name, "string", other)),
             },
-            "bool" => match value {
+            "Boolean" => match value {
                 graphql_parser::schema::Value::Boolean(b) => Ok(serde_json::Value::Bool(*b)),
-                other => Err(default_type_error("bool", "boolean", other)),
+                other => Err(default_type_error(name, "boolean", other)),
             },
-            "int" => match value {
+            "Int" => match value {
                 graphql_parser::schema::Value::Int(n) => {
                     let int_val = n.as_i64().ok_or_else(|| {
                         QueryError::parse("@default int value is out of i64 range")
                     })?;
                     Ok(serde_json::Value::Number(serde_json::Number::from(int_val)))
                 }
-                other => Err(default_type_error("int", "integer", other)),
+                other => Err(default_type_error(name, "integer", other)),
             },
-            "float" | "float64" => match value {
+            "Float" | "Float64" => match value {
                 graphql_parser::schema::Value::Float(f) => serde_json::Number::from_f64(*f)
                     .map(serde_json::Value::Number)
                     .ok_or_else(|| {
@@ -560,9 +570,9 @@ impl<'a> SdlParser<'a> {
                     })?;
                     Ok(serde_json::Value::Number(serde_json::Number::from(int_val)))
                 }
-                other => Err(default_type_error("float", "float", other)),
+                other => Err(default_type_error(name, "float", other)),
             },
-            "float32" => match value {
+            "Float32" => match value {
                 graphql_parser::schema::Value::Float(f) => {
                     let f32_val = *f as f32;
                     if f32_val.is_infinite() && !f.is_infinite() {
@@ -585,9 +595,9 @@ impl<'a> SdlParser<'a> {
                     })?;
                     Ok(serde_json::Value::Number(serde_json::Number::from(int_val)))
                 }
-                other => Err(default_type_error("float32", "float", other)),
+                other => Err(default_type_error(name, "float", other)),
             },
-            "dateTime" => match value {
+            "DateTime" => match value {
                 graphql_parser::schema::Value::String(s) => {
                     // Normalize to RFC3339 format to match Go's time.Time serialization.
                     // Go parses the datetime string into time.Time then formats it back,
@@ -598,9 +608,9 @@ impl<'a> SdlParser<'a> {
                 }
                 // Accept Enum for special values like UTC_NOW
                 graphql_parser::schema::Value::Enum(s) => Ok(serde_json::Value::String(s.clone())),
-                other => Err(default_type_error("dateTime", "string", other)),
+                other => Err(default_type_error(name, "string", other)),
             },
-            "json" => {
+            "JSON" => {
                 // JSON @default accepts various value types
                 match value {
                     // String containing JSON - validate but store as string literal
@@ -620,12 +630,16 @@ impl<'a> SdlParser<'a> {
                     }
                     graphql_parser::schema::Value::Float(f) => serde_json::Number::from_f64(*f)
                         .map(serde_json::Value::Number)
-                        .ok_or_else(|| QueryError::parse("@default json float is invalid (NaN or Infinity)")),
+                        .ok_or_else(|| {
+                            QueryError::parse("@default json float is invalid (NaN or Infinity)")
+                        }),
                     graphql_parser::schema::Value::Boolean(b) => Ok(serde_json::Value::Bool(*b)),
                     graphql_parser::schema::Value::Null => {
                         Err(QueryError::parse("default value is invalid for type JSON"))
                     }
-                    graphql_parser::schema::Value::Enum(s) => Ok(serde_json::Value::String(s.clone())),
+                    graphql_parser::schema::Value::Enum(s) => {
+                        Ok(serde_json::Value::String(s.clone()))
+                    }
                     // JSON array/object defaults are stored as serialized strings to match Go behavior
                     graphql_parser::schema::Value::List(arr) => {
                         let items: Vec<serde_json::Value> = arr
@@ -633,7 +647,9 @@ impl<'a> SdlParser<'a> {
                             .map(|v| graphql_schema_value_to_json(v))
                             .collect();
                         let json_array = serde_json::Value::Array(items);
-                        Ok(serde_json::Value::String(serde_json::to_string(&json_array).unwrap_or_default()))
+                        Ok(serde_json::Value::String(
+                            serde_json::to_string(&json_array).unwrap_or_default(),
+                        ))
                     }
                     graphql_parser::schema::Value::Object(obj) => {
                         let items: serde_json::Map<String, serde_json::Value> = obj
@@ -641,18 +657,24 @@ impl<'a> SdlParser<'a> {
                             .map(|(k, v)| (k.clone(), graphql_schema_value_to_json(v)))
                             .collect();
                         let json_obj = serde_json::Value::Object(items);
-                        Ok(serde_json::Value::String(serde_json::to_string(&json_obj).unwrap_or_default()))
+                        Ok(serde_json::Value::String(
+                            serde_json::to_string(&json_obj).unwrap_or_default(),
+                        ))
                     }
-                    graphql_parser::schema::Value::Variable(v) => Ok(serde_json::Value::String(format!("${}", v))),
+                    graphql_parser::schema::Value::Variable(v) => {
+                        Ok(serde_json::Value::String(format!("${}", v)))
+                    }
                 }
             }
-            "blob" => match value {
-                graphql_parser::schema::Value::String(s) => Ok(serde_json::Value::String(s.clone())),
-                other => Err(default_type_error("blob", "string", other)),
+            "Blob" => match value {
+                graphql_parser::schema::Value::String(s) => {
+                    Ok(serde_json::Value::String(s.clone()))
+                }
+                other => Err(default_type_error(name, "string", other)),
             },
-            unknown => Err(QueryError::parse(format!(
-                "unknown @default argument '{}'. Valid arguments are: string, value, bool, int, float, float32, float64, dateTime, json, blob",
-                unknown
+            _ => Err(QueryError::parse(format!(
+                "default value is not allowed for this field type. Name: {}, Type: {}",
+                field_name, field_type
             ))),
         }
     }

--- a/crates/query-parse/src/sdl_parse/parser_tests.rs
+++ b/crates/query-parse/src/sdl_parse/parser_tests.rs
@@ -353,7 +353,7 @@ fn test_relation_directive_explicit_name() {
 fn test_default_directive_string() {
     let sdl = r#"
         type User {
-            role: String @default(string: "member")
+            role: String @default(value: "member")
         }
     "#;
 
@@ -371,7 +371,7 @@ fn test_default_directive_string() {
 fn test_default_directive_int() {
     let sdl = r#"
         type Counter {
-            count: Int @default(int: 0)
+            count: Int @default(value: 0)
         }
     "#;
 
@@ -389,7 +389,7 @@ fn test_default_directive_int() {
 fn test_default_directive_bool() {
     let sdl = r#"
         type Settings {
-            enabled: Boolean @default(bool: true)
+            enabled: Boolean @default(value: true)
         }
     "#;
 
@@ -873,10 +873,10 @@ fn test_default_directive_missing_value_returns_error() {
 }
 
 #[test]
-fn test_default_directive_unknown_argument_returns_error() {
+fn test_default_directive_legacy_argument_returns_error() {
     let sdl = r#"
         type User {
-            role: String @default(invalid_arg: "test")
+            role: String @default(string: "test")
         }
     "#;
     let result = parse_sdl(sdl);
@@ -893,7 +893,7 @@ fn test_default_directive_unknown_argument_returns_error() {
 fn test_default_directive_invalid_json_returns_error() {
     let sdl = r#"
         type Config {
-            settings: JSON @default(json: "{ invalid json }")
+            settings: JSON @default(value: "{ invalid json }")
         }
     "#;
     let result = parse_sdl(sdl);
@@ -927,7 +927,7 @@ fn test_constraints_directive_negative_size_returns_error() {
 fn test_default_directive_float() {
     let sdl = r#"
         type Measurement {
-            value: Float @default(float: 3.15)
+            value: Float @default(value: 3.15)
         }
     "#;
     let collections = parse_sdl(sdl).unwrap();
@@ -945,7 +945,7 @@ fn test_default_directive_float() {
 fn test_default_directive_json() {
     let sdl = r#"
         type Config {
-            settings: JSON @default(json: "{\"key\": \"value\"}")
+            settings: JSON @default(value: "{\"key\": \"value\"}")
         }
     "#;
     let collections = parse_sdl(sdl).unwrap();
@@ -964,7 +964,7 @@ fn test_default_directive_json() {
 fn test_default_directive_float32() {
     let sdl = r#"
         type Sensor {
-            temp: Float32 @default(float32: 25.5)
+            temp: Float32 @default(value: 25.5)
         }
     "#;
     let collections = parse_sdl(sdl).unwrap();
@@ -982,7 +982,7 @@ fn test_default_directive_float32() {
 fn test_default_directive_datetime() {
     let sdl = r#"
         type Event {
-            created: DateTime @default(dateTime: "2024-01-15T10:30:00Z")
+            created: DateTime @default(value: "2024-01-15T10:30:00Z")
         }
     "#;
     let collections = parse_sdl(sdl).unwrap();
@@ -1000,7 +1000,7 @@ fn test_default_directive_datetime() {
 fn test_default_directive_blob() {
     let sdl = r#"
         type Document {
-            data: Blob @default(blob: "SGVsbG8gV29ybGQ=")
+            data: Blob @default(value: "SGVsbG8gV29ybGQ=")
         }
     "#;
     let collections = parse_sdl(sdl).unwrap();
@@ -1140,7 +1140,7 @@ fn test_known_directives_no_warnings() {
         type User @materialized @branchable {
             name: String @index(unique: true)
             age: Int @crdt(type: "pncounter")
-            role: String @default(string: "user")
+            role: String @default(value: "user")
             agent_did: String @immutable
         }
     "#;
@@ -1483,7 +1483,7 @@ fn test_encrypted_index_unknown_argument_emits_warning() {
 fn test_default_float32_wrong_type_returns_error() {
     let sdl = r#"
         type Sensor {
-            temp: Float32 @default(float32: "not a float")
+            temp: Float32 @default(value: "not a float")
         }
     "#;
 
@@ -1501,7 +1501,7 @@ fn test_default_float32_wrong_type_returns_error() {
 fn test_default_datetime_wrong_type_returns_error() {
     let sdl = r#"
         type Event {
-            created: DateTime @default(dateTime: 12345)
+            created: DateTime @default(value: 12345)
         }
     "#;
 
@@ -1519,7 +1519,7 @@ fn test_default_datetime_wrong_type_returns_error() {
 fn test_default_blob_wrong_type_returns_error() {
     let sdl = r#"
         type Document {
-            data: Blob @default(blob: 12345)
+            data: Blob @default(value: 12345)
         }
     "#;
 
@@ -1534,19 +1534,73 @@ fn test_default_blob_wrong_type_returns_error() {
 }
 
 #[test]
-fn test_default_directive_value_alias() {
+fn test_default_directive_value_for_all_scalar_types() {
     let sdl = r#"
-        type User {
-            role: String @default(value: "member")
+        type Defaults {
+            active: Boolean @default(value: true)
+            age: Int @default(value: 40)
+            points: Float @default(value: 10)
+            points32: Float32 @default(value: 11.5)
+            points64: Float64 @default(value: 12)
+            name: String @default(value: "Bob")
+            created: DateTime @default(value: "2000-07-23T03:00:00-00:00")
+            metadata: JSON @default(value: "{\"one\":1}")
+            image: Blob @default(value: "ff0099")
         }
     "#;
 
     let collections = parse_sdl(sdl).unwrap();
-    let user = &collections[0];
-    let role = user.field_by_name("role").unwrap();
-    assert_eq!(
-        role.default_value,
-        Some(serde_json::Value::String("member".to_string()))
+    let defaults = &collections[0];
+    for (field, expected) in [
+        ("active", serde_json::json!(true)),
+        ("age", serde_json::json!(40)),
+        ("points", serde_json::json!(10)),
+        ("points32", serde_json::json!(11.5)),
+        ("points64", serde_json::json!(12)),
+        ("name", serde_json::json!("Bob")),
+        ("created", serde_json::json!("2000-07-23T03:00:00Z")),
+        ("metadata", serde_json::json!("{\"one\":1}")),
+        ("image", serde_json::json!("ff0099")),
+    ] {
+        assert_eq!(
+            defaults.field_by_name(field).unwrap().default_value,
+            Some(expected),
+            "unexpected default for {field}"
+        );
+    }
+}
+
+#[test]
+fn test_default_directive_value_uses_field_type_coercion() {
+    let result = parse_sdl(
+        r#"
+            type Defaults {
+                age: Int @default(value: "forty")
+            }
+        "#,
+    );
+
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains(r#"Argument "value" has invalid value "forty""#),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn test_default_directive_value_rejects_unsupported_field_type() {
+    let result = parse_sdl(
+        r#"
+            type Defaults {
+                externalID: ID @default(value: "bae-example")
+            }
+        "#,
+    );
+
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("default value is not allowed for this field type"),
+        "unexpected error: {err}"
     );
 }
 

--- a/crates/query-parse/src/sdl_parse/validation.rs
+++ b/crates/query-parse/src/sdl_parse/validation.rs
@@ -56,34 +56,6 @@ impl<'a> SdlParser<'a> {
                             field.name
                         )));
                     }
-
-                    // Type mismatch: check @default argument name against field type
-                    if let Some(ref default_arg_name) = field.directives.default_arg_name {
-                        let expected = match base_type.as_str() {
-                            "Boolean" => Some("bool"),
-                            "Int" => Some("int"),
-                            "Float" | "Float64" => Some("float"),
-                            "Float32" => Some("float32"),
-                            "String" => Some("string"),
-                            "DateTime" => Some("dateTime"),
-                            "JSON" => Some("json"),
-                            "Blob" => Some("blob"),
-                            _ => None,
-                        };
-                        if let Some(expected_arg) = expected {
-                            // "value" is a generic alias for "string", always valid for String fields
-                            let arg = default_arg_name.as_str();
-                            if arg != expected_arg
-                                && !(arg == "value" && expected_arg == "string")
-                                && !(arg == "float64" && expected_arg == "float")
-                            {
-                                return Err(QueryError::parse(format!(
-                                    "default value type must match field type. Name: {}, Expected: {}, Actual: {}",
-                                    field.name, expected_arg, arg
-                                )));
-                            }
-                        }
-                    }
                 }
             }
         }

--- a/tools/integration-test/tests/query.rs
+++ b/tools/integration-test/tests/query.rs
@@ -6,6 +6,8 @@ mod commits_collection_id;
 mod commits_height_filter;
 #[path = "query/continuous_rollup.rs"]
 mod continuous_rollup;
+#[path = "query/default_values_v1.rs"]
+mod default_values_v1;
 #[path = "query/downsample.rs"]
 mod downsample;
 #[path = "query/downsample_gc.rs"]

--- a/tools/integration-test/tests/query/default_values_v1.rs
+++ b/tools/integration-test/tests/query/default_values_v1.rs
@@ -1,0 +1,61 @@
+use integration_test::{for_each_runtime, TestCluster};
+use serde_json::{json, Value};
+
+const SCHEMA: &str = r#"
+    type Defaults {
+        active: Boolean @default(value: true)
+        created: DateTime @default(value: "2000-07-23T03:00:00-00:00")
+        name: String @default(value: "Bob")
+        age: Int @default(value: 40)
+        points: Float @default(value: 10)
+        points32: Float32 @default(value: 11)
+        points64: Float64 @default(value: 12)
+        metadata: JSON @default(value: "{\"one\":1}")
+        image: Blob @default(value: "ff0099")
+    }
+"#;
+
+fn row(result: &Value) -> &Value {
+    result["Defaults"]
+        .as_array()
+        .and_then(|rows| rows.first())
+        .unwrap_or_else(|| panic!("Defaults row missing from response: {result}"))
+}
+
+async fn default_directive_value_v1_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    node.schema_add(SCHEMA).expect("add Defaults schema");
+    node.query(r#"mutation { add_Defaults(input: {}) { _docID } }"#)
+        .expect("create document with omitted fields");
+
+    let result = node
+        .query(
+            r#"query {
+                Defaults {
+                    active
+                    created
+                    name
+                    age
+                    points
+                    points32
+                    points64
+                    metadata
+                    image
+                }
+            }"#,
+        )
+        .expect("query materialized defaults");
+    let defaults = row(&result);
+
+    assert_eq!(defaults["active"], json!(true));
+    assert_eq!(defaults["created"], json!("2000-07-23T03:00:00Z"));
+    assert_eq!(defaults["name"], json!("Bob"));
+    assert_eq!(defaults["age"], json!(40));
+    assert_eq!(defaults["points"].as_f64(), Some(10.0));
+    assert_eq!(defaults["points32"].as_f64(), Some(11.0));
+    assert_eq!(defaults["points64"].as_f64(), Some(12.0));
+    assert_eq!(defaults["metadata"], json!("{\"one\":1}"));
+    assert_eq!(defaults["image"], json!("ff0099"));
+}
+
+for_each_runtime!(default_directive_value_v1, default_directive_value_v1_test);


### PR DESCRIPTION
Advances #1081. Ports Go DefraDB #4938.

## What changed

Go v1 defines `@default` with one generic `value` argument and coerces its literal according to the field type. Rust previously exposed type-specific arguments such as `int`, `bool`, and `dateTime`, while `value` worked only as a String alias.

- Make `value` the only valid `@default` argument, matching the Go v1 SDL shape.
- Coerce defaults from the host scalar type for Boolean, Int, Float, Float32, Float64, String, DateTime, JSON, and Blob fields.
- Reject legacy typed arguments, mismatched literals, list/relation defaults, and unsupported scalar types.
- Remove the obsolete argument-name bookkeeping and validation branch; type correctness is now enforced directly while parsing the value.
- Add a dual-runtime integration scenario that creates an empty document and verifies every default materializes identically on Rust and Go.

## Validation

- [x] `cargo test -p query-parse` (190 passed)
- [x] `cargo test -p integration-test --test query rust_default_directive_value_v1 -- --nocapture --test-threads=1`
- [x] `cargo test -p integration-test --test query go_default_directive_value_v1 -- --nocapture --test-threads=1`
- [x] `cargo clippy -p query-parse --all-targets -- -D warnings`
- [x] `cargo clippy -p integration-test --test query -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`