### PR TITLE
test(ffi): make embedding tests hermetic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4566,6 +4566,7 @@ dependencies = [
 name = "ffi-test"
 version = "0.1.0"
 dependencies = [
+ "axum",
  "chrono",
  "clap",
  "colored",

--- a/tools/ffi-test/Cargo.toml
+++ b/tools/ffi-test/Cargo.toml
@@ -10,8 +10,9 @@ name = "ffi-test"
 path = "src/main.rs"
 
 [dependencies]
+axum = { workspace = true }
 clap = { version = "4.5", features = ["derive"] }
-tokio = { version = "1.35", features = ["process", "fs", "rt-multi-thread", "macros", "io-util"] }
+tokio = { version = "1.35", features = ["process", "fs", "net", "rt-multi-thread", "macros", "io-util"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"

--- a/tools/ffi-test/src/commands/run.rs
+++ b/tools/ffi-test/src/commands/run.rs
@@ -1,6 +1,7 @@
 use colored::Colorize;
 
 use crate::builder::build_ffi;
+use crate::embedding_fixture::EmbeddingFixture;
 use crate::error::Result;
 use crate::report::Report;
 use crate::runner::{discover_subpackages, run_tests, RunResult, TestStatus, TestSummary};
@@ -31,13 +32,6 @@ pub async fn execute(
     println!("  Go:   {}", ctx.go_path.display());
     println!();
 
-    // Build FFI library (unless skipped)
-    if !skip_build {
-        println!("{}", "Building FFI...".bold());
-        build_ffi(&ctx, verbose).await?;
-        println!();
-    }
-
     // Discover all subpackages under this package
     let packages = discover_subpackages(&ctx.go_path, package).await?;
 
@@ -48,6 +42,15 @@ pub async fn execute(
             package
         );
         return Ok(());
+    }
+
+    let _embedding_fixture = EmbeddingFixture::start_for(&packages).await?;
+
+    // Build FFI library (unless skipped)
+    if !skip_build {
+        println!("{}", "Building FFI...".bold());
+        build_ffi(&ctx, verbose).await?;
+        println!();
     }
 
     // Run tests for each package

--- a/tools/ffi-test/src/embedding_fixture.rs
+++ b/tools/ffi-test/src/embedding_fixture.rs
@@ -1,0 +1,128 @@
+#[cfg(test)]
+use std::net::SocketAddr;
+
+use axum::{routing::post, Json, Router};
+use serde_json::{json, Value};
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+
+use crate::error::{FfiTestError, Result};
+
+const OLLAMA_TEST_ADDRESS: &str = "localhost:11434";
+const OLLAMA_TEST_IPV4: &str = "127.0.0.1:11434";
+const OLLAMA_TEST_IPV6: &str = "[::1]:11434";
+const EMBEDDING_DIMENSIONS: usize = 768;
+
+pub(crate) struct EmbeddingFixture {
+    tasks: Vec<JoinHandle<()>>,
+}
+
+impl EmbeddingFixture {
+    pub(crate) async fn start_for(packages: &[String]) -> Result<Option<Self>> {
+        if !packages
+            .iter()
+            .any(|package| package.starts_with("mutation/") && package.ends_with("/embeddings"))
+        {
+            return Ok(None);
+        }
+
+        Self::start_localhost()
+            .await
+            .map(Some)
+            .map_err(|error| {
+                FfiTestError::TestExecution(format!(
+                    "cannot start the embedding fixture on {OLLAMA_TEST_ADDRESS}: {error}; stop Ollama or any other service using that port"
+                ))
+            })
+    }
+
+    async fn start_localhost() -> std::io::Result<Self> {
+        let ipv4 = TcpListener::bind(OLLAMA_TEST_IPV4).await?;
+        let ipv6 = match TcpListener::bind(OLLAMA_TEST_IPV6).await {
+            Ok(listener) => Some(listener),
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::AddrNotAvailable | std::io::ErrorKind::Unsupported
+                ) =>
+            {
+                None
+            }
+            Err(error) => return Err(error),
+        };
+
+        let mut tasks = vec![Self::serve(ipv4)];
+        if let Some(listener) = ipv6 {
+            tasks.push(Self::serve(listener));
+        }
+        Ok(Self { tasks })
+    }
+
+    #[cfg(test)]
+    async fn start_on(address: &str) -> std::io::Result<(Self, SocketAddr)> {
+        let listener = TcpListener::bind(address).await?;
+        let local_addr = listener.local_addr()?;
+        Ok((
+            Self {
+                tasks: vec![Self::serve(listener)],
+            },
+            local_addr,
+        ))
+    }
+
+    fn serve(listener: TcpListener) -> JoinHandle<()> {
+        let app = Router::new().route("/api/embeddings", post(embeddings));
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        })
+    }
+}
+
+impl Drop for EmbeddingFixture {
+    fn drop(&mut self) {
+        for task in &self.tasks {
+            task.abort();
+        }
+    }
+}
+
+async fn embeddings(Json(_request): Json<Value>) -> Json<Value> {
+    Json(json!({
+        "data": [{
+            "embedding": vec![0.0; EMBEDDING_DIMENSIONS],
+        }],
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpStream;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn serves_openai_compatible_embedding() {
+        let (_fixture, address) = EmbeddingFixture::start_on("127.0.0.1:0").await.unwrap();
+        let body = r#"{"model":"nomic-embed-text","input":"hello"}"#;
+        let request = format!(
+            "POST /api/embeddings HTTP/1.1\r\nHost: {address}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        );
+
+        let mut stream = TcpStream::connect(address).await.unwrap();
+        stream.write_all(request.as_bytes()).await.unwrap();
+        let mut response = Vec::new();
+        stream.read_to_end(&mut response).await.unwrap();
+
+        let response = String::from_utf8(response).unwrap();
+        let (_, body) = response.split_once("\r\n\r\n").unwrap();
+        let json: Value = serde_json::from_str(body).unwrap();
+        assert_eq!(
+            json.pointer("/data/0/embedding")
+                .and_then(Value::as_array)
+                .map(Vec::len),
+            Some(EMBEDDING_DIMENSIONS)
+        );
+    }
+}

--- a/tools/ffi-test/src/main.rs
+++ b/tools/ffi-test/src/main.rs
@@ -3,6 +3,7 @@ use clap::{Parser, Subcommand};
 mod builder;
 mod commands;
 mod config;
+mod embedding_fixture;
 mod error;
 mod report;
 mod runner;


### PR DESCRIPTION
Fixes #1023.

## Problem

The Go FFI mutation embedding tests hard-coded `http://localhost:11434/api`, while the Rust FFI runner enabled them without provisioning the endpoint. A normal local or CI run therefore depended on an unmanaged Ollama process and model.

## What changed

- Add a process-local OpenAI-compatible embedding fixture for mutation embedding packages.
- Serve deterministic 768-dimensional embeddings from `/api/embeddings` on IPv4 and IPv6 loopback.
- Fail before building when another service owns port `11434`, with an actionable error.
- Scope the fixture lifetime to the FFI run and leave unrelated packages unchanged.
- Add socket-level coverage for the request/response contract.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `git diff origin/main...HEAD --check`
- [x] `cargo clippy -p ffi-test --all-targets -- -D warnings`
- [x] `cargo test -p ffi-test` (1 passed)