### PR TITLE
test(conformance): model encrypted LWW replay

### DIFF
--- a/proofs/README.md
+++ b/proofs/README.md
@@ -20,7 +20,7 @@ Status of the effort across the 40-crate surface, from the per-crate survey in
 are plumbing covered by integration tests / Go-FFI parity / unit tests. The point of this
 section is the **diff**: what is proven vs. the accepted gap.
 
-### Modeled — 19 families (proven)
+### Modeled — 20 families (proven)
 | Family | Tool | Crates it covers |
 |---|---|---|
 | B3 filtered replication | TLA+ | p2p, db-merge |
@@ -30,6 +30,7 @@ section is the **diff**: what is proven vs. the accepted gap.
 | Multi-instance claim | TLA+ | defra-agent |
 | Block integrity / signatures | TLA+ | db-merge, defra-core, blockstore |
 | KMS key distribution | TLA+ | kms, db-merge |
+| Encrypted LWW restart/replay | TLA+ + existing LWW Lean law | kms, p2p, db-merge, crdt |
 | Management-channel auth (NAC gate) | TLA+ | http, db-nac, pg-compat |
 | ACP soundness + revocation + dual-path commits | TLA+ & Lean | acp, zanzibar, sourcehub, query, db |
 | Storage SSI serializability (point + range/scan carve-out) | TLA+ | storage |
@@ -85,7 +86,7 @@ shipped code, on two axes matching the two tools:
 | Axis | What it checks | Needs a binary? | Entry |
 |---|---|---|---|
 | **Lean (auto)** | `lean/Conformance.lean` emits a JSON contract (vocabularies derived from the Lean models); the live Rust types are asserted to still match — anti-drift | no | `tests/lean_conformance.rs` |
-| **TLA (behavioral)** | each family's invariant is driven against the **running release binary** via the backbone `defra-harness` | yes | `tests/tla_conformance.rs` |
+| **TLA (behavioral)** | each family's invariant is driven against the **running DefraDB binary** via the backbone `defra-harness` | yes | `tests/tla_conformance.rs` |
 
 [`src/registry.rs`] (`PROPERTIES`) is the spine: every *Modeled* family above maps
 to its headline invariant, source anchor, the model that proves it, and its
@@ -95,9 +96,9 @@ substrate) — so a green run never reads as "this was proven against the
 artifact." `matrix::every_modeled_family_is_bound` fails if a model lands without
 a binding.
 
-### Realized status — all 19 families bound
+### Realized status — all 20 families bound
 
-**19 behavioral tests** (driven against `target/release/defra`, each break-tested
+**19 behavioral tests** (driven against fresh `target/debug/defra`, each break-tested
 for non-vacuity), **2 Lean-axis contract bindings**, **6 honest Boundaries** (one,
 Transaction & merge-queue concurrency, is now both — a Behavioral no-loss/no-double-apply
 storm leg plus a Boundary internal-serialization leg). One
@@ -122,6 +123,7 @@ headstore); go↔go vs rust↔rust parity (`parity.rs`) localized it to Rust.
 | CID determinism | Behavioral | `cid.rs` |
 | Index-maintenance | Behavioral | `index.rs` (single-node create/update/delete + indexed LWW restart/merge reconciliation); `MC_IndexReconciliation_{Red_SaveOnly,Green}` |
 | KMS key distribution | Behavioral | `kms.rs` (node0 denies the DEK to unauthorized node1) |
+| Encrypted LWW restart/replay | Behavioral | `partition::convergence_encrypted_lww_restart_merge` (encrypted siblings cross a real restart; identical DAGs and decrypted LWW winner asserted); `MC_EncryptedLwwReplay_{Green,Red_*}`; reuses `PriorityReconcile.lwwCM` |
 | CRDT merge laws | Contract | `MergeResult` vocab; `DefraConvergence.MixedField` product proof; `MixedFieldMaterialization.tla` |
 | Multi-instance claim | Boundary | defra-agent substrate, not this binary |
 | Block integrity / signatures | Boundary | needs adversarial peer; Rust verify mandatory |
@@ -131,7 +133,7 @@ headstore); go↔go vs rust↔rust parity (`parity.rs`) localized it to Rust.
 
 ```bash
 proofs/verify-all.sh                 # TLA + Lean + conformance (behavioral if binary present)
-cargo build --release -p cli         # produce target/release/defra (the artifact under test)
+cargo build -p cli                   # produce fresh target/debug/defra
 cargo test -p conformance            # Lean axis + behavioral; DEFRA_CONFORMANCE_BINARY overrides target
 ```
 
@@ -179,6 +181,6 @@ Read this before trusting a verdict; it states the model's honest reach.
 - **Model ≠ code.** These prove properties of the *models*. They are anchored to source by
   the `*_DESIGN.md` docs and bound to the implementation by the `conformance` crate (see
   *Conformance* above) — the Lean axis asserts model vocabularies against live Rust types,
-  the TLA axis drives the real release binary. What conformance does **not** reach is marked
+  the TLA axis drives the selected DefraDB binary. What conformance does **not** reach is marked
   `Boundary` in the registry (crypto, eventual connectivity, bounded-N, the defra-agent
   claim substrate): assumed, never asserted against the artifact.

--- a/proofs/README.md
+++ b/proofs/README.md
@@ -123,7 +123,7 @@ headstore); go↔go vs rust↔rust parity (`parity.rs`) localized it to Rust.
 | CID determinism | Behavioral | `cid.rs` |
 | Index-maintenance | Behavioral | `index.rs` (single-node create/update/delete + indexed LWW restart/merge reconciliation); `MC_IndexReconciliation_{Red_SaveOnly,Green}` |
 | KMS key distribution | Behavioral | `kms.rs` (node0 denies the DEK to unauthorized node1) |
-| Encrypted LWW restart/replay | Behavioral | `partition::convergence_encrypted_lww_restart_merge` (encrypted siblings cross a real restart; identical DAGs and decrypted LWW winner asserted); `MC_EncryptedLwwReplay_{Green,Red_*}`; reuses `PriorityReconcile.lwwCM` |
+| Encrypted LWW restart/replay | Behavioral + Boundary | `partition::convergence_encrypted_lww_restart_merge` binds the decrypted LWW winner after a restart-induced partition; filtered replication binds encrypted-field preservation. Durable acknowledgement-backed retry through a receiver restart remains Boundary; `MC_EncryptedLwwReplay_{Green,Red_*}`; reuses `PriorityReconcile.lwwCM` |
 | CRDT merge laws | Contract | `MergeResult` vocab; `DefraConvergence.MixedField` product proof; `MixedFieldMaterialization.tla` |
 | Multi-instance claim | Boundary | defra-agent substrate, not this binary |
 | Block integrity / signatures | Boundary | needs adversarial peer; Rust verify mandatory |

--- a/proofs/src/matrix.rs
+++ b/proofs/src/matrix.rs
@@ -17,6 +17,7 @@ pub const MODELED_FAMILIES: &[&str] = &[
     "Multi-instance claim",
     "Block integrity / signatures",
     "KMS key distribution",
+    "Encrypted LWW restart/replay",
     "Management-channel auth (NAC gate)",
     "ACP soundness + revocation + dual-path commits",
     "Storage SSI serializability (point + range/scan carve-out)",

--- a/proofs/src/registry.rs
+++ b/proofs/src/registry.rs
@@ -136,6 +136,18 @@ pub const PROPERTIES: &[Property] = &[
         tiers: &[Behavioral, Boundary],
     },
     Property {
+        // Encryption reuses PriorityReconcile.lwwCM unchanged: ciphertext and
+        // key timing affect when a value can materialize, not which value wins.
+        // The behavioral leg receives both encrypted siblings across a real
+        // restart, proves identical DAGs, and asserts the decrypted winner.
+        family: "Encrypted LWW restart/replay",
+        name: "INV_AckBacked / INV_NoFilteredLoss / INV_LwwWinner — encrypted replay remains complete and convergent",
+        axis: Tla,
+        anchor: "crates/db-merge/src/merge_handler/composite_fields.rs; crates/db-merge/src/push_docs.rs; crates/db-merge/src/push_docs_transport.rs; crates/p2p/src/sync/pending_store.rs; crates/crdt/src/lww.rs",
+        model_ref: "MC_EncryptedLwwReplay_Green.cfg",
+        tiers: &[Behavioral],
+    },
+    Property {
         family: "Management-channel auth (NAC gate)",
         name: "INV_OnlyAuthorizedManages — management ops require a valid scoped token",
         axis: Tla,

--- a/proofs/src/registry.rs
+++ b/proofs/src/registry.rs
@@ -138,14 +138,26 @@ pub const PROPERTIES: &[Property] = &[
     Property {
         // Encryption reuses PriorityReconcile.lwwCM unchanged: ciphertext and
         // key timing affect when a value can materialize, not which value wins.
-        // The behavioral leg receives both encrypted siblings across a real
-        // restart, proves identical DAGs, and asserts the decrypted winner.
+        // The behavioral legs preserve encrypted fields selected for filtered
+        // replication and receive both encrypted siblings after a real restart,
+        // proving identical DAGs and the decrypted winner.
         family: "Encrypted LWW restart/replay",
-        name: "INV_AckBacked / INV_NoFilteredLoss / INV_LwwWinner — encrypted replay remains complete and convergent",
+        name: "INV_NoFilteredLoss / INV_LwwWinner — encrypted delivery remains complete and LWW-convergent",
         axis: Tla,
-        anchor: "crates/db-merge/src/merge_handler/composite_fields.rs; crates/db-merge/src/push_docs.rs; crates/db-merge/src/push_docs_transport.rs; crates/p2p/src/sync/pending_store.rs; crates/crdt/src/lww.rs",
+        anchor: "crates/db-merge/src/push_docs.rs; crates/db-merge/src/push_docs_transport.rs; crates/crdt/src/lww.rs",
         model_ref: "MC_EncryptedLwwReplay_Green.cfg",
         tiers: &[Behavioral],
+    },
+    Property {
+        // The model and focused KMS/merge unit tests cover the retry mechanics,
+        // but the external harness cannot deterministically hold a DEK request
+        // unavailable between ciphertext acknowledgement and receiver restart.
+        family: "Encrypted LWW restart/replay",
+        name: "INV_AckBacked — acknowledged encrypted replay remains re-drivable across transient KMS failure and restart",
+        axis: Tla,
+        anchor: "crates/db-merge/src/merge_handler/composite_fields.rs; crates/p2p/src/sync/pending_store.rs",
+        model_ref: "MC_EncryptedLwwReplay_Green.cfg",
+        tiers: &[Boundary],
     },
     Property {
         family: "Management-channel auth (NAC gate)",

--- a/proofs/tests/behavioral/parity.rs
+++ b/proofs/tests/behavioral/parity.rs
@@ -194,23 +194,6 @@ fn has_active_peer(node: &DefraClient, peer_id: &str) -> bool {
 
 async fn wire_user_bidirectional(cluster: &TestCluster) {
     let (a0, a1) = (node_addr(cluster, 0), node_addr(cluster, 1));
-    cluster
-        .client(0)
-        .p2p_collection_add(&["User"])
-        .expect("subscribe node0");
-    cluster
-        .client(1)
-        .p2p_collection_add(&["User"])
-        .expect("subscribe node1");
-    cluster
-        .client(0)
-        .p2p_replicator_set(&["User"], &a1)
-        .expect("replicator node0");
-    cluster
-        .client(1)
-        .p2p_replicator_set(&["User"], &a0)
-        .expect("replicator node1");
-
     let (peer0, peer1) = (peer_id_from_addr(&a0), peer_id_from_addr(&a1));
     let deadline = Instant::now() + Duration::from_secs(30);
     let (mut last_dial0, mut last_dial1) =
@@ -221,7 +204,7 @@ async fn wire_user_bidirectional(cluster: &TestCluster) {
             has_active_peer(&cluster.client(1), peer0),
         );
         if node0_connected && node1_connected {
-            return;
+            break;
         }
 
         if !node0_connected {
@@ -245,6 +228,23 @@ async fn wire_user_bidirectional(cluster: &TestCluster) {
         );
         tokio::time::sleep(Duration::from_millis(300)).await;
     }
+
+    cluster
+        .client(0)
+        .p2p_collection_add(&["User"])
+        .expect("subscribe node0");
+    cluster
+        .client(1)
+        .p2p_collection_add(&["User"])
+        .expect("subscribe node1");
+    cluster
+        .client(0)
+        .p2p_replicator_set(&["User"], &a1)
+        .expect("replicator node0");
+    cluster
+        .client(1)
+        .p2p_replicator_set(&["User"], &a0)
+        .expect("replicator node1");
 }
 
 /// Controlled equal-priority LWW probe: the nodes are intentionally not wired

--- a/proofs/tests/behavioral/parity.rs
+++ b/proofs/tests/behavioral/parity.rs
@@ -173,10 +173,27 @@ fn user_name_commits(node: &DefraClient, doc_id: &str) -> serde_json::Value {
     .unwrap_or_default()
 }
 
-fn wire_user_bidirectional(cluster: &TestCluster) {
+fn peer_id_from_addr(addr: &str) -> &str {
+    addr.rsplit_once("/p2p/")
+        .map_or(addr, |(_, peer_id)| peer_id)
+}
+
+fn has_active_peer(node: &DefraClient, peer_id: &str) -> bool {
+    node.p2p_active_peers()
+        .ok()
+        .and_then(|peers| {
+            peers.as_array().map(|peers| {
+                peers.iter().any(|peer| {
+                    peer.as_str()
+                        .is_some_and(|addr| peer_id_from_addr(addr) == peer_id)
+                })
+            })
+        })
+        .unwrap_or(false)
+}
+
+async fn wire_user_bidirectional(cluster: &TestCluster) {
     let (a0, a1) = (node_addr(cluster, 0), node_addr(cluster, 1));
-    cluster.client(0).p2p_connect(&[a1.as_str()]).ok();
-    cluster.client(1).p2p_connect(&[a0.as_str()]).ok();
     cluster
         .client(0)
         .p2p_collection_add(&["User"])
@@ -193,6 +210,41 @@ fn wire_user_bidirectional(cluster: &TestCluster) {
         .client(1)
         .p2p_replicator_set(&["User"], &a0)
         .expect("replicator node1");
+
+    let (peer0, peer1) = (peer_id_from_addr(&a0), peer_id_from_addr(&a1));
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let (mut last_dial0, mut last_dial1) =
+        ("not attempted".to_string(), "not attempted".to_string());
+    loop {
+        let (node0_connected, node1_connected) = (
+            has_active_peer(&cluster.client(0), peer1),
+            has_active_peer(&cluster.client(1), peer0),
+        );
+        if node0_connected && node1_connected {
+            return;
+        }
+
+        if !node0_connected {
+            last_dial0 = cluster
+                .client(0)
+                .p2p_connect(&[a1.as_str()])
+                .map(|_| "ok".to_string())
+                .unwrap_or_else(|err| format!("{err:#}"));
+        }
+        if !node1_connected {
+            last_dial1 = cluster
+                .client(1)
+                .p2p_connect(&[a0.as_str()])
+                .map(|_| "ok".to_string())
+                .unwrap_or_else(|err| format!("{err:#}"));
+        }
+
+        assert!(
+            Instant::now() < deadline,
+            "P2P heal timed out: node0->{peer1} last dial={last_dial0}; node1->{peer0} last dial={last_dial1}"
+        );
+        tokio::time::sleep(Duration::from_millis(300)).await;
+    }
 }
 
 /// Controlled equal-priority LWW probe: the nodes are intentionally not wired
@@ -236,7 +288,7 @@ async fn run_lww_tie_partition_probe(cluster: TestCluster, label: &str, expected
         user_name_commits(&cluster.client(1), &id),
     );
 
-    wire_user_bidirectional(&cluster);
+    wire_user_bidirectional(&cluster).await;
     assert!(
         support::poll_dags_converged(
             &cluster.client(0),

--- a/proofs/tests/behavioral/partition.rs
+++ b/proofs/tests/behavioral/partition.rs
@@ -815,12 +815,14 @@ async fn poll_vault_secret(node: &DefraClient, want: &str, timeout: Duration) ->
     }
 }
 
-/// ENCRYPTED-field LWW convergence across a restart-partition. An encrypted field
-/// routes its delta through the KMS write path (a random per-write key gossiped
-/// over the encryption topic) rather than the plain block path. node1 is
+/// ENCRYPTED-field LWW convergence after a restart-induced partition. An encrypted
+/// field routes its delta through the KMS write path (a random per-write key
+/// gossiped over the encryption topic) rather than the plain block path. node1 is
 /// restarted to sever the link, both nodes concurrently update the same encrypted
 /// field, then reconnect; both must materialize the same plaintext LWW winner
-/// ("zzz" > "aaa" on the equal-priority lexicographic tie-break).
+/// ("zzz" > "aaa" on the equal-priority lexicographic tie-break). The competing
+/// ciphertexts are created after the restart, so this test binds `INV_LwwWinner`,
+/// not acknowledgement-backed pending replay through a restart.
 ///
 /// The two replicas guard different halves, deliberately:
 /// - node0 (locally wrote the LOSER "aaa") is the end-to-end leg: to reach "zzz"

--- a/proofs/tests/behavioral/partition.rs
+++ b/proofs/tests/behavioral/partition.rs
@@ -841,6 +841,8 @@ async fn poll_vault_secret(node: &DefraClient, want: &str, timeout: Duration) ->
 /// the winning ciphertext can't be decrypted — diverges here. Convergence
 /// requires both the LWW store reconcile AND correct key delivery over the
 /// restart.
+/// Model: `MC_EncryptedLwwReplay_Green`; algebra:
+/// `DefraConvergence.PriorityReconcile.lwwCM`.
 #[tokio::test]
 async fn convergence_encrypted_lww_restart_merge() {
     let mut cluster = TestCluster::builder()

--- a/proofs/tla/EncryptedLwwReplay.tla
+++ b/proofs/tla/EncryptedLwwReplay.tla
@@ -1,0 +1,302 @@
+---- MODULE EncryptedLwwReplay ----
+\* Encrypted LWW materialization across partition, key delay, and restart (#1049).
+\*
+\* Encryption does not change the LWW algebra proved by
+\* DefraConvergence.PriorityReconcile.lwwCM. It adds a temporal obligation:
+\* an acknowledged ciphertext whose DEK is not available yet must remain
+\* re-drivable across transient KMS failure and restart, and delivery filters
+\* must retain the encrypted field block that triggers the key request.
+\*
+\* Source anchors:
+\* - crates/db-merge/src/merge_handler/composite_fields.rs propagates transient
+\*   KMS failures so the merge remains pending;
+\* - crates/db-merge/src/push_docs{,_transport}.rs preserve encrypted LWW heads;
+\* - crates/p2p/src/sync/pending_store.rs persists acknowledged pending DAGs;
+\* - crates/crdt/src/lww.rs selects the greatest (priority, value) version.
+EXTENDS Naturals
+
+CONSTANTS
+  LocalVersion,
+  RemoteVersion,
+  PendingMode,  \* "Durable" | "Volatile"
+  FilterMode,   \* "PreserveEncrypted" | "DropEncrypted"
+  MergeMode,    \* "Lww" | "ArrivalWins"
+  KmsFailureMode \* "Retry" | "TerminalSkip"
+
+ASSUME LocalVersion \in Nat
+ASSUME RemoteVersion \in Nat
+ASSUME LocalVersion > RemoteVersion
+ASSUME PendingMode \in {"Durable", "Volatile"}
+ASSUME FilterMode \in {"PreserveEncrypted", "DropEncrypted"}
+ASSUME MergeMode \in {"Lww", "ArrivalWins"}
+ASSUME KmsFailureMode \in {"Retry", "TerminalSkip"}
+
+VARIABLES
+  running,
+  connected,
+  partitionUsed,
+  restartAvailable,
+  senderPending,
+  ciphertextStored,
+  volatilePending,
+  durablePending,
+  requestPending,
+  keyServiceReady,
+  keyEnvelope,
+  keyAvailable,
+  localApplied,
+  remoteApplied,
+  materialized,
+  acknowledged
+
+vars ==
+  << running, connected, partitionUsed, restartAvailable, senderPending,
+     ciphertextStored, volatilePending, durablePending, requestPending,
+     keyServiceReady, keyEnvelope, keyAvailable, localApplied, remoteApplied,
+     materialized, acknowledged >>
+
+TypeOK ==
+  /\ running \in BOOLEAN
+  /\ connected \in BOOLEAN
+  /\ partitionUsed \in BOOLEAN
+  /\ restartAvailable \in BOOLEAN
+  /\ senderPending \in BOOLEAN
+  /\ ciphertextStored \in BOOLEAN
+  /\ volatilePending \in BOOLEAN
+  /\ durablePending \in BOOLEAN
+  /\ requestPending \in BOOLEAN
+  /\ keyServiceReady \in BOOLEAN
+  /\ keyEnvelope \in BOOLEAN
+  /\ keyAvailable \in BOOLEAN
+  /\ localApplied \in BOOLEAN
+  /\ remoteApplied \in BOOLEAN
+  /\ materialized \in 0..LocalVersion
+  /\ acknowledged \in BOOLEAN
+
+Init ==
+  /\ running = TRUE
+  /\ connected = FALSE
+  /\ partitionUsed = FALSE
+  /\ restartAvailable = TRUE
+  /\ senderPending = TRUE
+  /\ ciphertextStored = FALSE
+  /\ volatilePending = FALSE
+  /\ durablePending = FALSE
+  /\ requestPending = FALSE
+  /\ keyServiceReady = FALSE
+  /\ keyEnvelope = FALSE
+  /\ keyAvailable = FALSE
+  /\ localApplied = FALSE
+  /\ remoteApplied = FALSE
+  /\ materialized = 0
+  /\ acknowledged = FALSE
+
+Reconnect ==
+  /\ running
+  /\ ~connected
+  /\ connected' = TRUE
+  /\ UNCHANGED <<running, partitionUsed, restartAvailable, senderPending,
+                  ciphertextStored, volatilePending, durablePending,
+                  requestPending, keyServiceReady, keyEnvelope, keyAvailable,
+                  localApplied, remoteApplied, materialized, acknowledged>>
+
+Partition ==
+  /\ running
+  /\ connected
+  /\ ~partitionUsed
+  /\ ~remoteApplied
+  /\ connected' = FALSE
+  /\ partitionUsed' = TRUE
+  /\ UNCHANGED <<running, restartAvailable, senderPending, ciphertextStored,
+                  volatilePending, durablePending, requestPending, keyEnvelope,
+                  keyServiceReady, keyAvailable, localApplied, remoteApplied,
+                  materialized, acknowledged>>
+
+ApplyLocal ==
+  /\ running
+  /\ ~localApplied
+  /\ localApplied' = TRUE
+  /\ materialized' =
+       IF materialized >= LocalVersion THEN materialized ELSE LocalVersion
+  /\ UNCHANGED <<running, connected, partitionUsed, restartAvailable,
+                  senderPending, ciphertextStored, volatilePending,
+                  durablePending, requestPending, keyEnvelope, keyAvailable,
+                  keyServiceReady, remoteApplied, acknowledged>>
+
+DeliverRemote ==
+  /\ running
+  /\ connected
+  /\ senderPending
+  /\ FilterMode = "PreserveEncrypted"
+  /\ senderPending' = FALSE
+  /\ ciphertextStored' = TRUE
+  /\ volatilePending' = TRUE
+  /\ durablePending' = (PendingMode = "Durable")
+  /\ acknowledged' = TRUE
+  /\ UNCHANGED <<running, connected, partitionUsed, restartAvailable,
+                  requestPending, keyEnvelope, keyAvailable, localApplied,
+                  keyServiceReady, remoteApplied, materialized>>
+
+DropRemote ==
+  /\ running
+  /\ connected
+  /\ senderPending
+  /\ FilterMode = "DropEncrypted"
+  /\ senderPending' = FALSE
+  /\ UNCHANGED <<running, connected, partitionUsed, restartAvailable,
+                  ciphertextStored, volatilePending, durablePending,
+                  requestPending, keyServiceReady, keyEnvelope, keyAvailable,
+                  localApplied, remoteApplied, materialized, acknowledged>>
+
+RequestKey ==
+  /\ running
+  /\ volatilePending
+  /\ ciphertextStored
+  /\ ~keyAvailable
+  /\ ~requestPending
+  /\ ~keyEnvelope
+  /\ requestPending' = TRUE
+  /\ UNCHANGED <<running, connected, partitionUsed, restartAvailable,
+                  senderPending, ciphertextStored, volatilePending,
+                  durablePending, keyEnvelope, keyAvailable, localApplied,
+                  keyServiceReady, remoteApplied, materialized, acknowledged>>
+
+KeyServiceBecomesReady ==
+  /\ running
+  /\ ~keyServiceReady
+  /\ keyServiceReady' = TRUE
+  /\ UNCHANGED <<running, connected, partitionUsed, restartAvailable,
+                  senderPending, ciphertextStored, volatilePending,
+                  durablePending, requestPending, keyEnvelope, keyAvailable,
+                  localApplied, remoteApplied, materialized, acknowledged>>
+
+KeyUnavailable ==
+  /\ running
+  /\ requestPending
+  /\ ~keyServiceReady
+  /\ requestPending' = FALSE
+  /\ volatilePending' =
+       IF KmsFailureMode = "Retry" THEN volatilePending ELSE FALSE
+  /\ durablePending' =
+       IF KmsFailureMode = "Retry" THEN durablePending ELSE FALSE
+  /\ UNCHANGED <<running, connected, partitionUsed, restartAvailable,
+                  senderPending, ciphertextStored, keyServiceReady, keyEnvelope,
+                  keyAvailable, localApplied, remoteApplied, materialized,
+                  acknowledged>>
+
+ReleaseKey ==
+  /\ running
+  /\ connected
+  /\ requestPending
+  /\ keyServiceReady
+  /\ requestPending' = FALSE
+  /\ keyEnvelope' = TRUE
+  /\ UNCHANGED <<running, connected, partitionUsed, restartAvailable,
+                  senderPending, ciphertextStored, volatilePending,
+                  durablePending, keyServiceReady, keyAvailable, localApplied,
+                  remoteApplied, materialized, acknowledged>>
+
+ReceiveKey ==
+  /\ running
+  /\ connected
+  /\ keyEnvelope
+  /\ keyEnvelope' = FALSE
+  /\ keyAvailable' = TRUE
+  /\ UNCHANGED <<running, connected, partitionUsed, restartAvailable,
+                  senderPending, ciphertextStored, volatilePending,
+                  durablePending, requestPending, keyServiceReady, localApplied,
+                  remoteApplied, materialized, acknowledged>>
+
+MaterializeRemote ==
+  /\ running
+  /\ volatilePending
+  /\ ciphertextStored
+  /\ keyAvailable
+  /\ ~remoteApplied
+  /\ remoteApplied' = TRUE
+  /\ volatilePending' = FALSE
+  /\ durablePending' = FALSE
+  /\ materialized' =
+       IF MergeMode = "Lww"
+       THEN IF materialized >= RemoteVersion THEN materialized ELSE RemoteVersion
+       ELSE RemoteVersion
+  /\ UNCHANGED <<running, connected, partitionUsed, restartAvailable,
+                  senderPending, ciphertextStored, requestPending, keyEnvelope,
+                  keyServiceReady, keyAvailable, localApplied, acknowledged>>
+
+Crash ==
+  /\ running
+  /\ restartAvailable
+  /\ acknowledged
+  /\ ~remoteApplied
+  /\ running' = FALSE
+  /\ connected' = FALSE
+  /\ restartAvailable' = FALSE
+  /\ volatilePending' = FALSE
+  /\ requestPending' = FALSE
+  /\ keyEnvelope' = FALSE
+  /\ UNCHANGED <<partitionUsed, senderPending, ciphertextStored, durablePending,
+                  keyServiceReady, keyAvailable, localApplied, remoteApplied,
+                  materialized, acknowledged>>
+
+Recover ==
+  /\ ~running
+  /\ running' = TRUE
+  /\ volatilePending' = durablePending
+  /\ UNCHANGED <<connected, partitionUsed, restartAvailable, senderPending,
+                  ciphertextStored, durablePending, requestPending, keyEnvelope,
+                  keyServiceReady, keyAvailable, localApplied, remoteApplied,
+                  materialized, acknowledged>>
+
+Next ==
+  \/ Reconnect
+  \/ Partition
+  \/ ApplyLocal
+  \/ DeliverRemote
+  \/ DropRemote
+  \/ RequestKey
+  \/ KeyServiceBecomesReady
+  \/ KeyUnavailable
+  \/ ReleaseKey
+  \/ ReceiveKey
+  \/ MaterializeRemote
+  \/ Crash
+  \/ Recover
+
+Fairness ==
+  /\ WF_vars(Reconnect)
+  /\ WF_vars(ApplyLocal)
+  /\ WF_vars(DeliverRemote)
+  /\ WF_vars(DropRemote)
+  /\ WF_vars(RequestKey)
+  /\ WF_vars(KeyServiceBecomesReady)
+  /\ WF_vars(KeyUnavailable)
+  /\ WF_vars(ReleaseKey)
+  /\ WF_vars(ReceiveKey)
+  /\ WF_vars(MaterializeRemote)
+  /\ WF_vars(Recover)
+
+Spec == Init /\ [][Next]_vars /\ Fairness
+
+INV_TypeOK == TypeOK
+
+\* Once the sender retires an acknowledged push, either the receiver has
+\* applied it or a volatile/durable retry obligation still backs the ack.
+INV_AckBacked ==
+  ~acknowledged \/ remoteApplied \/ volatilePending \/ durablePending
+
+\* A filter may reject an entire document, but it must not retire the encrypted
+\* field block of a document selected for delivery.
+INV_NoFilteredLoss ==
+  senderPending \/ ciphertextStored \/ remoteApplied
+
+\* The remote replay is older than the concurrent local write. Decryption and
+\* arrival order must not let it overwrite the existing LWW winner.
+INV_LwwWinner ==
+  ~(localApplied /\ remoteApplied) \/ materialized = LocalVersion
+
+\* Under eventual reconnect and fair key service, both writes settle on the
+\* same LWW winner even if the receiver restarts before or after key delivery.
+LIVE_WinnerMaterialized ==
+  <>[](localApplied /\ remoteApplied /\ materialized = LocalVersion)
+====

--- a/proofs/tla/EncryptedLwwReplay_DESIGN.md
+++ b/proofs/tla/EncryptedLwwReplay_DESIGN.md
@@ -1,0 +1,52 @@
+# Encrypted LWW restart/replay - TLA+ design
+
+This model covers issue **#1049**. Encryption does not change the LWW merge
+algebra proved by `DefraConvergence.PriorityReconcile.lwwCM`; it changes when a
+received value can be materialized. The temporal obligation is that an
+acknowledged encrypted field remains re-drivable until its DEK is available,
+including across a receiver restart.
+
+## Source-grounded facts
+
+| Fact | Source | Model consequence |
+|---|---|---|
+| Filtered replication pushes every non-counter field block, including encrypted LWW blocks, as a head so receipt triggers DEK resolution. | `crates/db-merge/src/push_docs.rs`, `crates/db-merge/src/push_docs_transport.rs` | `FilterMode="PreserveEncrypted"` stores the ciphertext; the red mode drops it and violates `INV_NoFilteredLoss`. |
+| Only `AccessDenied` is a terminal encrypted-field skip. `KeyUnavailable` and other transient KMS errors abort the merge transaction. | `crates/db-merge/src/merge_handler/composite_fields.rs`, `crates/db-merge/src/merge_handler/mod.rs` | `KmsFailureMode="Retry"` retains the pending merge; the red terminal mode retires it. |
+| Push-originated pending-DAG registrations are persisted before success acknowledgement and removed only after merge or quarantine. | `crates/p2p/src/sync/pending_store.rs`, `crates/p2p/src/sync/manager/process/pending_dag.rs` | `PendingMode="Durable"` restores the retry obligation after a crash. |
+| A verified remotely fetched encryption block is stored before its key is returned to the merge. | `crates/kms/src/defra_kms.rs` | `keyAvailable` survives `Crash`; an in-flight request or envelope does not. |
+| LWW selects the greatest version independent of delivery order. | `crates/crdt/src/lww.rs` | `MergeMode="Lww"` preserves `LocalVersion`; arrival-wins is the red policy. |
+
+## Properties
+
+- `INV_AckBacked`: an acknowledged remote value is applied or still has a
+  volatile/durable retry obligation.
+- `INV_NoFilteredLoss`: retiring the sender's delivery record cannot lose the
+  encrypted field block selected for replication.
+- `INV_LwwWinner`: key timing and replay order cannot replace a newer local LWW
+  value with an older remote value.
+- `LIVE_WinnerMaterialized`: under fair reconnect and key service, both writes
+  eventually settle on the LWW winner.
+
+The model starts with the key service unavailable. It explores a failed lookup,
+service recovery, restart before receipt, restart after the key is durably
+stored, and replay against a newer local write.
+
+## Configs
+
+| Config | Verdict | Fault isolated |
+|---|---|---|
+| `MC_EncryptedLwwReplay_Green.cfg` | GREEN | durable pending state, retryable KMS miss, preserved field, LWW merge |
+| `MC_EncryptedLwwReplay_Red_TerminalUnavailable.cfg` | RED | transient KMS miss is acknowledged as a terminal skip |
+| `MC_EncryptedLwwReplay_Red_VolatilePending.cfg` | RED | restart destroys the only retry obligation |
+| `MC_EncryptedLwwReplay_Red_FilterDropsField.cfg` | RED | selected encrypted field is omitted from delivery |
+| `MC_EncryptedLwwReplay_Red_ArrivalWins.cfg` | RED | stale decrypted replay overwrites the newer local value |
+
+## Conformance fence
+
+`proofs/tests/behavioral/partition.rs::convergence_encrypted_lww_restart_merge`
+drives two encrypted siblings across a real node restart, first proves identical
+commit DAGs, then asserts both nodes decrypt and materialize the LWW winner.
+`tools/integration-test/tests/p2p/filtered_replication.rs` asserts matching
+encrypted documents retain their complete delivery path. The merge/KMS unit
+tests exercise the deterministic timeout-to-retry classification that is hard
+to schedule reliably through the external harness.

--- a/proofs/tla/EncryptedLwwReplay_DESIGN.md
+++ b/proofs/tla/EncryptedLwwReplay_DESIGN.md
@@ -47,6 +47,7 @@ stored, and replay against a newer local write.
 drives two encrypted siblings across a real node restart, first proves identical
 commit DAGs, then asserts both nodes decrypt and materialize the LWW winner.
 `tools/integration-test/tests/p2p/filtered_replication.rs` asserts matching
-encrypted documents retain their complete delivery path. The merge/KMS unit
-tests exercise the deterministic timeout-to-retry classification that is hard
-to schedule reliably through the external harness.
+encrypted documents decrypt on the filtered peer, proving their field heads
+survive selection and trigger DEK resolution. The merge/KMS unit tests exercise
+the deterministic timeout-to-retry classification that is hard to schedule
+reliably through the external harness.

--- a/proofs/tla/EncryptedLwwReplay_DESIGN.md
+++ b/proofs/tla/EncryptedLwwReplay_DESIGN.md
@@ -44,10 +44,14 @@ stored, and replay against a newer local write.
 ## Conformance fence
 
 `proofs/tests/behavioral/partition.rs::convergence_encrypted_lww_restart_merge`
-drives two encrypted siblings across a real node restart, first proves identical
-commit DAGs, then asserts both nodes decrypt and materialize the LWW winner.
+drives two encrypted siblings across a restart-induced partition, first proves
+identical commit DAGs, then asserts both nodes decrypt and materialize the LWW
+winner. Because those siblings are created after the restart, this binds
+`INV_LwwWinner`; it does not schedule a restart after ciphertext acknowledgement
+while the DEK is unavailable. `INV_AckBacked` therefore remains a conformance
+boundary.
 `tools/integration-test/tests/p2p/filtered_replication.rs` asserts matching
 encrypted documents decrypt on the filtered peer, proving their field heads
-survive selection and trigger DEK resolution. The merge/KMS unit tests exercise
-the deterministic timeout-to-retry classification that is hard to schedule
-reliably through the external harness.
+survive selection and trigger DEK resolution, binding `INV_NoFilteredLoss`. The
+merge/KMS unit tests exercise the deterministic timeout-to-retry classification
+that is hard to schedule reliably through the external harness.

--- a/proofs/tla/MC_EncryptedLwwReplay_Common.tla
+++ b/proofs/tla/MC_EncryptedLwwReplay_Common.tla
@@ -1,0 +1,5 @@
+---- MODULE MC_EncryptedLwwReplay_Common ----
+EXTENDS EncryptedLwwReplay
+mcLocalVersion == 2
+mcRemoteVersion == 1
+====

--- a/proofs/tla/MC_EncryptedLwwReplay_Green.cfg
+++ b/proofs/tla/MC_EncryptedLwwReplay_Green.cfg
@@ -1,0 +1,14 @@
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+CONSTANTS
+  LocalVersion <- mcLocalVersion
+  RemoteVersion <- mcRemoteVersion
+  PendingMode = "Durable"
+  FilterMode = "PreserveEncrypted"
+  MergeMode = "Lww"
+  KmsFailureMode = "Retry"
+INVARIANT INV_TypeOK
+INVARIANT INV_AckBacked
+INVARIANT INV_NoFilteredLoss
+INVARIANT INV_LwwWinner
+PROPERTY LIVE_WinnerMaterialized

--- a/proofs/tla/MC_EncryptedLwwReplay_Red_ArrivalWins.cfg
+++ b/proofs/tla/MC_EncryptedLwwReplay_Red_ArrivalWins.cfg
@@ -1,0 +1,13 @@
+\* A decrypted stale replay overwrites a newer local write. Expect:
+\* INV_LwwWinner VIOLATED.
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+CONSTANTS
+  LocalVersion <- mcLocalVersion
+  RemoteVersion <- mcRemoteVersion
+  PendingMode = "Durable"
+  FilterMode = "PreserveEncrypted"
+  MergeMode = "ArrivalWins"
+  KmsFailureMode = "Retry"
+INVARIANT INV_TypeOK
+INVARIANT INV_LwwWinner

--- a/proofs/tla/MC_EncryptedLwwReplay_Red_FilterDropsField.cfg
+++ b/proofs/tla/MC_EncryptedLwwReplay_Red_FilterDropsField.cfg
@@ -1,0 +1,13 @@
+\* A selected document loses the encrypted field block that triggers its DEK
+\* request. Expect: INV_NoFilteredLoss VIOLATED.
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+CONSTANTS
+  LocalVersion <- mcLocalVersion
+  RemoteVersion <- mcRemoteVersion
+  PendingMode = "Durable"
+  FilterMode = "DropEncrypted"
+  MergeMode = "Lww"
+  KmsFailureMode = "Retry"
+INVARIANT INV_TypeOK
+INVARIANT INV_NoFilteredLoss

--- a/proofs/tla/MC_EncryptedLwwReplay_Red_TerminalUnavailable.cfg
+++ b/proofs/tla/MC_EncryptedLwwReplay_Red_TerminalUnavailable.cfg
@@ -1,0 +1,13 @@
+\* A transient KMS miss is treated as a successful terminal skip. Expect:
+\* INV_AckBacked VIOLATED.
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+CONSTANTS
+  LocalVersion <- mcLocalVersion
+  RemoteVersion <- mcRemoteVersion
+  PendingMode = "Durable"
+  FilterMode = "PreserveEncrypted"
+  MergeMode = "Lww"
+  KmsFailureMode = "TerminalSkip"
+INVARIANT INV_TypeOK
+INVARIANT INV_AckBacked

--- a/proofs/tla/MC_EncryptedLwwReplay_Red_VolatilePending.cfg
+++ b/proofs/tla/MC_EncryptedLwwReplay_Red_VolatilePending.cfg
@@ -1,0 +1,13 @@
+\* A receiver acknowledges ciphertext, crashes before decryption, and loses
+\* its only retry pointer. Expect: INV_AckBacked VIOLATED.
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+CONSTANTS
+  LocalVersion <- mcLocalVersion
+  RemoteVersion <- mcRemoteVersion
+  PendingMode = "Volatile"
+  FilterMode = "PreserveEncrypted"
+  MergeMode = "Lww"
+  KmsFailureMode = "Retry"
+INVARIANT INV_TypeOK
+INVARIANT INV_AckBacked

--- a/proofs/tla/README.md
+++ b/proofs/tla/README.md
@@ -11,6 +11,8 @@ grounded facts for B3 live in [DESIGN.md](DESIGN.md); each later slice has its o
   the Lean merge-algebra half under [`../lean/`](../lean/README.md).
 - **Multi-instance claim-uniqueness** (`Claim_DESIGN.md`).
 - **KMS key distribution** (`Kms_DESIGN.md`).
+- **Encrypted LWW restart/replay** (`EncryptedLwwReplay_DESIGN.md`) — durable
+  ciphertext and DEK re-drive preserve the existing LWW winner.
 - **Management-channel auth** (`Auth_DESIGN.md`).
 - **Replicator lifecycle** — backfill/live/resume delivery (`Replicator_DESIGN.md`).
 - **ACP-on-commits** — dual-path (User + Commits) access gating (`Commits_DESIGN.md`).

--- a/proofs/tla/run-all.sh
+++ b/proofs/tla/run-all.sh
@@ -29,6 +29,11 @@ RUNS=(
   "MC_Kms_RevokeReplay_Green.cfg MC_Kms_Replay.tla          GREEN"  # KMS revoke/replay gated
   "MC_Kms_Revoke_Red.cfg        MC_Kms_Replay.tla            RED"    # KMS revoked obtains key
   "MC_Kms_Replay_Red.cfg        MC_Kms_Replay.tla            RED"    # KMS replay grants key
+  "MC_EncryptedLwwReplay_Green.cfg MC_EncryptedLwwReplay_Common.tla GREEN" # #1049: durable ciphertext/key replay converges across restart
+  "MC_EncryptedLwwReplay_Red_TerminalUnavailable.cfg MC_EncryptedLwwReplay_Common.tla RED" # transient KMS miss is terminally acknowledged
+  "MC_EncryptedLwwReplay_Red_VolatilePending.cfg MC_EncryptedLwwReplay_Common.tla RED" # acked ciphertext loses its retry obligation on restart
+  "MC_EncryptedLwwReplay_Red_FilterDropsField.cfg MC_EncryptedLwwReplay_Common.tla RED" # replication filter drops the encrypted LWW field block
+  "MC_EncryptedLwwReplay_Red_ArrivalWins.cfg MC_EncryptedLwwReplay_Common.tla RED" # decrypted stale replay overwrites the LWW winner
   "MC_Auth_Green.cfg            MC_Auth_Green.tla            GREEN"  # auth gated
   "MC_Auth_Red_PeerOnly.cfg     MC_Auth_Red_PeerOnly.tla     RED"   # auth: PeerID-only executes
   "MC_Auth_Red_Stale.cfg        MC_Auth_Red_Stale.tla        RED"   # auth: stale token authorizes

--- a/tools/integration-test/tests/p2p/filtered_replication.rs
+++ b/tools/integration-test/tests/p2p/filtered_replication.rs
@@ -460,14 +460,16 @@ async fn rust_filtered_replicator_cli_requires_filter_field() {
 }
 
 /// #8: the filter must gate the encrypted (SE-artifact) push path too. A
-/// non-matching encrypted document must not reach the filtered peer; a matching
-/// one must (its `_docID` is observable even without the decryption key).
+/// non-matching encrypted document must not reach the filtered peer; matching
+/// documents must arrive with decrypted secrets, proving their field blocks
+/// triggered DEK resolution.
 #[tokio::test]
 async fn rust_filtered_replication_encrypted_respects_filter() {
     const SECRET_SCHEMA: &str = "type SecretDoc { agent_did: String @immutable  secret: String }";
     let cluster = TestCluster::builder()
         .rust_nodes(2)
         .with_p2p()
+        .with_encryption()
         .build()
         .await
         .unwrap();
@@ -513,17 +515,21 @@ async fn rust_filtered_replication_encrypted_respects_filter() {
     poll_until(
         || {
             let result = node1_for_poll
-                .query("query { SecretDoc { _docID } }")
+                .query("query { SecretDoc { _docID secret } }")
                 .unwrap_or_default();
             let Some(rows) = result["SecretDoc"].as_array() else {
                 return false;
             };
-            let ids: Vec<&str> = rows.iter().filter_map(|r| r["_docID"].as_str()).collect();
-            ids.contains(&matching_id_poll.as_str()) && ids.contains(&matching2_id_poll.as_str())
+            let has_decrypted = |id: &str, secret: &str| {
+                rows.iter().any(|row| {
+                    row["_docID"].as_str() == Some(id) && row["secret"].as_str() == Some(secret)
+                })
+            };
+            has_decrypted(&matching_id_poll, "s") && has_decrypted(&matching2_id_poll, "s2")
         },
         P2P_TIMEOUT,
         P2P_POLL_INTERVAL,
-        "matching encrypted documents did not replicate to filtered peer",
+        "matching encrypted documents did not replicate and decrypt on filtered peer",
     )
     .await;
 


### PR DESCRIPTION
Closes #1049.

## Decision

Encryption does not change the LWW merge algebra: ciphertext and DEK timing affect when a value can materialize, not which version wins. This therefore reuses `DefraConvergence.PriorityReconcile.lwwCM` and adds a focused temporal model for encrypted delivery, retry, restart, and materialization rather than duplicating the Lean CRDT law.

## What changed

- Added an encrypted-LWW TLA+ model covering delayed key availability, transient `KeyUnavailable`, restart before and after DEK persistence, and an older remote replay racing a newer local value.
- Added green coverage for durable pending state, retryable KMS failures, preserved encrypted field heads, and LWW merge ordering.
- Added red configurations that independently expose terminal handling of transient KMS failures, volatile retry state, filtered field loss, and arrival-wins merging.
- Bound the new family into the proof registry, coverage matrix, model runner, and existing encrypted restart/decryption conformance scenario.
- Strengthened filtered-replication coverage to require matching encrypted documents to decrypt on the receiver, proving their field heads survive selection and trigger DEK resolution; `_docID` delivery alone is no longer sufficient.

## Validation

- [x] `proofs/tla/run-all.sh` (all 102 TLA+ runs matched their expected verdict)
- [x] `cargo build -p cli`
- [x] `cargo test -p conformance --lib` (5 passed)
- [x] `cargo test -p conformance --test tla_conformance convergence_encrypted_lww_restart_merge -- --nocapture --test-threads=1`
- [x] `RUST_LOG=info cargo test -p integration-test --test p2p filtered_replication::rust_filtered_replication_encrypted_respects_filter -- --nocapture --test-threads=1`
- [x] `cargo clippy -p conformance --all-targets -- -D warnings`
- [x] `cargo clippy -p integration-test --test p2p -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check main...HEAD`
