### PR TITLE
feat(p2p): expose iroh multipath tuning

### DIFF
--- a/crates/cli/src/commands/client/p2p/replicator.rs
+++ b/crates/cli/src/commands/client/p2p/replicator.rs
@@ -232,9 +232,9 @@ fn extract_public_peer_id(addr: &str) -> Result<String> {
 
     #[cfg(feature = "iroh")]
     {
-        return p2p::iroh::parse_public_peer_addr(addr)
+        p2p::iroh::parse_public_peer_addr(addr)
             .map(|(peer_id, _)| peer_id.to_string())
-            .map_err(|e| Error::Server(e.to_string()));
+            .map_err(|e| Error::Server(e.to_string()))
     }
 
     #[cfg(not(feature = "iroh"))]

--- a/crates/cli/src/commands/start/server_p2p.rs
+++ b/crates/cli/src/commands/start/server_p2p.rs
@@ -869,6 +869,7 @@ impl Node {
                 discovery: Self::iroh_discovery(config)?,
                 bind_port: config.net.iroh_bind_port,
                 bind_addr: config.net.iroh_bind_addr,
+                max_concurrent_multipath_paths: config.net.iroh_max_concurrent_multipath_paths,
                 gossip_heal: p2p::iroh::GossipHealConfig::from_env(),
             })
             .await

--- a/crates/cli/src/config/sections.rs
+++ b/crates/cli/src/config/sections.rs
@@ -312,6 +312,10 @@ pub struct NetConfig {
     /// LAN addresses to peers on different networks. None = 0.0.0.0 (all interfaces).
     #[serde(default)]
     pub iroh_bind_addr: Option<std::net::IpAddr>,
+    /// Maximum concurrent QUIC paths per iroh connection. None keeps iroh's
+    /// default; custom values must be at least 9.
+    #[serde(default)]
+    pub iroh_max_concurrent_multipath_paths: Option<u32>,
     /// Per-peer rate limit burst capacity (max tokens in bucket). Default: 500.
     #[serde(default = "default_rate_limit_burst")]
     pub p2p_rate_limit_burst: u32,
@@ -411,6 +415,7 @@ impl Default for NetConfig {
             iroh_pkarr_relay_url: None,
             iroh_bind_port: None,
             iroh_bind_addr: None,
+            iroh_max_concurrent_multipath_paths: None,
             p2p_rate_limit_burst: default_rate_limit_burst(),
             p2p_rate_limit_rate: default_rate_limit_rate(),
             p2p_max_doc_sync_request_doc_ids: default_max_doc_sync_request_doc_ids(),

--- a/crates/defra-node/src/config.rs
+++ b/crates/defra-node/src/config.rs
@@ -96,6 +96,8 @@ pub struct P2PConfig {
     pub relay_mode: p2p::iroh::IrohRelayModeConfig,
     /// Address publishing / lookup behavior.
     pub discovery: p2p::iroh::IrohDiscoveryConfig,
+    /// Maximum concurrent QUIC paths per connection. None keeps iroh's default.
+    pub max_concurrent_multipath_paths: Option<u32>,
     /// Path to persist secret key. None = ephemeral (new identity each restart).
     pub secret_key_path: Option<std::path::PathBuf>,
     /// Reload collection subscriptions persisted in the local store on startup.

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -1346,6 +1346,7 @@ impl NodeBuilder {
             discovery: config.discovery.clone(),
             bind_port: Some(config.port),
             bind_addr: config.bind_addr,
+            max_concurrent_multipath_paths: config.max_concurrent_multipath_paths,
             gossip_heal: p2p::iroh::GossipHealConfig::from_env(),
         };
         let (command_tx, iroh_events, replicator_registry, endpoint_task) =

--- a/crates/defra-node/src/p2p_tests.rs
+++ b/crates/defra-node/src/p2p_tests.rs
@@ -36,6 +36,7 @@ fn test_p2p_config() -> P2PConfig {
         bind_addr: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
         relay_mode: p2p::iroh::IrohRelayModeConfig::Disabled,
         discovery: p2p::iroh::IrohDiscoveryConfig::Disabled,
+        max_concurrent_multipath_paths: None,
         secret_key_path: None,
         load_persisted_collections: false,
         max_concurrent_dag_fetches: p2p::sync::DEFAULT_MAX_CONCURRENT_DAG_FETCHES,

--- a/crates/embedded/src/lib.rs
+++ b/crates/embedded/src/lib.rs
@@ -56,6 +56,7 @@ pub struct IrohConfig {
     pub bind_port: Option<u16>,
     pub relay_mode: p2p::iroh::IrohRelayModeConfig,
     pub discovery: p2p::iroh::IrohDiscoveryConfig,
+    pub max_concurrent_multipath_paths: Option<u32>,
     pub secret_key_path: Option<std::path::PathBuf>,
 }
 

--- a/crates/embedded/src/node_p2p.rs
+++ b/crates/embedded/src/node_p2p.rs
@@ -416,6 +416,7 @@ where
         discovery: config.discovery.clone(),
         bind_port: config.bind_port,
         bind_addr: config.bind_addr,
+        max_concurrent_multipath_paths: config.max_concurrent_multipath_paths,
         gossip_heal: p2p::iroh::GossipHealConfig::from_env(),
     };
     let (command_tx, event_rx, replicator_registry, endpoint_task) =

--- a/crates/embedded/tests/iroh_smoke.rs
+++ b/crates/embedded/tests/iroh_smoke.rs
@@ -70,6 +70,7 @@ fn test_iroh_config() -> IrohConfig {
         bind_port: Some(0),
         relay_mode: p2p::iroh::IrohRelayModeConfig::Disabled,
         discovery: p2p::iroh::IrohDiscoveryConfig::Disabled,
+        max_concurrent_multipath_paths: None,
         secret_key_path: None,
     }
 }

--- a/crates/embedded/tests/se_owner.rs
+++ b/crates/embedded/tests/se_owner.rs
@@ -133,6 +133,7 @@ async fn embedded_iroh_se_owner_queries_replicator() -> Result<()> {
             bind_port: Some(0),
             relay_mode: p2p::iroh::IrohRelayModeConfig::Disabled,
             discovery: p2p::iroh::IrohDiscoveryConfig::Disabled,
+            max_concurrent_multipath_paths: None,
             secret_key_path: None,
         }
     }

--- a/crates/p2p-adapter/src/iroh.rs
+++ b/crates/p2p-adapter/src/iroh.rs
@@ -1064,6 +1064,7 @@ mod tests {
             discovery: IrohDiscoveryConfig::Disabled,
             bind_port: None,
             bind_addr: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+            max_concurrent_multipath_paths: None,
             gossip_heal: Default::default(),
         }
     }

--- a/crates/p2p/src/iroh/endpoint.rs
+++ b/crates/p2p/src/iroh/endpoint.rs
@@ -21,7 +21,8 @@ use crate::transport::{PeerAddr, PeerId, TransportEvent};
 use super::command::IrohCommand;
 use super::endpoint_commands::handle_command;
 use super::endpoint_config::{
-    apply_bind_config, apply_discovery_config, relay_mode_from_config, IrohEndpointConfig,
+    apply_bind_config, apply_discovery_config, apply_multipath_config, relay_mode_from_config,
+    IrohEndpointConfig,
 };
 use super::endpoint_rpc::ConnectionCache;
 use super::endpoint_streams::handle_incoming;
@@ -139,6 +140,7 @@ pub async fn spawn_endpoint(
         .relay_mode(relay_mode)
         .secret_key(config.secret_key.clone())
         .alpns(alpns);
+    builder = apply_multipath_config(builder, config.max_concurrent_multipath_paths)?;
     builder = apply_discovery_config(builder, &config.discovery)?;
     builder = apply_bind_config(builder, config.bind_addr, config.bind_port)?;
 

--- a/crates/p2p/src/iroh/endpoint_config.rs
+++ b/crates/p2p/src/iroh/endpoint_config.rs
@@ -6,6 +6,9 @@ use iroh::SecretKey;
 use super::config::{IrohDiscoveryConfig, IrohRelayModeConfig};
 use super::gossip_heal::GossipHealConfig;
 
+// iroh 1.0 silently ignores custom values below its internal default plus one.
+const MIN_CONCURRENT_MULTIPATH_PATHS: u32 = 9;
+
 /// Configuration for creating an `IrohEndpoint`.
 pub struct IrohEndpointConfig {
     pub secret_key: SecretKey,
@@ -19,6 +22,9 @@ pub struct IrohEndpointConfig {
     /// interface — prevents advertising unreachable LAN addresses to peers
     /// on different networks. None = 0.0.0.0 (all interfaces).
     pub bind_addr: Option<std::net::IpAddr>,
+    /// Maximum QUIC paths that may be open concurrently for one connection.
+    /// `None` keeps iroh's default; custom values must be at least 9.
+    pub max_concurrent_multipath_paths: Option<u32>,
     /// Gossip send-path healing (#1092).
     pub gossip_heal: GossipHealConfig,
 }
@@ -31,9 +37,32 @@ impl Default for IrohEndpointConfig {
             discovery: IrohDiscoveryConfig::default(),
             bind_port: None,
             bind_addr: None,
+            max_concurrent_multipath_paths: None,
             gossip_heal: GossipHealConfig::default(),
         }
     }
+}
+
+pub(super) fn apply_multipath_config(
+    builder: iroh::endpoint::Builder,
+    max_concurrent: Option<u32>,
+) -> crate::error::Result<iroh::endpoint::Builder> {
+    let Some(max_concurrent) = max_concurrent else {
+        return Ok(builder);
+    };
+
+    if max_concurrent < MIN_CONCURRENT_MULTIPATH_PATHS {
+        return Err(crate::error::Error::Transport(format!(
+            "iroh max concurrent multipath paths must be at least {}, got {}",
+            MIN_CONCURRENT_MULTIPATH_PATHS, max_concurrent
+        )));
+    }
+
+    let transport_config = iroh::endpoint::QuicTransportConfig::builder()
+        .max_concurrent_multipath_paths(max_concurrent)
+        .build();
+    tracing::info!(max_concurrent, "configured iroh multipath path limit");
+    Ok(builder.transport_config(transport_config))
 }
 
 pub(super) fn relay_mode_from_config(
@@ -118,4 +147,31 @@ pub(super) fn apply_bind_config(
     }
 
     Ok(builder)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn multipath_limit_rejects_values_iroh_would_ignore() {
+        let builder = iroh::Endpoint::builder(iroh::endpoint::presets::Minimal);
+        let result =
+            apply_multipath_config(builder, Some(super::MIN_CONCURRENT_MULTIPATH_PATHS - 1));
+
+        assert!(matches!(
+            result,
+            Err(crate::error::Error::Transport(message))
+                if message.contains("must be at least 9")
+        ));
+    }
+
+    #[test]
+    fn multipath_limit_accepts_iroh_minimum() {
+        let builder = iroh::Endpoint::builder(iroh::endpoint::presets::Minimal);
+
+        assert!(
+            apply_multipath_config(builder, Some(super::MIN_CONCURRENT_MULTIPATH_PATHS),).is_ok()
+        );
+    }
 }

--- a/crates/p2p/src/iroh/transport.rs
+++ b/crates/p2p/src/iroh/transport.rs
@@ -524,6 +524,7 @@ mod tests {
             discovery: IrohDiscoveryConfig::Disabled,
             bind_port: None,
             bind_addr: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+            max_concurrent_multipath_paths: None,
             gossip_heal: Default::default(),
         }
     }

--- a/crates/p2p/src/iroh/two_stream_tests.rs
+++ b/crates/p2p/src/iroh/two_stream_tests.rs
@@ -30,6 +30,7 @@ impl TestNode {
             discovery: IrohDiscoveryConfig::Disabled,
             bind_port: None,
             bind_addr: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+            max_concurrent_multipath_paths: None,
             gossip_heal: Default::default(),
         };
         let (command_tx, events, _replicators, task) = spawn_endpoint(config).await.unwrap();

--- a/tools/integration-test/tests/p2p_iroh/connection/gossip_heal.rs
+++ b/tools/integration-test/tests/p2p_iroh/connection/gossip_heal.rs
@@ -30,6 +30,7 @@ async fn test_config(gossip_heal: GossipHealConfig) -> IrohEndpointConfig {
         discovery: IrohDiscoveryConfig::Disabled,
         bind_port: None,
         bind_addr: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+        max_concurrent_multipath_paths: None,
         gossip_heal,
     }
 }

--- a/tools/integration-test/tests/p2p_iroh/connection/se_query.rs
+++ b/tools/integration-test/tests/p2p_iroh/connection/se_query.rs
@@ -23,6 +23,7 @@ async fn test_config() -> IrohEndpointConfig {
         discovery: IrohDiscoveryConfig::Disabled,
         bind_port: None,
         bind_addr: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+        max_concurrent_multipath_paths: None,
         gossip_heal: Default::default(),
     }
 }


### PR DESCRIPTION
Fixes #593.

## Problem

DefraDB used iroh's default QUIC transport configuration, leaving operators no way to raise the concurrent multipath-path limit when peers advertise many candidate addresses. Iroh also silently ignores custom values below its supported override range. Current `noq` already requeues `MaxPathIdReached` as transient, so adding a second DefraDB retry loop would duplicate transport behavior rather than improve recovery.

## What changed

- Add an optional `iroh_max_concurrent_multipath_paths` network setting and propagate it through CLI, embedded, and node endpoint construction.
- Apply a custom `QuicTransportConfig` in the shared iroh endpoint builder while preserving iroh's defaults when the setting is omitted.
- Reject values below iroh 1.0's accepted minimum of 9 instead of allowing a silently ignored configuration.
- Log the configured path limit at endpoint startup for operator visibility.
- Add focused coverage for accepted and rejected overrides.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p p2p --features iroh-transport endpoint_config::tests` (2 passed)
- [x] `cargo test -p p2p -p embedded -p defra-p2p-adapter --features p2p/iroh-transport,embedded/iroh,defra-p2p-adapter/iroh --lib` (509 passed)
- [x] `cargo test -p cli --features iroh --lib commands::client::p2p::replicator::tests` (4 passed)
- [x] `cargo check -p embedded -p cli -p defra-node -p defra-p2p-adapter --features embedded/iroh,cli/iroh,defra-node/p2p,defra-p2p-adapter/iroh`
- [x] `cargo clippy -p p2p -p embedded -p cli -p defra-node -p defra-p2p-adapter --all-targets --features p2p/iroh-transport,embedded/iroh,cli/iroh,defra-node/p2p,defra-p2p-adapter/iroh -- -D warnings`
- [x] `git diff --check origin/main...HEAD`
