### PR TITLE
fix(p2p): enforce pending DAG peer quotas

### DIFF
--- a/crates/cli/src/commands/start/mod.rs
+++ b/crates/cli/src/commands/start/mod.rs
@@ -218,7 +218,8 @@ pub struct StartArgs {
     pub p2p_max_doc_sync_request_doc_ids: Option<usize>,
 
     /// Max pending-DAG registrations awaiting Bitswap completion; overflow is
-    /// nacked back to the pusher. Default: 1000.
+    /// nacked back to the pusher. Each source peer may use at most one quarter.
+    /// Default: 1000.
     #[arg(long, env = "DEFRA_P2P_MAX_PENDING_DAGS")]
     pub p2p_max_pending_dags: Option<usize>,
 

--- a/crates/cli/src/config/sections.rs
+++ b/crates/cli/src/config/sections.rs
@@ -322,7 +322,8 @@ pub struct NetConfig {
     #[serde(default = "default_max_doc_sync_request_doc_ids")]
     pub p2p_max_doc_sync_request_doc_ids: usize,
     /// Max pending-DAG registrations held while Bitswap completes missing
-    /// links; overflow is nacked back to the pusher. Default: 1000.
+    /// links; overflow is nacked back to the pusher. Each source peer may use
+    /// at most one quarter of this capacity. Default: 1000.
     #[serde(default = "default_max_pending_dags")]
     pub p2p_max_pending_dags: usize,
     /// Max queued outbound push jobs; overflow defers to the persisted retry

--- a/crates/defra-node/src/config.rs
+++ b/crates/defra-node/src/config.rs
@@ -114,6 +114,7 @@ pub struct P2PConfig {
     /// Per-peer rate limit refill rate (tokens per second). Default: 50.
     pub rate_limit_rate: f64,
     /// Maximum pending-DAG registrations held while Bitswap completes missing
-    /// links; overflow is nacked back to the pusher. Default: 1000.
+    /// links; overflow is nacked back to the pusher. Each source peer may use
+    /// at most one quarter of this capacity. Default: 1000.
     pub max_pending_dags: usize,
 }

--- a/crates/p2p/src/error.rs
+++ b/crates/p2p/src/error.rs
@@ -221,13 +221,13 @@ pub enum Error {
         collection_id: String,
     },
 
-    /// The pending-DAG map is at capacity, so an incoming push with missing
-    /// links could not be registered. Reply seams map this to the byte-exact
-    /// `RATE_LIMITED_MESSAGE` nack so the pusher retries instead of treating
-    /// the push as landed (#1088 W1).
+    /// The pending-DAG map or the source peer's share is at capacity, so an
+    /// incoming push with missing links could not be registered. Reply seams
+    /// map this to the byte-exact at-capacity nack so the pusher retries
+    /// instead of treating the push as landed (#1088 W1/W2).
     #[error("pending DAG registrations at capacity ({max}), retry later")]
     PendingDagCapacity {
-        /// The configured `SyncConfig::max_pending_dags` in effect.
+        /// The configured global pending-DAG capacity.
         max: usize,
     },
 

--- a/crates/p2p/src/sync/manager/config.rs
+++ b/crates/p2p/src/sync/manager/config.rs
@@ -117,6 +117,7 @@ pub struct SyncConfig {
 
     /// Maximum number of pending-DAG registrations held while Bitswap
     /// completes missing links. Overflow is rejected with a backpressure nack.
+    /// Each known source peer may occupy at most one quarter of this capacity.
     /// Values below 1 are normalized to 1 (a zero cap would reject every
     /// missing-link push forever).
     pub max_pending_dags: usize,

--- a/crates/p2p/src/sync/manager/pending.rs
+++ b/crates/p2p/src/sync/manager/pending.rs
@@ -63,6 +63,7 @@ pub struct PendingDag {
 pub(super) struct PendingDagRegistry {
     roots: HashMap<Cid, PendingDag>,
     waiters: HashMap<Cid, HashSet<Cid>>,
+    roots_by_source: HashMap<String, usize>,
 }
 
 impl Deref for PendingDagRegistry {
@@ -90,6 +91,9 @@ impl PendingDagRegistry {
                 .or_default()
                 .insert(root_cid);
         }
+        if let Some(source_peer) = &dag.source_peer {
+            *self.roots_by_source.entry(source_peer.clone()).or_default() += 1;
+        }
         self.roots.insert(root_cid, dag);
         previous
     }
@@ -99,7 +103,27 @@ impl PendingDagRegistry {
         for missing_cid in &dag.missing {
             self.remove_waiter(missing_cid, root_cid);
         }
+        if let Some(source_peer) = &dag.source_peer {
+            let remove_source = self
+                .roots_by_source
+                .get_mut(source_peer)
+                .is_some_and(|count| {
+                    debug_assert!(*count > 0);
+                    *count = count.saturating_sub(1);
+                    *count == 0
+                });
+            if remove_source {
+                self.roots_by_source.remove(source_peer);
+            }
+        }
         Some(dag)
+    }
+
+    pub(super) fn source_count(&self, source_peer: &str) -> usize {
+        self.roots_by_source
+            .get(source_peer)
+            .copied()
+            .unwrap_or_default()
     }
 
     pub(super) fn replace_missing(&mut self, root_cid: &Cid, missing: HashSet<Cid>) -> bool {

--- a/crates/p2p/src/sync/manager/process/pending_dag.rs
+++ b/crates/p2p/src/sync/manager/process/pending_dag.rs
@@ -16,6 +16,10 @@ use crate::sync::pending_store::{PersistedPendingDag, PersistedQuarantinedDag};
 
 use super::SyncManager;
 
+/// Match the outbound backlog's fairness policy: one peer may occupy at most
+/// one quarter of the global pending-DAG capacity.
+const PENDING_DAG_PEER_CAPACITY_DIVISOR: usize = 4;
+
 #[derive(Debug, Clone)]
 pub struct PendingDagFetchFailure {
     pub doc_id: String,
@@ -46,6 +50,10 @@ impl<B: Blockstore + 'static> SyncManager<B> {
     /// Get the pending DAGs count (for testing/monitoring).
     pub fn pending_dag_count(&self) -> usize {
         self.pending_dags.read().len()
+    }
+
+    pub(super) fn max_pending_dags_per_peer(&self) -> usize {
+        (self.max_pending_dags / PENDING_DAG_PEER_CAPACITY_DIVISOR).max(1)
     }
 
     pub(super) fn is_pending_dag_recovery_registered(&self, root_cid: &Cid) -> bool {
@@ -225,8 +233,10 @@ impl<B: Blockstore + 'static> SyncManager<B> {
     ///
     /// Expired entries (older than `PENDING_DAG_TTL`) are removed before checking
     /// the capacity. If the map is still at `max_pending_dags` after eviction the
-    /// new entry is dropped and `false` is returned so callers can reject with a
-    /// backpressure nack (#1088 W1) instead of acking a discarded registration.
+    /// new entry is rejected so callers can return a backpressure nack (#1088
+    /// W1) instead of acking a discarded registration. A source peer may hold
+    /// at most one quarter of the global map so one noisy pusher cannot starve
+    /// every other peer (#1088 W2).
     /// TTL eviction frees the in-memory slot only: a push-originated entry's
     /// durable record survives (the recovery obligation is discharged solely
     /// by a successful merge) and is re-driven by restart or the durable
@@ -237,6 +247,18 @@ impl<B: Blockstore + 'static> SyncManager<B> {
 
         if pending.len() >= self.max_pending_dags && !pending.contains_key(&root_cid) {
             return false;
+        }
+
+        if let Some(source_peer) = dag.source_peer.as_deref() {
+            let existing_source = pending
+                .get(&root_cid)
+                .and_then(|existing| existing.source_peer.as_deref());
+            let max_per_peer = self.max_pending_dags_per_peer();
+            if existing_source != Some(source_peer)
+                && pending.source_count(source_peer) >= max_per_peer
+            {
+                return false;
+            }
         }
 
         pending.insert(root_cid, dag);
@@ -373,6 +395,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                 doc_id = %doc_id,
                 source_peer = %source_peer,
                 max = self.max_pending_dags,
+                max_per_peer = self.max_pending_dags_per_peer(),
                 "Pending DAGs at capacity, dropping DocSync registration"
             );
         }
@@ -419,6 +442,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                 collection_id = %collection_id,
                 source_peer = %source_peer,
                 max = self.max_pending_dags,
+                max_per_peer = self.max_pending_dags_per_peer(),
                 "Pending DAGs at capacity, dropping branchable DAG registration"
             );
         }
@@ -739,6 +763,8 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                     root_cid = %root_cid,
                     doc_id = %record.doc_id,
                     max = self.max_pending_dags,
+                    max_per_peer = self.max_pending_dags_per_peer(),
+                    source_peer = ?record.source_peer,
                     "Pending DAGs at capacity during resync; record kept for the next sweep"
                 );
                 continue;
@@ -969,21 +995,29 @@ mod tests {
         )
     }
 
-    fn test_manager() -> SyncManager<DefraBlockstore<MemoryStore>> {
+    fn test_manager_with_config(config: SyncConfig) -> SyncManager<DefraBlockstore<MemoryStore>> {
         let store = Arc::new(MemoryStore::new());
         let blockstore = Arc::new(DefraBlockstore::new(store, true));
         let peer_state = Arc::new(PeerStateTracker::new());
-        let (manager, _events) = SyncManager::new(blockstore, peer_state, SyncConfig::default());
+        let (manager, _events) = SyncManager::new(blockstore, peer_state, config);
         manager
     }
 
-    fn pending_dag(doc_id: &str, inserted_at: Instant) -> PendingDag {
+    fn test_manager() -> SyncManager<DefraBlockstore<MemoryStore>> {
+        test_manager_with_config(SyncConfig::default())
+    }
+
+    fn pending_dag_from(
+        doc_id: &str,
+        source_peer: Option<&str>,
+        inserted_at: Instant,
+    ) -> PendingDag {
         PendingDag {
             doc_id: doc_id.to_string(),
             collection_id: "collection".to_string(),
             creator: "creator".to_string(),
             missing: HashSet::new(),
-            source_peer: Some("peer".to_string()),
+            source_peer: source_peer.map(str::to_owned),
             is_explicit_replicator: false,
             explicit_replay_authorization: None,
             is_recovery_registered: false,
@@ -996,21 +1030,32 @@ mod tests {
         }
     }
 
+    fn pending_dag(doc_id: &str, inserted_at: Instant) -> PendingDag {
+        pending_dag_from(doc_id, Some("peer"), inserted_at)
+    }
+
     #[test]
     fn insert_pending_dag_replaces_existing_entry_at_capacity() {
         let manager = test_manager();
         let root = test_cid(0);
 
-        assert!(manager.insert_pending_dag(root, pending_dag("original", Instant::now())));
+        assert!(manager.insert_pending_dag(
+            root,
+            pending_dag_from("original", Some("peer-0"), Instant::now()),
+        ));
         for idx in 1..DEFAULT_MAX_PENDING_DAGS {
+            let source_peer = format!("peer-{}", idx % PENDING_DAG_PEER_CAPACITY_DIVISOR);
             assert!(manager.insert_pending_dag(
                 test_cid(idx),
-                pending_dag(&format!("doc-{idx}"), Instant::now()),
+                pending_dag_from(&format!("doc-{idx}"), Some(&source_peer), Instant::now(),),
             ));
         }
         assert_eq!(manager.pending_dag_count(), DEFAULT_MAX_PENDING_DAGS);
 
-        assert!(manager.insert_pending_dag(root, pending_dag("replacement", Instant::now())));
+        assert!(manager.insert_pending_dag(
+            root,
+            pending_dag_from("replacement", Some("peer-0"), Instant::now()),
+        ));
         assert_eq!(manager.pending_dag_count(), DEFAULT_MAX_PENDING_DAGS);
         assert_eq!(
             manager
@@ -1020,6 +1065,51 @@ mod tests {
                 .map(|dag| dag.doc_id.as_str()),
             Some("replacement")
         );
+    }
+
+    #[test]
+    fn pending_dag_peer_quota_preserves_capacity_for_other_sources() {
+        let manager = test_manager_with_config(SyncConfig {
+            max_pending_dags: 8,
+            ..Default::default()
+        });
+        let first = test_cid(0);
+        let second = test_cid(1);
+        let rejected = test_cid(2);
+
+        for (root, doc_id) in [(first, "first"), (second, "second")] {
+            assert!(manager.insert_pending_dag(
+                root,
+                pending_dag_from(doc_id, Some("noisy"), Instant::now()),
+            ));
+        }
+        assert!(!manager.insert_pending_dag(
+            rejected,
+            pending_dag_from("rejected", Some("noisy"), Instant::now()),
+        ));
+        assert!(manager.insert_pending_dag(
+            test_cid(3),
+            pending_dag_from("healthy", Some("healthy"), Instant::now()),
+        ));
+
+        assert!(manager.clear_pending_dag(&first));
+        assert!(manager.insert_pending_dag(
+            rejected,
+            pending_dag_from("retried", Some("noisy"), Instant::now()),
+        ));
+        assert!(manager.insert_pending_dag(
+            second,
+            pending_dag_from("replacement", Some("noisy"), Instant::now()),
+        ));
+        assert_eq!(manager.pending_dags.read().source_count("noisy"), 2);
+
+        assert!(manager.insert_pending_dag(
+            second,
+            pending_dag_from("transferred", Some("healthy"), Instant::now()),
+        ));
+        assert_eq!(manager.pending_dags.read().source_count("noisy"), 1);
+        assert_eq!(manager.pending_dags.read().source_count("healthy"), 2);
+        assert_eq!(manager.pending_dag_count(), 3);
     }
 
     #[test]

--- a/crates/p2p/src/sync/manager/process/pushlog.rs
+++ b/crates/p2p/src/sync/manager/process/pushlog.rs
@@ -357,7 +357,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                     // tracked. This must surface as an error: a success reply
                     // deletes the pusher's retry record, silently losing the
                     // document. The reply seams map this typed error to the
-                    // RATE_LIMITED_MESSAGE nack so the pusher re-pushes later.
+                    // at-capacity nack so the pusher retains and retries it.
                     tracing::warn!(
                         cid = %cid,
                         doc_id = %msg.doc_id,
@@ -365,6 +365,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                         source_peer = ?sender_peer,
                         missing_count = missing.len(),
                         max = self.max_pending_dags,
+                        max_per_peer = self.max_pending_dags_per_peer(),
                         "Pending DAGs at capacity, rejecting PushLog DAG registration"
                     );
                     return Err(Error::PendingDagCapacity {


### PR DESCRIPTION
Advances #1088.

## Problem

The pending-DAG registry had a global capacity bound, but no per-source admission bound. One noisy pusher could therefore occupy every slot and force healthy peers into backpressure, even though the queue itself remained correctly bounded. The outbound push backlog already reserves fairness by limiting one peer to one quarter of its item budget; inbound pending-DAG admission lacked the matching protection.

## What changed

- Track pending roots per known source peer in the shared registry with O(1) accounting.
- Limit one source peer to one quarter of the configured global pending-DAG capacity, with a minimum of one slot.
- Apply the quota atomically when a new pending root is registered across PushLog, DocSync, branchable sync, and durable restore paths.
- Enforce admission at registration rather than PushLog preflight so completion blocks can still drain a source's existing roots.
- Keep same-root replacement admissible without inflating occupancy, and transfer or release counts through the registry's existing replacement and removal paths.
- Reuse the existing at-capacity nack so rejected pushes remain in the sender's retry ladder.
- Document the per-peer share on the existing global capacity setting.
- Add regression coverage proving a saturated source cannot block another peer and that cleanup and source transfer restore quota accurately.

## Validation

- [x] `cargo test -p p2p -q` (612 passed, 8 ignored)
- [x] `cargo clippy -p p2p --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check origin/main...HEAD`
