### PR TITLE
ci: make signed-docs integration blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,15 +233,10 @@ jobs:
           # DEFRA_MULTIPLIERS=signed-docs so every cluster gets
           # .with_signing() auto-applied. Catches regressions in
           # unrelated features that only surface when blocks carry
-          # Signature links (mirrors Go DefraDB PR #4746). Non-blocking
-          # until in-tree .no_signing_multiplier() opt-outs land for
-          # known-incompatible tests; flip continue_on_error to false
-          # once the suite is green.
+          # Signature links (mirrors Go DefraDB PR #4746).
           - suite: signed-docs
             needs_go: false
             multipliers: signed-docs
-            continue_on_error: true
-    continue-on-error: ${{ matrix.continue_on_error == true }}
     env:
       DEFRA_RUST_BINARY: ${{ github.workspace }}/target/ci/defra
       DEFRA_IROH_BINARY: ${{ github.workspace }}/target/ci/defra-iroh


### PR DESCRIPTION
Closes #978.

## Problem

The signed-docs integration matrix auto-enables document signing across the Rust suite to catch regressions that only appear when blocks carry signature links, mirroring Go DefraDB #4746. The matrix remained configured with `continue-on-error`, so a signed-docs regression could not block a merge even after the complete suite became green.

## What changed

- Remove the signed-docs matrix exception so failures now fail CI like the standard Rust integration suite.
- Update the workflow comment to remove the obsolete known-incompatibility guidance.

No test behavior or production code changes; this promotes the existing green parity sweep into an enforced regression gate.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `git diff --check`
- [x] `RUST_LOG=info DEFRA_MULTIPLIERS=signed-docs cargo test -p integration-test --test basic -- --test-threads=1 --skip ::go_` (24 passed)
- [x] `RUST_LOG=info DEFRA_MULTIPLIERS=signed-docs cargo test -p integration-test --test query --test acp --test nac --test encryption --test identity --test backup --test fts -- --test-threads=1 --skip ::go_` (229 passed)
- [x] `RUST_LOG=info DEFRA_MULTIPLIERS=signed-docs cargo test -p integration-test --test p2p -- --test-threads=1 --skip ::go_` (73 passed, 3 ignored)