### PR TITLE
fix(storage): retain conflicts for active snapshots

### DIFF
--- a/crates/storage/src/backends/fjall/store.rs
+++ b/crates/storage/src/backends/fjall/store.rs
@@ -172,7 +172,11 @@ impl Store for FjallStore {
         }
         let mut guard = NewTxnGuard(&self.active_txn_count, false);
 
-        let read_version = self.conflict_tracker.current_version();
+        let conflict_snapshot = (!readonly).then(|| self.conflict_tracker.begin_snapshot());
+        let read_version = conflict_snapshot.as_ref().map_or_else(
+            || self.conflict_tracker.current_version(),
+            |snapshot| snapshot.version(),
+        );
         let snapshot = self.db.snapshot();
 
         // Defuse guard — transaction will manage its own count via Drop
@@ -182,6 +186,7 @@ impl Store for FjallStore {
             db: self.db.clone(),
             keyspace: self.keyspace.clone(),
             conflict_tracker: Arc::clone(&self.conflict_tracker),
+            _conflict_snapshot: conflict_snapshot,
             active_txn_count: Arc::clone(&self.active_txn_count),
             read_version,
             snapshot,

--- a/crates/storage/src/backends/fjall/transaction.rs
+++ b/crates/storage/src/backends/fjall/transaction.rs
@@ -7,7 +7,9 @@ use std::sync::Arc;
 use super::compute_range_bounds;
 use super::iterator::MergingIterator;
 use crate::backends::shared::DurabilityMode;
-use crate::backends::shared::{CallbackCounts, CallbackManager, ConflictTracker, ReadSet};
+use crate::backends::shared::{
+    CallbackCounts, CallbackManager, ConflictSnapshot, ConflictTracker, ReadSet,
+};
 use crate::corekv::{
     AsyncTxnCallback, Error, IterOptions, Iterator, Reader, Result, Txn, TxnCallback, Writer,
 };
@@ -17,6 +19,7 @@ pub(crate) struct FjallTxn {
     pub(crate) db: fjall::Database,
     pub(crate) keyspace: fjall::Keyspace,
     pub(crate) conflict_tracker: Arc<ConflictTracker>,
+    pub(crate) _conflict_snapshot: Option<ConflictSnapshot>,
     pub(crate) active_txn_count: Arc<AtomicUsize>,
     pub(crate) read_version: u64,
     pub(crate) snapshot: fjall::Snapshot,

--- a/crates/storage/src/backends/lark/transaction.rs
+++ b/crates/storage/src/backends/lark/transaction.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use super::iterator::MergingIterator;
 use crate::backends::shared::DurabilityMode;
-use crate::backends::shared::{CallbackManager, ConflictTracker, ReadSet};
+use crate::backends::shared::{CallbackManager, ConflictSnapshot, ConflictTracker, ReadSet};
 use crate::corekv::{
     AsyncTxnCallback, Error, IterOptions, Iterator, Reader, Result, Txn, TxnCallback, Writer,
 };
@@ -21,6 +21,7 @@ pub(crate) struct LarkTxn {
     db: Arc<lark_kv::Db>,
     snapshot: lark_kv::Snapshot,
     conflict_tracker: Arc<ConflictTracker>,
+    _conflict_snapshot: Option<ConflictSnapshot>,
     active_txn_count: Arc<AtomicUsize>,
     read_version: u64,
     pending: Mutex<PendingWrites>,
@@ -186,13 +187,18 @@ impl LarkTxn {
         readonly: bool,
         durability: DurabilityMode,
     ) -> Self {
-        let read_version = conflict_tracker.current_version();
+        let conflict_snapshot = (!readonly).then(|| conflict_tracker.begin_snapshot());
+        let read_version = conflict_snapshot.as_ref().map_or_else(
+            || conflict_tracker.current_version(),
+            |snapshot| snapshot.version(),
+        );
         let snapshot = db.snapshot();
 
         Self {
             db,
             snapshot,
             conflict_tracker,
+            _conflict_snapshot: conflict_snapshot,
             active_txn_count,
             read_version,
             pending: Mutex::new(PendingWrites::default()),

--- a/crates/storage/src/backends/memory/store.rs
+++ b/crates/storage/src/backends/memory/store.rs
@@ -52,8 +52,11 @@ impl Store for MemoryStore {
             return Err(Error::DBClosed);
         }
 
-        // Record version before taking snapshot for conflict detection
-        let read_version = self.conflict_tracker.current_version();
+        let conflict_snapshot = (!readonly).then(|| self.conflict_tracker.begin_snapshot());
+        let read_version = conflict_snapshot.as_ref().map_or_else(
+            || self.conflict_tracker.current_version(),
+            |snapshot| snapshot.version(),
+        );
 
         // Take a snapshot of current data for isolation
         let snapshot = self.data.read().await.clone();
@@ -61,6 +64,7 @@ impl Store for MemoryStore {
         Ok(Box::new(MemoryTxn {
             store: Arc::clone(&self.data),
             conflict_tracker: Arc::clone(&self.conflict_tracker),
+            _conflict_snapshot: conflict_snapshot,
             read_version,
             snapshot,
             pending: Mutex::new(BTreeMap::new()),

--- a/crates/storage/src/backends/memory/tests.rs
+++ b/crates/storage/src/backends/memory/tests.rs
@@ -145,4 +145,46 @@ mod memory_specific_tests {
             );
         }
     }
+
+    #[tokio::test]
+    async fn test_memory_long_lived_create_cannot_overwrite_committed_document() {
+        let store = Arc::new(MemoryStore::new());
+
+        let mut stale = store.new_txn(false).await.unwrap();
+        assert_eq!(stale.get(b"/seq/doc").await.unwrap(), None);
+
+        let mut winner = store.new_txn(false).await.unwrap();
+        winner.set(b"/seq/doc", &1_u64.to_be_bytes()).await.unwrap();
+        winner.set(b"/d/s/1", b"winner").await.unwrap();
+        winner.set(b"/d/p/winner", b"1").await.unwrap();
+        winner.set(b"/data/1", b"winner-body").await.unwrap();
+        winner.commit().await.unwrap();
+
+        for i in 0..1000 {
+            let mut txn = store.new_txn(false).await.unwrap();
+            txn.set(format!("unrelated-{i}").as_bytes(), b"value")
+                .await
+                .unwrap();
+            txn.commit().await.unwrap();
+        }
+
+        stale.set(b"/seq/doc", &1_u64.to_be_bytes()).await.unwrap();
+        stale.set(b"/d/s/1", b"stale").await.unwrap();
+        stale.set(b"/d/p/stale", b"1").await.unwrap();
+        stale.set(b"/data/1", b"stale-body").await.unwrap();
+        assert!(matches!(
+            stale.commit().await,
+            Err(crate::corekv::Error::TxnConflict)
+        ));
+
+        let reader = store.new_txn(true).await.unwrap();
+        assert_eq!(
+            reader.get(b"/d/s/1").await.unwrap(),
+            Some(b"winner".to_vec())
+        );
+        assert_eq!(
+            reader.get(b"/data/1").await.unwrap(),
+            Some(b"winner-body".to_vec())
+        );
+    }
 }

--- a/crates/storage/src/backends/memory/transaction.rs
+++ b/crates/storage/src/backends/memory/transaction.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use super::iterator::MemoryIterator;
-use crate::backends::shared::{CallbackManager, ConflictTracker, ReadSet};
+use crate::backends::shared::{CallbackManager, ConflictSnapshot, ConflictTracker, ReadSet};
 use crate::corekv::{
     AsyncTxnCallback, Error, IterOptions, Iterator, Reader, Result, Txn, TxnCallback, Writer,
 };
@@ -22,6 +22,9 @@ pub(crate) struct MemoryTxn {
 
     /// Conflict tracker for write-write conflict detection
     pub(crate) conflict_tracker: Arc<ConflictTracker>,
+
+    /// Keeps conflict history alive for this write transaction's snapshot.
+    pub(crate) _conflict_snapshot: Option<ConflictSnapshot>,
 
     /// Version at which this transaction's snapshot was taken
     pub(crate) read_version: u64,

--- a/crates/storage/src/backends/redb/group_commit.rs
+++ b/crates/storage/src/backends/redb/group_commit.rs
@@ -7,7 +7,7 @@ use tokio::sync::{mpsc, oneshot, RwLock as AsyncRwLock};
 
 use super::config::DurabilityMode;
 use super::KV_TABLE;
-use crate::backends::shared::{CallbackManager, ConflictTracker, ReadSet};
+use crate::backends::shared::{CallbackManager, ConflictSnapshot, ConflictTracker, ReadSet};
 use crate::corekv::{AsyncTxnCallback, Error, Result, TxnCallback};
 
 /// Payload for a single transaction's pending commit.
@@ -15,6 +15,7 @@ pub(crate) struct PendingCommit {
     pub changes: BTreeMap<Vec<u8>, Option<Vec<u8>>>,
     pub read_version: u64,
     pub read_set: ReadSet,
+    pub _conflict_snapshot: ConflictSnapshot,
     pub result_tx: oneshot::Sender<Result<()>>,
     pub on_success: Vec<TxnCallback>,
     pub on_success_async: Vec<AsyncTxnCallback>,

--- a/crates/storage/src/backends/redb/store.rs
+++ b/crates/storage/src/backends/redb/store.rs
@@ -306,12 +306,16 @@ impl Store for RedbStore {
         }
         let mut guard = NewTxnGuard(&self.active_txn_count, false);
 
-        let (read_version, read_txn) = {
+        let (read_version, read_txn, conflict_snapshot) = {
             // Pair the conflict version and Redb snapshot without a commit between them.
             let _commit_guard = self.commit_gate.read().await;
-            let read_version = self.conflict_tracker.current_version();
+            let conflict_snapshot = (!readonly).then(|| self.conflict_tracker.begin_snapshot());
+            let read_version = conflict_snapshot.as_ref().map_or_else(
+                || self.conflict_tracker.current_version(),
+                |snapshot| snapshot.version(),
+            );
             let read_txn = self.db.begin_read()?;
-            (read_version, read_txn)
+            (read_version, read_txn, conflict_snapshot)
         };
 
         // Defuse the guard - transaction will manage its own count via its Drop impl
@@ -321,6 +325,7 @@ impl Store for RedbStore {
             db: Arc::clone(&self.db),
             active_txn_count: Arc::clone(&self.active_txn_count),
             conflict_tracker: Arc::clone(&self.conflict_tracker),
+            _conflict_snapshot: conflict_snapshot,
             commit_gate: Arc::clone(&self.commit_gate),
             read_version,
             read_txn,

--- a/crates/storage/src/backends/redb/transaction.rs
+++ b/crates/storage/src/backends/redb/transaction.rs
@@ -10,7 +10,9 @@ use super::config::DurabilityMode;
 use super::group_commit::{GroupCommitBuffer, PendingCommit};
 use super::iterator::MergingIterator;
 use super::{bound_as_ref, compute_range_bounds, KV_TABLE};
-use crate::backends::shared::{CallbackCounts, CallbackManager, ConflictTracker, ReadSet};
+use crate::backends::shared::{
+    CallbackCounts, CallbackManager, ConflictSnapshot, ConflictTracker, ReadSet,
+};
 use crate::corekv::{
     AsyncTxnCallback, Error, IterOptions, Iterator, Reader, Result, Txn, TxnCallback, Writer,
 };
@@ -37,6 +39,9 @@ pub(crate) struct RedbTxn {
 
     /// Conflict tracker for write-write conflict detection
     pub(crate) conflict_tracker: Arc<ConflictTracker>,
+
+    /// Keeps conflict history alive for this write transaction's snapshot.
+    pub(crate) _conflict_snapshot: Option<ConflictSnapshot>,
 
     /// Keeps transaction snapshots aligned with committed conflict versions.
     pub(crate) commit_gate: Arc<tokio::sync::RwLock<()>>,
@@ -304,7 +309,7 @@ impl Writer for RedbTxn {
 #[async_trait]
 impl Txn for RedbTxn {
     #[instrument(level = "trace", skip(self))]
-    async fn commit(self: Box<Self>) -> Result<()> {
+    async fn commit(mut self: Box<Self>) -> Result<()> {
         // Note: active_txn_count is decremented by Drop impl when self is dropped
         // at the end of this function (on any exit path).
 
@@ -335,6 +340,10 @@ impl Txn for RedbTxn {
                     changes: pending,
                     read_version: self.read_version,
                     read_set,
+                    _conflict_snapshot: self
+                        ._conflict_snapshot
+                        .take()
+                        .expect("write transaction has a conflict snapshot"),
                     result_tx,
                     on_success: self.callbacks.take_success(),
                     on_success_async: self.callbacks.take_success_async(),
@@ -361,10 +370,15 @@ impl Txn for RedbTxn {
             let commit_gate = self.commit_gate.clone();
             let read_version = self.read_version;
             let durability = self.durability;
+            let conflict_snapshot = self
+                ._conflict_snapshot
+                .take()
+                .expect("write transaction has a conflict snapshot");
             let error_callbacks = self.callbacks.take_error();
             let error_async_callbacks = self.callbacks.take_error_async();
 
             let write_result = tokio::task::spawn_blocking(move || -> Result<()> {
+                let _conflict_snapshot = conflict_snapshot;
                 let _commit_guard = commit_gate.blocking_write();
                 conflict_tracker.check_and_record(read_version, pending.keys(), &read_set)?;
 

--- a/crates/storage/src/backends/rocksdb/store.rs
+++ b/crates/storage/src/backends/rocksdb/store.rs
@@ -16,6 +16,7 @@ pub struct RocksDbStore {
     db: Arc<rocksdb::OptimisticTransactionDB>,
     closed: AtomicBool,
     conflict_tracker: Arc<ConflictTracker>,
+    commit_gate: Arc<tokio::sync::RwLock<()>>,
     db_path: std::path::PathBuf,
     active_txn_count: Arc<AtomicUsize>,
     close_timeout: std::time::Duration,
@@ -124,6 +125,7 @@ impl RocksDbStore {
             db: Arc::new(db),
             closed: AtomicBool::new(false),
             conflict_tracker: Arc::new(ConflictTracker::new()),
+            commit_gate: Arc::new(tokio::sync::RwLock::new(())),
             db_path,
             active_txn_count: Arc::new(AtomicUsize::new(0)),
             close_timeout: opts.close_timeout(),
@@ -156,13 +158,33 @@ impl Store for RocksDbStore {
             return Err(Error::DBClosed);
         }
 
-        Ok(Box::new(RocksDbTxn::new(
+        // Ensure cancellation while waiting for the commit gate does not leak
+        // the active transaction count and prevent store shutdown.
+        struct NewTxnGuard<'a>(&'a AtomicUsize, bool);
+        impl Drop for NewTxnGuard<'_> {
+            fn drop(&mut self) {
+                if !self.1 {
+                    self.0.fetch_sub(1, Ordering::AcqRel);
+                }
+            }
+        }
+        let mut guard = NewTxnGuard(&self.active_txn_count, false);
+
+        // Pair the conflict version and RocksDB snapshot without a commit
+        // becoming visible between them.
+        let _commit_guard = self.commit_gate.read().await;
+        let txn = RocksDbTxn::new(
             Arc::clone(&self.db),
             Arc::clone(&self.conflict_tracker),
+            Arc::clone(&self.commit_gate),
             Arc::clone(&self.active_txn_count),
             readonly,
             self.durability,
-        )))
+        );
+
+        // The transaction now owns the active-count decrement through Drop.
+        guard.1 = true;
+        Ok(Box::new(txn))
     }
 
     async fn close(&self) -> Result<()> {
@@ -229,5 +251,117 @@ impl Dropable for RocksDbStore {
         })?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backends::shared::ReadSet;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn snapshot_waits_for_physical_write_after_conflict_version_advances() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let store = Arc::new(RocksDbStore::open(temp_dir.path()).unwrap());
+        let sequence_key = b"/seq/doc".to_vec();
+        let sequence_value = 14_u64.to_be_bytes();
+
+        // Reproduce the critical interval inside commit: the logical conflict
+        // version has advanced, but the corresponding RocksDB batch has not
+        // yet been written. A new transaction must not snapshot in this gap.
+        let gate = Arc::clone(&store.commit_gate);
+        let commit_guard = gate.write().await;
+        store
+            .conflict_tracker
+            .check_and_record(
+                store.conflict_tracker.current_version(),
+                std::slice::from_ref(&sequence_key).iter(),
+                &ReadSet::default(),
+            )
+            .unwrap();
+
+        let snapshot_store = Arc::clone(&store);
+        let mut snapshot_task = tokio::spawn(async move { snapshot_store.new_txn(false).await });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), &mut snapshot_task)
+                .await
+                .is_err(),
+            "new transaction took a snapshot during an in-flight physical commit"
+        );
+
+        store.db.put(&sequence_key, sequence_value).unwrap();
+        drop(commit_guard);
+
+        let snapshot = tokio::time::timeout(Duration::from_secs(1), snapshot_task)
+            .await
+            .expect("snapshot remained blocked after commit")
+            .expect("snapshot task panicked")
+            .expect("snapshot creation failed");
+        assert_eq!(
+            snapshot.get(&sequence_key).await.unwrap(),
+            Some(sequence_value.to_vec())
+        );
+    }
+
+    #[tokio::test]
+    async fn physical_write_waits_for_snapshot_pairing() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let store = Arc::new(RocksDbStore::open(temp_dir.path()).unwrap());
+        let key = b"commit-gate-key".to_vec();
+
+        let mut writer = store.new_txn(false).await.unwrap();
+        writer.set(&key, b"committed").await.unwrap();
+
+        let gate = Arc::clone(&store.commit_gate);
+        let snapshot_guard = gate.read().await;
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let mut commit_task = tokio::spawn(async move {
+            started_tx.send(()).unwrap();
+            writer.commit().await
+        });
+        started_rx.await.unwrap();
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), &mut commit_task)
+                .await
+                .is_err(),
+            "physical commit did not wait for snapshot pairing"
+        );
+        assert_eq!(store.db.get(&key).unwrap(), None);
+
+        drop(snapshot_guard);
+        tokio::time::timeout(Duration::from_secs(1), commit_task)
+            .await
+            .expect("commit remained blocked after snapshot pairing")
+            .expect("commit task panicked")
+            .expect("commit failed");
+        assert_eq!(store.db.get(&key).unwrap(), Some(b"committed".to_vec()));
+    }
+
+    #[tokio::test]
+    async fn cancelling_snapshot_wait_does_not_leak_active_transaction_count() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let store = Arc::new(RocksDbStore::open(temp_dir.path()).unwrap());
+        let gate = Arc::clone(&store.commit_gate);
+        let commit_guard = gate.write().await;
+
+        let snapshot_store = Arc::clone(&store);
+        let snapshot_task = tokio::spawn(async move { snapshot_store.new_txn(false).await });
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while store.active_txn_count.load(Ordering::Acquire) == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("snapshot task did not reach the commit gate");
+
+        snapshot_task.abort();
+        match snapshot_task.await {
+            Err(error) => assert!(error.is_cancelled()),
+            Ok(_) => panic!("snapshot task completed instead of being cancelled"),
+        }
+        drop(commit_guard);
+        assert_eq!(store.active_txn_count.load(Ordering::Acquire), 0);
     }
 }

--- a/crates/storage/src/backends/rocksdb/transaction.rs
+++ b/crates/storage/src/backends/rocksdb/transaction.rs
@@ -7,7 +7,9 @@ use std::sync::Arc;
 
 use super::iterator::RocksDbMergingIterator;
 use crate::backends::shared::DurabilityMode;
-use crate::backends::shared::{CallbackCounts, CallbackManager, ConflictTracker, ReadSet};
+use crate::backends::shared::{
+    CallbackCounts, CallbackManager, ConflictSnapshot, ConflictTracker, ReadSet,
+};
 use crate::corekv::{
     AsyncTxnCallback, Error, IterOptions, Iterator, Reader, Result, Txn, TxnCallback, Writer,
 };
@@ -64,6 +66,7 @@ pub(crate) struct RocksDbTxn {
     pub(crate) db: Arc<rocksdb::OptimisticTransactionDB>,
     snapshot: OwnedSnapshot,
     pub(crate) conflict_tracker: Arc<ConflictTracker>,
+    pub(crate) _conflict_snapshot: Option<ConflictSnapshot>,
     pub(crate) active_txn_count: Arc<AtomicUsize>,
     pub(crate) read_version: u64,
     /// Pending changes (Some(value) = set, None = delete)
@@ -114,13 +117,18 @@ impl RocksDbTxn {
         readonly: bool,
         durability: DurabilityMode,
     ) -> Self {
-        let read_version = conflict_tracker.current_version();
+        let conflict_snapshot = (!readonly).then(|| conflict_tracker.begin_snapshot());
+        let read_version = conflict_snapshot.as_ref().map_or_else(
+            || conflict_tracker.current_version(),
+            |snapshot| snapshot.version(),
+        );
         let snapshot = OwnedSnapshot::new(Arc::clone(&db));
 
         Self {
             db,
             snapshot,
             conflict_tracker,
+            _conflict_snapshot: conflict_snapshot,
             active_txn_count,
             read_version,
             pending: Mutex::new(BTreeMap::new()),

--- a/crates/storage/src/backends/rocksdb/transaction.rs
+++ b/crates/storage/src/backends/rocksdb/transaction.rs
@@ -67,6 +67,7 @@ pub(crate) struct RocksDbTxn {
     snapshot: OwnedSnapshot,
     pub(crate) conflict_tracker: Arc<ConflictTracker>,
     pub(crate) _conflict_snapshot: Option<ConflictSnapshot>,
+    pub(crate) commit_gate: Arc<tokio::sync::RwLock<()>>,
     pub(crate) active_txn_count: Arc<AtomicUsize>,
     pub(crate) read_version: u64,
     /// Pending changes (Some(value) = set, None = delete)
@@ -113,6 +114,7 @@ impl RocksDbTxn {
     pub(crate) fn new(
         db: Arc<rocksdb::OptimisticTransactionDB>,
         conflict_tracker: Arc<ConflictTracker>,
+        commit_gate: Arc<tokio::sync::RwLock<()>>,
         active_txn_count: Arc<AtomicUsize>,
         readonly: bool,
         durability: DurabilityMode,
@@ -129,6 +131,7 @@ impl RocksDbTxn {
             snapshot,
             conflict_tracker,
             _conflict_snapshot: conflict_snapshot,
+            commit_gate,
             active_txn_count,
             read_version,
             pending: Mutex::new(BTreeMap::new()),
@@ -391,15 +394,11 @@ impl Txn for RocksDbTxn {
         let read_set = self.read_set.lock().clone();
 
         if !pending.is_empty() {
-            // Check conflicts
-            if let Err(e) =
-                self.conflict_tracker
-                    .check_and_record(self.read_version, pending.keys(), &read_set)
-            {
-                CallbackManager::execute_callbacks(self.callbacks.take_error());
-                CallbackManager::execute_async_callbacks(self.callbacks.take_error_async()).await;
-                return Err(e);
-            }
+            // Keep the logical conflict version and physical RocksDB commit
+            // atomic with respect to new transaction snapshots. Without this,
+            // a transaction can observe the advanced conflict version while
+            // taking a RocksDB snapshot from before the corresponding write.
+            let commit_guard = self.commit_gate.write().await;
 
             // Apply via WriteBatch
             let mut batch = rocksdb::WriteBatchWithTransaction::<true>::default();
@@ -420,15 +419,27 @@ impl Txn for RocksDbTxn {
                 }
             }
 
-            if let Err(e) = self.db.write_opt(batch, &write_opts) {
-                tracing::error!(
-                    error = %e,
-                    pending_changes = pending.len(),
-                    "Failed to commit RocksDB batch"
-                );
+            let commit_result = match self.conflict_tracker.check_and_record(
+                self.read_version,
+                pending.keys(),
+                &read_set,
+            ) {
+                Ok(()) => self.db.write_opt(batch, &write_opts).map_err(Error::from),
+                Err(error) => Err(error),
+            };
+            drop(commit_guard);
+
+            if let Err(e) = commit_result {
+                if !matches!(e, Error::TxnConflict) {
+                    tracing::error!(
+                        error = %e,
+                        pending_changes = pending.len(),
+                        "Failed to commit RocksDB batch"
+                    );
+                }
                 CallbackManager::execute_callbacks(self.callbacks.take_error());
                 CallbackManager::execute_async_callbacks(self.callbacks.take_error_async()).await;
-                return Err(e.into());
+                return Err(e);
             }
         }
 

--- a/crates/storage/src/backends/shared.rs
+++ b/crates/storage/src/backends/shared.rs
@@ -1,6 +1,13 @@
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
+#[cfg(not(target_arch = "wasm32"))]
+use std::collections::BTreeMap;
 use std::collections::HashSet;
+#[cfg(not(target_arch = "wasm32"))]
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
 
 use crate::corekv::{AsyncTxnCallback, IterOptions, TxnCallback};
 
@@ -246,27 +253,90 @@ type CommittedTxnRecord = (u64, HashSet<Vec<u8>>, ReadSet);
 
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) struct ConflictTracker {
-    /// Monotonically increasing version counter.
-    version: std::sync::atomic::AtomicU64,
-    /// Read/write sets from committed transactions.
-    /// Protected by a mutex since we only access it during commit (not hot path).
-    committed: Mutex<Vec<CommittedTxnRecord>>,
+    version: AtomicU64,
+    state: Mutex<ConflictTrackerState>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Default)]
+struct ConflictTrackerState {
+    committed: Vec<CommittedTxnRecord>,
+    active_snapshots: BTreeMap<u64, usize>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) struct ConflictSnapshot {
+    tracker: Arc<ConflictTracker>,
+    version: u64,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl ConflictSnapshot {
+    pub(crate) fn version(&self) -> u64 {
+        self.version
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl Drop for ConflictSnapshot {
+    fn drop(&mut self) {
+        self.tracker.release_snapshot(self.version);
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl ConflictTrackerState {
+    fn prune(&mut self, current_version: u64) {
+        let oldest_active = self
+            .active_snapshots
+            .first_key_value()
+            .map_or(current_version, |(version, _)| *version);
+        let drain_count = self
+            .committed
+            .partition_point(|(version, _, _)| *version <= oldest_active);
+        self.committed.drain(..drain_count);
+    }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
 impl ConflictTracker {
     pub(crate) fn new() -> Self {
-        use std::sync::atomic::AtomicU64;
         Self {
             version: AtomicU64::new(0),
-            committed: Mutex::new(Vec::new()),
+            state: Mutex::new(ConflictTrackerState::default()),
         }
     }
 
     /// Get the current version for a new transaction's snapshot.
     pub(crate) fn current_version(&self) -> u64 {
-        use std::sync::atomic::Ordering;
         self.version.load(Ordering::SeqCst)
+    }
+
+    /// Register a write transaction snapshot until its transaction is finalized.
+    pub(crate) fn begin_snapshot(self: &Arc<Self>) -> ConflictSnapshot {
+        let version = {
+            let mut state = self.state.lock();
+            let version = self.current_version();
+            *state.active_snapshots.entry(version).or_default() += 1;
+            version
+        };
+        ConflictSnapshot {
+            tracker: Arc::clone(self),
+            version,
+        }
+    }
+
+    fn release_snapshot(&self, version: u64) {
+        let mut state = self.state.lock();
+        let count = state
+            .active_snapshots
+            .get_mut(&version)
+            .expect("registered conflict snapshot");
+        *count -= 1;
+        if *count == 0 {
+            state.active_snapshots.remove(&version);
+        }
+        state.prune(self.current_version());
     }
 
     /// Check for conflicts and record the read/write set if no conflict.
@@ -278,17 +348,15 @@ impl ConflictTracker {
         write_keys: impl Iterator<Item = &'a Vec<u8>>,
         read_set: &ReadSet,
     ) -> std::result::Result<(), crate::corekv::Error> {
-        use std::sync::atomic::Ordering;
-
         let write_keys: Vec<&Vec<u8>> = write_keys.collect();
         if write_keys.is_empty() {
             return Ok(());
         }
 
-        let mut committed = self.committed.lock();
+        let mut state = self.state.lock();
 
         // Check for conflicts against transactions committed after our snapshot.
-        for (commit_ver, committed_writes, committed_reads) in committed.iter() {
+        for (commit_ver, committed_writes, committed_reads) in &state.committed {
             if *commit_ver > read_version {
                 for write_key in &write_keys {
                     if committed_writes.contains(*write_key)
@@ -310,15 +378,10 @@ impl ConflictTracker {
         // No conflict - clone keys into storage (single clone per key)
         let new_version = self.version.fetch_add(1, Ordering::SeqCst) + 1;
         let write_set = write_keys.into_iter().cloned().collect();
-        committed.push((new_version, write_set, read_set.clone()));
-
-        // Prune old entries that can no longer conflict (optional GC).
-        // Keep entries that are newer than the oldest possible active transaction.
-        // For simplicity, keep last 1000 entries.
-        if committed.len() > 1000 {
-            let drain_count = committed.len() - 1000;
-            committed.drain(..drain_count);
-        }
+        state
+            .committed
+            .push((new_version, write_set, read_set.clone()));
+        state.prune(new_version);
 
         Ok(())
     }
@@ -330,19 +393,25 @@ mod tests {
 
     #[test]
     fn detects_write_to_committed_read_prefix() {
-        let tracker = ConflictTracker::new();
-        let snapshot = tracker.current_version();
+        let tracker = Arc::new(ConflictTracker::new());
+        let first_snapshot = tracker.begin_snapshot();
+        let second_snapshot = tracker.begin_snapshot();
 
         let mut first_reads = ReadSet::default();
         first_reads.record_iter_options(&IterOptions::new().with_prefix(b"d/i/books/".to_vec()));
         let first_writes = [b"d/d/publishers/website".to_vec()];
         tracker
-            .check_and_record(snapshot, first_writes.iter(), &first_reads)
+            .check_and_record(first_snapshot.version(), first_writes.iter(), &first_reads)
             .unwrap();
+        drop(first_snapshot);
 
         let second_writes = [b"d/i/books/online-book".to_vec()];
         let err = tracker
-            .check_and_record(snapshot, second_writes.iter(), &ReadSet::default())
+            .check_and_record(
+                second_snapshot.version(),
+                second_writes.iter(),
+                &ReadSet::default(),
+            )
             .unwrap_err();
 
         assert!(matches!(err, crate::corekv::Error::TxnConflict));
@@ -350,37 +419,53 @@ mod tests {
 
     #[test]
     fn ignores_document_collection_scan_prefixes() {
-        let tracker = ConflictTracker::new();
-        let snapshot = tracker.current_version();
+        let tracker = Arc::new(ConflictTracker::new());
+        let first_snapshot = tracker.begin_snapshot();
+        let second_snapshot = tracker.begin_snapshot();
 
         let mut first_reads = ReadSet::default();
         first_reads.record_iter_options(&IterOptions::new().with_prefix(b"d/d/books/".to_vec()));
         let first_writes = [b"d/d/publishers/website".to_vec()];
         tracker
-            .check_and_record(snapshot, first_writes.iter(), &first_reads)
+            .check_and_record(first_snapshot.version(), first_writes.iter(), &first_reads)
             .unwrap();
+        drop(first_snapshot);
 
         let second_writes = [b"d/d/books/online-book".to_vec()];
         tracker
-            .check_and_record(snapshot, second_writes.iter(), &ReadSet::default())
+            .check_and_record(
+                second_snapshot.version(),
+                second_writes.iter(),
+                &ReadSet::default(),
+            )
             .unwrap();
     }
 
     #[test]
     fn detects_read_of_committed_write_key() {
-        let tracker = ConflictTracker::new();
-        let snapshot = tracker.current_version();
+        let tracker = Arc::new(ConflictTracker::new());
+        let first_snapshot = tracker.begin_snapshot();
+        let second_snapshot = tracker.begin_snapshot();
 
         let first_writes = [b"d/d/books/website-book".to_vec()];
         tracker
-            .check_and_record(snapshot, first_writes.iter(), &ReadSet::default())
+            .check_and_record(
+                first_snapshot.version(),
+                first_writes.iter(),
+                &ReadSet::default(),
+            )
             .unwrap();
+        drop(first_snapshot);
 
         let mut second_reads = ReadSet::default();
         second_reads.record_key(b"d/d/books/website-book");
         let second_writes = [b"d/d/publishers/online".to_vec()];
         let err = tracker
-            .check_and_record(snapshot, second_writes.iter(), &second_reads)
+            .check_and_record(
+                second_snapshot.version(),
+                second_writes.iter(),
+                &second_reads,
+            )
             .unwrap_err();
 
         assert!(matches!(err, crate::corekv::Error::TxnConflict));


### PR DESCRIPTION
Fixes #1158.

## Root cause

The shared optimistic conflict tracker retained only the latest 1,000 committed read/write sets, regardless of which write snapshots were still active. Under sustained commit activity, a long-lived write transaction could therefore outlive the committed record that should make it conflict.

For concurrent creates, both transactions can read the same `/seq/doc` value. If the newer create commits and its conflict record is pruned before the older create commits, the older transaction can be accepted and reuse the same short ID. That replaces the canonical mapping and document body after the newer create already returned success, making the acknowledged document unqueryable by its returned DocID and indexes.

## What changed

- Track active write snapshots per conflict version and prune committed records only once they are no longer needed by the oldest active snapshot.
- Register snapshot guards for Redb, Lark, Fjall, RocksDB, and memory transactions while preserving the lock-free read-only version path.
- Transfer Redb guards into queued group commits and blocking direct commits so cancellation cannot release required history while a commit remains in flight.
- Add a deterministic regression with 1,000 intervening commits that verifies a stale create conflicts instead of overwriting the acknowledged document.

## Validation

- [x] `cargo test -p storage --all-features`
- [x] `cargo clippy -p storage --all-features --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check origin/main...HEAD`