### PR TITLE
fix(p2p): scope replay capabilities to their authorizer

### DIFF
--- a/crates/p2p/src/host/handle.rs
+++ b/crates/p2p/src/host/handle.rs
@@ -18,6 +18,12 @@ use crate::QueryId;
 use super::command::HostCommand;
 use super::ResponseChannel;
 
+#[derive(Clone)]
+struct CachedExplicitReplayCapability {
+    capability: String,
+    authorizer_did: String,
+}
+
 /// Handle to interact with the P2P host.
 #[derive(Clone)]
 pub struct P2PHostHandle {
@@ -29,7 +35,8 @@ pub struct P2PHostHandle {
     /// Keypair for signing messages.
     keypair: Keypair,
     /// Optional explicit replay capabilities keyed by (peer_id, collection_id).
-    explicit_replay_capabilities: Arc<RwLock<HashMap<(String, String), String>>>,
+    explicit_replay_capabilities:
+        Arc<RwLock<HashMap<(String, String), CachedExplicitReplayCapability>>>,
 }
 
 impl P2PHostHandle {
@@ -39,13 +46,39 @@ impl P2PHostHandle {
         collections: &[String],
         capability: &str,
     ) {
-        let peer_id = peer_id.to_string();
-        let mut capabilities = self.explicit_replay_capabilities.write();
+        let source_peer_id = self.local_peer_id.to_string();
+        let target_peer_id = peer_id.to_string();
+        let mut validated = Vec::with_capacity(collections.len());
         for collection_id in collections {
-            capabilities.insert(
-                (peer_id.clone(), collection_id.clone()),
-                capability.to_string(),
-            );
+            let authorization = match crate::verify_explicit_replay_capability(
+                capability,
+                &source_peer_id,
+                &target_peer_id,
+                collection_id,
+            ) {
+                Ok(authorization) => authorization,
+                Err(error) => {
+                    tracing::warn!(
+                        peer_id = %peer_id,
+                        collection_id,
+                        error = %error,
+                        "Refusing to cache invalid explicit replay capability"
+                    );
+                    continue;
+                }
+            };
+            validated.push((
+                collection_id.clone(),
+                CachedExplicitReplayCapability {
+                    capability: capability.to_string(),
+                    authorizer_did: authorization.authorizer_did,
+                },
+            ));
+        }
+
+        let mut capabilities = self.explicit_replay_capabilities.write();
+        for (collection_id, capability) in validated {
+            capabilities.insert((target_peer_id.clone(), collection_id), capability);
         }
     }
 
@@ -69,11 +102,22 @@ impl P2PHostHandle {
             return;
         }
 
-        request.explicit_replay_capability = self
+        let cached = self
             .explicit_replay_capabilities
             .read()
             .get(&(peer_id.to_string(), request.collection_id.clone()))
             .cloned();
+        let Some(cached) = cached else {
+            return;
+        };
+
+        // A capability delegates replay authority for one DID. Attaching it to
+        // an unrelated live/public push makes the receiver validate that block
+        // against the wrong authorizer and reject otherwise valid replication.
+        // Keep ordinary pushes on the normal admission path (#1161).
+        if request.creator == cached.authorizer_did {
+            request.explicit_replay_capability = Some(cached.capability);
+        }
     }
 
     /// Create a new handle (internal use only).
@@ -470,7 +514,7 @@ impl P2PHostHandle {
         collections: &[String],
         capability: &str,
     ) {
-        self.set_explicit_replay_capability_inner(&peer_id, collections, capability);
+        self.set_explicit_replay_capability_inner(&peer_id, collections, capability)
     }
 
     /// Clear cached explicit replay capabilities for the provided collections.
@@ -488,7 +532,7 @@ impl P2PHostHandle {
         self.explicit_replay_capabilities
             .read()
             .get(&(peer_id.to_string(), collection.to_string()))
-            .is_some_and(|existing| existing == capability)
+            .is_some_and(|existing| existing.capability == capability)
     }
 
     /// Delete a replicator.

--- a/crates/p2p/tests/host_tests.rs
+++ b/crates/p2p/tests/host_tests.rs
@@ -90,7 +90,7 @@ async fn send_two_stream_request_and_capture_flag(
     events: &mut tokio::sync::mpsc::Receiver<p2p::HostEvent>,
     target_peer_id: PeerId,
     request: PushLogRequest,
-) -> bool {
+) -> (bool, Option<String>) {
     let sender_handle = sender.clone();
     let receiver_handle = receiver.clone();
     let send_task = tokio::spawn(async move {
@@ -101,7 +101,7 @@ async fn send_two_stream_request_and_capture_flag(
     });
 
     let deadline = std::time::Instant::now() + Duration::from_secs(5);
-    let is_explicit_replicator = loop {
+    let captured = loop {
         let remaining = deadline.saturating_duration_since(std::time::Instant::now());
         let event = timeout(remaining, events.recv())
             .await
@@ -121,14 +121,17 @@ async fn send_two_stream_request_and_capture_flag(
                     .send_two_stream_response(peer_id, reply)
                     .await
                     .unwrap();
-                break is_explicit_replicator;
+                break (
+                    is_explicit_replicator,
+                    request.explicit_replay_capability.clone(),
+                );
             }
             _ => continue,
         }
     };
 
     send_task.await.unwrap();
-    is_explicit_replicator
+    captured
 }
 
 fn explicit_replay_capability(
@@ -204,7 +207,7 @@ async fn test_two_stream_non_replicator_is_not_marked_explicit() {
     );
     sign_message(handle0.keypair(), &mut request).unwrap();
 
-    let is_explicit =
+    let (is_explicit, _) =
         send_two_stream_request_and_capture_flag(&handle0, &handle1, &mut events1, peer1, request)
             .await;
     assert!(
@@ -483,7 +486,7 @@ async fn test_two_stream_registered_replicator_without_capability_is_not_marked_
     );
     sign_message(handle0.keypair(), &mut request).unwrap();
 
-    let is_explicit =
+    let (is_explicit, _) =
         send_two_stream_request_and_capture_flag(&handle0, &handle1, &mut events1, peer1, request)
             .await;
     assert!(
@@ -534,12 +537,66 @@ async fn test_two_stream_registered_replicator_with_capability_is_marked_explici
     );
     sign_message(handle0.keypair(), &mut request).unwrap();
 
-    let is_explicit =
+    let (is_explicit, _) =
         send_two_stream_request_and_capture_flag(&handle0, &handle1, &mut events1, peer1, request)
             .await;
     assert!(
         is_explicit,
         "registered replicator with capability must get explicit trust"
+    );
+
+    handle0.shutdown().await.unwrap();
+    handle1.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_cached_capability_is_not_attached_to_public_push() {
+    let store0 = MockBitswapStore::new();
+    let store1 = MockBitswapStore::new();
+    let (host0, handle0, _events0, _replicators0) = P2PHost::new(store0).await.unwrap();
+    let (host1, handle1, mut events1, _replicators1) = P2PHost::new(store1).await.unwrap();
+
+    tokio::spawn(host0.run());
+    tokio::spawn(host1.run());
+
+    handle1
+        .listen("/ip4/127.0.0.1/tcp/0".parse().unwrap())
+        .await
+        .unwrap();
+    let addr1 = handle1.listen_addresses().await.unwrap().remove(0);
+    let peer1 = handle1.local_peer_id_cached();
+    let peer0 = handle0.local_peer_id_cached();
+
+    handle0.dial(peer1, vec![addr1]).await.unwrap();
+    wait_until_connected(&handle0, peer1).await;
+    wait_until_connected(&handle1, peer0).await;
+
+    handle0
+        .create_replicator(peer1, vec!["collection1".to_string()])
+        .await
+        .unwrap();
+
+    let (_authorizer, capability) = explicit_replay_capability(&handle0, peer1, "collection1");
+    handle0.set_explicit_replay_capability(peer1, &["collection1".to_string()], &capability);
+
+    let request = PushLogRequest::new(
+        "public-doc".to_string(),
+        Bytes::from(vec![1, 2, 3]),
+        "collection1".to_string(),
+        peer0.to_string(),
+        Bytes::from(b"public-block-data".to_vec()),
+    );
+
+    let (is_explicit, attached_capability) =
+        send_two_stream_request_and_capture_flag(&handle0, &handle1, &mut events1, peer1, request)
+            .await;
+    assert!(
+        !is_explicit,
+        "a public push must stay on ordinary replicator admission"
+    );
+    assert!(
+        attached_capability.is_none(),
+        "a different-author capability must not taint a public push"
     );
 
     handle0.shutdown().await.unwrap();
@@ -579,7 +636,7 @@ async fn test_two_stream_capability_for_other_collection_is_rejected() {
     request.explicit_replay_capability = Some(capability);
     sign_message(handle0.keypair(), &mut request).unwrap();
 
-    let is_explicit =
+    let (is_explicit, _) =
         send_two_stream_request_and_capture_flag(&handle0, &handle1, &mut events1, peer1, request)
             .await;
     assert!(
@@ -640,7 +697,7 @@ async fn test_two_stream_expired_capability_is_rejected() {
     request.explicit_replay_capability = Some(capability);
     sign_message(handle0.keypair(), &mut request).unwrap();
 
-    let is_explicit =
+    let (is_explicit, _) =
         send_two_stream_request_and_capture_flag(&handle0, &handle1, &mut events1, peer1, request)
             .await;
     assert!(!is_explicit, "expired capability must be rejected");
@@ -699,7 +756,7 @@ async fn test_two_stream_invalid_authorizer_signature_is_rejected() {
     request.explicit_replay_capability = Some(capability);
     sign_message(handle0.keypair(), &mut request).unwrap();
 
-    let is_explicit =
+    let (is_explicit, _) =
         send_two_stream_request_and_capture_flag(&handle0, &handle1, &mut events1, peer1, request)
             .await;
     assert!(
@@ -748,7 +805,7 @@ async fn test_two_stream_capability_is_edge_scoped() {
     request.explicit_replay_capability = Some(capability_for_a_to_b);
     sign_message(handle1.keypair(), &mut request).unwrap();
 
-    let is_explicit =
+    let (is_explicit, _) =
         send_two_stream_request_and_capture_flag(&handle1, &handle2, &mut events2, peer2, request)
             .await;
     assert!(


### PR DESCRIPTION
## What changed

- verify explicit-replay capabilities before caching them
- retain the verified authorizer DID with each cached capability
- attach a cached capability only when the outgoing block creator matches that authorizer
- keep public and other-author pushes on ordinary replication admission
- add a regression proving a cached replay capability cannot taint a public push

## Why

The explicit-replay capability cache was keyed only by peer and collection. Once populated, it was attached to every subsequent two-stream push on that edge. A valid public document could therefore arrive carrying another DID replay capability and be rejected by the receiver with:

`explicit replay authorization authorizer ... does not match block creator ...`

Arrival order between gossip and two-stream delivery made the existing trust-boundary test flaky. This failed both PR #1160 P2P CI and the exact merged-main P2P CI run.

## Impact

Authorized historical replay continues to use the explicit capability path. Unrelated live/public replication no longer inherits a capability for the wrong authorizer.

Closes #1161.

## Validation

- `cargo test -p p2p` — 441 unit tests plus enabled integration/doc tests passed
- `cargo clippy -p p2p --all-targets -- -D warnings`
- `trust_boundary::rust_rust_p2p_trust_boundary` — exact previously failing integration test passed locally
- new `test_cached_capability_is_not_attached_to_public_push`
- existing authorized replay capability regression remains green