### PR TITLE
fix(query): resolve cursor seeks through short IDs

### DIFF
--- a/crates/db/src/doc_fetcher.rs
+++ b/crates/db/src/doc_fetcher.rs
@@ -212,7 +212,7 @@ impl<S: Store + 'static> DocFetcher for DbDocFetcher<S> {
         use std::collections::HashSet;
         use storage::index::IndexIterator;
 
-        let (_collection, datastore, systemstore, index_manager) =
+        let (collection, datastore, systemstore, index_manager) =
             get_collection_with_index_manager(&self.txn, collection_name).await?;
 
         // Get the index
@@ -359,7 +359,13 @@ impl<S: Store + 'static> DocFetcher for DbDocFetcher<S> {
                     .map_err(|e| {
                         query::error::QueryError::execution(format!("index error: {}", e))
                     })?;
-                apply_cursor_seek_to_iterator(&mut iter, &params.cursor_seek).await?;
+                apply_cursor_seek_to_iterator(
+                    &mut iter,
+                    &params.cursor_seek,
+                    &systemstore,
+                    collection.resolved_root_id(),
+                )
+                .await?;
                 collect_with_limit(&mut iter, limit, offset, vf).await?
             }
             IndexScanType::RangeScan {
@@ -380,7 +386,13 @@ impl<S: Store + 'static> DocFetcher for DbDocFetcher<S> {
                     .map_err(|e| {
                         query::error::QueryError::execution(format!("index error: {}", e))
                     })?;
-                apply_cursor_seek_to_iterator(&mut iter, &params.cursor_seek).await?;
+                apply_cursor_seek_to_iterator(
+                    &mut iter,
+                    &params.cursor_seek,
+                    &systemstore,
+                    collection.resolved_root_id(),
+                )
+                .await?;
                 collect_with_limit(&mut iter, limit, offset, vf).await?
             }
             IndexScanType::OrScan { branches } => {

--- a/crates/db/src/index_seek.rs
+++ b/crates/db/src/index_seek.rs
@@ -1,7 +1,9 @@
 //! Shared cursor-seek helper for index scan fetchers.
 
+use datastore::NamespaceView;
 use query::planner::index_selection::CursorSeek;
 use storage::index::RangeIterator;
+use storage::keys::{doc_id_index::encode_doc_short_id, SEPARATOR};
 
 /// Apply a cursor seek to a `RangeIterator` when `cursor_seek` is `Some`.
 ///
@@ -10,13 +12,74 @@ use storage::index::RangeIterator;
 pub(crate) async fn apply_cursor_seek_to_iterator(
     iter: &mut RangeIterator,
     cursor_seek: &Option<CursorSeek>,
+    systemstore: &NamespaceView,
+    collection_short_id: u32,
 ) -> Result<(), query::error::QueryError> {
     if let Some(ref seek) = cursor_seek {
-        iter.apply_cursor_seek(seek.seek_key.clone(), seek.inclusive, seek.reversed)
+        let seek_key = resolve_cursor_seek_key(seek, systemstore, collection_short_id).await?;
+        iter.apply_cursor_seek(seek_key, seek.inclusive, seek.reversed)
             .await
             .map_err(|e| {
                 query::error::QueryError::execution(format!("cursor seek error: {}", e))
             })?;
     }
     Ok(())
+}
+
+async fn resolve_cursor_seek_key(
+    seek: &CursorSeek,
+    systemstore: &NamespaceView,
+    collection_short_id: u32,
+) -> Result<Vec<u8>, query::error::QueryError> {
+    let mut key = seek.seek_key.clone();
+    let Some(doc_id) = seek.boundary_doc_id.as_deref() else {
+        return Ok(key);
+    };
+
+    let doc_short_id =
+        crate::doc_id_map::get_doc_short_id(systemstore, collection_short_id, doc_id)
+            .await
+            .map_err(|e| {
+                query::error::QueryError::execution(format!("doc ID resolution error: {e}"))
+            })?
+            .ok_or_else(query::error::QueryError::cursor_invalid)?;
+
+    key.push(SEPARATOR);
+    key.extend_from_slice(&encode_doc_short_id(doc_short_id));
+    Ok(key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datastore::SharedTxn;
+    use storage::backends::MemoryStore;
+    use storage::corekv::Store;
+    use storage::namespace::Namespace;
+
+    #[tokio::test]
+    async fn cursor_boundary_uses_doc_short_id_suffix() {
+        let store = MemoryStore::new();
+        let txn = store.new_txn(false).await.unwrap();
+        let systemstore = NamespaceView::new(SharedTxn::new(txn), Namespace::Systemstore);
+        crate::doc_id_map::set_doc_id_mapping(&systemstore, 7, 42, "bae-boundary")
+            .await
+            .unwrap();
+
+        let seek = CursorSeek {
+            seek_key: vec![1, 2, 3],
+            boundary_doc_id: Some("bae-boundary".to_string()),
+            inclusive: false,
+            reversed: false,
+            expected_index_name: "idx".to_string(),
+            fetch_limit: None,
+        };
+
+        let key = resolve_cursor_seek_key(&seek, &systemstore, 7)
+            .await
+            .unwrap();
+        let mut expected = vec![1, 2, 3, SEPARATOR];
+        expected.extend_from_slice(&encode_doc_short_id(42));
+        assert_eq!(key, expected);
+    }
 }

--- a/crates/db/src/lensed_auto_commit_fetcher/index_scan.rs
+++ b/crates/db/src/lensed_auto_commit_fetcher/index_scan.rs
@@ -39,6 +39,9 @@ impl<S: Store + 'static> LensedAutoCommitFetcher<S> {
         let datastore = txn.datastore().map_err(|e| {
             query::error::QueryError::execution(format!("failed to get datastore: {}", e))
         })?;
+        let systemstore = txn.systemstore().map_err(|e| {
+            query::error::QueryError::execution(format!("failed to get systemstore: {}", e))
+        })?;
 
         let short_id = collection.resolved_root_id();
         let index_manager =
@@ -176,7 +179,13 @@ impl<S: Store + 'static> LensedAutoCommitFetcher<S> {
                     .map_err(|e| {
                         query::error::QueryError::execution(format!("index error: {}", e))
                     })?;
-                apply_cursor_seek_to_iterator(&mut iter, &params.cursor_seek).await?;
+                apply_cursor_seek_to_iterator(
+                    &mut iter,
+                    &params.cursor_seek,
+                    &systemstore,
+                    short_id,
+                )
+                .await?;
                 collect_with_limit(&mut iter, limit, offset, vf).await?
             }
             IndexScanType::RangeScan {
@@ -197,7 +206,13 @@ impl<S: Store + 'static> LensedAutoCommitFetcher<S> {
                     .map_err(|e| {
                         query::error::QueryError::execution(format!("index error: {}", e))
                     })?;
-                apply_cursor_seek_to_iterator(&mut iter, &params.cursor_seek).await?;
+                apply_cursor_seek_to_iterator(
+                    &mut iter,
+                    &params.cursor_seek,
+                    &systemstore,
+                    short_id,
+                )
+                .await?;
                 collect_with_limit(&mut iter, limit, offset, vf).await?
             }
             IndexScanType::OrScan { branches } => {
@@ -241,9 +256,6 @@ impl<S: Store + 'static> LensedAutoCommitFetcher<S> {
             .filter(|id| seen.insert(*id))
             .collect();
 
-        let systemstore = txn.systemstore().map_err(|e| {
-            query::error::QueryError::execution(format!("failed to get systemstore: {}", e))
-        })?;
         let doc_ids = crate::doc_id_map::resolve_doc_ids(&systemstore, &doc_short_ids)
             .await
             .map_err(|e| {

--- a/crates/db/src/lensed_fetcher/index_scan.rs
+++ b/crates/db/src/lensed_fetcher/index_scan.rs
@@ -166,7 +166,13 @@ impl<S: Store + 'static> LensedDocFetcher<S> {
                     .map_err(|e| {
                         query::error::QueryError::execution(format!("index error: {}", e))
                     })?;
-                apply_cursor_seek_to_iterator(&mut iter, &params.cursor_seek).await?;
+                apply_cursor_seek_to_iterator(
+                    &mut iter,
+                    &params.cursor_seek,
+                    &systemstore,
+                    short_id,
+                )
+                .await?;
                 collect_with_limit(&mut iter, limit, offset, vf).await?
             }
             IndexScanType::RangeScan {
@@ -187,7 +193,13 @@ impl<S: Store + 'static> LensedDocFetcher<S> {
                     .map_err(|e| {
                         query::error::QueryError::execution(format!("index error: {}", e))
                     })?;
-                apply_cursor_seek_to_iterator(&mut iter, &params.cursor_seek).await?;
+                apply_cursor_seek_to_iterator(
+                    &mut iter,
+                    &params.cursor_seek,
+                    &systemstore,
+                    short_id,
+                )
+                .await?;
                 collect_with_limit(&mut iter, limit, offset, vf).await?
             }
             IndexScanType::OrScan { branches } => {

--- a/crates/query-plan/src/fetcher.rs
+++ b/crates/query-plan/src/fetcher.rs
@@ -209,11 +209,11 @@ pub trait DocFetcher: MaybeSendSync {
     ///
     /// The caller can then use `get_by_ids` to fetch the full documents.
     ///
-    /// When `params.cursor_seek` is `Some`, the implementation must position
-    /// the storage iterator at `cursor_seek.seek_key` before iterating, honoring
-    /// `inclusive` (skip the boundary if false) and `reversed` (iterate
-    /// descending if true). This is used by cursor pagination to seek directly
-    /// into an index without offset-scan.
+    /// When `params.cursor_seek` is `Some`, the implementation must resolve any
+    /// `boundary_doc_id` into its storage-local key suffix, then position the
+    /// iterator at `cursor_seek.seek_key`, honoring `inclusive` and `reversed`.
+    /// This is used by cursor pagination to seek directly into an index without
+    /// offset-scan.
     ///
     /// Default implementation returns an error - implementations that support
     /// index queries should override this.

--- a/crates/query-plan/src/plan/index_scan.rs
+++ b/crates/query-plan/src/plan/index_scan.rs
@@ -388,6 +388,7 @@ mod tests {
     fn make_seek() -> CursorSeek {
         CursorSeek {
             seek_key: vec![0, 1, 2],
+            boundary_doc_id: None,
             inclusive: false,
             reversed: false,
             expected_index_name: "idx_test".to_string(),
@@ -477,6 +478,7 @@ mod tests {
         });
         let seek = CursorSeek {
             seek_key: vec![0, 1, 2],
+            boundary_doc_id: None,
             inclusive: false,
             reversed: true, // cursor wants backward iteration
             expected_index_name: "idx_test".to_string(),
@@ -506,6 +508,7 @@ mod tests {
         });
         let seek = CursorSeek {
             seek_key: vec![0, 1, 2],
+            boundary_doc_id: None,
             inclusive: false,
             reversed: true, // cursor wants backward iteration
             expected_index_name: "idx_test".to_string(),
@@ -535,6 +538,7 @@ mod tests {
         });
         let seek = CursorSeek {
             seek_key: vec![0, 1, 2],
+            boundary_doc_id: None,
             inclusive: false,
             reversed: false,
             expected_index_name: "idx_different".to_string(), // does not match "idx_test"

--- a/crates/query-plan/src/planner/builder/cursor.rs
+++ b/crates/query-plan/src/planner/builder/cursor.rs
@@ -284,6 +284,7 @@ fn configure_scan_for_cursor(
 /// The key format matches the one used by `RangeIterator` bounds:
 ///   `IndexDataStoreKey::index_prefix(collection_short_id, index_id)`
 ///   + `encode_field_value(...)` for each ordered field.
+///
 /// The DB fetcher appends the boundary document's node-local short ID when
 /// the on-disk index key requires one.
 ///

--- a/crates/query-plan/src/planner/builder/cursor.rs
+++ b/crates/query-plan/src/planner/builder/cursor.rs
@@ -255,9 +255,11 @@ fn configure_scan_for_cursor(
         return Ok((plan, false));
     }
 
-    let seek_key = build_cursor_seek_key(cursor_token, order_fields, collection, idx)?;
+    let (seek_key, boundary_doc_id) =
+        build_cursor_seek_key(cursor_token, order_fields, collection, idx)?;
     let seek = CursorSeek {
         seek_key,
+        boundary_doc_id,
         // Both `after` (forward) and `before` (backward) identify the boundary
         // row that should NOT appear in the page — both are exclusive.
         inclusive: false,
@@ -282,6 +284,8 @@ fn configure_scan_for_cursor(
 /// The key format matches the one used by `RangeIterator` bounds:
 ///   `IndexDataStoreKey::index_prefix(collection_short_id, index_id)`
 ///   + `encode_field_value(...)` for each ordered field.
+/// The DB fetcher appends the boundary document's node-local short ID when
+/// the on-disk index key requires one.
 ///
 /// Field values are extracted from `cursor.keys` in the order given by
 /// `order_fields` and encoded using the same direction (ascending/descending)
@@ -291,7 +295,7 @@ fn build_cursor_seek_key(
     order_fields: &[OrderCondition],
     collection: &CollectionVersion,
     idx: &IndexDescription,
-) -> Result<Vec<u8>> {
+) -> Result<(Vec<u8>, Option<String>)> {
     let collection_short_id = collection.resolved_root_id();
     let index_id = idx.id;
 
@@ -315,32 +319,31 @@ fn build_cursor_seek_key(
     }
 
     // On-disk key shape:
-    // - Non-unique:          [prefix][values][doc_id]   (doc_id always in key)
-    // - Unique non-null:     [prefix][values]           (doc_id in value)
-    // - Unique with any nil: [prefix][values][doc_id]   (per unique.rs:228 — has_nil_field)
+    // - Non-unique:          [prefix][values][doc short ID]   (short ID always in key)
+    // - Unique non-null:     [prefix][values]                 (short ID in value)
+    // - Unique with any nil: [prefix][values][doc short ID]   (per unique.rs:228 — has_nil_field)
     //
-    // Without the doc_id suffix for non-unique indexes, the seek key matches the
+    // Without the short-ID suffix for non-unique indexes, the seek key matches the
     // prefix of EVERY row sharing those field values. An exclusive forward seek at
     // that prefix would reject all of them — not just the boundary doc — causing
     // the query to skip every row with the same indexed values (the duplicate-keys bug).
     //
-    // For unique indexes with non-null values, the doc_id is stored in the VALUE so
+    // For unique indexes with non-null values, the short ID is stored in the VALUE so
     // the key alone identifies one row. But when any cursor key is null, the on-disk
-    // format appends doc_id to the key (same as non-unique), so we must include it.
+    // format appends the short ID to the key (same as non-unique), so the DB fetcher
+    // must resolve it from the cursor's public DocID.
     // Only consider the values that correspond to actual index fields.
     // Checking all cursor.keys.values() would be vulnerable to extra unrelated
-    // keys in a malicious or stale token triggering (or suppressing) the doc_id
+    // keys in a malicious or stale token triggering (or suppressing) the short-ID
     // suffix incorrectly.
     let has_null_value = idx
         .fields
         .iter()
         .filter_map(|f| cursor.keys.get(&f.name))
         .any(|v| v.is_null());
-    if !idx.unique || has_null_value {
-        key.extend_from_slice(cursor.doc_id.as_bytes());
-    }
+    let boundary_doc_id = (!idx.unique || has_null_value).then(|| cursor.doc_id.clone());
 
-    Ok(key)
+    Ok((key, boundary_doc_id))
 }
 
 #[cfg(test)]
@@ -484,7 +487,7 @@ mod tests {
         };
         let order = order_asc("score");
 
-        let key = build_cursor_seek_key(&cursor, &order, &coll, &idx).unwrap();
+        let (key, boundary_doc_id) = build_cursor_seek_key(&cursor, &order, &coll, &idx).unwrap();
 
         // Verify the key is non-empty and matches what a Float32-encoded value produces.
         let prefix = IndexDataStoreKey::index_prefix(coll.resolved_root_id(), idx.id);
@@ -494,6 +497,7 @@ mod tests {
             key, expected,
             "seek key must use Float32 encoding to match index bytes"
         );
+        assert!(boundary_doc_id.is_none());
     }
 
     #[test]
@@ -519,7 +523,7 @@ mod tests {
         };
         let order = order_asc("stamp");
 
-        let key = build_cursor_seek_key(&cursor, &order, &coll, &idx).unwrap();
+        let (key, boundary_doc_id) = build_cursor_seek_key(&cursor, &order, &coll, &idx).unwrap();
 
         let prefix = IndexDataStoreKey::index_prefix(coll.resolved_root_id(), idx.id);
         let expected = encode_field_value(
@@ -540,6 +544,7 @@ mod tests {
             key, time_encoded,
             "seek key must not use DateTime bytes for a String field"
         );
+        assert!(boundary_doc_id.is_none());
     }
 
     // Converse of the date-like-String case: a real DateTime field must seek
@@ -568,7 +573,7 @@ mod tests {
         };
         let order = order_asc("stamp");
 
-        let key = build_cursor_seek_key(&cursor, &order, &coll, &idx).unwrap();
+        let (key, boundary_doc_id) = build_cursor_seek_key(&cursor, &order, &coll, &idx).unwrap();
 
         let prefix = IndexDataStoreKey::index_prefix(coll.resolved_root_id(), idx.id);
         let parsed_time = chrono::DateTime::parse_from_rfc3339(stamp).unwrap();
@@ -586,6 +591,7 @@ mod tests {
             key, string_encoded,
             "seek key must not use String bytes for a DateTime field"
         );
+        assert!(boundary_doc_id.is_none());
     }
 
     #[test]
@@ -611,15 +617,15 @@ mod tests {
         };
         let order = order_asc("stamp");
 
-        let key = build_cursor_seek_key(&cursor, &order, &coll, &idx).unwrap();
+        let (key, boundary_doc_id) = build_cursor_seek_key(&cursor, &order, &coll, &idx).unwrap();
 
         let prefix = IndexDataStoreKey::index_prefix(coll.resolved_root_id(), idx.id);
-        let mut expected = encode_field_value(prefix, &NormalValue::Null, false).unwrap();
-        expected.extend_from_slice(doc_id.as_bytes());
+        let expected = encode_field_value(prefix, &NormalValue::Null, false).unwrap();
 
         assert_eq!(
             key, expected,
-            "null cursor keys remain valid and include doc_id for unique null entries"
+            "the planner must leave the node-local short-ID suffix to the DB fetcher"
         );
+        assert_eq!(boundary_doc_id.as_deref(), Some(doc_id));
     }
 }

--- a/crates/query-plan/src/planner/index_selection/types.rs
+++ b/crates/query-plan/src/planner/index_selection/types.rs
@@ -34,8 +34,11 @@ pub struct IndexScanParams {
 /// `IndexScanParams` to the concrete fetcher.
 #[derive(Debug, Clone)]
 pub struct CursorSeek {
-    /// Raw bytes of the storage-encoded index key to seek to.
+    /// Raw bytes of the storage-encoded index field prefix to seek to.
     pub seek_key: Vec<u8>,
+    /// Public boundary DocID to resolve into the node-local short-ID suffix.
+    /// `None` for unique, non-null index entries whose key has no suffix.
+    pub boundary_doc_id: Option<String>,
     /// `true` for backward pagination (seek inclusive, then iterate);
     /// `false` for forward pagination (seek exclusive — skip the boundary).
     pub inclusive: bool,


### PR DESCRIPTION
Follow-up to #1131.

## Problem

Go v1 DocID parity stores index tie-breaker suffixes as node-local short IDs. Cursor planning still appended public DocID bytes, producing seek keys that do not exist for non-unique indexes and unique indexes with null values. Indexed cursor pagination could therefore skip or repeat rows at the boundary.

## What changed

- Carry the public boundary DocID separately from the storage-encoded index prefix.
- Resolve that DocID through the collection short-ID map immediately before applying the seek.
- Apply the same resolution in regular, lensed, and lensed auto-commit index fetchers.
- Keep unique non-null index seeks suffix-free and reject stale cursor boundaries with no local mapping.
- Add focused coverage for the storage seek-key suffix.

## Validation

- [x] `cargo test -p query-plan -p db --lib` (122 query-plan tests and 144 db tests passed)
- [x] `cargo clippy -p query-plan -p db --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check origin/main...HEAD`