### PR TITLE
fix(storage): pair RocksDB conflict versions with physical snapshots

### DIFF
--- a/crates/storage/src/backends/rocksdb/store.rs
+++ b/crates/storage/src/backends/rocksdb/store.rs
@@ -16,6 +16,7 @@ pub struct RocksDbStore {
     db: Arc<rocksdb::OptimisticTransactionDB>,
     closed: AtomicBool,
     conflict_tracker: Arc<ConflictTracker>,
+    commit_gate: Arc<tokio::sync::RwLock<()>>,
     db_path: std::path::PathBuf,
     active_txn_count: Arc<AtomicUsize>,
     close_timeout: std::time::Duration,
@@ -124,6 +125,7 @@ impl RocksDbStore {
             db: Arc::new(db),
             closed: AtomicBool::new(false),
             conflict_tracker: Arc::new(ConflictTracker::new()),
+            commit_gate: Arc::new(tokio::sync::RwLock::new(())),
             db_path,
             active_txn_count: Arc::new(AtomicUsize::new(0)),
             close_timeout: opts.close_timeout(),
@@ -156,13 +158,33 @@ impl Store for RocksDbStore {
             return Err(Error::DBClosed);
         }
 
-        Ok(Box::new(RocksDbTxn::new(
+        // Ensure cancellation while waiting for the commit gate does not leak
+        // the active transaction count and prevent store shutdown.
+        struct NewTxnGuard<'a>(&'a AtomicUsize, bool);
+        impl Drop for NewTxnGuard<'_> {
+            fn drop(&mut self) {
+                if !self.1 {
+                    self.0.fetch_sub(1, Ordering::AcqRel);
+                }
+            }
+        }
+        let mut guard = NewTxnGuard(&self.active_txn_count, false);
+
+        // Pair the conflict version and RocksDB snapshot without a commit
+        // becoming visible between them.
+        let _commit_guard = self.commit_gate.read().await;
+        let txn = RocksDbTxn::new(
             Arc::clone(&self.db),
             Arc::clone(&self.conflict_tracker),
+            Arc::clone(&self.commit_gate),
             Arc::clone(&self.active_txn_count),
             readonly,
             self.durability,
-        )))
+        );
+
+        // The transaction now owns the active-count decrement through Drop.
+        guard.1 = true;
+        Ok(Box::new(txn))
     }
 
     async fn close(&self) -> Result<()> {
@@ -229,5 +251,117 @@ impl Dropable for RocksDbStore {
         })?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backends::shared::ReadSet;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn snapshot_waits_for_physical_write_after_conflict_version_advances() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let store = Arc::new(RocksDbStore::open(temp_dir.path()).unwrap());
+        let sequence_key = b"/seq/doc".to_vec();
+        let sequence_value = 14_u64.to_be_bytes();
+
+        // Reproduce the critical interval inside commit: the logical conflict
+        // version has advanced, but the corresponding RocksDB batch has not
+        // yet been written. A new transaction must not snapshot in this gap.
+        let gate = Arc::clone(&store.commit_gate);
+        let commit_guard = gate.write().await;
+        store
+            .conflict_tracker
+            .check_and_record(
+                store.conflict_tracker.current_version(),
+                std::slice::from_ref(&sequence_key).iter(),
+                &ReadSet::default(),
+            )
+            .unwrap();
+
+        let snapshot_store = Arc::clone(&store);
+        let mut snapshot_task = tokio::spawn(async move { snapshot_store.new_txn(false).await });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), &mut snapshot_task)
+                .await
+                .is_err(),
+            "new transaction took a snapshot during an in-flight physical commit"
+        );
+
+        store.db.put(&sequence_key, sequence_value).unwrap();
+        drop(commit_guard);
+
+        let snapshot = tokio::time::timeout(Duration::from_secs(1), snapshot_task)
+            .await
+            .expect("snapshot remained blocked after commit")
+            .expect("snapshot task panicked")
+            .expect("snapshot creation failed");
+        assert_eq!(
+            snapshot.get(&sequence_key).await.unwrap(),
+            Some(sequence_value.to_vec())
+        );
+    }
+
+    #[tokio::test]
+    async fn physical_write_waits_for_snapshot_pairing() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let store = Arc::new(RocksDbStore::open(temp_dir.path()).unwrap());
+        let key = b"commit-gate-key".to_vec();
+
+        let mut writer = store.new_txn(false).await.unwrap();
+        writer.set(&key, b"committed").await.unwrap();
+
+        let gate = Arc::clone(&store.commit_gate);
+        let snapshot_guard = gate.read().await;
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let mut commit_task = tokio::spawn(async move {
+            started_tx.send(()).unwrap();
+            writer.commit().await
+        });
+        started_rx.await.unwrap();
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), &mut commit_task)
+                .await
+                .is_err(),
+            "physical commit did not wait for snapshot pairing"
+        );
+        assert_eq!(store.db.get(&key).unwrap(), None);
+
+        drop(snapshot_guard);
+        tokio::time::timeout(Duration::from_secs(1), commit_task)
+            .await
+            .expect("commit remained blocked after snapshot pairing")
+            .expect("commit task panicked")
+            .expect("commit failed");
+        assert_eq!(store.db.get(&key).unwrap(), Some(b"committed".to_vec()));
+    }
+
+    #[tokio::test]
+    async fn cancelling_snapshot_wait_does_not_leak_active_transaction_count() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let store = Arc::new(RocksDbStore::open(temp_dir.path()).unwrap());
+        let gate = Arc::clone(&store.commit_gate);
+        let commit_guard = gate.write().await;
+
+        let snapshot_store = Arc::clone(&store);
+        let snapshot_task = tokio::spawn(async move { snapshot_store.new_txn(false).await });
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while store.active_txn_count.load(Ordering::Acquire) == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("snapshot task did not reach the commit gate");
+
+        snapshot_task.abort();
+        match snapshot_task.await {
+            Err(error) => assert!(error.is_cancelled()),
+            Ok(_) => panic!("snapshot task completed instead of being cancelled"),
+        }
+        drop(commit_guard);
+        assert_eq!(store.active_txn_count.load(Ordering::Acquire), 0);
     }
 }

--- a/crates/storage/src/backends/rocksdb/transaction.rs
+++ b/crates/storage/src/backends/rocksdb/transaction.rs
@@ -67,6 +67,7 @@ pub(crate) struct RocksDbTxn {
     snapshot: OwnedSnapshot,
     pub(crate) conflict_tracker: Arc<ConflictTracker>,
     pub(crate) _conflict_snapshot: Option<ConflictSnapshot>,
+    pub(crate) commit_gate: Arc<tokio::sync::RwLock<()>>,
     pub(crate) active_txn_count: Arc<AtomicUsize>,
     pub(crate) read_version: u64,
     /// Pending changes (Some(value) = set, None = delete)
@@ -113,6 +114,7 @@ impl RocksDbTxn {
     pub(crate) fn new(
         db: Arc<rocksdb::OptimisticTransactionDB>,
         conflict_tracker: Arc<ConflictTracker>,
+        commit_gate: Arc<tokio::sync::RwLock<()>>,
         active_txn_count: Arc<AtomicUsize>,
         readonly: bool,
         durability: DurabilityMode,
@@ -129,6 +131,7 @@ impl RocksDbTxn {
             snapshot,
             conflict_tracker,
             _conflict_snapshot: conflict_snapshot,
+            commit_gate,
             active_txn_count,
             read_version,
             pending: Mutex::new(BTreeMap::new()),
@@ -391,15 +394,11 @@ impl Txn for RocksDbTxn {
         let read_set = self.read_set.lock().clone();
 
         if !pending.is_empty() {
-            // Check conflicts
-            if let Err(e) =
-                self.conflict_tracker
-                    .check_and_record(self.read_version, pending.keys(), &read_set)
-            {
-                CallbackManager::execute_callbacks(self.callbacks.take_error());
-                CallbackManager::execute_async_callbacks(self.callbacks.take_error_async()).await;
-                return Err(e);
-            }
+            // Keep the logical conflict version and physical RocksDB commit
+            // atomic with respect to new transaction snapshots. Without this,
+            // a transaction can observe the advanced conflict version while
+            // taking a RocksDB snapshot from before the corresponding write.
+            let commit_guard = self.commit_gate.write().await;
 
             // Apply via WriteBatch
             let mut batch = rocksdb::WriteBatchWithTransaction::<true>::default();
@@ -420,15 +419,27 @@ impl Txn for RocksDbTxn {
                 }
             }
 
-            if let Err(e) = self.db.write_opt(batch, &write_opts) {
-                tracing::error!(
-                    error = %e,
-                    pending_changes = pending.len(),
-                    "Failed to commit RocksDB batch"
-                );
+            let commit_result = match self.conflict_tracker.check_and_record(
+                self.read_version,
+                pending.keys(),
+                &read_set,
+            ) {
+                Ok(()) => self.db.write_opt(batch, &write_opts).map_err(Error::from),
+                Err(error) => Err(error),
+            };
+            drop(commit_guard);
+
+            if let Err(e) = commit_result {
+                if !matches!(e, Error::TxnConflict) {
+                    tracing::error!(
+                        error = %e,
+                        pending_changes = pending.len(),
+                        "Failed to commit RocksDB batch"
+                    );
+                }
                 CallbackManager::execute_callbacks(self.callbacks.take_error());
                 CallbackManager::execute_async_callbacks(self.callbacks.take_error_async()).await;
-                return Err(e.into());
+                return Err(e);
             }
         }
 


### PR DESCRIPTION
Follow-up to #1162 for #1158. This PR is intentionally stacked on the #1162 branch and contains one additional commit.

## Root cause

#1162 correctly preserves conflict history for active snapshots, but downstream stress testing still reproduced the acknowledged-create disappearance.

RocksDB commits advanced the logical conflict version in check_and_record before applying the corresponding physical write. Concurrent transaction creation could therefore observe:

1. the new logical conflict version;
2. a RocksDB snapshot taken before that write became visible.

Because the transaction read_version already included the commit version, later conflict detection could accept writes based on stale physical state. In the reproduced failure, two creates both allocated short document ID 14; the later commit replaced the canonical mapping while indexes still referenced the acknowledged document.

## Fix

- Add a shared RocksDB commit gate.
- Hold its write side across conflict validation/recording and the physical RocksDB batch write.
- Hold its read side while pairing the conflict snapshot/version with the physical OwnedSnapshot.
- Release the gate before running error callbacks to avoid callback deadlocks.
- Make transaction creation cancellation-safe so waiting on the gate cannot leak the active transaction count.

## Validation

- [x] cargo test -p storage --features rocksdb backends::rocksdb::store::tests -- --nocapture
- [x] cargo check -p storage
- [x] downstream formerly failing CLI chat reproduction
- [x] downstream CLI chat stress: 50/50 passes (the #1162-only implementation failed by runs 13 and 18)

The regression coverage verifies snapshot creation waits between logical-version advancement and physical write, physical commits wait while a snapshot is being paired, and cancellation while waiting does not leak the active transaction count.

Downstream reproduction and WAL evidence are tracked in source-inc/defra-agent#853 and #1158.