### PR TITLE
fix(storage): pair conflict versions with snapshots

### DIFF
--- a/crates/storage/src/backends/fjall/store.rs
+++ b/crates/storage/src/backends/fjall/store.rs
@@ -24,6 +24,9 @@ pub struct FjallStore {
     keyspace: fjall::Keyspace,
     closed: AtomicBool,
     conflict_tracker: Arc<ConflictTracker>,
+    /// Read-locks pair versions with snapshots; write-locks pair conflict
+    /// publication with physical commits.
+    commit_gate: Arc<tokio::sync::RwLock<()>>,
     db_path: std::path::PathBuf,
     active_txn_count: Arc<AtomicUsize>,
     close_timeout: std::time::Duration,
@@ -119,6 +122,7 @@ impl FjallStore {
             keyspace,
             closed: AtomicBool::new(false),
             conflict_tracker: Arc::new(ConflictTracker::new()),
+            commit_gate: Arc::new(tokio::sync::RwLock::new(())),
             db_path,
             active_txn_count: Arc::new(AtomicUsize::new(0)),
             close_timeout: opts.close_timeout(),
@@ -172,6 +176,7 @@ impl Store for FjallStore {
         }
         let mut guard = NewTxnGuard(&self.active_txn_count, false);
 
+        let _commit_guard = self.commit_gate.read().await;
         let conflict_snapshot = (!readonly).then(|| self.conflict_tracker.begin_snapshot());
         let read_version = conflict_snapshot.as_ref().map_or_else(
             || self.conflict_tracker.current_version(),
@@ -187,6 +192,7 @@ impl Store for FjallStore {
             keyspace: self.keyspace.clone(),
             conflict_tracker: Arc::clone(&self.conflict_tracker),
             _conflict_snapshot: conflict_snapshot,
+            commit_gate: Arc::clone(&self.commit_gate),
             active_txn_count: Arc::clone(&self.active_txn_count),
             read_version,
             snapshot,
@@ -254,5 +260,123 @@ impl Dropable for FjallStore {
         })?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod pairing_tests {
+    use super::*;
+    use crate::backends::shared::ReadSet;
+    use crate::corekv::{Reader, Writer};
+    use fjall::Readable;
+    use std::time::Duration;
+
+    fn physical_value(store: &FjallStore, key: &[u8]) -> Option<Vec<u8>> {
+        store
+            .db
+            .snapshot()
+            .get(&store.keyspace, key)
+            .unwrap()
+            .map(|value| value.to_vec())
+    }
+
+    #[tokio::test]
+    async fn snapshot_waits_for_physical_write_after_conflict_version_advances() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let store = Arc::new(FjallStore::open(temp_dir.path()).unwrap());
+        let key = b"paired-snapshot".to_vec();
+        let value = b"committed".to_vec();
+
+        let gate = Arc::clone(&store.commit_gate);
+        let commit_guard = gate.write().await;
+        store
+            .conflict_tracker
+            .check_and_record(
+                store.conflict_tracker.current_version(),
+                std::slice::from_ref(&key).iter(),
+                &ReadSet::default(),
+            )
+            .unwrap();
+
+        let snapshot_store = Arc::clone(&store);
+        let mut snapshot_task = tokio::spawn(async move { snapshot_store.new_txn(false).await });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), &mut snapshot_task)
+                .await
+                .is_err(),
+            "new transaction took a snapshot during an in-flight physical commit"
+        );
+
+        let mut batch = store.db.batch();
+        batch.insert(&store.keyspace, key.as_slice(), value.as_slice());
+        batch.commit().unwrap();
+        drop(commit_guard);
+
+        let snapshot = tokio::time::timeout(Duration::from_secs(1), snapshot_task)
+            .await
+            .expect("snapshot remained blocked after commit")
+            .expect("snapshot task panicked")
+            .expect("snapshot creation failed");
+        assert_eq!(snapshot.get(&key).await.unwrap(), Some(value));
+    }
+
+    #[tokio::test]
+    async fn physical_write_waits_for_snapshot_pairing() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let store = Arc::new(FjallStore::open(temp_dir.path()).unwrap());
+        let key = b"paired-commit".to_vec();
+        let mut writer = store.new_txn(false).await.unwrap();
+        writer.set(&key, b"committed").await.unwrap();
+
+        let gate = Arc::clone(&store.commit_gate);
+        let snapshot_guard = gate.read().await;
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let mut commit_task = tokio::spawn(async move {
+            started_tx.send(()).unwrap();
+            writer.commit().await
+        });
+        started_rx.await.unwrap();
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), &mut commit_task)
+                .await
+                .is_err(),
+            "physical commit did not wait for snapshot pairing"
+        );
+        assert_eq!(physical_value(&store, &key), None);
+
+        drop(snapshot_guard);
+        tokio::time::timeout(Duration::from_secs(1), commit_task)
+            .await
+            .expect("commit remained blocked after snapshot pairing")
+            .expect("commit task panicked")
+            .expect("commit failed");
+        assert_eq!(physical_value(&store, &key), Some(b"committed".to_vec()));
+    }
+
+    #[tokio::test]
+    async fn cancelling_snapshot_wait_does_not_leak_active_transaction_count() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let store = Arc::new(FjallStore::open(temp_dir.path()).unwrap());
+        let gate = Arc::clone(&store.commit_gate);
+        let commit_guard = gate.write().await;
+
+        let snapshot_store = Arc::clone(&store);
+        let snapshot_task = tokio::spawn(async move { snapshot_store.new_txn(false).await });
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while store.active_txn_count.load(Ordering::Acquire) == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("snapshot task did not reach the commit gate");
+
+        snapshot_task.abort();
+        match snapshot_task.await {
+            Err(error) => assert!(error.is_cancelled()),
+            Ok(_) => panic!("snapshot task completed instead of being cancelled"),
+        }
+        drop(commit_guard);
+        assert_eq!(store.active_txn_count.load(Ordering::Acquire), 0);
     }
 }

--- a/crates/storage/src/backends/fjall/transaction.rs
+++ b/crates/storage/src/backends/fjall/transaction.rs
@@ -20,6 +20,8 @@ pub(crate) struct FjallTxn {
     pub(crate) keyspace: fjall::Keyspace,
     pub(crate) conflict_tracker: Arc<ConflictTracker>,
     pub(crate) _conflict_snapshot: Option<ConflictSnapshot>,
+    /// Keeps conflict versions aligned with physical snapshots and commits.
+    pub(crate) commit_gate: Arc<tokio::sync::RwLock<()>>,
     pub(crate) active_txn_count: Arc<AtomicUsize>,
     pub(crate) read_version: u64,
     pub(crate) snapshot: fjall::Snapshot,
@@ -262,42 +264,48 @@ impl Txn for FjallTxn {
         let read_set = self.read_set.lock().clone();
 
         if !pending.is_empty() {
-            // Check conflicts
-            if let Err(e) =
-                self.conflict_tracker
-                    .check_and_record(self.read_version, pending.keys(), &read_set)
-            {
+            let commit_result = {
+                let _commit_guard = self.commit_gate.write().await;
+                match self.conflict_tracker.check_and_record(
+                    self.read_version,
+                    pending.keys(),
+                    &read_set,
+                ) {
+                    Err(error) => Err(error),
+                    Ok(()) => {
+                        let mut batch = self.db.batch();
+                        match self.durability {
+                            DurabilityMode::Immediate => {
+                                batch = batch.durability(Some(fjall::PersistMode::SyncAll));
+                            }
+                            DurabilityMode::Eventual => {
+                                batch = batch.durability(Some(fjall::PersistMode::Buffer));
+                            }
+                        }
+                        for (key, value) in &pending {
+                            match value {
+                                Some(v) => {
+                                    batch.insert(&self.keyspace, key.as_slice(), v.as_slice())
+                                }
+                                None => batch.remove(&self.keyspace, key.as_slice()),
+                            }
+                        }
+                        batch.commit().map_err(Error::from)
+                    }
+                }
+            };
+
+            if let Err(e) = commit_result {
+                if !matches!(e, Error::TxnConflict) {
+                    tracing::error!(
+                        error = %e,
+                        pending_changes = pending.len(),
+                        "Failed to commit fjall batch"
+                    );
+                }
                 CallbackManager::execute_callbacks(self.callbacks.take_error());
                 CallbackManager::execute_async_callbacks(self.callbacks.take_error_async()).await;
                 return Err(e);
-            }
-
-            // Apply via WriteBatch (no global lock)
-            let mut batch = self.db.batch();
-            match self.durability {
-                DurabilityMode::Immediate => {
-                    batch = batch.durability(Some(fjall::PersistMode::SyncAll));
-                }
-                DurabilityMode::Eventual => {
-                    batch = batch.durability(Some(fjall::PersistMode::Buffer));
-                }
-            }
-            for (key, value) in &pending {
-                match value {
-                    Some(v) => batch.insert(&self.keyspace, key.as_slice(), v.as_slice()),
-                    None => batch.remove(&self.keyspace, key.as_slice()),
-                }
-            }
-
-            if let Err(e) = batch.commit() {
-                tracing::error!(
-                    error = %e,
-                    pending_changes = pending.len(),
-                    "Failed to commit fjall batch"
-                );
-                CallbackManager::execute_callbacks(self.callbacks.take_error());
-                CallbackManager::execute_async_callbacks(self.callbacks.take_error_async()).await;
-                return Err(e.into());
             }
         }
 

--- a/crates/storage/src/backends/lark/store.rs
+++ b/crates/storage/src/backends/lark/store.rs
@@ -13,6 +13,9 @@ pub struct LarkStore {
     db: Arc<lark_kv::Db>,
     closed: AtomicBool,
     conflict_tracker: Arc<ConflictTracker>,
+    /// Read-locks pair versions with snapshots; write-locks pair conflict
+    /// publication with physical commits.
+    commit_gate: Arc<tokio::sync::RwLock<()>>,
     db_path: std::path::PathBuf,
     active_txn_count: Arc<AtomicUsize>,
     close_timeout: std::time::Duration,
@@ -58,6 +61,7 @@ impl LarkStore {
             db: Arc::new(db),
             closed: AtomicBool::new(false),
             conflict_tracker: Arc::new(ConflictTracker::new()),
+            commit_gate: Arc::new(tokio::sync::RwLock::new(())),
             db_path,
             active_txn_count: Arc::new(AtomicUsize::new(0)),
             close_timeout: opts.close_timeout(),
@@ -84,13 +88,28 @@ impl Store for LarkStore {
             return Err(Error::DBClosed);
         }
 
-        Ok(Box::new(LarkTxn::new(
+        struct NewTxnGuard<'a>(&'a AtomicUsize, bool);
+        impl Drop for NewTxnGuard<'_> {
+            fn drop(&mut self) {
+                if !self.1 {
+                    self.0.fetch_sub(1, Ordering::AcqRel);
+                }
+            }
+        }
+        let mut guard = NewTxnGuard(&self.active_txn_count, false);
+
+        let _commit_guard = self.commit_gate.read().await;
+        let txn = LarkTxn::new(
             Arc::clone(&self.db),
             Arc::clone(&self.conflict_tracker),
+            Arc::clone(&self.commit_gate),
             Arc::clone(&self.active_txn_count),
             readonly,
             self.durability,
-        )))
+        );
+
+        guard.1 = true;
+        Ok(Box::new(txn))
     }
 
     async fn close(&self) -> Result<()> {
@@ -148,5 +167,120 @@ impl Dropable for LarkStore {
             .map_err(|e| Error::Backend(format!("failed to drop all: {}", e)))?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod pairing_tests {
+    use super::*;
+    use crate::backends::shared::ReadSet;
+    use crate::corekv::{Reader, Writer};
+    use std::time::Duration;
+
+    fn physical_value(store: &LarkStore, key: &[u8]) -> Option<Vec<u8>> {
+        store.db.snapshot().get(key).unwrap()
+    }
+
+    #[tokio::test]
+    async fn snapshot_waits_for_physical_write_after_conflict_version_advances() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let store = Arc::new(LarkStore::open(temp_dir.path()).unwrap());
+        let key = b"paired-snapshot".to_vec();
+        let value = b"committed".to_vec();
+
+        let gate = Arc::clone(&store.commit_gate);
+        let commit_guard = gate.write().await;
+        store
+            .conflict_tracker
+            .check_and_record(
+                store.conflict_tracker.current_version(),
+                std::slice::from_ref(&key).iter(),
+                &ReadSet::default(),
+            )
+            .unwrap();
+
+        let snapshot_store = Arc::clone(&store);
+        let mut snapshot_task = tokio::spawn(async move { snapshot_store.new_txn(false).await });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), &mut snapshot_task)
+                .await
+                .is_err(),
+            "new transaction took a snapshot during an in-flight physical commit"
+        );
+
+        let mut batch = lark_kv::WriteBatch::new();
+        batch.put(&key, &value);
+        store
+            .db
+            .write_with_durability(batch, lark_kv::DurabilityMode::Eventual)
+            .unwrap();
+        drop(commit_guard);
+
+        let snapshot = tokio::time::timeout(Duration::from_secs(1), snapshot_task)
+            .await
+            .expect("snapshot remained blocked after commit")
+            .expect("snapshot task panicked")
+            .expect("snapshot creation failed");
+        assert_eq!(snapshot.get(&key).await.unwrap(), Some(value));
+    }
+
+    #[tokio::test]
+    async fn physical_write_waits_for_snapshot_pairing() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let store = Arc::new(LarkStore::open(temp_dir.path()).unwrap());
+        let key = b"paired-commit".to_vec();
+        let mut writer = store.new_txn(false).await.unwrap();
+        writer.set(&key, b"committed").await.unwrap();
+
+        let gate = Arc::clone(&store.commit_gate);
+        let snapshot_guard = gate.read().await;
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let mut commit_task = tokio::spawn(async move {
+            started_tx.send(()).unwrap();
+            writer.commit().await
+        });
+        started_rx.await.unwrap();
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), &mut commit_task)
+                .await
+                .is_err(),
+            "physical commit did not wait for snapshot pairing"
+        );
+        assert_eq!(physical_value(&store, &key), None);
+
+        drop(snapshot_guard);
+        tokio::time::timeout(Duration::from_secs(1), commit_task)
+            .await
+            .expect("commit remained blocked after snapshot pairing")
+            .expect("commit task panicked")
+            .expect("commit failed");
+        assert_eq!(physical_value(&store, &key), Some(b"committed".to_vec()));
+    }
+
+    #[tokio::test]
+    async fn cancelling_snapshot_wait_does_not_leak_active_transaction_count() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let store = Arc::new(LarkStore::open(temp_dir.path()).unwrap());
+        let gate = Arc::clone(&store.commit_gate);
+        let commit_guard = gate.write().await;
+
+        let snapshot_store = Arc::clone(&store);
+        let snapshot_task = tokio::spawn(async move { snapshot_store.new_txn(false).await });
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while store.active_txn_count.load(Ordering::Acquire) == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("snapshot task did not reach the commit gate");
+
+        snapshot_task.abort();
+        match snapshot_task.await {
+            Err(error) => assert!(error.is_cancelled()),
+            Ok(_) => panic!("snapshot task completed instead of being cancelled"),
+        }
+        drop(commit_guard);
+        assert_eq!(store.active_txn_count.load(Ordering::Acquire), 0);
     }
 }

--- a/crates/storage/src/backends/lark/transaction.rs
+++ b/crates/storage/src/backends/lark/transaction.rs
@@ -22,6 +22,8 @@ pub(crate) struct LarkTxn {
     snapshot: lark_kv::Snapshot,
     conflict_tracker: Arc<ConflictTracker>,
     _conflict_snapshot: Option<ConflictSnapshot>,
+    /// Keeps conflict versions aligned with physical snapshots and commits.
+    commit_gate: Arc<tokio::sync::RwLock<()>>,
     active_txn_count: Arc<AtomicUsize>,
     read_version: u64,
     pending: Mutex<PendingWrites>,
@@ -183,6 +185,7 @@ impl LarkTxn {
     pub(crate) fn new(
         db: Arc<lark_kv::Db>,
         conflict_tracker: Arc<ConflictTracker>,
+        commit_gate: Arc<tokio::sync::RwLock<()>>,
         active_txn_count: Arc<AtomicUsize>,
         readonly: bool,
         durability: DurabilityMode,
@@ -199,6 +202,7 @@ impl LarkTxn {
             snapshot,
             conflict_tracker,
             _conflict_snapshot: conflict_snapshot,
+            commit_gate,
             active_txn_count,
             read_version,
             pending: Mutex::new(PendingWrites::default()),
@@ -437,29 +441,34 @@ impl Txn for LarkTxn {
         let read_set = self.read_set.lock().clone();
 
         if !pending.is_empty() {
-            // Check conflicts
-            if let Err(e) = pending.check_and_record_conflicts(
-                &self.conflict_tracker,
-                self.read_version,
-                &read_set,
-            ) {
+            let commit_result = {
+                let _commit_guard = self.commit_gate.write().await;
+                match pending.check_and_record_conflicts(
+                    &self.conflict_tracker,
+                    self.read_version,
+                    &read_set,
+                ) {
+                    Err(error) => Err(error),
+                    Ok(()) => {
+                        let batch = pending.into_write_batch();
+                        let durability = match self.durability {
+                            DurabilityMode::Immediate => lark_kv::DurabilityMode::Immediate,
+                            DurabilityMode::Eventual => lark_kv::DurabilityMode::Eventual,
+                        };
+                        self.db
+                            .write_with_durability(batch, durability)
+                            .map_err(|error| Error::Backend(error.to_string()))
+                    }
+                }
+            };
+
+            if let Err(e) = commit_result {
+                if !matches!(e, Error::TxnConflict) {
+                    tracing::error!(error = %e, "Failed to commit lark batch");
+                }
                 CallbackManager::execute_callbacks(self.callbacks.take_error());
                 CallbackManager::execute_async_callbacks(self.callbacks.take_error_async()).await;
                 return Err(e);
-            }
-
-            // Apply via lark WriteBatch
-            let batch = pending.into_write_batch();
-            let durability = match self.durability {
-                DurabilityMode::Immediate => lark_kv::DurabilityMode::Immediate,
-                DurabilityMode::Eventual => lark_kv::DurabilityMode::Eventual,
-            };
-
-            if let Err(e) = self.db.write_with_durability(batch, durability) {
-                tracing::error!(error = %e, "Failed to commit lark batch");
-                CallbackManager::execute_callbacks(self.callbacks.take_error());
-                CallbackManager::execute_async_callbacks(self.callbacks.take_error_async()).await;
-                return Err(Error::Backend(e.to_string()));
             }
         }
 

--- a/crates/storage/src/backends/memory/store.rs
+++ b/crates/storage/src/backends/memory/store.rs
@@ -19,6 +19,9 @@ pub struct MemoryStore {
     data: Arc<RwLock<BTreeMap<Vec<u8>, Vec<u8>>>>,
     closed: Arc<AtomicBool>,
     conflict_tracker: Arc<ConflictTracker>,
+    /// Read-locks pair versions with snapshots; write-locks pair conflict
+    /// publication with physical commits.
+    commit_gate: Arc<RwLock<()>>,
 }
 
 impl MemoryStore {
@@ -28,6 +31,7 @@ impl MemoryStore {
             data: Arc::new(RwLock::new(BTreeMap::new())),
             closed: Arc::new(AtomicBool::new(false)),
             conflict_tracker: Arc::new(ConflictTracker::new()),
+            commit_gate: Arc::new(RwLock::new(())),
         }
     }
 
@@ -52,19 +56,20 @@ impl Store for MemoryStore {
             return Err(Error::DBClosed);
         }
 
+        let _commit_guard = self.commit_gate.read().await;
+        let data = self.data.read().await;
         let conflict_snapshot = (!readonly).then(|| self.conflict_tracker.begin_snapshot());
         let read_version = conflict_snapshot.as_ref().map_or_else(
             || self.conflict_tracker.current_version(),
             |snapshot| snapshot.version(),
         );
-
-        // Take a snapshot of current data for isolation
-        let snapshot = self.data.read().await.clone();
+        let snapshot = data.clone();
 
         Ok(Box::new(MemoryTxn {
             store: Arc::clone(&self.data),
             conflict_tracker: Arc::clone(&self.conflict_tracker),
             _conflict_snapshot: conflict_snapshot,
+            commit_gate: Arc::clone(&self.commit_gate),
             read_version,
             snapshot,
             pending: Mutex::new(BTreeMap::new()),
@@ -93,5 +98,123 @@ impl Dropable for MemoryStore {
         let mut data = self.data.write().await;
         data.clear();
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod pairing_tests {
+    use super::*;
+    use crate::backends::shared::ReadSet;
+    use crate::corekv::{Reader, Writer};
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn snapshot_waits_for_physical_write_after_conflict_version_advances() {
+        let store = Arc::new(MemoryStore::new());
+        let key = b"paired-snapshot".to_vec();
+        let value = b"committed".to_vec();
+
+        let gate = Arc::clone(&store.commit_gate);
+        let commit_guard = gate.write().await;
+        store
+            .conflict_tracker
+            .check_and_record(
+                store.conflict_tracker.current_version(),
+                std::slice::from_ref(&key).iter(),
+                &ReadSet::default(),
+            )
+            .unwrap();
+
+        let snapshot_store = Arc::clone(&store);
+        let mut snapshot_task = tokio::spawn(async move { snapshot_store.new_txn(false).await });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), &mut snapshot_task)
+                .await
+                .is_err(),
+            "new transaction took a snapshot during an in-flight physical commit"
+        );
+
+        store.data.write().await.insert(key.clone(), value.clone());
+        drop(commit_guard);
+
+        let snapshot = tokio::time::timeout(Duration::from_secs(1), snapshot_task)
+            .await
+            .expect("snapshot remained blocked after commit")
+            .expect("snapshot task panicked")
+            .expect("snapshot creation failed");
+        assert_eq!(snapshot.get(&key).await.unwrap(), Some(value));
+    }
+
+    #[tokio::test]
+    async fn physical_write_waits_for_snapshot_pairing() {
+        let store = Arc::new(MemoryStore::new());
+        let key = b"paired-commit".to_vec();
+        let mut writer = store.new_txn(false).await.unwrap();
+        writer.set(&key, b"committed").await.unwrap();
+
+        let gate = Arc::clone(&store.commit_gate);
+        let snapshot_guard = gate.read().await;
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let mut commit_task = tokio::spawn(async move {
+            started_tx.send(()).unwrap();
+            writer.commit().await
+        });
+        started_rx.await.unwrap();
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), &mut commit_task)
+                .await
+                .is_err(),
+            "physical commit did not wait for snapshot pairing"
+        );
+        assert!(!store.data.read().await.contains_key(&key));
+
+        drop(snapshot_guard);
+        tokio::time::timeout(Duration::from_secs(1), commit_task)
+            .await
+            .expect("commit remained blocked after snapshot pairing")
+            .expect("commit task panicked")
+            .expect("commit failed");
+        assert_eq!(
+            store.data.read().await.get(&key).cloned(),
+            Some(b"committed".to_vec())
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelling_commit_before_physical_lock_does_not_advance_version() {
+        let store = Arc::new(MemoryStore::new());
+        let mut writer = store.new_txn(false).await.unwrap();
+        writer.set(b"cancelled", b"value").await.unwrap();
+
+        let data_guard = store.data.write().await;
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let commit_task = tokio::spawn(async move {
+            started_tx.send(()).unwrap();
+            writer.commit().await
+        });
+        started_rx.await.unwrap();
+
+        let gate = Arc::clone(&store.commit_gate);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), gate.read())
+                .await
+                .is_err(),
+            "commit did not reach the physical data lock"
+        );
+
+        commit_task.abort();
+        match commit_task.await {
+            Err(error) => assert!(error.is_cancelled()),
+            Ok(_) => panic!("commit completed instead of being cancelled"),
+        }
+        drop(data_guard);
+
+        assert_eq!(store.conflict_tracker.current_version(), 0);
+        assert!(!store
+            .data
+            .read()
+            .await
+            .contains_key(b"cancelled".as_slice()));
     }
 }

--- a/crates/storage/src/backends/memory/transaction.rs
+++ b/crates/storage/src/backends/memory/transaction.rs
@@ -26,6 +26,9 @@ pub(crate) struct MemoryTxn {
     /// Keeps conflict history alive for this write transaction's snapshot.
     pub(crate) _conflict_snapshot: Option<ConflictSnapshot>,
 
+    /// Keeps conflict versions aligned with physical snapshots and commits.
+    pub(crate) commit_gate: Arc<RwLock<()>>,
+
     /// Version at which this transaction's snapshot was taken
     pub(crate) read_version: u64,
 
@@ -205,24 +208,20 @@ impl Txn for MemoryTxn {
         let pending = self.pending.lock().clone();
         let read_set = self.read_set.lock().clone();
 
-        // Check for write-write conflicts before applying
         if !pending.is_empty() {
+            let commit_guard = self.commit_gate.write().await;
+            let mut store = self.store.write().await;
+
             if let Err(e) =
                 self.conflict_tracker
                     .check_and_record(self.read_version, pending.keys(), &read_set)
             {
+                drop(store);
+                drop(commit_guard);
                 CallbackManager::execute_callbacks(self.callbacks.take_error());
                 CallbackManager::execute_async_callbacks(self.callbacks.take_error_async()).await;
                 return Err(e);
             }
-        }
-
-        // Mark as committed
-        self.committed.store(true, Ordering::Release);
-
-        // Apply pending changes to store
-        if !pending.is_empty() {
-            let mut store = self.store.write().await;
 
             for (key, value) in pending.iter() {
                 match value {
@@ -235,6 +234,9 @@ impl Txn for MemoryTxn {
                 }
             }
         }
+
+        // Mark as committed
+        self.committed.store(true, Ordering::Release);
 
         // Execute success callbacks
         CallbackManager::execute_callbacks(self.callbacks.take_success());


### PR DESCRIPTION
Closes #1168.

## Problem

Memory, Fjall, and Lark published optimistic conflict versions separately from their physical commits and captured conflict versions separately from their physical snapshots. A transaction could therefore record a newly advanced logical version while reading physical state from before that commit, then incorrectly ignore the conflicting write later.

## What changed

- Add a shared read/write pairing gate to each affected backend.
- Pair conflict-version acquisition with physical snapshot creation under the read side.
- Pair conflict recording with physical commit visibility under the write side.
- Release the gate before transaction callbacks run.
- Keep Memory conflict publication cancellation-safe while waiting for its data lock.
- Add cancellation-safe active-transaction accounting to Lark, matching Fjall and RocksDB.
- Add nine deterministic regressions covering both interleaving windows and cancellation behavior.

## Validation

- [x] `cargo test -p storage --all-features` (761 passed; existing ignored tests unchanged)
- [x] `cargo test -p storage --all-features pairing_tests` (9 passed)
- [x] `cargo clippy -p storage --all-features --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check origin/main...HEAD`