### PR TITLE
refactor(telemetry): remove unused metrics pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,8 @@ jobs:
 
       # OTel feature paths are opt-in (mirror Go's `//go:build telemetry`),
       # so the default clippy pass doesn't exercise them. These checks keep
-      # the feature-gated code from rotting silently. The `metrics` feature
-      # gates a whole separate code path (meter provider, metric exporter)
-      # that no other job builds. Issue #977.
+      # the feature-gated code from rotting silently. Issue #977.
       - run: cargo clippy -p telemetry --features otlp --all-targets -- -D warnings
-      - run: cargo clippy -p telemetry --features metrics --all-targets -- -D warnings
       - run: cargo clippy -p cli --features otel --all-targets -- -D warnings
       - run: cargo clippy -p defra-node --features otel --all-targets -- -D warnings
 
@@ -129,13 +126,11 @@ jobs:
           ln -sf "$CACHE_DIR/defra-iroh" "$HOME/.sourcenetwork/bin/defra-iroh"
 
       # OTel-only tests, run AFTER caching so the otel rebuild of target/debug/defra
-      # never pollutes the cached standard binary. The `metrics` build keeps the
-      # metric-exporter path compiling; the cli otel test spawns a real node
-      # against an unreachable collector and asserts the dedup hint fires exactly
-      # once — the Docker-free regression guard for the SDK's `internal-logs`
-      # feature. Issue #977 / #1004.
+      # never pollutes the cached standard binary. The cli otel test spawns a real
+      # node against an unreachable collector and asserts the dedup hint fires
+      # exactly once — the Docker-free regression guard for the SDK's
+      # `internal-logs` feature. Issue #977 / #1004.
       - run: cargo test -p telemetry --features otlp
-      - run: cargo test -p telemetry --features metrics
       - run: cargo test -p cli --features otel --test telemetry_dedup
 
       - name: Cleanup

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12319,7 +12319,6 @@ dependencies = [
  "opentelemetry-otlp 0.32.0",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk 0.32.1",
- "reqwest 0.13.3",
  "thiserror 2.0.18",
  "tracing",
  "tracing-opentelemetry 0.33.0",

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ cargo build --release -p cli --features otel
 
 Mirrors Go DefraDB's `//go:build telemetry` tag — when not compiled in, zero OTel dependencies and zero runtime cost. When compiled in, **traces** export to `http://localhost:4318` (OTLP/HTTP) by default, same endpoint as Go.
 
-Metrics are a separate opt-in (the `metrics` feature on the `telemetry` crate). They're off by default because nothing in defradb.rs records metric instruments yet — enabling the metric pipeline would just export empty batches every 60 s. Turn it on once instruments exist.
+Metrics export is planned alongside the first application metric.
 
 | Flag / env var | Effect |
 | --- | --- |
@@ -66,9 +66,9 @@ When no collector is reachable, the OTel SDK's repeated export errors are suppre
 
 ### Embedded usage
 
-Library consumers (via `defra-node`) own the OTel lifecycle and hand the resulting handle to the node. The node flushes it via `Drop` or via an explicit `shutdown()` — explicit is preferred because `Drop` blocks for up to ~5 s on the SDK's trace batch-thread join (double that if you also enable the `metrics` feature).
+Library consumers (via `defra-node`) own the OTel lifecycle and hand the resulting handle to the node. The node flushes it via `Drop` or via an explicit `shutdown()` — explicit is preferred because `Drop` blocks for up to ~5 s on the SDK's trace batch-thread join.
 
-Add `telemetry` to your `Cargo.toml` (add `"metrics"` alongside `"otlp"` if you record metric instruments):
+Add `telemetry` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
@@ -101,10 +101,10 @@ let node = EmbeddedNode::builder()
 // ... use the node ...
 
 // Explicit shutdown flushes the buffered batch. Drop is a safety net,
-// but blocks the calling thread on the SDK batch-thread join (~5 s for
-// traces, double with the metrics feature); call shutdown() explicitly
-// from an async-aware path when possible. Note that the node should not
-// be used after shutdown — subsequent spans go to a no-op tracer.
+// but blocks the calling thread on the SDK batch-thread join (~5 s);
+// call shutdown() explicitly from an async-aware path when possible.
+// Note that the node should not be used after shutdown — subsequent spans
+// go to a no-op tracer.
 node.shutdown().await;
 ```
 

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -31,13 +31,6 @@ otlp = [
     "opentelemetry_sdk/internal-logs",
     "opentelemetry-otlp/internal-logs",
 ]
-# Also compile in the OTLP metric exporter. Off by default because nothing in
-# defradb.rs records metric instruments today — leaving the metric pipeline on
-# spawns a `PeriodicReader` background task that wakes every 60 s to export an
-# empty batch (wasted bandwidth + collector ingest). Turn this on alongside
-# `otlp` once application code starts emitting instruments.
-metrics = ["otlp", "opentelemetry_sdk/metrics", "opentelemetry-otlp/metrics", "dep:reqwest"]
-
 [dependencies]
 tracing.workspace = true
 tracing-subscriber = { version = "0.3", features = ["registry", "std"] }
@@ -60,11 +53,6 @@ opentelemetry-otlp = { version = "0.32", default-features = false, features = ["
 # matching Go's `resource.WithSchemaURL(semconv.SchemaURL)`.
 opentelemetry-semantic-conventions = { version = "0.32", optional = true }
 tracing-opentelemetry = { version = "0.33", optional = true }
-# Only used (under the `metrics` feature) to build a single blocking HTTP
-# client shared by the span + metric exporters. Pinned to 0.13 to match the
-# reqwest `opentelemetry-http` resolves; cargo unifies the `blocking` feature
-# with otlp's `reqwest-blocking-client`.
-reqwest = { version = "0.13", default-features = false, features = ["blocking"], optional = true }
 
 [lints]
 workspace = true

--- a/crates/telemetry/src/handle.rs
+++ b/crates/telemetry/src/handle.rs
@@ -7,27 +7,18 @@
 //! caller forgot, etc.).
 //!
 //! **Prefer explicit `shutdown`.** Drop is a safety net, not a primary path.
-//! The opentelemetry-sdk 0.32 batch span processor + periodic metric reader
-//! each spawn dedicated OS threads; `shutdown` joins them synchronously
-//! with up to a 5 s timeout per signal (~10 s combined). Dropping a handle
-//! on a Tokio worker stalls that worker for the duration; dropping on a
-//! current-thread runtime stalls the whole reactor. The Drop impl also
-//! wraps the join in `catch_unwind` so a panicked batch thread can't
-//! propagate a second panic during stack unwinding (which would abort the
-//! process).
+//! The opentelemetry-sdk 0.32 batch span processor spawns a dedicated OS
+//! thread; `shutdown` joins it synchronously with up to a 5 s timeout. Dropping
+//! a handle on a Tokio worker stalls that worker for the duration; dropping on
+//! a current-thread runtime stalls the whole reactor. The Drop impl also wraps
+//! the join in `catch_unwind` so a panicked batch thread can't propagate a
+//! second panic during stack unwinding (which would abort the process).
 //!
 //! [`shutdown`]: TelemetryHandle::shutdown
 
 pub struct TelemetryHandle {
     #[cfg(feature = "otlp")]
-    pub(crate) inner: Option<OtelProviders>,
-}
-
-#[cfg(feature = "otlp")]
-pub(crate) struct OtelProviders {
-    pub tracer_provider: opentelemetry_sdk::trace::SdkTracerProvider,
-    #[cfg(feature = "metrics")]
-    pub meter_provider: opentelemetry_sdk::metrics::SdkMeterProvider,
+    pub(crate) inner: Option<opentelemetry_sdk::trace::SdkTracerProvider>,
 }
 
 impl TelemetryHandle {
@@ -54,15 +45,13 @@ impl TelemetryHandle {
     pub fn shutdown(mut self) {
         #[cfg(feature = "otlp")]
         if let Some(p) = self.inner.take() {
-            Self::shutdown_providers(p);
+            Self::shutdown_provider(p);
         }
     }
 
     #[cfg(feature = "otlp")]
-    fn shutdown_providers(p: OtelProviders) {
-        let _ = p.tracer_provider.shutdown();
-        #[cfg(feature = "metrics")]
-        let _ = p.meter_provider.shutdown();
+    fn shutdown_provider(provider: opentelemetry_sdk::trace::SdkTracerProvider) {
+        let _ = provider.shutdown();
     }
 }
 
@@ -84,7 +73,7 @@ impl Drop for TelemetryHandle {
             // the panic is swallowed — but we surface it so a dead batch
             // thread isn't completely silent.
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
-                Self::shutdown_providers(p);
+                Self::shutdown_provider(p);
             }));
             if let Err(panic) = result {
                 let msg = panic

--- a/crates/telemetry/src/init.rs
+++ b/crates/telemetry/src/init.rs
@@ -10,10 +10,8 @@
 //!   `resource.WithOS()` + `resource.WithProcess()` (which we approximate
 //!   with `std::env::consts` + `std::process` to avoid an extra dep).
 //!
-//! Traces are always exported. Metrics export is off until the `metrics`
-//! feature is enabled — nothing in defradb.rs records metric instruments
-//! today, so leaving the metric pipeline running would burn an empty
-//! periodic export every 60 s.
+//! DefraDB currently exports traces only. Add a metrics pipeline alongside the
+//! first application metric rather than running an empty periodic exporter.
 
 use opentelemetry::global;
 use opentelemetry::trace::TracerProvider as _;
@@ -26,15 +24,8 @@ use tracing::Subscriber;
 use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::registry::LookupSpan;
 
-#[cfg(feature = "metrics")]
-use opentelemetry_otlp::MetricExporter;
-#[cfg(feature = "metrics")]
-use opentelemetry_otlp::WithHttpConfig;
-#[cfg(feature = "metrics")]
-use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
-
 use crate::config::TelemetryConfig;
-use crate::handle::{OtelProviders, TelemetryHandle};
+use crate::handle::TelemetryHandle;
 
 pub use opentelemetry_sdk::trace::SdkTracer as Tracer;
 
@@ -42,9 +33,6 @@ pub use opentelemetry_sdk::trace::SdkTracer as Tracer;
 pub enum InitError {
     #[error("failed to build OTLP span exporter: {0}")]
     SpanExporter(#[source] Box<dyn std::error::Error + Send + Sync>),
-    #[cfg(feature = "metrics")]
-    #[error("failed to build OTLP metric exporter: {0}")]
-    MetricExporter(#[source] Box<dyn std::error::Error + Send + Sync>),
 }
 
 /// Returns the lifecycle handle and a configured [`SdkTracer`]. The caller
@@ -54,9 +42,8 @@ pub enum InitError {
 ///
 /// Safe to call from any context (no Tokio runtime required): with the
 /// `reqwest-blocking-client` transport selected in this crate's `Cargo.toml`,
-/// both `BatchSpanProcessor` and `PeriodicReader` (opentelemetry_sdk 0.32)
-/// spawn dedicated OS threads via `std::thread`. No `Handle::current()`
-/// call happens at init.
+/// `BatchSpanProcessor` spawns a dedicated OS thread via `std::thread`. No
+/// `Handle::current()` call happens at init.
 ///
 /// By default `init` installs the providers in the process-wide
 /// `opentelemetry::global` slot. Set [`TelemetryConfig::install_global`] to
@@ -85,39 +72,10 @@ pub fn init(config: TelemetryConfig) -> Result<(TelemetryHandle, SdkTracer), Ini
         .with_attribute(KeyValue::new("process.executable.name", executable_name))
         .build();
 
-    // When both signals export (metrics feature on) they share one HTTP
-    // client — one connection pool / TLS context / worker instead of two,
-    // since both target the same OTLP endpoint. Without metrics there's a
-    // single exporter, so the default build keeps the transitive client and
-    // takes no direct reqwest dependency.
-    #[cfg(feature = "metrics")]
-    let http_client = reqwest::blocking::Client::new();
-
-    let span_exporter = {
-        let builder = SpanExporter::builder().with_http();
-        #[cfg(feature = "metrics")]
-        let builder = builder.with_http_client(http_client.clone());
-        builder
-            .build()
-            .map_err(|e| InitError::SpanExporter(Box::new(e)))?
-    };
-
-    // Build the meter provider first (when enabled) so the trace provider can
-    // take `resource` by value — avoids a clone-then-discard dance on the
-    // metrics-off path.
-    #[cfg(feature = "metrics")]
-    let meter_provider = {
-        let metric_exporter = MetricExporter::builder()
-            .with_http()
-            .with_http_client(http_client)
-            .build()
-            .map_err(|e| InitError::MetricExporter(Box::new(e)))?;
-        let reader = PeriodicReader::builder(metric_exporter).build();
-        SdkMeterProvider::builder()
-            .with_reader(reader)
-            .with_resource(resource.clone())
-            .build()
-    };
+    let span_exporter = SpanExporter::builder()
+        .with_http()
+        .build()
+        .map_err(|e| InitError::SpanExporter(Box::new(e)))?;
 
     let tracer_provider = SdkTracerProvider::builder()
         .with_batch_exporter(span_exporter)
@@ -126,18 +84,12 @@ pub fn init(config: TelemetryConfig) -> Result<(TelemetryHandle, SdkTracer), Ini
 
     if config.install_global {
         global::set_tracer_provider(tracer_provider.clone());
-        #[cfg(feature = "metrics")]
-        global::set_meter_provider(meter_provider.clone());
     }
 
     let tracer = tracer_provider.tracer(config.service_name);
 
     let handle = TelemetryHandle {
-        inner: Some(OtelProviders {
-            tracer_provider,
-            #[cfg(feature = "metrics")]
-            meter_provider,
-        }),
+        inner: Some(tracer_provider),
     };
 
     Ok((handle, tracer))

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -1,9 +1,9 @@
 //! OpenTelemetry exporter setup for DefraDB.
 //!
 //! Mirrors Go DefraDB's `internal/telemetry/otel.go`. The `otlp` feature
-//! compiles in OTLP/gRPC trace + metric exporters; without it the crate
-//! provides only a no-op [`TelemetryHandle`] and the [`OtelDedupFilter`]
-//! (always available, no-op when no `opentelemetry*` events exist).
+//! compiles in OTLP/HTTP trace export; without it the crate provides only a
+//! no-op [`TelemetryHandle`] and the [`OtelDedupFilter`] (always available,
+//! no-op when no `opentelemetry*` events exist).
 //!
 //! Connection-refused log spam from the OTEL SDK is deduped via
 //! [`OtelDedupFilter`] — the Rust equivalent of Go's `sync.Once`-guarded


### PR DESCRIPTION
## Problem

The telemetry crate exposes a `metrics` feature that builds a meter provider, periodic reader, and OTLP metric exporter even though DefraDB records no metric instruments. Keeping that speculative path adds a direct dependency, provider lifecycle code, documentation, and two CI checks whose only purpose is compiling an exporter that can emit only empty batches.

## What changed

- Remove the unused `metrics` feature and its direct `reqwest` dependency.
- Simplify telemetry initialization and shutdown around the single trace provider that DefraDB actually uses.
- Remove the metric-only clippy and test commands from CI while retaining all `otlp` trace checks.
- Update telemetry documentation to describe metrics export as planned alongside the first application metric.

## Validation

- [x] `cargo test -p telemetry`
- [x] `cargo test -p telemetry --features otlp`
- [x] `cargo test -p cli --features otel --test telemetry_dedup`
- [x] `cargo clippy -p telemetry -p cli -p defra-node --all-targets --features telemetry/otlp,cli/otel,defra-node/otel -- -D warnings`
- [x] `cargo clippy -p telemetry --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`

Closes #1002.
