### PR TITLE
fix(db-merge): bound parent replay stack usage

### DIFF
--- a/crates/db-merge/src/merge_handler/collection.rs
+++ b/crates/db-merge/src/merge_handler/collection.rs
@@ -1,13 +1,79 @@
 use super::batch::{PendingFieldBlockFinalization, PendingMergeEvent, PendingPostCommitAction};
 use super::*;
 
+enum CollectionMergeFrame {
+    Enter {
+        cid: Cid,
+        block: Option<Block>,
+        payload: Option<defra_core::block::CollectionDeltaPayload>,
+        child_cid: Option<Cid>,
+        depth: usize,
+        is_root: bool,
+    },
+    Exit {
+        cid: Cid,
+        block: Block,
+        payload: defra_core::block::CollectionDeltaPayload,
+        depth: usize,
+        is_root: bool,
+    },
+}
+
 impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
+    fn has_merged_collection(&self, cid: &Cid) -> bool {
+        self.merged_collections
+            .lock()
+            .unwrap_or_else(|error| {
+                tracing::warn!("merged_collections lock poisoned, recovering");
+                error.into_inner()
+            })
+            .contains(cid)
+    }
+
+    fn has_batch_merged_collection(
+        batch_merged_collections: &std::sync::Mutex<HashSet<Cid>>,
+        cid: &Cid,
+    ) -> bool {
+        batch_merged_collections
+            .lock()
+            .unwrap_or_else(|error| {
+                tracing::warn!("batch_merged_collections lock poisoned, recovering");
+                error.into_inner()
+            })
+            .contains(cid)
+    }
+
+    async fn load_parent_collection(&self, parent_cid: &Cid, child_cid: &Cid) -> Option<Block> {
+        let data = match self.blockstore.get(parent_cid).await {
+            Ok(Some(data)) => data,
+            Ok(None) => {
+                tracing::debug!(
+                    %parent_cid,
+                    %child_cid,
+                    "Parent collection block not in blockstore, skipping"
+                );
+                return None;
+            }
+            Err(error) => {
+                tracing::debug!(
+                    %parent_cid,
+                    %child_cid,
+                    %error,
+                    "Failed to load parent collection block, skipping"
+                );
+                return None;
+            }
+        };
+
+        Block::from_dag_cbor(&data).ok()
+    }
+
     /// Process a Collection delta from a block.
     ///
     /// Collection blocks are metadata containers that link to document composite
     /// blocks. The collection CRDT merge itself is a no-op (matching Go behavior).
     /// The real work is:
-    /// 1. Recursively process parent collection blocks from `heads`
+    /// 1. Process parent collection blocks from `heads`, oldest first
     /// 2. Process each linked document composite via `process_composite_delta`
     /// 3. Update the collection headstore with the new head CID
     pub(crate) async fn process_collection_delta(
@@ -18,89 +84,145 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
         metadata: &BlockMetadata<'_>,
         depth: usize,
     ) -> std::result::Result<MergeOutcome, MergeError> {
-        if depth >= super::MAX_MERGE_DEPTH {
-            return Err(MergeError::depth_exceeded(cid, depth));
-        }
+        let mut frames = vec![CollectionMergeFrame::Enter {
+            cid: *cid,
+            block: Some(block.clone()),
+            payload: Some(payload.clone()),
+            child_cid: None,
+            depth,
+            is_root: true,
+        }];
 
-        {
-            let merged = self.merged_collections.lock().unwrap_or_else(|e| {
-                tracing::warn!("merged_collections lock poisoned, recovering");
-                e.into_inner()
-            });
-            if merged.contains(cid) {
-                tracing::debug!(cid = %cid, "Collection block already merged, skipping replay");
-                return Ok(MergeOutcome::terminal_skip("collection already merged"));
-            }
-        }
-
-        tracing::debug!(
-            cid = %cid,
-            schema_version = %payload.schema_version_id,
-            priority = payload.priority,
-            links_count = block.links.as_ref().map(|l| l.len()).unwrap_or(0),
-            heads_count = block.heads.as_ref().map(|h| h.len()).unwrap_or(0),
-            "Processing Collection delta"
-        );
-
-        // Recursively process parent collection blocks from `heads` before
-        // this block, ensuring older documents are merged first.
-        if let Some(heads) = &block.heads {
-            for head_cid in heads {
-                let head_data = match self.blockstore.get(head_cid).await {
-                    Ok(Some(data)) => data,
-                    Ok(None) => {
+        while let Some(frame) = frames.pop() {
+            match frame {
+                CollectionMergeFrame::Enter {
+                    cid,
+                    block,
+                    payload,
+                    child_cid,
+                    depth,
+                    is_root,
+                } => {
+                    if depth >= super::MAX_MERGE_DEPTH {
+                        let error = MergeError::depth_exceeded(&cid, depth);
+                        if is_root {
+                            return Err(error);
+                        }
                         tracing::debug!(
-                            parent_cid = %head_cid,
-                            child_cid = %cid,
-                            "Parent collection block not in blockstore, skipping"
+                            parent_cid = %cid,
+                            %error,
+                            "Parent collection merge failed"
                         );
                         continue;
                     }
-                    Err(e) => {
-                        tracing::debug!(
-                            parent_cid = %head_cid,
-                            error = %e,
-                            "Failed to load parent collection block, skipping"
-                        );
+                    if self.has_merged_collection(&cid) {
+                        if is_root {
+                            return Ok(MergeOutcome::terminal_skip("collection already merged"));
+                        }
                         continue;
                     }
-                };
 
-                let head_block = match Block::from_dag_cbor(&head_data) {
-                    Ok(b) => b,
-                    Err(_) => continue,
-                };
+                    let block = match block {
+                        Some(block) => block,
+                        None => {
+                            let Some(block) = self
+                                .load_parent_collection(
+                                    &cid,
+                                    &child_cid.expect("parent frame has a child CID"),
+                                )
+                                .await
+                            else {
+                                continue;
+                            };
+                            block
+                        }
+                    };
+                    let payload = match payload {
+                        Some(payload) => payload,
+                        None => {
+                            let CrdtDelta::Collection(payload) = &block.delta else {
+                                continue;
+                            };
+                            payload.clone()
+                        }
+                    };
 
-                if let CrdtDelta::Collection(head_payload) = &head_block.delta {
-                    tracing::info!(
-                        parent_cid = %head_cid,
-                        child_cid = %cid,
-                        "Recursively merging parent collection block"
+                    tracing::debug!(
+                        %cid,
+                        schema_version = %payload.schema_version_id,
+                        priority = payload.priority,
+                        links_count = block.links.as_ref().map(|links| links.len()).unwrap_or(0),
+                        heads_count = block.heads.as_ref().map(|heads| heads.len()).unwrap_or(0),
+                        "Processing Collection delta"
                     );
-                    match Box::pin(self.process_collection_delta(
-                        head_cid,
-                        &head_block,
-                        head_payload,
-                        metadata,
-                        depth + 1,
-                    ))
-                    .await
+
+                    let heads = block.heads.clone();
+                    frames.push(CollectionMergeFrame::Exit {
+                        cid,
+                        block,
+                        payload,
+                        depth,
+                        is_root,
+                    });
+                    if let Some(heads) = heads {
+                        for parent_cid in heads.into_iter().rev() {
+                            frames.push(CollectionMergeFrame::Enter {
+                                cid: parent_cid,
+                                block: None,
+                                payload: None,
+                                child_cid: Some(cid),
+                                depth: depth + 1,
+                                is_root: false,
+                            });
+                        }
+                    }
+                }
+                CollectionMergeFrame::Exit {
+                    cid,
+                    block,
+                    payload,
+                    depth,
+                    is_root,
+                } => {
+                    if self.has_merged_collection(&cid) {
+                        if is_root {
+                            return Ok(MergeOutcome::terminal_skip("collection already merged"));
+                        }
+                        continue;
+                    }
+                    let outcome = match self
+                        .process_collection_delta_body(&cid, &block, &payload, metadata, depth)
+                        .await
                     {
-                        Ok(MergeOutcome::Merged) => {}
-                        Ok(outcome) if outcome.is_terminal_skip() => {}
-                        Ok(outcome) => return Ok(outcome),
-                        Err(e) => {
+                        Ok(outcome) => outcome,
+                        Err(error) if !is_root => {
                             tracing::debug!(
-                                parent_cid = %head_cid,
-                                error = %e,
+                                parent_cid = %cid,
+                                %error,
                                 "Parent collection merge failed"
                             );
+                            continue;
                         }
+                        Err(error) => return Err(error),
+                    };
+                    if is_root || (!outcome.is_merged() && !outcome.is_terminal_skip()) {
+                        return Ok(outcome);
                     }
                 }
             }
         }
 
+        Ok(MergeOutcome::terminal_skip("collection already merged"))
+    }
+
+    async fn process_collection_delta_body(
+        &self,
+        cid: &Cid,
+        block: &Block,
+        payload: &defra_core::block::CollectionDeltaPayload,
+        metadata: &BlockMetadata<'_>,
+        depth: usize,
+    ) -> std::result::Result<MergeOutcome, MergeError> {
         // Process linked document composites
         let mut any_merged = false;
         let mut retryable_skip: Option<MergeOutcome> = None;
@@ -338,83 +460,175 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
         pending_field_block_finalizations: &std::sync::Mutex<Vec<PendingFieldBlockFinalization>>,
         depth: usize,
     ) -> std::result::Result<MergeOutcome, MergeError> {
-        if depth >= super::MAX_MERGE_DEPTH {
-            return Err(MergeError::depth_exceeded(cid, depth));
-        }
+        let mut frames = vec![CollectionMergeFrame::Enter {
+            cid: *cid,
+            block: Some(block.clone()),
+            payload: Some(payload.clone()),
+            child_cid: None,
+            depth,
+            is_root: true,
+        }];
 
-        {
-            let merged = self.merged_collections.lock().unwrap_or_else(|e| {
-                tracing::warn!("merged_collections lock poisoned, recovering");
-                e.into_inner()
-            });
-            if merged.contains(cid) {
-                return Ok(MergeOutcome::terminal_skip("collection already merged"));
-            }
-        }
-        {
-            let batch_merged_guard = batch_merged_collections.lock().unwrap_or_else(|e| {
-                tracing::warn!("batch_merged_collections lock poisoned, recovering");
-                e.into_inner()
-            });
-            if batch_merged_guard.contains(cid) {
-                return Ok(MergeOutcome::terminal_skip(
-                    "collection already merged in batch",
-                ));
-            }
-        }
+        while let Some(frame) = frames.pop() {
+            match frame {
+                CollectionMergeFrame::Enter {
+                    cid,
+                    block,
+                    payload,
+                    child_cid,
+                    depth,
+                    is_root,
+                } => {
+                    if depth >= super::MAX_MERGE_DEPTH {
+                        let error = MergeError::depth_exceeded(&cid, depth);
+                        if is_root {
+                            return Err(error);
+                        }
+                        tracing::debug!(
+                            parent_cid = %cid,
+                            %error,
+                            "Parent collection merge failed in batch"
+                        );
+                        continue;
+                    }
+                    if self.has_merged_collection(&cid) {
+                        if is_root {
+                            return Ok(MergeOutcome::terminal_skip("collection already merged"));
+                        }
+                        continue;
+                    }
+                    if Self::has_batch_merged_collection(batch_merged_collections, &cid) {
+                        if is_root {
+                            return Ok(MergeOutcome::terminal_skip(
+                                "collection already merged in batch",
+                            ));
+                        }
+                        continue;
+                    }
 
-        tracing::debug!(
-            cid = %cid,
-            schema_version = %payload.schema_version_id,
-            "Processing Collection delta in batch txn"
-        );
+                    let block = match block {
+                        Some(block) => block,
+                        None => {
+                            let Some(block) = self
+                                .load_parent_collection(
+                                    &cid,
+                                    &child_cid.expect("parent frame has a child CID"),
+                                )
+                                .await
+                            else {
+                                continue;
+                            };
+                            block
+                        }
+                    };
+                    let payload = match payload {
+                        Some(payload) => payload,
+                        None => {
+                            let CrdtDelta::Collection(payload) = &block.delta else {
+                                continue;
+                            };
+                            payload.clone()
+                        }
+                    };
 
-        // Recursively process parent collection blocks
-        if let Some(heads) = &block.heads {
-            for head_cid in heads {
-                let head_data = match self.blockstore.get(head_cid).await {
-                    Ok(Some(data)) => data,
-                    _ => continue,
-                };
+                    tracing::debug!(
+                        %cid,
+                        schema_version = %payload.schema_version_id,
+                        "Processing Collection delta in batch txn"
+                    );
 
-                let head_block = match Block::from_dag_cbor(&head_data) {
-                    Ok(b) => b,
-                    Err(_) => continue,
-                };
-
-                if let CrdtDelta::Collection(head_payload) = &head_block.delta {
-                    match Box::pin(self.process_collection_delta_in_txn(
-                        datastore,
-                        headstore,
-                        systemstore,
-                        head_cid,
-                        &head_block,
-                        head_payload,
-                        metadata,
-                        batch_merged,
-                        batch_merged_collections,
-                        pending_events,
-                        pending_post_commit_actions,
-                        pending_field_block_finalizations,
-                        depth + 1,
-                    ))
-                    .await
+                    let heads = block.heads.clone();
+                    frames.push(CollectionMergeFrame::Exit {
+                        cid,
+                        block,
+                        payload,
+                        depth,
+                        is_root,
+                    });
+                    if let Some(heads) = heads {
+                        for parent_cid in heads.into_iter().rev() {
+                            frames.push(CollectionMergeFrame::Enter {
+                                cid: parent_cid,
+                                block: None,
+                                payload: None,
+                                child_cid: Some(cid),
+                                depth: depth + 1,
+                                is_root: false,
+                            });
+                        }
+                    }
+                }
+                CollectionMergeFrame::Exit {
+                    cid,
+                    block,
+                    payload,
+                    depth,
+                    is_root,
+                } => {
+                    if self.has_merged_collection(&cid)
+                        || Self::has_batch_merged_collection(batch_merged_collections, &cid)
                     {
-                        Ok(MergeOutcome::Merged) => {}
-                        Ok(outcome) if outcome.is_terminal_skip() => {}
-                        Ok(outcome) => return Ok(outcome),
-                        Err(e) => {
+                        if is_root {
+                            return Ok(MergeOutcome::terminal_skip("collection already merged"));
+                        }
+                        continue;
+                    }
+                    let outcome = match self
+                        .process_collection_delta_in_txn_body(
+                            datastore,
+                            headstore,
+                            systemstore,
+                            &cid,
+                            &block,
+                            &payload,
+                            metadata,
+                            batch_merged,
+                            batch_merged_collections,
+                            pending_events,
+                            pending_post_commit_actions,
+                            pending_field_block_finalizations,
+                            depth,
+                        )
+                        .await
+                    {
+                        Ok(outcome) => outcome,
+                        Err(error) if !is_root => {
                             tracing::debug!(
-                                parent_cid = %head_cid,
-                                error = %e,
+                                parent_cid = %cid,
+                                %error,
                                 "Parent collection merge failed in batch"
                             );
+                            continue;
                         }
+                        Err(error) => return Err(error),
+                    };
+                    if is_root || (!outcome.is_merged() && !outcome.is_terminal_skip()) {
+                        return Ok(outcome);
                     }
                 }
             }
         }
 
+        Ok(MergeOutcome::terminal_skip("collection already merged"))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn process_collection_delta_in_txn_body(
+        &self,
+        datastore: &NamespaceView,
+        headstore: &NamespaceView,
+        systemstore: &NamespaceView,
+        cid: &Cid,
+        block: &Block,
+        payload: &defra_core::block::CollectionDeltaPayload,
+        metadata: &BlockMetadata<'_>,
+        batch_merged: &std::sync::Mutex<HashSet<Cid>>,
+        batch_merged_collections: &std::sync::Mutex<HashSet<Cid>>,
+        pending_events: &std::sync::Mutex<Vec<PendingMergeEvent>>,
+        pending_post_commit_actions: &std::sync::Mutex<Vec<PendingPostCommitAction>>,
+        pending_field_block_finalizations: &std::sync::Mutex<Vec<PendingFieldBlockFinalization>>,
+        depth: usize,
+    ) -> std::result::Result<MergeOutcome, MergeError> {
         // Process linked document composites
         let mut any_merged = false;
         let mut retryable_skip: Option<MergeOutcome> = None;

--- a/crates/db-merge/src/merge_handler/composite.rs
+++ b/crates/db-merge/src/merge_handler/composite.rs
@@ -61,6 +61,30 @@ pub(crate) struct CompositeMergeState {
     pub(crate) is_branchable: bool,
 }
 
+enum CompositeMergePreparation {
+    Ready(Option<Box<Collection>>),
+    Complete(MergeOutcome),
+}
+
+enum CompositeMergeFrame {
+    Enter {
+        cid: Cid,
+        block: Option<Block>,
+        payload: Option<defra_core::block::CompositeDeltaPayload>,
+        child_cid: Option<Cid>,
+        depth: usize,
+        is_root: bool,
+    },
+    Exit {
+        cid: Cid,
+        block: Block,
+        payload: defra_core::block::CompositeDeltaPayload,
+        doc_id: String,
+        collection: Option<Box<Collection>>,
+        is_root: bool,
+    },
+}
+
 impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
     /// Process a Composite delta from a block.
     ///
@@ -111,6 +135,122 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
         .await
     }
 
+    fn has_merged_composite(&self, cid: &Cid) -> bool {
+        self.merged_composites
+            .lock()
+            .unwrap_or_else(|error| {
+                tracing::warn!("merged_composites lock poisoned, recovering");
+                error.into_inner()
+            })
+            .contains(cid)
+    }
+
+    fn has_batch_merged_composite(
+        batch_merged: &std::sync::Mutex<HashSet<Cid>>,
+        cid: &Cid,
+    ) -> bool {
+        batch_merged
+            .lock()
+            .unwrap_or_else(|error| {
+                tracing::warn!("batch_merged lock poisoned, recovering");
+                error.into_inner()
+            })
+            .contains(cid)
+    }
+
+    async fn load_parent_composite(&self, parent_cid: &Cid, child_cid: &Cid) -> Option<Block> {
+        let data = match self.blockstore.get(parent_cid).await {
+            Ok(Some(data)) => data,
+            Ok(None) => {
+                tracing::debug!(
+                    %parent_cid,
+                    %child_cid,
+                    "Parent composite not in blockstore, skipping"
+                );
+                return None;
+            }
+            Err(error) => {
+                tracing::debug!(
+                    %parent_cid,
+                    %child_cid,
+                    %error,
+                    "Failed to load parent composite, skipping"
+                );
+                return None;
+            }
+        };
+
+        Block::from_dag_cbor(&data).ok()
+    }
+
+    async fn prepare_composite_merge(
+        &self,
+        cid: &Cid,
+        block: &Block,
+        payload: &defra_core::block::CompositeDeltaPayload,
+        metadata: &BlockMetadata<'_>,
+        doc_id: &str,
+        mode: CompositeMergeMode,
+    ) -> std::result::Result<CompositeMergePreparation, MergeError> {
+        if mode.is_standalone() {
+            tracing::info!(
+                %cid,
+                %doc_id,
+                priority = payload.priority,
+                status = payload.status,
+                links = ?block.links,
+                heads = ?block.heads,
+                "Processing Composite delta (document-level)"
+            );
+        } else {
+            tracing::info!(
+                %cid,
+                %doc_id,
+                priority = payload.priority,
+                "Processing Composite delta in batch txn"
+            );
+        }
+
+        let collection = self
+            .db
+            .find_collection_by_id(&payload.schema_version_id)
+            .ok()
+            .flatten()
+            .or_else(|| {
+                metadata
+                    .collection_id
+                    .and_then(|cid| self.db.find_collection_by_id(cid).ok().flatten())
+            });
+
+        if let Some(collection) = collection.as_ref() {
+            if let Some(reason) = self
+                .db
+                .replicated_downsample_source_skip_reason(collection.schema())?
+            {
+                tracing::warn!(
+                    collection = %collection.name(),
+                    %doc_id,
+                    %reason,
+                    "Skipping replicated write into local-only downsample source"
+                );
+                return Ok(CompositeMergePreparation::Complete(
+                    MergeOutcome::terminal_skip(reason),
+                ));
+            }
+
+            if let Some(hook) = self.composite_merge_hook() {
+                if let Some(outcome) = hook
+                    .on_protected_composite(doc_id, collection.schema(), metadata)
+                    .await?
+                {
+                    return Ok(CompositeMergePreparation::Complete(outcome));
+                }
+            }
+        }
+
+        Ok(CompositeMergePreparation::Ready(collection.map(Box::new)))
+    }
+
     #[allow(clippy::too_many_arguments)]
     async fn process_composite_delta_locked(
         &self,
@@ -122,149 +262,147 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
         depth: usize,
         doc_id_str: String,
     ) -> std::result::Result<MergeOutcome, MergeError> {
-        if depth >= super::MAX_MERGE_DEPTH {
-            return Err(MergeError::depth_exceeded(cid, depth));
-        }
+        let mut frames = vec![CompositeMergeFrame::Enter {
+            cid: *cid,
+            block: Some(block.clone()),
+            payload: Some(payload.clone()),
+            child_cid: None,
+            depth,
+            is_root: true,
+        }];
 
-        {
-            let merged = self.merged_composites.lock().unwrap_or_else(|e| {
-                tracing::warn!("merged_composites lock poisoned, recovering");
-                e.into_inner()
-            });
-            if merged.contains(cid) {
-                tracing::debug!(cid = %cid, "Composite already merged, skipping");
-                return Ok(MergeOutcome::terminal_skip("already merged"));
-            }
-        }
-
-        // Identity was resolved by the caller: `process_composite_delta` for the
-        // entry block, or the recursive head walk below for parents. A
-        // composite's heads are prior composites of the same document, so the
-        // DocID is invariant across the recursion.
-
-        tracing::info!(
-            cid = %cid,
-            doc_id = %doc_id_str,
-            priority = payload.priority,
-            status = payload.status,
-            links = ?block.links,
-            heads = ?block.heads,
-            "Processing Composite delta (document-level)"
-        );
-
-        let collection_lookup = self
-            .db
-            .find_collection_by_id(&payload.schema_version_id)
-            .ok()
-            .flatten()
-            .or_else(|| {
-                metadata
-                    .collection_id
-                    .and_then(|cid| self.db.find_collection_by_id(cid).ok().flatten())
-            });
-
-        if let Some(collection) = collection_lookup.as_ref() {
-            if let Some(reason) = self
-                .db
-                .replicated_downsample_source_skip_reason(collection.schema())?
-            {
-                tracing::warn!(
-                    collection = %collection.name(),
-                    doc_id = %doc_id_str,
-                    reason = %reason,
-                    "Skipping replicated write into local-only downsample source"
-                );
-                return Ok(MergeOutcome::terminal_skip(reason));
-            }
-
-            if let Some(hook) = self.composite_merge_hook() {
-                if let Some(outcome) = hook
-                    .on_protected_composite(&doc_id_str, collection.schema(), metadata)
-                    .await?
-                {
-                    return Ok(outcome);
-                }
-            }
-        }
-
-        // Recursively merge parent composites referenced in `heads` before
-        // processing this block.  This matches Go's processLog which walks
-        // the DAG backwards and merges from oldest to newest, ensuring all
-        // prior CRDT deltas are applied before the current one.
-        //
-        // Dedup guard: use merged_composites to skip parents already processed
-        // by another path. Go serializes merge events per-collection and checks
-        // `mt.heads` in loadComposites. In Rust, dual broadcast (doc topic +
-        // collection topic) can trigger concurrent recursive walks that
-        // temporarily re-add stale headstore entries. The guard prevents
-        // re-processing parents that were already merged.
-        if let Some(heads) = &block.heads {
-            for head_cid in heads {
-                {
-                    let merged = self.merged_composites.lock().unwrap_or_else(|e| {
-                        tracing::warn!("merged_composites lock poisoned, recovering");
-                        e.into_inner()
-                    });
-                    if merged.contains(head_cid) {
-                        tracing::debug!(
-                            parent_cid = %head_cid,
-                            child_cid = %cid,
-                            "Parent composite already merged, skipping recursive processing"
-                        );
+        while let Some(frame) = frames.pop() {
+            match frame {
+                CompositeMergeFrame::Enter {
+                    cid,
+                    block,
+                    payload,
+                    child_cid,
+                    depth,
+                    is_root,
+                } => {
+                    if depth >= super::MAX_MERGE_DEPTH {
+                        return Err(MergeError::depth_exceeded(&cid, depth));
+                    }
+                    if self.has_merged_composite(&cid) {
+                        if is_root {
+                            return Ok(MergeOutcome::terminal_skip("already merged"));
+                        }
                         continue;
                     }
-                }
-                let head_data = match self.blockstore.get(head_cid).await {
-                    Ok(Some(data)) => data,
-                    Ok(None) => {
-                        tracing::debug!(
-                            parent_cid = %head_cid,
-                            child_cid = %cid,
-                            "Parent composite not in blockstore, skipping"
-                        );
-                        continue;
-                    }
-                    Err(e) => {
-                        tracing::debug!(
-                            parent_cid = %head_cid,
-                            error = %e,
-                            "Failed to load parent composite, skipping"
-                        );
-                        continue;
-                    }
-                };
 
-                let head_block = match Block::from_dag_cbor(&head_data) {
-                    Ok(block) => block,
-                    Err(_) => continue,
-                };
+                    let block = match block {
+                        Some(block) => block,
+                        None => {
+                            let Some(block) = self
+                                .load_parent_composite(
+                                    &cid,
+                                    &child_cid.expect("parent frame has a child CID"),
+                                )
+                                .await
+                            else {
+                                continue;
+                            };
+                            block
+                        }
+                    };
+                    let payload = match payload {
+                        Some(payload) => payload,
+                        None => {
+                            let CrdtDelta::Composite(payload) = &block.delta else {
+                                continue;
+                            };
+                            payload.clone()
+                        }
+                    };
 
-                if let CrdtDelta::Composite(head_payload) = &head_block.delta {
-                    tracing::info!(
-                        parent_cid = %head_cid,
-                        child_cid = %cid,
-                        "Recursively merging parent composite before current"
-                    );
-                    match Box::pin(self.process_composite_delta_locked(
-                        head_cid,
-                        &head_block,
-                        head_payload,
-                        metadata,
-                        from_collection,
-                        depth + 1,
-                        doc_id_str.clone(),
-                    ))
-                    .await
+                    match self
+                        .prepare_composite_merge(
+                            &cid,
+                            &block,
+                            &payload,
+                            metadata,
+                            &doc_id_str,
+                            CompositeMergeMode::Standalone,
+                        )
+                        .await?
                     {
-                        Ok(MergeOutcome::Merged) => {}
-                        Ok(outcome) if outcome.is_terminal_skip() => {}
-                        Ok(outcome) => return Ok(outcome),
-                        Err(e) => return Err(e),
+                        CompositeMergePreparation::Ready(collection) => {
+                            let heads = block.heads.clone();
+                            frames.push(CompositeMergeFrame::Exit {
+                                cid,
+                                block,
+                                payload,
+                                doc_id: doc_id_str.clone(),
+                                collection,
+                                is_root,
+                            });
+                            if let Some(heads) = heads {
+                                for parent_cid in heads.into_iter().rev() {
+                                    frames.push(CompositeMergeFrame::Enter {
+                                        cid: parent_cid,
+                                        block: None,
+                                        payload: None,
+                                        child_cid: Some(cid),
+                                        depth: depth + 1,
+                                        is_root: false,
+                                    });
+                                }
+                            }
+                        }
+                        CompositeMergePreparation::Complete(outcome) => {
+                            if is_root || !outcome.is_terminal_skip() {
+                                return Ok(outcome);
+                            }
+                        }
+                    }
+                }
+                CompositeMergeFrame::Exit {
+                    cid,
+                    block,
+                    payload,
+                    doc_id,
+                    collection,
+                    is_root,
+                } => {
+                    if self.has_merged_composite(&cid) {
+                        if is_root {
+                            return Ok(MergeOutcome::terminal_skip("already merged"));
+                        }
+                        continue;
+                    }
+                    let outcome = self
+                        .process_composite_delta_body(
+                            &cid,
+                            &block,
+                            &payload,
+                            metadata,
+                            from_collection,
+                            &doc_id,
+                            collection.map(|collection| *collection),
+                        )
+                        .await?;
+                    if is_root || (!outcome.is_merged() && !outcome.is_terminal_skip()) {
+                        return Ok(outcome);
                     }
                 }
             }
         }
 
+        Ok(MergeOutcome::terminal_skip("already merged"))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn process_composite_delta_body(
+        &self,
+        cid: &Cid,
+        block: &Block,
+        payload: &defra_core::block::CompositeDeltaPayload,
+        metadata: &BlockMetadata<'_>,
+        from_collection: bool,
+        doc_id_str: &str,
+        collection_lookup: Option<Collection>,
+    ) -> std::result::Result<MergeOutcome, MergeError> {
         let txn = self.db.new_txn(false).await?;
         let doc_short_id = {
             let collection = collection_lookup.as_ref().ok_or_else(|| {
@@ -283,7 +421,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
             match db::doc_id_map::resolve_or_allocate_doc_short_id(
                 &systemstore,
                 collection.resolved_root_id(),
-                &doc_id_str,
+                doc_id_str,
             )
             .await
             {
@@ -299,7 +437,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
             block,
             payload,
             metadata,
-            &doc_id_str,
+            doc_id_str,
             doc_short_id,
             collection_lookup.clone(),
             CompositeMergeMode::Standalone,
@@ -382,7 +520,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                 if let Ok(systemstore) = txn.systemstore() {
                     self.record_block_ownership(
                         &systemstore,
-                        &doc_id_str,
+                        doc_id_str,
                         cid,
                         block,
                         &state.owned_field_cids,
@@ -415,7 +553,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                     (context.collection.as_ref(), self.composite_merge_hook())
                 {
                     if let Some(action) =
-                        hook.post_commit_action(&doc_id_str, collection.schema(), metadata)
+                        hook.post_commit_action(doc_id_str, collection.schema(), metadata)
                     {
                         if let Err(e) = action.run().await {
                             tracing::warn!(
@@ -509,133 +647,166 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
         pending_field_block_finalizations: &std::sync::Mutex<Vec<PendingFieldBlockFinalization>>,
         depth: usize,
     ) -> std::result::Result<MergeOutcome, MergeError> {
-        if depth >= super::MAX_MERGE_DEPTH {
-            return Err(MergeError::depth_exceeded(cid, depth));
-        }
+        let mut frames = vec![CompositeMergeFrame::Enter {
+            cid: *cid,
+            block: Some(block.clone()),
+            payload: Some(payload.clone()),
+            child_cid: None,
+            depth,
+            is_root: true,
+        }];
 
-        {
-            let merged = self.merged_composites.lock().unwrap_or_else(|e| {
-                tracing::warn!("merged_composites lock poisoned, recovering");
-                e.into_inner()
-            });
-            if merged.contains(cid) {
-                tracing::debug!(cid = %cid, "Composite already merged in permanent dedup set, skipping");
-                return Ok(MergeOutcome::terminal_skip("already merged"));
-            }
-        }
-        {
-            let batch_merged_guard = batch_merged.lock().unwrap_or_else(|e| {
-                tracing::warn!("batch_merged lock poisoned, recovering");
-                e.into_inner()
-            });
-            if batch_merged_guard.contains(cid) {
-                tracing::debug!(cid = %cid, "Composite already merged in batch dedup set, skipping");
-                return Ok(MergeOutcome::terminal_skip("already merged"));
-            }
-        }
-
-        let doc_id_str = self.resolve_composite_doc_id(cid, block).await?;
-
-        tracing::info!(
-            cid = %cid,
-            doc_id = %doc_id_str,
-            priority = payload.priority,
-            "Processing Composite delta in batch txn"
-        );
-
-        let collection_lookup = self
-            .db
-            .find_collection_by_id(&payload.schema_version_id)
-            .ok()
-            .flatten()
-            .or_else(|| {
-                metadata
-                    .collection_id
-                    .and_then(|cid| self.db.find_collection_by_id(cid).ok().flatten())
-            });
-
-        if let Some(collection) = collection_lookup.as_ref() {
-            if let Some(reason) = self
-                .db
-                .replicated_downsample_source_skip_reason(collection.schema())?
-            {
-                tracing::warn!(
-                    collection = %collection.name(),
-                    doc_id = %doc_id_str,
-                    reason = %reason,
-                    "Skipping replicated write into local-only downsample source"
-                );
-                return Ok(MergeOutcome::terminal_skip(reason));
-            }
-
-            if let Some(hook) = self.composite_merge_hook() {
-                if let Some(outcome) = hook
-                    .on_protected_composite(&doc_id_str, collection.schema(), metadata)
-                    .await?
-                {
-                    return Ok(outcome);
-                }
-            }
-        }
-
-        if let Some(heads) = &block.heads {
-            for head_cid in heads {
-                {
-                    let merged = self.merged_composites.lock().unwrap_or_else(|e| {
-                        tracing::warn!("merged_composites lock poisoned, recovering");
-                        e.into_inner()
-                    });
-                    if merged.contains(head_cid) {
-                        continue;
+        while let Some(frame) = frames.pop() {
+            match frame {
+                CompositeMergeFrame::Enter {
+                    cid,
+                    block,
+                    payload,
+                    child_cid,
+                    depth,
+                    is_root,
+                } => {
+                    if depth >= super::MAX_MERGE_DEPTH {
+                        return Err(MergeError::depth_exceeded(&cid, depth));
                     }
-                }
-                {
-                    let batch_merged_guard = batch_merged.lock().unwrap_or_else(|e| {
-                        tracing::warn!("batch_merged lock poisoned, recovering");
-                        e.into_inner()
-                    });
-                    if batch_merged_guard.contains(head_cid) {
-                        continue;
-                    }
-                }
-                let head_data = match self.blockstore.get(head_cid).await {
-                    Ok(Some(data)) => data,
-                    _ => continue,
-                };
-
-                let head_block = match Block::from_dag_cbor(&head_data) {
-                    Ok(block) => block,
-                    Err(_) => continue,
-                };
-
-                if let CrdtDelta::Composite(head_payload) = &head_block.delta {
-                    match Box::pin(self.process_composite_delta_in_txn(
-                        datastore,
-                        headstore,
-                        systemstore,
-                        head_cid,
-                        &head_block,
-                        head_payload,
-                        metadata,
-                        from_collection,
-                        batch_merged,
-                        _batch_merged_collections,
-                        pending_events,
-                        pending_post_commit_actions,
-                        pending_field_block_finalizations,
-                        depth + 1,
-                    ))
-                    .await
+                    if self.has_merged_composite(&cid)
+                        || Self::has_batch_merged_composite(batch_merged, &cid)
                     {
-                        Ok(MergeOutcome::Merged) => {}
-                        Ok(outcome) if outcome.is_terminal_skip() => {}
-                        Ok(outcome) => return Ok(outcome),
-                        Err(e) => return Err(e),
+                        if is_root {
+                            return Ok(MergeOutcome::terminal_skip("already merged"));
+                        }
+                        continue;
+                    }
+
+                    let block = match block {
+                        Some(block) => block,
+                        None => {
+                            let Some(block) = self
+                                .load_parent_composite(
+                                    &cid,
+                                    &child_cid.expect("parent frame has a child CID"),
+                                )
+                                .await
+                            else {
+                                continue;
+                            };
+                            block
+                        }
+                    };
+                    let payload = match payload {
+                        Some(payload) => payload,
+                        None => {
+                            let CrdtDelta::Composite(payload) = &block.delta else {
+                                continue;
+                            };
+                            payload.clone()
+                        }
+                    };
+                    let doc_id = self.resolve_composite_doc_id(&cid, &block).await?;
+
+                    match self
+                        .prepare_composite_merge(
+                            &cid,
+                            &block,
+                            &payload,
+                            metadata,
+                            &doc_id,
+                            CompositeMergeMode::Batch,
+                        )
+                        .await?
+                    {
+                        CompositeMergePreparation::Ready(collection) => {
+                            let heads = block.heads.clone();
+                            frames.push(CompositeMergeFrame::Exit {
+                                cid,
+                                block,
+                                payload,
+                                doc_id,
+                                collection,
+                                is_root,
+                            });
+                            if let Some(heads) = heads {
+                                for parent_cid in heads.into_iter().rev() {
+                                    frames.push(CompositeMergeFrame::Enter {
+                                        cid: parent_cid,
+                                        block: None,
+                                        payload: None,
+                                        child_cid: Some(cid),
+                                        depth: depth + 1,
+                                        is_root: false,
+                                    });
+                                }
+                            }
+                        }
+                        CompositeMergePreparation::Complete(outcome) => {
+                            if is_root || !outcome.is_terminal_skip() {
+                                return Ok(outcome);
+                            }
+                        }
+                    }
+                }
+                CompositeMergeFrame::Exit {
+                    cid,
+                    block,
+                    payload,
+                    doc_id,
+                    collection,
+                    is_root,
+                } => {
+                    if self.has_merged_composite(&cid)
+                        || Self::has_batch_merged_composite(batch_merged, &cid)
+                    {
+                        if is_root {
+                            return Ok(MergeOutcome::terminal_skip("already merged"));
+                        }
+                        continue;
+                    }
+                    let outcome = self
+                        .process_composite_delta_in_txn_body(
+                            datastore,
+                            headstore,
+                            systemstore,
+                            &cid,
+                            &block,
+                            &payload,
+                            metadata,
+                            from_collection,
+                            batch_merged,
+                            pending_events,
+                            pending_post_commit_actions,
+                            pending_field_block_finalizations,
+                            &doc_id,
+                            collection.map(|collection| *collection),
+                        )
+                        .await?;
+                    if is_root || (!outcome.is_merged() && !outcome.is_terminal_skip()) {
+                        return Ok(outcome);
                     }
                 }
             }
         }
 
+        Ok(MergeOutcome::terminal_skip("already merged"))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn process_composite_delta_in_txn_body(
+        &self,
+        datastore: &NamespaceView,
+        headstore: &NamespaceView,
+        systemstore: &NamespaceView,
+        cid: &Cid,
+        block: &Block,
+        payload: &defra_core::block::CompositeDeltaPayload,
+        metadata: &BlockMetadata<'_>,
+        from_collection: bool,
+        batch_merged: &std::sync::Mutex<HashSet<Cid>>,
+        pending_events: &std::sync::Mutex<Vec<PendingMergeEvent>>,
+        pending_post_commit_actions: &std::sync::Mutex<Vec<PendingPostCommitAction>>,
+        pending_field_block_finalizations: &std::sync::Mutex<Vec<PendingFieldBlockFinalization>>,
+        doc_id_str: &str,
+        collection_lookup: Option<Collection>,
+    ) -> std::result::Result<MergeOutcome, MergeError> {
         let doc_short_id = {
             let collection = collection_lookup.as_ref().ok_or_else(|| {
                 MergeError::MissingMetadata(format!(
@@ -646,7 +817,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
             db::doc_id_map::resolve_or_allocate_doc_short_id(
                 systemstore,
                 collection.resolved_root_id(),
-                &doc_id_str,
+                doc_id_str,
             )
             .await
             .map_err(MergeError::Database)?
@@ -656,7 +827,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
             block,
             payload,
             metadata,
-            &doc_id_str,
+            doc_id_str,
             doc_short_id,
             collection_lookup.clone(),
             CompositeMergeMode::Batch,
@@ -702,7 +873,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
             Ok(Some(outcome)) => {
                 if outcome.is_terminal_skip() && !from_collection {
                     let merge_complete = MergeCompleteData {
-                        doc_id: doc_id_str.clone(),
+                        doc_id: doc_id_str.to_string(),
                         subject_doc_id: None,
                         cid: *cid,
                         collection_id: metadata
@@ -727,7 +898,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                 self.update_heads(headstore, &context, &state).await;
                 self.record_block_ownership(
                     systemstore,
-                    &doc_id_str,
+                    doc_id_str,
                     cid,
                     block,
                     &state.owned_field_cids,
@@ -761,7 +932,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                     (context.collection.as_ref(), self.composite_merge_hook())
                 {
                     if let Some(action) =
-                        hook.post_commit_action(&doc_id_str, collection.schema(), metadata)
+                        hook.post_commit_action(doc_id_str, collection.schema(), metadata)
                     {
                         pending_post_commit_actions
                             .lock()
@@ -782,7 +953,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                     });
 
                     let update = Update::new(
-                        doc_id_str.clone(),
+                        doc_id_str.to_string(),
                         *cid,
                         payload.schema_version_id.clone(),
                         vec![],
@@ -795,7 +966,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
 
                     if !from_collection {
                         let merge_complete = MergeCompleteData {
-                            doc_id: doc_id_str.clone(),
+                            doc_id: doc_id_str.to_string(),
                             subject_doc_id: None,
                             cid: *cid,
                             collection_id: metadata
@@ -812,7 +983,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                     if state.is_branchable {
                         let merge_complete = MergeCompleteData {
                             doc_id: String::new(),
-                            subject_doc_id: Some(doc_id_str.clone()),
+                            subject_doc_id: Some(doc_id_str.to_string()),
                             cid: *cid,
                             collection_id: metadata
                                 .collection_id

--- a/crates/db-merge/src/merge_handler/mod.rs
+++ b/crates/db-merge/src/merge_handler/mod.rs
@@ -49,11 +49,9 @@ use db::database::DB;
 use db::index_manager::IndexManager;
 use hook::CompositeMergeHook;
 
-/// Maximum DAG recursion depth for merge operations.
+/// Maximum parent-chain depth for merge operations.
 ///
-/// Prevents stack overflow from a malicious or corrupt DAG with deeply nested heads.
-/// Recursive async functions allocate a stack frame per level; 1024 is sufficient for
-/// legitimate replication chains while remaining well within typical stack limits.
+/// Bounds the work and heap used while traversing a malicious or corrupt DAG.
 pub(crate) const MAX_MERGE_DEPTH: usize = 1024;
 
 /// Encode a priority value as a varint (matches Go's binary.PutUvarint).
@@ -811,8 +809,9 @@ mod tests {
     use blockstore::{Blockstore as _, DefraBlockstore};
     use crypto::PrivateKey as _;
     use defra_core::block::{
-        Block, CollectionDefinitionDeltaPayload, CompositeDeltaPayload, CounterDeltaPayload,
-        CrdtDelta, DAGLink, Encryption, LwwDeltaPayload, Signature, SignatureHeader, SignatureType,
+        Block, CollectionDefinitionDeltaPayload, CollectionDeltaPayload, CompositeDeltaPayload,
+        CounterDeltaPayload, CrdtDelta, DAGLink, Encryption, LwwDeltaPayload, Signature,
+        SignatureHeader, SignatureType,
     };
     use events::{Bus, ChannelBus, EventName};
     use schema::{CType, CollectionVersion, FieldDescription, FieldKind};
@@ -3041,6 +3040,163 @@ mod tests {
                 child_field_cid
             )
             .bytes()]
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn deep_composite_parent_chain_merges_on_worker_stack() {
+        let (handler, blockstore, _bus) = make_handler_with_schema_and_bus().await;
+        let collection = handler
+            .db
+            .find_collection_by_id("col-users")
+            .unwrap()
+            .expect("users collection should exist");
+
+        let mut doc = Document::new();
+        doc.set("name", NormalValue::String("initial".to_string()));
+        doc.set_schema_version_id("v1");
+
+        let (doc_id, _doc_short_id, local_blocks) =
+            create_doc_locally(&handler, &collection, &mut doc, "v1").await;
+        let doc_id_str = doc_id.to_string();
+        let mut field_heads = local_blocks.field_cids;
+        let mut composite_heads = vec![local_blocks.cid];
+        let mut latest = None;
+
+        for priority in 2..=257 {
+            let name = format!("name-{priority}");
+            let mut data = Vec::new();
+            ciborium::into_writer(&NormalValue::String(name), &mut data).unwrap();
+            let field_block = Block::new(
+                CrdtDelta::Lww(LwwDeltaPayload {
+                    field_name: "name".to_string(),
+                    schema_version_id: "v1".to_string(),
+                    priority,
+                    data,
+                }),
+                field_heads,
+                vec![],
+            );
+            let field_cid = field_block.generate_cid().unwrap();
+            blockstore
+                .put(&field_cid, &field_block.to_dag_cbor().unwrap())
+                .await
+                .unwrap();
+
+            let payload = CompositeDeltaPayload {
+                schema_version_id: "v1".to_string(),
+                priority,
+                status: 1,
+            };
+            let composite_block = Block::new(
+                CrdtDelta::Composite(payload.clone()),
+                composite_heads,
+                vec![DAGLink::new("name", field_cid)],
+            );
+            let composite_cid = composite_block.generate_cid().unwrap();
+            blockstore
+                .put(&composite_cid, &composite_block.to_dag_cbor().unwrap())
+                .await
+                .unwrap();
+
+            field_heads = vec![field_cid];
+            composite_heads = vec![composite_cid];
+            latest = Some((composite_cid, composite_block, payload));
+        }
+
+        let (latest_cid, latest_block, latest_payload) = latest.expect("chain is not empty");
+        let (handler, outcome) = tokio::spawn(async move {
+            let metadata = BlockMetadata::normal(
+                &doc_id_str,
+                "col-users",
+                "did:key:z6MkrDeepCompositeReplay",
+                None,
+                false,
+            );
+            let outcome = handler
+                .process_composite_delta(
+                    &latest_cid,
+                    &latest_block,
+                    &latest_payload,
+                    &metadata,
+                    false,
+                    0,
+                )
+                .await
+                .unwrap();
+            (handler, outcome)
+        })
+        .await
+        .expect("composite merge task should not overflow its worker stack");
+        assert_eq!(outcome, MergeOutcome::Merged);
+
+        let stored = {
+            let txn = handler.db.new_txn(true).await.unwrap();
+            let stored = {
+                let datastore = txn.datastore().unwrap();
+                let systemstore = txn.systemstore().unwrap();
+                collection
+                    .get_by_doc_id(&datastore, &systemstore, &doc_id)
+                    .await
+                    .unwrap()
+                    .expect("document should exist")
+            };
+            txn.force_discard().unwrap();
+            stored
+        };
+        assert_eq!(
+            stored.get("name"),
+            Some(&NormalValue::String("name-257".to_string()))
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn deep_collection_parent_chain_merges_on_worker_stack() {
+        let (handler, blockstore, _bus) = make_handler_with_schema_and_bus().await;
+        let mut heads = Vec::new();
+        let mut latest = None;
+
+        for priority in 1..=256 {
+            let payload = CollectionDeltaPayload {
+                schema_version_id: "v1".to_string(),
+                priority,
+            };
+            let block = Block::new(CrdtDelta::Collection(payload.clone()), heads, vec![]);
+            let cid = block.generate_cid().unwrap();
+            blockstore
+                .put(&cid, &block.to_dag_cbor().unwrap())
+                .await
+                .unwrap();
+            heads = vec![cid];
+            latest = Some((cid, block, payload));
+        }
+
+        let (latest_cid, latest_block, latest_payload) = latest.expect("chain is not empty");
+        let (handler, outcome) = tokio::spawn(async move {
+            let metadata = BlockMetadata::normal(
+                "collection-chain",
+                "col-users",
+                "did:key:z6MkrDeepCollectionReplay",
+                None,
+                false,
+            );
+            let outcome = handler
+                .process_collection_delta(&latest_cid, &latest_block, &latest_payload, &metadata, 0)
+                .await
+                .unwrap();
+            (handler, outcome)
+        })
+        .await
+        .expect("collection merge task should not overflow its worker stack");
+
+        assert!(outcome.is_terminal_skip());
+        assert_eq!(
+            handler
+                .merged_collections
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .len(),
+            256
         );
     }
 


### PR DESCRIPTION
## Problem

Deep replicated document and collection histories are replayed through boxed async recursion. The configured depth bound allows chains far deeper than a Tokio worker stack can hold, so the desktop-like follow-up workload from #885 aborts the process with a stack overflow before replication can recover.

## What changed

- Traverse composite and collection parent chains with explicit heap-backed enter/exit frames.
- Preserve parent-first merge order, depth limits, deduplication, retryable outcomes, and standalone versus batch transaction behavior.
- Keep each root block's exact payload while loading parent payloads from the blockstore.
- Add worker-stack regressions covering 256-level composite and collection chains.

This isolates the merge-stack failure found through #885. The separate full-DAG sender backlog observed under the same stress workload remains tracked by #1116.

## Validation

- [x] `cargo test -p db-merge` (100 passed)
- [x] `cargo test -p defra-node --features p2p live_replicator_same_session_followup_turn_converges -- --ignored --nocapture` (passed without stack exhaustion)
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo clippy -p defra-node --features p2p --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`

Advances #885.
