### PR TITLE
fix(storage): stop serializing reads behind write commits

### DIFF
--- a/crates/storage/src/backends/fjall/store.rs
+++ b/crates/storage/src/backends/fjall/store.rs
@@ -176,7 +176,15 @@ impl Store for FjallStore {
         }
         let mut guard = NewTxnGuard(&self.active_txn_count, false);
 
-        let _commit_guard = self.commit_gate.read().await;
+        // Read-only transactions skip the gate: they never conflict-check,
+        // and commit() only returns after the physical write, so
+        // read-your-committed-writes holds without serializing readers
+        // behind in-flight commits.
+        let _commit_guard = if readonly {
+            None
+        } else {
+            Some(self.commit_gate.read().await)
+        };
         let conflict_snapshot = (!readonly).then(|| self.conflict_tracker.begin_snapshot());
         let read_version = conflict_snapshot.as_ref().map_or_else(
             || self.conflict_tracker.current_version(),
@@ -352,6 +360,84 @@ mod pairing_tests {
             .expect("commit task panicked")
             .expect("commit failed");
         assert_eq!(physical_value(&store, &key), Some(b"committed".to_vec()));
+    }
+
+    #[tokio::test]
+    async fn readonly_txn_skips_commit_gate() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let store = Arc::new(FjallStore::open(temp_dir.path()).unwrap());
+        let gate = Arc::clone(&store.commit_gate);
+        let commit_guard = gate.write().await;
+
+        // A read-only transaction must not queue behind an in-flight commit.
+        let readonly = tokio::time::timeout(Duration::from_secs(1), store.new_txn(true))
+            .await
+            .expect("read-only transaction blocked behind the commit gate")
+            .expect("read-only transaction failed");
+        drop(readonly);
+
+        // Writers still pair version and snapshot behind the gate.
+        let writer_store = Arc::clone(&store);
+        let mut writer_task = tokio::spawn(async move { writer_store.new_txn(false).await });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), &mut writer_task)
+                .await
+                .is_err(),
+            "write transaction skipped the commit gate"
+        );
+
+        drop(commit_guard);
+        tokio::time::timeout(Duration::from_secs(1), writer_task)
+            .await
+            .expect("write transaction remained blocked after gate release")
+            .expect("writer task panicked")
+            .expect("write transaction failed");
+    }
+
+    #[tokio::test]
+    async fn cancelled_commit_still_conflict_checks_against_pinned_records() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let store = Arc::new(FjallStore::open(temp_dir.path()).unwrap());
+        let key = b"contended-key".to_vec();
+
+        // Txn A snapshots at version 0 and stages a write to `key`.
+        let mut txn_a = store.new_txn(false).await.unwrap();
+        txn_a.set(&key, b"stale-A").await.unwrap();
+
+        // Txn B commits a write to the same key -> version 1 recorded.
+        let mut txn_b = store.new_txn(false).await.unwrap();
+        txn_b.set(&key, b"committed-B").await.unwrap();
+        txn_b.commit().await.unwrap();
+        assert_eq!(physical_value(&store, &key), Some(b"committed-B".to_vec()));
+
+        // Hold the gate so A's blocking commit task parks at blocking_write.
+        let gate = Arc::clone(&store.commit_gate);
+        let commit_guard = gate.write().await;
+
+        let commit_task = tokio::spawn(async move { txn_a.commit().await });
+        // Let the commit future run its first poll (dispatch spawn_blocking).
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Cancel the commit future while the blocking thread waits for the
+        // gate. A's ConflictSnapshot moved into the closure, so B's record
+        // must stay pinned for the detached conflict check.
+        commit_task.abort();
+        let join = commit_task.await;
+        assert!(join.is_err(), "commit task should have been aborted");
+
+        // Release the gate; the detached blocking thread (queued ahead of
+        // us) runs check_and_record + physical write, so reacquiring the
+        // gate sequences after its completion.
+        drop(commit_guard);
+        drop(gate.write().await);
+
+        // Correct SSI behavior: A conflicts with B (same key, B committed
+        // after A's snapshot) so B's value must survive.
+        assert_eq!(
+            physical_value(&store, &key),
+            Some(b"committed-B".to_vec()),
+            "cancelled commit overwrote a conflicting committed write"
+        );
     }
 
     #[tokio::test]

--- a/crates/storage/src/backends/fjall/transaction.rs
+++ b/crates/storage/src/backends/fjall/transaction.rs
@@ -247,7 +247,7 @@ impl Writer for FjallTxn {
 
 #[async_trait]
 impl Txn for FjallTxn {
-    async fn commit(self: Box<Self>) -> Result<()> {
+    async fn commit(mut self: Box<Self>) -> Result<()> {
         if self.discarded.load(Ordering::Acquire) {
             tracing::warn!("Attempted to commit a discarded transaction");
             CallbackManager::execute_callbacks(self.callbacks.take_error());
@@ -264,42 +264,73 @@ impl Txn for FjallTxn {
         let read_set = self.read_set.lock().clone();
 
         if !pending.is_empty() {
-            let commit_result = {
-                let _commit_guard = self.commit_gate.write().await;
-                match self.conflict_tracker.check_and_record(
-                    self.read_version,
-                    pending.keys(),
-                    &read_set,
-                ) {
-                    Err(error) => Err(error),
-                    Ok(()) => {
-                        let mut batch = self.db.batch();
-                        match self.durability {
-                            DurabilityMode::Immediate => {
-                                batch = batch.durability(Some(fjall::PersistMode::SyncAll));
-                            }
-                            DurabilityMode::Eventual => {
-                                batch = batch.durability(Some(fjall::PersistMode::Buffer));
-                            }
-                        }
-                        for (key, value) in &pending {
-                            match value {
-                                Some(v) => {
-                                    batch.insert(&self.keyspace, key.as_slice(), v.as_slice())
-                                }
-                                None => batch.remove(&self.keyspace, key.as_slice()),
-                            }
-                        }
-                        batch.commit().map_err(Error::from)
+            let pending_changes = pending.len();
+
+            // The gate is acquired inside spawn_blocking (redb precedent):
+            // the blocking thread owns the guard, so cancelling the commit
+            // future cannot release the gate mid-write, and the journal
+            // persist (fsync under PersistMode::SyncAll, journal-mutex waits
+            // even under Buffer) no longer blocks a tokio worker. The
+            // conflict snapshot moves into the closure with it: if the future
+            // is dropped mid-await, the snapshot must keep pinning the
+            // records this commit conflict-checks against, or prune() could
+            // empty the history before check_and_record runs. The tradeoff:
+            // a cancelled future can leave a durable commit whose success
+            // callbacks never ran (same as redb's direct path).
+            let db = self.db.clone();
+            let keyspace = self.keyspace.clone();
+            let conflict_tracker = Arc::clone(&self.conflict_tracker);
+            let commit_gate = Arc::clone(&self.commit_gate);
+            let read_version = self.read_version;
+            let durability = self.durability;
+            let conflict_snapshot = self._conflict_snapshot.take();
+
+            let write_result = tokio::task::spawn_blocking(move || -> Result<()> {
+                let _conflict_snapshot = conflict_snapshot;
+                let _commit_guard = commit_gate.blocking_write();
+                let version =
+                    conflict_tracker.check_and_record(read_version, pending.keys(), &read_set)?;
+                // Unrecords on error or panic before the write lands, so no
+                // phantom write-set survives a failed commit.
+                let record_guard =
+                    crate::backends::shared::RecordGuard::new(&conflict_tracker, version);
+
+                let mut batch = db.batch();
+                match durability {
+                    DurabilityMode::Immediate => {
+                        batch = batch.durability(Some(fjall::PersistMode::SyncAll));
+                    }
+                    DurabilityMode::Eventual => {
+                        batch = batch.durability(Some(fjall::PersistMode::Buffer));
                     }
                 }
+                for (key, value) in &pending {
+                    match value {
+                        Some(v) => batch.insert(&keyspace, key.as_slice(), v.as_slice()),
+                        None => batch.remove(&keyspace, key.as_slice()),
+                    }
+                }
+
+                batch.commit()?;
+                record_guard.defuse();
+                Ok(())
+            })
+            .await;
+
+            let commit_result = match write_result {
+                Ok(result) => result,
+                Err(join_err) => Err(Error::Other(if join_err.is_panic() {
+                    format!("commit task panicked: {join_err}")
+                } else {
+                    format!("commit task cancelled: {join_err}")
+                })),
             };
 
             if let Err(e) = commit_result {
                 if !matches!(e, Error::TxnConflict) {
                     tracing::error!(
                         error = %e,
-                        pending_changes = pending.len(),
+                        pending_changes,
                         "Failed to commit fjall batch"
                     );
                 }

--- a/crates/storage/src/backends/lark/store.rs
+++ b/crates/storage/src/backends/lark/store.rs
@@ -98,6 +98,12 @@ impl Store for LarkStore {
         }
         let mut guard = NewTxnGuard(&self.active_txn_count, false);
 
+        // Unlike the other backends, read-only transactions must NOT skip
+        // the gate here: lark publishes `latest_seq` before applying batch
+        // ops to the memtable, so an ungated snapshot taken mid-commit can
+        // claim visibility of sequence numbers whose data has not landed
+        // (torn batch). The gate is what keeps snapshot acquisition atomic
+        // against in-flight commits until lark publishes after applying.
         let _commit_guard = self.commit_gate.read().await;
         let txn = LarkTxn::new(
             Arc::clone(&self.db),
@@ -256,6 +262,33 @@ mod pairing_tests {
             .expect("commit task panicked")
             .expect("commit failed");
         assert_eq!(physical_value(&store, &key), Some(b"committed".to_vec()));
+    }
+
+    #[tokio::test]
+    async fn readonly_txn_still_gated_against_torn_batches() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let store = Arc::new(LarkStore::open(temp_dir.path()).unwrap());
+        let gate = Arc::clone(&store.commit_gate);
+        let commit_guard = gate.write().await;
+
+        // lark publishes its sequence counter before applying batch ops, so
+        // read-only snapshots must stay behind the gate (unlike the other
+        // backends) or they can observe a torn batch.
+        let readonly_store = Arc::clone(&store);
+        let mut readonly_task = tokio::spawn(async move { readonly_store.new_txn(true).await });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), &mut readonly_task)
+                .await
+                .is_err(),
+            "read-only transaction skipped the commit gate on lark"
+        );
+
+        drop(commit_guard);
+        tokio::time::timeout(Duration::from_secs(1), readonly_task)
+            .await
+            .expect("read-only transaction remained blocked after gate release")
+            .expect("readonly task panicked")
+            .expect("read-only transaction failed");
     }
 
     #[tokio::test]

--- a/crates/storage/src/backends/lark/transaction.rs
+++ b/crates/storage/src/backends/lark/transaction.rs
@@ -109,7 +109,7 @@ impl PendingWrites {
         conflict_tracker: &ConflictTracker,
         read_version: u64,
         read_set: &ReadSet,
-    ) -> Result<()> {
+    ) -> Result<u64> {
         if let Some(index) = &self.index {
             conflict_tracker.check_and_record(read_version, index.keys(), read_set)
         } else {
@@ -424,7 +424,7 @@ impl Writer for LarkTxn {
 
 #[async_trait]
 impl Txn for LarkTxn {
-    async fn commit(self: Box<Self>) -> Result<()> {
+    async fn commit(mut self: Box<Self>) -> Result<()> {
         if *self.discarded.lock() {
             tracing::warn!("Attempted to commit a discarded transaction");
             CallbackManager::execute_callbacks(self.callbacks.take_error());
@@ -441,25 +441,52 @@ impl Txn for LarkTxn {
         let read_set = self.read_set.lock().clone();
 
         if !pending.is_empty() {
-            let commit_result = {
-                let _commit_guard = self.commit_gate.write().await;
-                match pending.check_and_record_conflicts(
-                    &self.conflict_tracker,
-                    self.read_version,
-                    &read_set,
-                ) {
-                    Err(error) => Err(error),
-                    Ok(()) => {
-                        let batch = pending.into_write_batch();
-                        let durability = match self.durability {
-                            DurabilityMode::Immediate => lark_kv::DurabilityMode::Immediate,
-                            DurabilityMode::Eventual => lark_kv::DurabilityMode::Eventual,
-                        };
-                        self.db
-                            .write_with_durability(batch, durability)
-                            .map_err(|error| Error::Backend(error.to_string()))
-                    }
-                }
+            // The gate is acquired inside spawn_blocking (redb precedent):
+            // the blocking thread owns the guard, so cancelling the commit
+            // future cannot release the gate mid-write, and the write path
+            // (fsync under Immediate, write-capacity stalls even under
+            // Eventual) no longer blocks a tokio worker. The conflict
+            // snapshot moves into the closure with it: if the future is
+            // dropped mid-await, the snapshot must keep pinning the records
+            // this commit conflict-checks against, or prune() could empty
+            // the history before check_and_record runs. The tradeoff: a
+            // cancelled future can leave a durable commit whose success
+            // callbacks never ran (same as redb's direct path).
+            let db = Arc::clone(&self.db);
+            let conflict_tracker = Arc::clone(&self.conflict_tracker);
+            let commit_gate = Arc::clone(&self.commit_gate);
+            let read_version = self.read_version;
+            let durability = match self.durability {
+                DurabilityMode::Immediate => lark_kv::DurabilityMode::Immediate,
+                DurabilityMode::Eventual => lark_kv::DurabilityMode::Eventual,
+            };
+            let conflict_snapshot = self._conflict_snapshot.take();
+
+            let write_result = tokio::task::spawn_blocking(move || -> Result<()> {
+                let _conflict_snapshot = conflict_snapshot;
+                let _commit_guard = commit_gate.blocking_write();
+                // Unlike the other backends, a lark write error must NOT
+                // unrecord: lark can fail AFTER the batch is WAL-durable and
+                // memtable-visible (rotate_memtable on the same call), so an
+                // error is indeterminate. Keeping the record risks a phantom
+                // conflict (spurious retry); dropping it risks missing a real
+                // conflict against landed data (lost update).
+                pending.check_and_record_conflicts(&conflict_tracker, read_version, &read_set)?;
+
+                let batch = pending.into_write_batch();
+                db.write_with_durability(batch, durability)
+                    .map_err(|error| Error::Backend(error.to_string()))?;
+                Ok(())
+            })
+            .await;
+
+            let commit_result = match write_result {
+                Ok(result) => result,
+                Err(join_err) => Err(Error::Other(if join_err.is_panic() {
+                    format!("commit task panicked: {join_err}")
+                } else {
+                    format!("commit task cancelled: {join_err}")
+                })),
             };
 
             if let Err(e) = commit_result {

--- a/crates/storage/src/backends/memory/store.rs
+++ b/crates/storage/src/backends/memory/store.rs
@@ -56,7 +56,14 @@ impl Store for MemoryStore {
             return Err(Error::DBClosed);
         }
 
-        let _commit_guard = self.commit_gate.read().await;
+        // Read-only transactions skip the gate: they never conflict-check,
+        // and the data read-lock below is what guarantees the snapshot is
+        // not torn by an in-flight commit's mutation.
+        let _commit_guard = if readonly {
+            None
+        } else {
+            Some(self.commit_gate.read().await)
+        };
         let data = self.data.read().await;
         let conflict_snapshot = (!readonly).then(|| self.conflict_tracker.begin_snapshot());
         let read_version = conflict_snapshot.as_ref().map_or_else(
@@ -179,6 +186,37 @@ mod pairing_tests {
             store.data.read().await.get(&key).cloned(),
             Some(b"committed".to_vec())
         );
+    }
+
+    #[tokio::test]
+    async fn readonly_txn_skips_commit_gate() {
+        let store = Arc::new(MemoryStore::new());
+        let gate = Arc::clone(&store.commit_gate);
+        let commit_guard = gate.write().await;
+
+        // A read-only transaction must not queue behind an in-flight commit.
+        let readonly = tokio::time::timeout(Duration::from_secs(1), store.new_txn(true))
+            .await
+            .expect("read-only transaction blocked behind the commit gate")
+            .expect("read-only transaction failed");
+        drop(readonly);
+
+        // Writers still pair version and snapshot behind the gate.
+        let writer_store = Arc::clone(&store);
+        let mut writer_task = tokio::spawn(async move { writer_store.new_txn(false).await });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), &mut writer_task)
+                .await
+                .is_err(),
+            "write transaction skipped the commit gate"
+        );
+
+        drop(commit_guard);
+        tokio::time::timeout(Duration::from_secs(1), writer_task)
+            .await
+            .expect("write transaction remained blocked after gate release")
+            .expect("writer task panicked")
+            .expect("write transaction failed");
     }
 
     #[tokio::test]

--- a/crates/storage/src/backends/redb/group_commit.rs
+++ b/crates/storage/src/backends/redb/group_commit.rs
@@ -7,7 +7,9 @@ use tokio::sync::{mpsc, oneshot, RwLock as AsyncRwLock};
 
 use super::config::DurabilityMode;
 use super::KV_TABLE;
-use crate::backends::shared::{CallbackManager, ConflictSnapshot, ConflictTracker, ReadSet};
+use crate::backends::shared::{
+    CallbackManager, ConflictSnapshot, ConflictTracker, ReadSet, RecordGuard,
+};
 use crate::corekv::{AsyncTxnCallback, Error, Result, TxnCallback};
 
 /// Payload for a single transaction's pending commit.
@@ -111,19 +113,32 @@ async fn flush_loop(
             }
         }
 
-        let (passed, failed, result) = {
-            // Keep version publication and the Redb flush indivisible to new snapshots.
-            let _commit_guard = commit_gate.write().await;
+        // Keep version publication and the Redb flush indivisible to new
+        // snapshots. The gate is acquired inside spawn_blocking so the
+        // blocking thread owns it: aborting the flush loop (store drop)
+        // cannot release the gate mid-write, and the flush fsync no longer
+        // blocks a tokio worker.
+        let flush_db = Arc::clone(&db);
+        let flush_tracker = Arc::clone(&conflict_tracker);
+        let flush_gate = Arc::clone(&commit_gate);
+        let flush_result = tokio::task::spawn_blocking(move || {
+            let _commit_guard = flush_gate.blocking_write();
             let mut passed = Vec::with_capacity(batch.len());
+            let mut record_guards = Vec::with_capacity(batch.len());
             let mut failed: Vec<(PendingCommit, Error)> = Vec::new();
 
             for commit in batch {
-                match conflict_tracker.check_and_record(
+                match flush_tracker.check_and_record(
                     commit.read_version,
                     commit.changes.keys(),
                     &commit.read_set,
                 ) {
-                    Ok(()) => passed.push(commit),
+                    Ok(version) => {
+                        passed.push(commit);
+                        // Unrecords on flush error or panic, so no phantom
+                        // write-set survives a failed batch.
+                        record_guards.push(RecordGuard::new(&flush_tracker, version));
+                    }
                     Err(e) => failed.push((commit, e)),
                 }
             }
@@ -131,9 +146,27 @@ async fn flush_loop(
             let result = if passed.is_empty() {
                 None
             } else {
-                Some(flush_batch(&db, &passed, durability))
+                let result = flush_batch(&flush_db, &passed, durability);
+                if result.is_ok() {
+                    for guard in record_guards {
+                        guard.defuse();
+                    }
+                }
+                Some(result)
             };
             (passed, failed, result)
+        })
+        .await;
+
+        let (passed, failed, result) = match flush_result {
+            Ok(output) => output,
+            Err(join_err) => {
+                // A panicking flush (e.g. storage corruption) would repeat on
+                // every batch; shut the loop down so later commits fail fast
+                // at enqueue with "group commit channel closed" instead.
+                tracing::error!(error = %join_err, "Group commit flush task failed; stopping");
+                return;
+            }
         };
 
         for (commit, err) in failed {

--- a/crates/storage/src/backends/redb/store.rs
+++ b/crates/storage/src/backends/redb/store.rs
@@ -307,8 +307,16 @@ impl Store for RedbStore {
         let mut guard = NewTxnGuard(&self.active_txn_count, false);
 
         let (read_version, read_txn, conflict_snapshot) = {
-            // Pair the conflict version and Redb snapshot without a commit between them.
-            let _commit_guard = self.commit_gate.read().await;
+            // Pair the conflict version and Redb snapshot without a commit
+            // between them. Read-only transactions skip the gate: they never
+            // conflict-check, and commit() only returns after the physical
+            // write, so read-your-committed-writes holds without serializing
+            // readers behind in-flight commits.
+            let _commit_guard = if readonly {
+                None
+            } else {
+                Some(self.commit_gate.read().await)
+            };
             let conflict_snapshot = (!readonly).then(|| self.conflict_tracker.begin_snapshot());
             let read_version = conflict_snapshot.as_ref().map_or_else(
                 || self.conflict_tracker.current_version(),
@@ -438,5 +446,77 @@ impl IntegrityReport {
     /// Check if the database passed the integrity check.
     pub fn is_valid(&self) -> bool {
         self.is_valid
+    }
+}
+
+#[cfg(test)]
+mod pairing_tests {
+    use super::*;
+    use crate::corekv::{Reader, Writer};
+    use std::time::Duration;
+
+    /// Open a store on a plain OS thread so no tokio runtime is present:
+    /// `group_commit` stays `None` and commits take the direct
+    /// spawn_blocking path, which no runtime-opened store ever exercises.
+    fn open_without_group_commit(path: std::path::PathBuf) -> RedbStore {
+        std::thread::spawn(move || RedbStore::open(path).unwrap())
+            .join()
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn direct_commit_path_applies_writes_and_detects_conflicts() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let store = Arc::new(open_without_group_commit(
+            temp_dir.path().join("direct.redb"),
+        ));
+        assert!(store.group_commit.is_none(), "expected direct commit path");
+        let key = b"direct-key".to_vec();
+
+        // Two snapshots at version 0; the first commit wins, the second
+        // must hit the write-write conflict through the direct path.
+        let mut winner = store.new_txn(false).await.unwrap();
+        winner.set(&key, b"winner").await.unwrap();
+        let mut loser = store.new_txn(false).await.unwrap();
+        loser.set(&key, b"loser").await.unwrap();
+
+        winner.commit().await.unwrap();
+        let err = loser.commit().await.unwrap_err();
+        assert!(err.is_txn_conflict(), "expected TxnConflict, got: {err}");
+
+        let reader = store.new_txn(true).await.unwrap();
+        assert_eq!(reader.get(&key).await.unwrap(), Some(b"winner".to_vec()));
+    }
+
+    #[tokio::test]
+    async fn readonly_txn_skips_commit_gate() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let store = Arc::new(RedbStore::open(temp_dir.path().join("gate.redb")).unwrap());
+        let gate = Arc::clone(&store.commit_gate);
+        let commit_guard = gate.write().await;
+
+        // A read-only transaction must not queue behind an in-flight commit.
+        let readonly = tokio::time::timeout(Duration::from_secs(1), store.new_txn(true))
+            .await
+            .expect("read-only transaction blocked behind the commit gate")
+            .expect("read-only transaction failed");
+        drop(readonly);
+
+        // Writers still pair version and snapshot behind the gate.
+        let writer_store = Arc::clone(&store);
+        let mut writer_task = tokio::spawn(async move { writer_store.new_txn(false).await });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), &mut writer_task)
+                .await
+                .is_err(),
+            "write transaction skipped the commit gate"
+        );
+
+        drop(commit_guard);
+        tokio::time::timeout(Duration::from_secs(1), writer_task)
+            .await
+            .expect("write transaction remained blocked after gate release")
+            .expect("writer task panicked")
+            .expect("write transaction failed");
     }
 }

--- a/crates/storage/src/backends/redb/transaction.rs
+++ b/crates/storage/src/backends/redb/transaction.rs
@@ -380,51 +380,62 @@ impl Txn for RedbTxn {
             let write_result = tokio::task::spawn_blocking(move || -> Result<()> {
                 let _conflict_snapshot = conflict_snapshot;
                 let _commit_guard = commit_gate.blocking_write();
-                conflict_tracker.check_and_record(read_version, pending.keys(), &read_set)?;
+                let version =
+                    conflict_tracker.check_and_record(read_version, pending.keys(), &read_set)?;
+                // Unrecords on error or panic before the write lands, so no
+                // phantom write-set survives a failed commit.
+                let record_guard =
+                    crate::backends::shared::RecordGuard::new(&conflict_tracker, version);
 
-                let mut write_txn = db.begin_write().map_err(|e| {
-                    tracing::error!(error = %e, pending_changes = pending.len(),
-                        "Failed to begin write transaction during commit");
-                    Error::from(e)
-                })?;
-
-                write_txn.set_durability(match durability {
-                    DurabilityMode::Immediate => redb::Durability::Immediate,
-                    DurabilityMode::Eventual => redb::Durability::Eventual,
-                });
-
-                {
-                    let mut table = write_txn.open_table(KV_TABLE).map_err(|e| {
-                        tracing::error!(error = %e, "Failed to open KV table during commit");
+                let write = || -> Result<()> {
+                    let mut write_txn = db.begin_write().map_err(|e| {
+                        tracing::error!(error = %e, pending_changes = pending.len(),
+                            "Failed to begin write transaction during commit");
                         Error::from(e)
                     })?;
 
-                    for (key, value) in pending.iter() {
-                        match value {
-                            Some(v) => {
-                                if let Err(e) = table.insert(key.as_slice(), v.as_slice()) {
-                                    tracing::error!(error = %e, key_len = key.len(),
-                                        value_len = v.len(), "Failed to insert key during commit");
-                                    return Err(e.into());
+                    write_txn.set_durability(match durability {
+                        DurabilityMode::Immediate => redb::Durability::Immediate,
+                        DurabilityMode::Eventual => redb::Durability::Eventual,
+                    });
+
+                    {
+                        let mut table = write_txn.open_table(KV_TABLE).map_err(|e| {
+                            tracing::error!(error = %e, "Failed to open KV table during commit");
+                            Error::from(e)
+                        })?;
+
+                        for (key, value) in pending.iter() {
+                            match value {
+                                Some(v) => {
+                                    if let Err(e) = table.insert(key.as_slice(), v.as_slice()) {
+                                        tracing::error!(error = %e, key_len = key.len(),
+                                            value_len = v.len(), "Failed to insert key during commit");
+                                        return Err(e.into());
+                                    }
                                 }
-                            }
-                            None => {
-                                if let Err(e) = table.remove(key.as_slice()) {
-                                    tracing::error!(error = %e, key_len = key.len(),
-                                        "Failed to delete key during commit");
-                                    return Err(e.into());
+                                None => {
+                                    if let Err(e) = table.remove(key.as_slice()) {
+                                        tracing::error!(error = %e, key_len = key.len(),
+                                            "Failed to delete key during commit");
+                                        return Err(e.into());
+                                    }
                                 }
                             }
                         }
                     }
-                }
 
-                if let Err(e) = write_txn.commit() {
-                    tracing::error!(error = %e, pending_changes = pending.len(),
-                        "Failed to finalize commit");
-                    return Err(e.into());
-                }
+                    if let Err(e) = write_txn.commit() {
+                        tracing::error!(error = %e, pending_changes = pending.len(),
+                            "Failed to finalize commit");
+                        return Err(e.into());
+                    }
 
+                    Ok(())
+                };
+
+                write()?;
+                record_guard.defuse();
                 Ok(())
             })
             .await;

--- a/crates/storage/src/backends/rocksdb/store.rs
+++ b/crates/storage/src/backends/rocksdb/store.rs
@@ -171,8 +171,15 @@ impl Store for RocksDbStore {
         let mut guard = NewTxnGuard(&self.active_txn_count, false);
 
         // Pair the conflict version and RocksDB snapshot without a commit
-        // becoming visible between them.
-        let _commit_guard = self.commit_gate.read().await;
+        // becoming visible between them. Read-only transactions skip the
+        // gate: they never conflict-check, and commit() only returns to its
+        // caller after the physical write, so read-your-committed-writes
+        // holds without serializing readers behind in-flight commits.
+        let _commit_guard = if readonly {
+            None
+        } else {
+            Some(self.commit_gate.read().await)
+        };
         let txn = RocksDbTxn::new(
             Arc::clone(&self.db),
             Arc::clone(&self.conflict_tracker),
@@ -337,6 +344,84 @@ mod tests {
             .expect("commit task panicked")
             .expect("commit failed");
         assert_eq!(store.db.get(&key).unwrap(), Some(b"committed".to_vec()));
+    }
+
+    #[tokio::test]
+    async fn readonly_txn_skips_commit_gate() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let store = Arc::new(RocksDbStore::open(temp_dir.path()).unwrap());
+        let gate = Arc::clone(&store.commit_gate);
+        let commit_guard = gate.write().await;
+
+        // A read-only transaction must not queue behind an in-flight commit.
+        let readonly = tokio::time::timeout(Duration::from_secs(1), store.new_txn(true))
+            .await
+            .expect("read-only transaction blocked behind the commit gate")
+            .expect("read-only transaction failed");
+        drop(readonly);
+
+        // Writers still pair version and snapshot behind the gate.
+        let writer_store = Arc::clone(&store);
+        let mut writer_task = tokio::spawn(async move { writer_store.new_txn(false).await });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), &mut writer_task)
+                .await
+                .is_err(),
+            "write transaction skipped the commit gate"
+        );
+
+        drop(commit_guard);
+        tokio::time::timeout(Duration::from_secs(1), writer_task)
+            .await
+            .expect("write transaction remained blocked after gate release")
+            .expect("writer task panicked")
+            .expect("write transaction failed");
+    }
+
+    #[tokio::test]
+    async fn cancelled_commit_still_conflict_checks_against_pinned_records() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let store = Arc::new(RocksDbStore::open(temp_dir.path()).unwrap());
+        let key = b"contended-key".to_vec();
+
+        // Txn A snapshots at version 0 and stages a write to `key`.
+        let mut txn_a = store.new_txn(false).await.unwrap();
+        txn_a.set(&key, b"stale-A").await.unwrap();
+
+        // Txn B commits a write to the same key -> version 1 recorded.
+        let mut txn_b = store.new_txn(false).await.unwrap();
+        txn_b.set(&key, b"committed-B").await.unwrap();
+        txn_b.commit().await.unwrap();
+        assert_eq!(store.db.get(&key).unwrap(), Some(b"committed-B".to_vec()));
+
+        // Hold the gate so A's blocking commit task parks at blocking_write.
+        let gate = Arc::clone(&store.commit_gate);
+        let commit_guard = gate.write().await;
+
+        let commit_task = tokio::spawn(async move { txn_a.commit().await });
+        // Let the commit future run its first poll (dispatch spawn_blocking).
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Cancel the commit future while the blocking thread waits for the
+        // gate. A's ConflictSnapshot moved into the closure, so B's record
+        // must stay pinned for the detached conflict check.
+        commit_task.abort();
+        let join = commit_task.await;
+        assert!(join.is_err(), "commit task should have been aborted");
+
+        // Release the gate; the detached blocking thread (queued ahead of
+        // us) runs check_and_record + physical write, so reacquiring the
+        // gate sequences after its completion.
+        drop(commit_guard);
+        drop(gate.write().await);
+
+        // Correct SSI behavior: A conflicts with B (same key, B committed
+        // after A's snapshot) so B's value must survive.
+        assert_eq!(
+            store.db.get(&key).unwrap(),
+            Some(b"committed-B".to_vec()),
+            "cancelled commit overwrote a conflicting committed write"
+        );
     }
 
     #[tokio::test]

--- a/crates/storage/src/backends/rocksdb/transaction.rs
+++ b/crates/storage/src/backends/rocksdb/transaction.rs
@@ -377,7 +377,7 @@ impl Writer for RocksDbTxn {
 
 #[async_trait]
 impl Txn for RocksDbTxn {
-    async fn commit(self: Box<Self>) -> Result<()> {
+    async fn commit(mut self: Box<Self>) -> Result<()> {
         if self.discarded.load(Ordering::Acquire) {
             tracing::warn!("Attempted to commit a discarded transaction");
             CallbackManager::execute_callbacks(self.callbacks.take_error());
@@ -394,46 +394,75 @@ impl Txn for RocksDbTxn {
         let read_set = self.read_set.lock().clone();
 
         if !pending.is_empty() {
+            let pending_changes = pending.len();
+
             // Keep the logical conflict version and physical RocksDB commit
-            // atomic with respect to new transaction snapshots. Without this,
-            // a transaction can observe the advanced conflict version while
-            // taking a RocksDB snapshot from before the corresponding write.
-            let commit_guard = self.commit_gate.write().await;
+            // atomic with respect to new transaction snapshots. The gate is
+            // acquired inside spawn_blocking (redb precedent): the blocking
+            // thread owns the guard, so cancelling the commit future cannot
+            // release the gate while the write is still in flight, and the
+            // fsync (WriteOptions::set_sync) no longer blocks a tokio worker.
+            // The conflict snapshot moves into the closure with it: if the
+            // future is dropped mid-await, the snapshot must keep pinning the
+            // records this commit conflict-checks against, or prune() could
+            // empty the history before check_and_record runs. The tradeoff:
+            // a cancelled future can leave a durable commit whose success
+            // callbacks never ran (same as redb's direct path).
+            let db = Arc::clone(&self.db);
+            let conflict_tracker = Arc::clone(&self.conflict_tracker);
+            let commit_gate = Arc::clone(&self.commit_gate);
+            let read_version = self.read_version;
+            let durability = self.durability;
+            let conflict_snapshot = self._conflict_snapshot.take();
 
-            // Apply via WriteBatch
-            let mut batch = rocksdb::WriteBatchWithTransaction::<true>::default();
-            for (key, value) in &pending {
-                match value {
-                    Some(v) => batch.put(key, v),
-                    None => batch.delete(key),
-                }
-            }
+            let write_result = tokio::task::spawn_blocking(move || -> Result<()> {
+                let _conflict_snapshot = conflict_snapshot;
+                let _commit_guard = commit_gate.blocking_write();
+                let version =
+                    conflict_tracker.check_and_record(read_version, pending.keys(), &read_set)?;
+                // Unrecords on error or panic before the write lands, so no
+                // phantom write-set survives a failed commit.
+                let record_guard =
+                    crate::backends::shared::RecordGuard::new(&conflict_tracker, version);
 
-            let mut write_opts = rocksdb::WriteOptions::default();
-            match self.durability {
-                DurabilityMode::Immediate => {
-                    write_opts.set_sync(true);
+                let mut batch = rocksdb::WriteBatchWithTransaction::<true>::default();
+                for (key, value) in &pending {
+                    match value {
+                        Some(v) => batch.put(key, v),
+                        None => batch.delete(key),
+                    }
                 }
-                DurabilityMode::Eventual => {
-                    write_opts.set_sync(false);
-                }
-            }
 
-            let commit_result = match self.conflict_tracker.check_and_record(
-                self.read_version,
-                pending.keys(),
-                &read_set,
-            ) {
-                Ok(()) => self.db.write_opt(batch, &write_opts).map_err(Error::from),
-                Err(error) => Err(error),
+                let mut write_opts = rocksdb::WriteOptions::default();
+                match durability {
+                    DurabilityMode::Immediate => {
+                        write_opts.set_sync(true);
+                    }
+                    DurabilityMode::Eventual => {
+                        write_opts.set_sync(false);
+                    }
+                }
+
+                db.write_opt(batch, &write_opts)?;
+                record_guard.defuse();
+                Ok(())
+            })
+            .await;
+
+            let commit_result = match write_result {
+                Ok(result) => result,
+                Err(join_err) => Err(Error::Other(if join_err.is_panic() {
+                    format!("commit task panicked: {join_err}")
+                } else {
+                    format!("commit task cancelled: {join_err}")
+                })),
             };
-            drop(commit_guard);
 
             if let Err(e) = commit_result {
                 if !matches!(e, Error::TxnConflict) {
                     tracing::error!(
                         error = %e,
-                        pending_changes = pending.len(),
+                        pending_changes,
                         "Failed to commit RocksDB batch"
                     );
                 }

--- a/crates/storage/src/backends/shared.rs
+++ b/crates/storage/src/backends/shared.rs
@@ -403,6 +403,16 @@ impl ConflictTracker {
     /// record. A version already pruned (or 0) is a no-op; the version
     /// counter keeps its gap, which `committed_after` tolerates.
     /// Prefer [`RecordGuard`], which also covers unwinds.
+    ///
+    /// Only compiled for backends with fallible physical writes; the
+    /// memory backend's writes cannot fail after the conflict check.
+    #[cfg(any(
+        test,
+        feature = "redb",
+        feature = "fjall",
+        feature = "rocksdb",
+        feature = "lark"
+    ))]
     pub(crate) fn unrecord(&self, version: u64) {
         if version == 0 {
             return;
@@ -424,14 +434,32 @@ impl ConflictTracker {
 /// panics during the write into an `unrecord`, so no phantom write-set can
 /// survive a failed commit. Hold it (and drop/defuse it) while the commit
 /// gate is still held.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    any(
+        test,
+        feature = "redb",
+        feature = "fjall",
+        feature = "rocksdb",
+        feature = "lark"
+    )
+))]
 pub(crate) struct RecordGuard<'t> {
     tracker: &'t ConflictTracker,
     version: u64,
     defused: bool,
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    any(
+        test,
+        feature = "redb",
+        feature = "fjall",
+        feature = "rocksdb",
+        feature = "lark"
+    )
+))]
 impl<'t> RecordGuard<'t> {
     pub(crate) fn new(tracker: &'t ConflictTracker, version: u64) -> Self {
         Self {
@@ -447,7 +475,16 @@ impl<'t> RecordGuard<'t> {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    any(
+        test,
+        feature = "redb",
+        feature = "fjall",
+        feature = "rocksdb",
+        feature = "lark"
+    )
+))]
 impl Drop for RecordGuard<'_> {
     fn drop(&mut self) {
         if !self.defused {

--- a/crates/storage/src/backends/shared.rs
+++ b/crates/storage/src/backends/shared.rs
@@ -348,16 +348,20 @@ impl ConflictTracker {
 
     /// Check for conflicts and record the read/write set if no conflict.
     /// Returns Err(TxnConflict) if the transaction conflicts with any
-    /// transaction that committed after `read_version`.
+    /// transaction that committed after `read_version`; otherwise returns the
+    /// recorded commit version (0 when the write set is empty and nothing was
+    /// recorded). If the physical write backing this record subsequently
+    /// fails, the caller must `unrecord` the returned version while still
+    /// holding the store's commit gate.
     pub(crate) fn check_and_record<'a>(
         &self,
         read_version: u64,
         write_keys: impl Iterator<Item = &'a Vec<u8>>,
         read_set: &ReadSet,
-    ) -> std::result::Result<(), crate::corekv::Error> {
+    ) -> std::result::Result<u64, crate::corekv::Error> {
         let write_keys: Vec<&Vec<u8>> = write_keys.collect();
         if write_keys.is_empty() {
-            return Ok(());
+            return Ok(0);
         }
 
         let mut state = self.state.lock();
@@ -387,7 +391,68 @@ impl ConflictTracker {
             .push((new_version, write_set, read_set.clone()));
         state.prune(new_version);
 
-        Ok(())
+        Ok(new_version)
+    }
+
+    /// Remove the record for `version` after its physical write failed.
+    ///
+    /// Without this, the recorded write-set describes data that never landed
+    /// and later writers get phantom `TxnConflict` errors against it. Must be
+    /// called while still holding the commit gate that covered the failed
+    /// `check_and_record`, so no other committer can observe the phantom
+    /// record. A version already pruned (or 0) is a no-op; the version
+    /// counter keeps its gap, which `committed_after` tolerates.
+    /// Prefer [`RecordGuard`], which also covers unwinds.
+    pub(crate) fn unrecord(&self, version: u64) {
+        if version == 0 {
+            return;
+        }
+        let mut state = self.state.lock();
+        if let Ok(index) = state
+            .committed
+            .binary_search_by_key(&version, |(v, _, _)| *v)
+        {
+            state.committed.remove(index);
+        }
+    }
+}
+
+/// Rolls back a `check_and_record` entry unless defused.
+///
+/// Armed right after a successful `check_and_record` and defused only once
+/// the physical write has succeeded, it converts BOTH error returns and
+/// panics during the write into an `unrecord`, so no phantom write-set can
+/// survive a failed commit. Hold it (and drop/defuse it) while the commit
+/// gate is still held.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) struct RecordGuard<'t> {
+    tracker: &'t ConflictTracker,
+    version: u64,
+    defused: bool,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl<'t> RecordGuard<'t> {
+    pub(crate) fn new(tracker: &'t ConflictTracker, version: u64) -> Self {
+        Self {
+            tracker,
+            version,
+            defused: false,
+        }
+    }
+
+    /// The physical write succeeded; keep the record.
+    pub(crate) fn defuse(mut self) {
+        self.defused = true;
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl Drop for RecordGuard<'_> {
+    fn drop(&mut self) {
+        if !self.defused {
+            self.tracker.unrecord(self.version);
+        }
     }
 }
 
@@ -473,6 +538,126 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(err, crate::corekv::Error::TxnConflict));
+    }
+
+    #[test]
+    fn unrecord_removes_phantom_record() {
+        let tracker = Arc::new(ConflictTracker::new());
+        let first_snapshot = tracker.begin_snapshot();
+        let second_snapshot = tracker.begin_snapshot();
+
+        let writes = [b"d/i/books/failed-write".to_vec()];
+        let version = tracker
+            .check_and_record(first_snapshot.version(), writes.iter(), &ReadSet::default())
+            .unwrap();
+        drop(first_snapshot);
+
+        // Simulate the physical write failing: without unrecord the second
+        // transaction would hit a phantom conflict against data that never
+        // landed.
+        tracker.unrecord(version);
+
+        tracker
+            .check_and_record(
+                second_snapshot.version(),
+                writes.iter(),
+                &ReadSet::default(),
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn unrecord_tolerates_pruned_and_empty_versions() {
+        let tracker = Arc::new(ConflictTracker::new());
+
+        // Version 0 marks "nothing recorded" (empty write set).
+        let empty_version = tracker
+            .check_and_record(0, [].iter(), &ReadSet::default())
+            .unwrap();
+        assert_eq!(empty_version, 0);
+        tracker.unrecord(empty_version);
+
+        // A record pruned before unrecord (no active snapshots pin it) is
+        // silently gone; unrecord must not panic or disturb later commits.
+        let snapshot = tracker.begin_snapshot();
+        let writes = [b"d/i/books/pruned".to_vec()];
+        let version = tracker
+            .check_and_record(snapshot.version(), writes.iter(), &ReadSet::default())
+            .unwrap();
+        drop(snapshot);
+        tracker.unrecord(version);
+        tracker.unrecord(version);
+
+        let survivor = tracker.begin_snapshot();
+        tracker
+            .check_and_record(survivor.version(), writes.iter(), &ReadSet::default())
+            .unwrap();
+    }
+
+    #[test]
+    fn record_guard_unrecords_on_drop() {
+        let tracker = Arc::new(ConflictTracker::new());
+        let loser_snapshot = tracker.begin_snapshot();
+        let writes = [b"d/i/books/guarded".to_vec()];
+
+        let version = tracker
+            .check_and_record(
+                tracker.current_version(),
+                writes.iter(),
+                &ReadSet::default(),
+            )
+            .unwrap();
+        drop(RecordGuard::new(&tracker, version));
+
+        // The dropped (armed) guard removed the record: no phantom conflict.
+        tracker
+            .check_and_record(loser_snapshot.version(), writes.iter(), &ReadSet::default())
+            .unwrap();
+    }
+
+    #[test]
+    fn record_guard_defuse_keeps_record() {
+        let tracker = Arc::new(ConflictTracker::new());
+        let loser_snapshot = tracker.begin_snapshot();
+        let writes = [b"d/i/books/kept".to_vec()];
+
+        let version = tracker
+            .check_and_record(
+                tracker.current_version(),
+                writes.iter(),
+                &ReadSet::default(),
+            )
+            .unwrap();
+        RecordGuard::new(&tracker, version).defuse();
+
+        let err = tracker
+            .check_and_record(loser_snapshot.version(), writes.iter(), &ReadSet::default())
+            .unwrap_err();
+        assert!(matches!(err, crate::corekv::Error::TxnConflict));
+    }
+
+    #[test]
+    fn record_guard_unrecords_on_panic() {
+        let tracker = Arc::new(ConflictTracker::new());
+        let loser_snapshot = tracker.begin_snapshot();
+        let writes = [b"d/i/books/panicked".to_vec()];
+
+        let version = tracker
+            .check_and_record(
+                tracker.current_version(),
+                writes.iter(),
+                &ReadSet::default(),
+            )
+            .unwrap();
+        let unwound = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = RecordGuard::new(&tracker, version);
+            panic!("physical write panicked");
+        }));
+        assert!(unwound.is_err());
+
+        tracker
+            .check_and_record(loser_snapshot.version(), writes.iter(), &ReadSet::default())
+            .unwrap();
     }
 
     #[test]


### PR DESCRIPTION
Closes #1182, closes #1179, closes #1178.

Three commit-gate fixes in one change, since they all live in the same gated commit sequence:

**#1182 — read-only transactions skip the commit gate.** The gate pairs conflict versions with writer snapshots; readers never conflict-check, and `commit()` only returns after the physical write, so read-your-committed-writes holds without queueing readers behind in-flight commits. Under concurrent write load this is the difference between 1.5ms and 20s+ reads. Exception: **lark keeps the gate for readers** — lark_kv publishes `latest_seq` *before* applying batch ops to the memtable (`apply_batch_locked`), so an ungated snapshot could claim visibility of sequence numbers whose data hasn't landed. fjall/rocksdb/redb all publish after applying (verified in their sources). Documented in `lark/store.rs` with a pinning test; follow-up issue to fix upstream and lift the exception.

**#1178 — gated commits run on blocking threads.** rocksdb, fjall, lark, and the redb *group flush* (its default path) now run gate acquisition + conflict check + physical write inside `spawn_blocking`, mirroring redb's direct path. The gate is taken with `blocking_write()` *inside* the closure and the txn's `ConflictSnapshot` moves in with it — so a cancelled commit future can neither release the gate mid-write nor unpin the conflict history the detached check still needs (a cancelled future dropping the snapshot would let `prune()` empty the records the commit must conflict-check against). Pinned by `cancelled_commit_still_conflict_checks_against_pinned_records` on rocksdb and fjall.

**#1179 — no phantom conflict records.** `check_and_record` now returns the recorded version and a `RecordGuard` rolls the record back if the physical write errors *or panics*, so failed commits stop leaving write-sets that surface as `TxnConflict` against data that never landed. The redb group flush rolls back per-commit on batch failure. Exception: **lark does not roll back** — a lark batch can be WAL-durable and memtable-visible and *then* fail (`rotate_memtable` on the same call), so errors are indeterminate; keeping the record risks a spurious retry, dropping it risks a missed conflict against landed data.

Also: a panicking redb group flush now shuts the flush loop down so later commits fail fast at enqueue instead of retrying a deterministic panic forever, and the redb direct commit path (previously unreachable under any tokio test) got a dedicated conflict test via an off-runtime store.

Validation: 666 storage tests (5 backends), db/datastore suites, basic + query integration suites (24/24, 40/40), wasm32 check, clippy/fmt clean. Known tradeoff, documented in-code: a commit future cancelled mid-`spawn_blocking` leaves a durable commit whose success callbacks never ran — same behavior redb's direct path already had; follow-up issue tracks moving callbacks into the closure like the group-commit path does.
