### PR TITLE
fix(p2p): pending-DAG quota reporting + replicator retry redial

### DIFF
--- a/crates/cli/src/commands/start/server_p2p.rs
+++ b/crates/cli/src/commands/start/server_p2p.rs
@@ -14,6 +14,35 @@ use p2p::P2PTransport;
 type WireDocumentAcp = Option<Box<dyn FnOnce(Arc<dyn acp::DocumentACP>)>>;
 type WireKms = Option<Box<dyn FnOnce(Arc<dyn kms::KmsService>) + Send>>;
 
+/// Redial a replicator target that dropped, using its stored addresses, so a
+/// stalled connection cannot strand the peer's persisted retry ledger after
+/// the target restarts (the connectivity gate below would otherwise skip it
+/// forever, while nothing else redials it).
+async fn redial_replicator<S: storage::corekv::Store>(
+    peerstore: &storage::stores::Peerstore<S>,
+    handle: &p2p::P2PHostHandle,
+    peer_id_str: &str,
+    peer_id: libp2p::PeerId,
+) {
+    let Ok(Some(bytes)) = peerstore.get_replicator(peer_id_str).await else {
+        return;
+    };
+    let Ok(info) = p2p::ReplicatorInfo::from_bytes(&bytes) else {
+        return;
+    };
+    let addrs: Vec<libp2p::Multiaddr> = info
+        .addresses
+        .iter()
+        .filter_map(|addr| addr.parse().ok())
+        .collect();
+    if addrs.is_empty() {
+        return;
+    }
+    if let Err(error) = handle.dial(peer_id, addrs).await {
+        tracing::debug!(peer_id = %peer_id, %error, "replicator retry redial failed");
+    }
+}
+
 async fn set_persisted_replicator_status<S: storage::corekv::Store>(
     peerstore: &storage::stores::Peerstore<S>,
     peer_id: &str,
@@ -618,6 +647,7 @@ impl Node {
                     };
                     let connected = retry_handle.connected_peers().await.unwrap_or_default();
                     if !connected.contains(&peer_id) {
+                        redial_replicator(&peerstore, &retry_handle, &peer_id_str, peer_id).await;
                         continue;
                     }
                     let mut docs = match peerstore.get_retry_documents(&peer_id_str).await {

--- a/crates/embedded/src/node_tasks.rs
+++ b/crates/embedded/src/node_tasks.rs
@@ -496,6 +496,33 @@ pub(crate) fn spawn_failure_recorder<S: storage::corekv::Store + 'static>(
 /// regenerate/re-push their SE artifacts to each connected replicator with due
 /// (or, when `force`, any) retries. Shared by the background ticker loop and the
 /// on-demand `p2p_retry_replicators` FFI trigger.
+/// Redial a replicator target that dropped, using its stored addresses, so a
+/// stalled connection cannot strand the peer's persisted retry ledger.
+async fn redial_replicator<S: storage::corekv::Store>(
+    peerstore: &storage::stores::Peerstore<S>,
+    handle: &p2p::P2PHostHandle,
+    peer_id_str: &str,
+    peer_id: libp2p::PeerId,
+) {
+    let Ok(Some(bytes)) = peerstore.get_replicator(peer_id_str).await else {
+        return;
+    };
+    let Ok(info) = p2p::ReplicatorInfo::from_bytes(&bytes) else {
+        return;
+    };
+    let addrs: Vec<libp2p::Multiaddr> = info
+        .addresses
+        .iter()
+        .filter_map(|addr| addr.parse().ok())
+        .collect();
+    if addrs.is_empty() {
+        return;
+    }
+    if let Err(error) = handle.dial(peer_id, addrs).await {
+        tracing::debug!(peer_id = %peer_id, %error, "replicator retry redial failed");
+    }
+}
+
 pub(crate) async fn run_libp2p_retry_pass<S: storage::corekv::Store + 'static>(
     store: &Arc<S>,
     handle: &p2p::P2PHostHandle,
@@ -527,6 +554,12 @@ pub(crate) async fn run_libp2p_retry_pass<S: storage::corekv::Store + 'static>(
 
         let connected = handle.connected_peers().await.unwrap_or_default();
         if !connected.contains(&peer_id) {
+            // Nothing else redials a replicator target once it restarts, so
+            // without this the peer's entire persisted retry ledger stalls
+            // forever behind the connectivity gate (the iroh path dials on
+            // demand instead). Redial from the stored replicator addresses;
+            // a later pass drains the ledger once the connection is back.
+            redial_replicator(&peerstore, handle, &peer_id_str, peer_id).await;
             continue;
         }
 

--- a/crates/p2p/src/sync/manager/process/pending_dag.rs
+++ b/crates/p2p/src/sync/manager/process/pending_dag.rs
@@ -20,6 +20,16 @@ use super::SyncManager;
 /// one quarter of the global pending-DAG capacity.
 const PENDING_DAG_PEER_CAPACITY_DIVISOR: usize = 4;
 
+/// Outcome of admitting a pending-DAG registration into the in-memory map.
+///
+/// The rejection variants carry the limit that tripped so the caller's nack
+/// reports the number the operator will see in logs (global vs per-peer).
+pub(super) enum PendingDagAdmission {
+    Admitted,
+    GlobalCapacity,
+    PeerQuota { max_per_peer: usize },
+}
+
 #[derive(Debug, Clone)]
 pub struct PendingDagFetchFailure {
     pub doc_id: String,
@@ -241,12 +251,26 @@ impl<B: Blockstore + 'static> SyncManager<B> {
     /// durable record survives (the recovery obligation is discharged solely
     /// by a successful merge) and is re-driven by restart or the durable
     /// resync sweep.
+    /// Admit a registration into the in-memory map, reporting `true` on
+    /// success. Callers that need to distinguish the failing limit (to nack
+    /// with the right number) use [`Self::try_insert_pending_dag`].
     pub(super) fn insert_pending_dag(&self, root_cid: Cid, dag: PendingDag) -> bool {
+        matches!(
+            self.try_insert_pending_dag(root_cid, dag),
+            PendingDagAdmission::Admitted
+        )
+    }
+
+    pub(super) fn try_insert_pending_dag(
+        &self,
+        root_cid: Cid,
+        dag: PendingDag,
+    ) -> PendingDagAdmission {
         let mut pending = self.pending_dags.write();
         evict_expired_pending_dags(&mut pending, Instant::now());
 
         if pending.len() >= self.max_pending_dags && !pending.contains_key(&root_cid) {
-            return false;
+            return PendingDagAdmission::GlobalCapacity;
         }
 
         if let Some(source_peer) = dag.source_peer.as_deref() {
@@ -257,12 +281,12 @@ impl<B: Blockstore + 'static> SyncManager<B> {
             if existing_source != Some(source_peer)
                 && pending.source_count(source_peer) >= max_per_peer
             {
-                return false;
+                return PendingDagAdmission::PeerQuota { max_per_peer };
             }
         }
 
         pending.insert(root_cid, dag);
-        true
+        PendingDagAdmission::Admitted
     }
 
     fn update_pending_dag_missing_if_current(
@@ -348,104 +372,6 @@ impl<B: Blockstore + 'static> SyncManager<B> {
             }
         }
         claimed
-    }
-
-    /// Register a pending DAG for DocSync.
-    ///
-    /// This is called when a DocSyncReply contains head CIDs that need to be
-    /// fetched via Bitswap. Unlike PushLog-initiated syncs, DocSync doesn't
-    /// have collection_id or creator in the message, so we use empty strings.
-    /// The merge handler will extract the actual metadata from the block data.
-    ///
-    /// # Arguments
-    ///
-    /// * `root_cid` - The head CID to fetch
-    /// * `doc_id` - Document ID from the DocSyncItem
-    pub fn register_docsync_dag(&self, root_cid: Cid, doc_id: String, source_peer: String) {
-        tracing::debug!(
-            cid = %root_cid,
-            doc_id = %doc_id,
-            source_peer = %source_peer,
-            "Registering DocSync pending DAG"
-        );
-
-        if !self.insert_pending_dag(
-            root_cid,
-            PendingDag {
-                doc_id: doc_id.clone(),
-                // DocSync protocol doesn't include collection_id or creator.
-                // The merge handler will extract these from the block data.
-                collection_id: String::new(),
-                creator: String::new(),
-                missing: std::iter::once(root_cid).collect(),
-                source_peer: Some(source_peer.clone()),
-                is_explicit_replicator: false,
-                explicit_replay_authorization: None,
-                is_recovery_registered: false,
-                inserted_at: Instant::now(),
-                attempts: 0,
-                fetch_failures: 0,
-                last_fetch_error: None,
-                next_retry_at: tokio::time::Instant::now(),
-                dispatches: 0,
-            },
-        ) {
-            tracing::warn!(
-                cid = %root_cid,
-                doc_id = %doc_id,
-                source_peer = %source_peer,
-                max = self.max_pending_dags,
-                max_per_peer = self.max_pending_dags_per_peer(),
-                "Pending DAGs at capacity, dropping DocSync registration"
-            );
-        }
-    }
-
-    /// Register a pending DAG for branchable collection sync.
-    ///
-    /// Unlike `register_docsync_dag` which stores the document ID,
-    /// this stores the collection ID so the merge handler can look up
-    /// the local collection for cross-schema-version merges.
-    pub fn register_branchable_dag(
-        &self,
-        root_cid: Cid,
-        collection_id: String,
-        source_peer: String,
-    ) {
-        tracing::debug!(
-            cid = %root_cid,
-            collection_id = %collection_id,
-            "Registering branchable sync pending DAG"
-        );
-
-        if !self.insert_pending_dag(
-            root_cid,
-            PendingDag {
-                doc_id: String::new(),
-                collection_id: collection_id.clone(),
-                creator: String::new(),
-                missing: std::iter::once(root_cid).collect(),
-                source_peer: Some(source_peer.clone()),
-                is_explicit_replicator: false,
-                explicit_replay_authorization: None,
-                is_recovery_registered: false,
-                inserted_at: Instant::now(),
-                attempts: 0,
-                fetch_failures: 0,
-                last_fetch_error: None,
-                next_retry_at: tokio::time::Instant::now(),
-                dispatches: 0,
-            },
-        ) {
-            tracing::warn!(
-                cid = %root_cid,
-                collection_id = %collection_id,
-                source_peer = %source_peer,
-                max = self.max_pending_dags,
-                max_per_peer = self.max_pending_dags_per_peer(),
-                "Pending DAGs at capacity, dropping branchable DAG registration"
-            );
-        }
     }
 
     /// Process a pending DAG after Bitswap blocks have been received.

--- a/crates/p2p/src/sync/manager/process/pushlog.rs
+++ b/crates/p2p/src/sync/manager/process/pushlog.rs
@@ -332,7 +332,8 @@ impl<B: Blockstore + 'static> SyncManager<B> {
             // Track this DAG as pending (enforces TTL eviction and capacity limit).
             let inserted_at = Instant::now();
             {
-                let inserted = self.insert_pending_dag(
+                use super::pending_dag::PendingDagAdmission;
+                let admission = self.try_insert_pending_dag(
                     *cid,
                     PendingDag {
                         doc_id: msg.doc_id.clone(),
@@ -351,7 +352,14 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                         dispatches: 0,
                     },
                 );
-                if !inserted {
+                // Report the limit that actually tripped so the nack and its
+                // WARN log agree (the global cap vs the smaller per-peer quota).
+                let rejected_max = match admission {
+                    PendingDagAdmission::Admitted => None,
+                    PendingDagAdmission::GlobalCapacity => Some(self.max_pending_dags),
+                    PendingDagAdmission::PeerQuota { max_per_peer } => Some(max_per_peer),
+                };
+                if let Some(max) = rejected_max {
                     self.diagnostics.record_pending_dag_capacity_shed();
                     // The block is stored but its DAG completion is not
                     // tracked. This must surface as an error: a success reply
@@ -364,13 +372,11 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                         collection_id = %msg.collection_id,
                         source_peer = ?sender_peer,
                         missing_count = missing.len(),
-                        max = self.max_pending_dags,
+                        max,
                         max_per_peer = self.max_pending_dags_per_peer(),
                         "Pending DAGs at capacity, rejecting PushLog DAG registration"
                     );
-                    return Err(Error::PendingDagCapacity {
-                        max: self.max_pending_dags,
-                    });
+                    return Err(Error::PendingDagCapacity { max });
                 }
             }
 

--- a/tools/integration-test/Cargo.toml
+++ b/tools/integration-test/Cargo.toml
@@ -35,6 +35,10 @@ name = "p2p_admission_restart"
 path = "tests/p2p_admission_restart.rs"
 
 [[test]]
+name = "p2p_admission_fairness"
+path = "tests/p2p_admission_fairness.rs"
+
+[[test]]
 name = "p2p_backlog"
 path = "tests/p2p_backlog.rs"
 

--- a/tools/integration-test/tests/p2p_admission_fairness.rs
+++ b/tools/integration-test/tests/p2p_admission_fairness.rs
@@ -1,0 +1,186 @@
+//! #1180 W2: per-source-peer pending-DAG quotas keep one noisy pusher from
+//! starving a healthy one.
+//!
+//! Own binary: injects `DEFRA_P2P_MAX_PENDING_DAGS`, inherited by every node
+//! spawned here, so it must not leak into other tests' clusters.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use integration_test::TestCluster;
+
+const SCHEMA: &str = "type User { name: String  age: Int }";
+const HEALTHY_DOCS: usize = 12;
+
+fn signal(pid: u32, signal: &str) {
+    let status = std::process::Command::new("kill")
+        .arg(signal)
+        .arg(pid.to_string())
+        .status()
+        .expect("spawn kill");
+    assert!(status.success(), "kill {signal} {pid} failed");
+}
+
+async fn pending_dags(hub_api: &str) -> u64 {
+    let Ok(response) = reqwest::get(format!("{hub_api}/api/v0/p2p/sync/status")).await else {
+        return 0;
+    };
+    response
+        .json::<serde_json::Value>()
+        .await
+        .ok()
+        .and_then(|status| status["pending_dags"].as_u64())
+        .unwrap_or(0)
+}
+
+/// With `MAX_PENDING_DAGS = 8` the per-peer quota is `max(8/4, 1) = 2`, well
+/// below the global cap. One noisy pusher floods head-only writes it never lets
+/// resolve (it is frozen), so it can occupy at most its 2-slot quota; a healthy
+/// pusher writing into the remaining slots must still land every document.
+///
+/// Anti-vacuity: only the noisy peer is active before the freeze, and the
+/// global cap (8) can never fill from a single peer capped at 2 — so any
+/// "Pending DAGs at capacity" rejection the hub logs is necessarily the
+/// per-peer quota, and the noisy peer's own backlog stays unmerged.
+#[tokio::test]
+async fn per_peer_quota_prevents_noisy_pusher_starvation() {
+    std::env::set_var("DEFRA_P2P_MAX_PENDING_DAGS", "8");
+
+    let cluster = TestCluster::builder()
+        .rust_nodes(3) // 0 = hub, 1 = noisy pusher, 2 = healthy pusher
+        .with_p2p()
+        .build()
+        .await
+        .expect("cluster start");
+
+    let startup_timeout = Duration::from_secs(30);
+    for node in 0..=2 {
+        cluster
+            .wait_for_log(node, "p2p_listening", startup_timeout)
+            .await
+            .unwrap_or_else(|e| panic!("node{node} P2P listener did not start: {e}"));
+    }
+
+    let hub = cluster.client(0);
+    let hub_info = hub.p2p_info().expect("hub p2p info");
+    let hub_addr = hub_info
+        .as_array()
+        .and_then(|arr| arr.first())
+        .and_then(|v| v.as_str())
+        .expect("hub has no P2P address")
+        .to_string();
+
+    hub.schema_add(SCHEMA).expect("hub schema");
+    for pusher in 1..=2 {
+        let client = cluster.client(pusher);
+        client.schema_add(SCHEMA).expect("pusher schema");
+        client.p2p_connect(&[&hub_addr]).expect("connect to hub");
+        client
+            .p2p_replicator_set(&["User"], &hub_addr)
+            .expect("replicator pusher -> hub");
+    }
+
+    // The noisy pusher writes continuously so several of its head-only pushes
+    // are pending on the hub at once — enough to trip its 2-slot quota.
+    let stop_noisy = Arc::new(AtomicBool::new(false));
+    let noisy_writer = {
+        let client = cluster.client(1);
+        let stop = Arc::clone(&stop_noisy);
+        std::thread::spawn(move || {
+            let mut doc = 0usize;
+            while !stop.load(Ordering::Relaxed) {
+                let mutation = format!(
+                    r#"mutation {{ add_User(input: {{name: "noisy-d{doc}", age: {doc}}}) {{ _docID }} }}"#
+                );
+                let _ = client.query(&mutation);
+                doc += 1;
+                std::thread::sleep(Duration::from_millis(10));
+            }
+        })
+    };
+
+    // Wait until the hub has actually rejected a noisy registration on the
+    // per-peer quota. Because only the noisy peer is pushing and the global cap
+    // is 8, an "at capacity" log can only be the quota tripping.
+    let hub_log = cluster.nodes[0]
+        .rootdir
+        .parent()
+        .expect("hub rootdir has a parent")
+        .join("logs/stdout.log");
+    let quota_deadline = Instant::now() + Duration::from_secs(90);
+    loop {
+        let log = std::fs::read_to_string(&hub_log).unwrap_or_default();
+        if log.contains("Pending DAGs at capacity, rejecting PushLog DAG registration") {
+            break;
+        }
+        assert!(
+            Instant::now() < quota_deadline,
+            "noisy pusher never tripped the per-peer pending-DAG quota"
+        );
+        assert!(
+            pending_dags(cluster.api_url(0)).await <= 8,
+            "global cap exceeded"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    // Freeze the noisy pusher so its quota slots stay occupied (Bitswap can no
+    // longer resolve them), then stop its writer.
+    let noisy_pid = cluster.nodes[1].process.id().expect("noisy pusher pid");
+    signal(noisy_pid, "-STOP");
+    stop_noisy.store(true, Ordering::Relaxed);
+
+    // The healthy pusher writes a fixed batch; every document must land despite
+    // the noisy peer holding its quota.
+    let healthy = cluster.client(2);
+    let mut healthy_ids = Vec::with_capacity(HEALTHY_DOCS);
+    for doc in 0..HEALTHY_DOCS {
+        let data = healthy
+            .query(&format!(
+                r#"mutation {{ add_User(input: {{name: "healthy-d{doc}", age: {doc}}}) {{ _docID }} }}"#
+            ))
+            .expect("create healthy doc");
+        healthy_ids.push(
+            data["add_User"][0]["_docID"]
+                .as_str()
+                .expect("missing _docID")
+                .to_string(),
+        );
+    }
+
+    let deadline = Instant::now() + Duration::from_secs(120);
+    loop {
+        let present: std::collections::HashSet<String> = hub
+            .query("query { User { _docID } }")
+            .ok()
+            .and_then(|result| {
+                result["User"].as_array().map(|rows| {
+                    rows.iter()
+                        .filter_map(|row| row["_docID"].as_str().map(str::to_string))
+                        .collect()
+                })
+            })
+            .unwrap_or_default();
+
+        let missing: Vec<&String> = healthy_ids
+            .iter()
+            .filter(|id| !present.contains(id.as_str()))
+            .collect();
+        if missing.is_empty() {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "{} of {} healthy-pusher documents were starved by the noisy pusher \
+             (per-peer quota not enforced): {:?}",
+            missing.len(),
+            healthy_ids.len(),
+            missing
+        );
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+
+    signal(noisy_pid, "-CONT");
+    noisy_writer.join().expect("noisy writer thread panicked");
+}


### PR DESCRIPTION
Closes #1180. Improves #1154 (kept open — see below).

### #1180 — per-source-peer pending-DAG quota follow-ups

- **Error field (#1180.2).** A per-peer-quota rejection returned `PendingDagCapacity { max: global_max }`, so the nack and its typed error read "at capacity (1000)" when the smaller per-peer quota (~250) actually tripped. `insert_pending_dag` now has a `try_insert_pending_dag` variant that returns which limit tripped, and the PushLog admission path reports that number.
- **Dead API (#1180.3).** Removed `register_docsync_dag` / `register_branchable_dag` — zero callers (real DocSync goes through the poll-based dag fetcher), and they silently dropped on quota.
- **Fairness e2e (#1180.1).** New `p2p_admission_fairness` binary: with `MAX_PENDING_DAGS=8` (per-peer quota 2), a frozen noisy pusher can hold at most its quota while a healthy pusher's writes must all land. Anti-vacuity is clean: with only the noisy peer active, the global cap can never fill from one peer, so any "at capacity" rejection is necessarily the per-peer quota. Passes in ~45–60s across runs.

### #1154 — replicator retry stalls after a target restart (partial fix, issue kept open)

Root cause: the libp2p retry pass skips any replicator peer not in `connected_peers()`, and **nothing redials a replicator target once it restarts** — so a pusher whose connection dropped keeps its entire persisted retry ledger parked behind the connectivity gate. The iroh path already dials on demand; the libp2p path did not. `redial_replicator` dials the peer's stored replicator addresses when it is absent, in both retry-loop copies (embedded + CLI).

This is a real fix — retries re-push the full DAG (immediate merge, no cap-1 bottleneck), so once the connection is re-established the ledger drains. The `hub_restart_recovers_success_acked_pending_dags` acceptance test went from **consistently losing ~744/3048 documents to full recovery (0 lost, 170s)** on a clean run.

**Why #1154 stays open:** recovery is still timing-racy. When reconnection lands, everything drains; when it doesn't, ~750 documents stall (same as before the fix). The residual is the reconnection reliability itself — a stale connection can linger after the hub dies (so the pusher pushes into a dead socket and times out instead of redialing) and the retry backoff ladder (30s→60s→120s…) races the test's 240s deadline. Fully closing #1154 needs the reconnection/expedite piece and warrants hub-log-level investigation; this PR removes the "ledger never fires at all" failure mode.

Validation: workspace `clippy --all -D warnings` + feature-gated `db`/`defra-node --features p2p` clippy clean, fmt clean, p2p unit tests green, pending-dag/pushlog tests green, fairness e2e green ×2.
