### PR TITLE
fix(storage): run commit callbacks from the commit task

### DIFF
--- a/crates/storage/src/backends/fjall/transaction.rs
+++ b/crates/storage/src/backends/fjall/transaction.rs
@@ -274,9 +274,9 @@ impl Txn for FjallTxn {
             // conflict snapshot moves into the closure with it: if the future
             // is dropped mid-await, the snapshot must keep pinning the
             // records this commit conflict-checks against, or prune() could
-            // empty the history before check_and_record runs. The tradeoff:
-            // a cancelled future can leave a durable commit whose success
-            // callbacks never ran (same as redb's direct path).
+            // empty the history before check_and_record runs. The callbacks
+            // move in for the same reason — a dropped future must not skip
+            // the events for a write that still lands (#1185).
             let db = self.db.clone();
             let keyspace = self.keyspace.clone();
             let conflict_tracker = Arc::clone(&self.conflict_tracker);
@@ -284,41 +284,68 @@ impl Txn for FjallTxn {
             let read_version = self.read_version;
             let durability = self.durability;
             let conflict_snapshot = self._conflict_snapshot.take();
+            let callbacks = crate::backends::shared::CommitCallbacks::drain(&self.callbacks);
 
-            let write_result = tokio::task::spawn_blocking(move || -> Result<()> {
-                let _conflict_snapshot = conflict_snapshot;
-                let _commit_guard = commit_gate.blocking_write();
-                let version =
-                    conflict_tracker.check_and_record(read_version, pending.keys(), &read_set)?;
-                // Unrecords on error or panic before the write lands, so no
-                // phantom write-set survives a failed commit.
-                let record_guard =
-                    crate::backends::shared::RecordGuard::new(&conflict_tracker, version);
+            let write_result = tokio::task::spawn_blocking(
+                move || -> (Result<()>, tokio::task::JoinHandle<()>) {
+                    let _conflict_snapshot = conflict_snapshot;
+                    // The gate covers only the write. Callbacks start after it
+                    // is released: one that opens a transaction would otherwise
+                    // deadlock against this thread's write lock, and holding it
+                    // across callback work would stall every new writer.
+                    let outcome = {
+                        let _commit_guard = commit_gate.blocking_write();
+                        (|| -> Result<()> {
+                            let version = conflict_tracker.check_and_record(
+                                read_version,
+                                pending.keys(),
+                                &read_set,
+                            )?;
+                            // Unrecords on error or panic before the write
+                            // lands, so no phantom write-set survives.
+                            let record_guard = crate::backends::shared::RecordGuard::new(
+                                &conflict_tracker,
+                                version,
+                            );
 
-                let mut batch = db.batch();
-                match durability {
-                    DurabilityMode::Immediate => {
-                        batch = batch.durability(Some(fjall::PersistMode::SyncAll));
-                    }
-                    DurabilityMode::Eventual => {
-                        batch = batch.durability(Some(fjall::PersistMode::Buffer));
-                    }
-                }
-                for (key, value) in &pending {
-                    match value {
-                        Some(v) => batch.insert(&keyspace, key.as_slice(), v.as_slice()),
-                        None => batch.remove(&keyspace, key.as_slice()),
-                    }
-                }
+                            let mut batch = db.batch();
+                            match durability {
+                                DurabilityMode::Immediate => {
+                                    batch = batch.durability(Some(fjall::PersistMode::SyncAll));
+                                }
+                                DurabilityMode::Eventual => {
+                                    batch = batch.durability(Some(fjall::PersistMode::Buffer));
+                                }
+                            }
+                            for (key, value) in &pending {
+                                match value {
+                                    Some(v) => {
+                                        batch.insert(&keyspace, key.as_slice(), v.as_slice())
+                                    }
+                                    None => batch.remove(&keyspace, key.as_slice()),
+                                }
+                            }
 
-                batch.commit()?;
-                record_guard.defuse();
-                Ok(())
-            })
+                            batch.commit()?;
+                            record_guard.defuse();
+                            Ok(())
+                        })()
+                    };
+                    let callbacks = callbacks.spawn(outcome.is_ok());
+                    (outcome, callbacks)
+                },
+            )
             .await;
 
             let commit_result = match write_result {
-                Ok(result) => result,
+                Ok((outcome, callbacks)) => {
+                    // Keep the guarantee that callbacks finish before commit()
+                    // returns (and that a callback panic still propagates); a
+                    // cancelled caller simply never gets here and the spawned
+                    // task runs on regardless.
+                    crate::backends::shared::join_commit_callbacks(callbacks).await;
+                    outcome
+                }
                 Err(join_err) => Err(Error::Other(if join_err.is_panic() {
                     format!("commit task panicked: {join_err}")
                 } else {
@@ -334,12 +361,14 @@ impl Txn for FjallTxn {
                         "Failed to commit fjall batch"
                     );
                 }
-                CallbackManager::execute_callbacks(self.callbacks.take_error());
-                CallbackManager::execute_async_callbacks(self.callbacks.take_error_async()).await;
                 return Err(e);
             }
+
+            self.committed.store(true, Ordering::Release);
+            return Ok(());
         }
 
+        // Nothing was written, so there is no commit task to carry them.
         self.committed.store(true, Ordering::Release);
 
         CallbackManager::execute_callbacks(self.callbacks.take_success());

--- a/crates/storage/src/backends/lark/transaction.rs
+++ b/crates/storage/src/backends/lark/transaction.rs
@@ -449,9 +449,9 @@ impl Txn for LarkTxn {
             // snapshot moves into the closure with it: if the future is
             // dropped mid-await, the snapshot must keep pinning the records
             // this commit conflict-checks against, or prune() could empty
-            // the history before check_and_record runs. The tradeoff: a
-            // cancelled future can leave a durable commit whose success
-            // callbacks never ran (same as redb's direct path).
+            // the history before check_and_record runs. The callbacks move in
+            // for the same reason — a dropped future must not skip the events
+            // for a write that still lands (#1185).
             let db = Arc::clone(&self.db);
             let conflict_tracker = Arc::clone(&self.conflict_tracker);
             let commit_gate = Arc::clone(&self.commit_gate);
@@ -461,27 +461,52 @@ impl Txn for LarkTxn {
                 DurabilityMode::Eventual => lark_kv::DurabilityMode::Eventual,
             };
             let conflict_snapshot = self._conflict_snapshot.take();
+            let callbacks = crate::backends::shared::CommitCallbacks::drain(&self.callbacks);
 
-            let write_result = tokio::task::spawn_blocking(move || -> Result<()> {
-                let _conflict_snapshot = conflict_snapshot;
-                let _commit_guard = commit_gate.blocking_write();
-                // Unlike the other backends, a lark write error must NOT
-                // unrecord: lark can fail AFTER the batch is WAL-durable and
-                // memtable-visible (rotate_memtable on the same call), so an
-                // error is indeterminate. Keeping the record risks a phantom
-                // conflict (spurious retry); dropping it risks missing a real
-                // conflict against landed data (lost update).
-                pending.check_and_record_conflicts(&conflict_tracker, read_version, &read_set)?;
+            let write_result = tokio::task::spawn_blocking(
+                move || -> (Result<()>, tokio::task::JoinHandle<()>) {
+                    let _conflict_snapshot = conflict_snapshot;
+                    // The gate covers only the write. Callbacks start after it
+                    // is released: one that opens a transaction would otherwise
+                    // deadlock against this thread's write lock, and holding it
+                    // across callback work would stall every new writer.
+                    let outcome = {
+                        let _commit_guard = commit_gate.blocking_write();
+                        (|| -> Result<()> {
+                            // Unlike the other backends, a lark write error
+                            // must NOT unrecord: lark can fail AFTER the batch
+                            // is WAL-durable and memtable-visible
+                            // (rotate_memtable on the same call), so an error
+                            // is indeterminate. Keeping the record risks a
+                            // phantom conflict (spurious retry); dropping it
+                            // risks missing a real conflict against landed data.
+                            pending.check_and_record_conflicts(
+                                &conflict_tracker,
+                                read_version,
+                                &read_set,
+                            )?;
 
-                let batch = pending.into_write_batch();
-                db.write_with_durability(batch, durability)
-                    .map_err(|error| Error::Backend(error.to_string()))?;
-                Ok(())
-            })
+                            let batch = pending.into_write_batch();
+                            db.write_with_durability(batch, durability)
+                                .map_err(|error| Error::Backend(error.to_string()))?;
+                            Ok(())
+                        })()
+                    };
+                    let callbacks = callbacks.spawn(outcome.is_ok());
+                    (outcome, callbacks)
+                },
+            )
             .await;
 
             let commit_result = match write_result {
-                Ok(result) => result,
+                Ok((outcome, callbacks)) => {
+                    // Keep the guarantee that callbacks finish before commit()
+                    // returns (and that a callback panic still propagates); a
+                    // cancelled caller simply never gets here and the spawned
+                    // task runs on regardless.
+                    crate::backends::shared::join_commit_callbacks(callbacks).await;
+                    outcome
+                }
                 Err(join_err) => Err(Error::Other(if join_err.is_panic() {
                     format!("commit task panicked: {join_err}")
                 } else {
@@ -493,12 +518,14 @@ impl Txn for LarkTxn {
                 if !matches!(e, Error::TxnConflict) {
                     tracing::error!(error = %e, "Failed to commit lark batch");
                 }
-                CallbackManager::execute_callbacks(self.callbacks.take_error());
-                CallbackManager::execute_async_callbacks(self.callbacks.take_error_async()).await;
                 return Err(e);
             }
+
+            *self.committed.lock() = true;
+            return Ok(());
         }
 
+        // Nothing was written, so there is no commit task to carry them.
         *self.committed.lock() = true;
 
         CallbackManager::execute_callbacks(self.callbacks.take_success());

--- a/crates/storage/src/backends/memory/transaction.rs
+++ b/crates/storage/src/backends/memory/transaction.rs
@@ -238,9 +238,28 @@ impl Txn for MemoryTxn {
         // Mark as committed
         self.committed.store(true, Ordering::Release);
 
-        // Execute success callbacks
+        // Execute success callbacks. The sync ones cannot be skipped — nothing
+        // awaits between the mutation above and here — but the async ones sit
+        // behind an await, so a caller cancelled there would drop the events
+        // for a mutation that already landed (#1185). Spawn them so they
+        // survive that, and await the handle so they still finish before
+        // commit() returns. There is no blocking task here to carry them, and
+        // no guarantee of a runtime, so fall back to running them inline.
         CallbackManager::execute_callbacks(self.callbacks.take_success());
-        CallbackManager::execute_async_callbacks(self.callbacks.take_success_async()).await;
+        let success_async = self.callbacks.take_success_async();
+        if !success_async.is_empty() {
+            match tokio::runtime::Handle::try_current() {
+                Ok(handle) => {
+                    crate::backends::shared::join_commit_callbacks(
+                        handle.spawn(CallbackManager::execute_async_callbacks(success_async)),
+                    )
+                    .await;
+                }
+                Err(_) => {
+                    CallbackManager::execute_async_callbacks(success_async).await;
+                }
+            }
+        }
 
         Ok(())
     }

--- a/crates/storage/src/backends/redb/transaction.rs
+++ b/crates/storage/src/backends/redb/transaction.rs
@@ -374,12 +374,20 @@ impl Txn for RedbTxn {
                 ._conflict_snapshot
                 .take()
                 .expect("write transaction has a conflict snapshot");
-            let error_callbacks = self.callbacks.take_error();
-            let error_async_callbacks = self.callbacks.take_error_async();
+            // Carried into the commit task so a dropped future does not skip
+            // the events for a write that still lands (#1185).
+            let callbacks = crate::backends::shared::CommitCallbacks::drain(&self.callbacks);
 
-            let write_result = tokio::task::spawn_blocking(move || -> Result<()> {
+            let write_result = tokio::task::spawn_blocking(
+                move || -> (Result<()>, tokio::task::JoinHandle<()>) {
                 let _conflict_snapshot = conflict_snapshot;
+                // The gate covers only the write. Callbacks start after it is
+                // released: one that opens a transaction would otherwise
+                // deadlock against this thread's write lock, and holding it
+                // across callback work would stall every new writer.
+                let outcome = {
                 let _commit_guard = commit_gate.blocking_write();
+                (|| -> Result<()> {
                 let version =
                     conflict_tracker.check_and_record(read_version, pending.keys(), &read_set)?;
                 // Unrecords on error or panic before the write lands, so no
@@ -437,19 +445,23 @@ impl Txn for RedbTxn {
                 write()?;
                 record_guard.defuse();
                 Ok(())
+                })()
+                };
+                let callbacks = callbacks.spawn(outcome.is_ok());
+                (outcome, callbacks)
             })
             .await;
 
             match write_result {
-                Ok(Ok(())) => {} // Success — fall through to callback execution
-                Ok(Err(e)) => {
-                    CallbackManager::execute_callbacks(error_callbacks);
-                    CallbackManager::execute_async_callbacks(error_async_callbacks).await;
-                    return Err(e);
+                Ok((outcome, callbacks)) => {
+                    // Keep the guarantee that callbacks finish before commit()
+                    // returns (and that a callback panic still propagates); a
+                    // cancelled caller simply never gets here and the spawned
+                    // task runs on regardless.
+                    crate::backends::shared::join_commit_callbacks(callbacks).await;
+                    outcome?;
                 }
                 Err(join_err) => {
-                    CallbackManager::execute_callbacks(error_callbacks);
-                    CallbackManager::execute_async_callbacks(error_async_callbacks).await;
                     let msg = if join_err.is_panic() {
                         let panic = join_err.into_panic();
                         if let Some(s) = panic.downcast_ref::<String>() {
@@ -465,12 +477,15 @@ impl Txn for RedbTxn {
                     return Err(Error::Other(msg));
                 }
             }
+
+            // Mark as committed AFTER successful database commit
+            self.committed.store(true, Ordering::Release);
+            return Ok(());
         }
 
-        // Mark as committed AFTER successful database commit
+        // Nothing was written, so there is no commit task to carry them.
         self.committed.store(true, Ordering::Release);
 
-        // Execute success callbacks
         CallbackManager::execute_callbacks(self.callbacks.take_success());
         CallbackManager::execute_async_callbacks(self.callbacks.take_success_async()).await;
 

--- a/crates/storage/src/backends/rocksdb/store.rs
+++ b/crates/storage/src/backends/rocksdb/store.rs
@@ -379,6 +379,65 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cancelled_commit_still_runs_success_callbacks() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let store = Arc::new(RocksDbStore::open(temp_dir.path()).unwrap());
+        let key = b"cancelled-callback-key".to_vec();
+
+        let fired = Arc::new(AtomicBool::new(false));
+        let async_fired = Arc::new(AtomicBool::new(false));
+
+        let mut txn = store.new_txn(false).await.unwrap();
+        txn.set(&key, b"committed").await.unwrap();
+        {
+            let fired = Arc::clone(&fired);
+            txn.on_success(Box::new(move || fired.store(true, Ordering::Release)));
+        }
+        {
+            let async_fired = Arc::clone(&async_fired);
+            txn.on_success_async(Box::new(move || {
+                Box::pin(async move {
+                    async_fired.store(true, Ordering::Release);
+                })
+            }));
+        }
+
+        // Park the commit's blocking task before it writes.
+        let gate = Arc::clone(&store.commit_gate);
+        let commit_guard = gate.write().await;
+
+        let commit_task = tokio::spawn(async move { txn.commit().await });
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Drop the caller's future while the write is still parked.
+        commit_task.abort();
+        assert!(
+            commit_task.await.is_err(),
+            "commit task should have been aborted"
+        );
+
+        // Releasing the gate lets the detached task finish the write and start
+        // the callbacks; they are spawned, so poll until they land.
+        drop(commit_guard);
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while !(fired.load(Ordering::Acquire) && async_fired.load(Ordering::Acquire)) {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "callbacks never ran for a commit that landed (sync={}, async={})",
+                fired.load(Ordering::Acquire),
+                async_fired.load(Ordering::Acquire)
+            );
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        assert_eq!(
+            store.db.get(&key).unwrap(),
+            Some(b"committed".to_vec()),
+            "cancelled commit lost a write it had already started"
+        );
+    }
+
+    #[tokio::test]
     async fn cancelled_commit_still_conflict_checks_against_pinned_records() {
         let temp_dir = tempfile::TempDir::new().unwrap();
         let store = Arc::new(RocksDbStore::open(temp_dir.path()).unwrap());

--- a/crates/storage/src/backends/rocksdb/transaction.rs
+++ b/crates/storage/src/backends/rocksdb/transaction.rs
@@ -405,52 +405,77 @@ impl Txn for RocksDbTxn {
             // The conflict snapshot moves into the closure with it: if the
             // future is dropped mid-await, the snapshot must keep pinning the
             // records this commit conflict-checks against, or prune() could
-            // empty the history before check_and_record runs. The tradeoff:
-            // a cancelled future can leave a durable commit whose success
-            // callbacks never ran (same as redb's direct path).
+            // empty the history before check_and_record runs. The callbacks
+            // move in for the same reason — a dropped future must not skip
+            // the events for a write that still lands (#1185).
             let db = Arc::clone(&self.db);
             let conflict_tracker = Arc::clone(&self.conflict_tracker);
             let commit_gate = Arc::clone(&self.commit_gate);
             let read_version = self.read_version;
             let durability = self.durability;
             let conflict_snapshot = self._conflict_snapshot.take();
+            let callbacks = crate::backends::shared::CommitCallbacks::drain(&self.callbacks);
 
-            let write_result = tokio::task::spawn_blocking(move || -> Result<()> {
-                let _conflict_snapshot = conflict_snapshot;
-                let _commit_guard = commit_gate.blocking_write();
-                let version =
-                    conflict_tracker.check_and_record(read_version, pending.keys(), &read_set)?;
-                // Unrecords on error or panic before the write lands, so no
-                // phantom write-set survives a failed commit.
-                let record_guard =
-                    crate::backends::shared::RecordGuard::new(&conflict_tracker, version);
+            let write_result = tokio::task::spawn_blocking(
+                move || -> (Result<()>, tokio::task::JoinHandle<()>) {
+                    let _conflict_snapshot = conflict_snapshot;
+                    // The gate covers only the write. Callbacks start after it
+                    // is released: one that opens a transaction would otherwise
+                    // deadlock against this thread's write lock, and holding it
+                    // across callback work would stall every new writer.
+                    let outcome = {
+                        let _commit_guard = commit_gate.blocking_write();
+                        (|| -> Result<()> {
+                            let version = conflict_tracker.check_and_record(
+                                read_version,
+                                pending.keys(),
+                                &read_set,
+                            )?;
+                            // Unrecords on error or panic before the write
+                            // lands, so no phantom write-set survives.
+                            let record_guard = crate::backends::shared::RecordGuard::new(
+                                &conflict_tracker,
+                                version,
+                            );
 
-                let mut batch = rocksdb::WriteBatchWithTransaction::<true>::default();
-                for (key, value) in &pending {
-                    match value {
-                        Some(v) => batch.put(key, v),
-                        None => batch.delete(key),
-                    }
-                }
+                            let mut batch = rocksdb::WriteBatchWithTransaction::<true>::default();
+                            for (key, value) in &pending {
+                                match value {
+                                    Some(v) => batch.put(key, v),
+                                    None => batch.delete(key),
+                                }
+                            }
 
-                let mut write_opts = rocksdb::WriteOptions::default();
-                match durability {
-                    DurabilityMode::Immediate => {
-                        write_opts.set_sync(true);
-                    }
-                    DurabilityMode::Eventual => {
-                        write_opts.set_sync(false);
-                    }
-                }
+                            let mut write_opts = rocksdb::WriteOptions::default();
+                            match durability {
+                                DurabilityMode::Immediate => {
+                                    write_opts.set_sync(true);
+                                }
+                                DurabilityMode::Eventual => {
+                                    write_opts.set_sync(false);
+                                }
+                            }
 
-                db.write_opt(batch, &write_opts)?;
-                record_guard.defuse();
-                Ok(())
-            })
+                            db.write_opt(batch, &write_opts)?;
+                            record_guard.defuse();
+                            Ok(())
+                        })()
+                    };
+                    let callbacks = callbacks.spawn(outcome.is_ok());
+                    (outcome, callbacks)
+                },
+            )
             .await;
 
             let commit_result = match write_result {
-                Ok(result) => result,
+                Ok((outcome, callbacks)) => {
+                    // Keep the guarantee that callbacks finish before commit()
+                    // returns (and that a callback panic still propagates); a
+                    // cancelled caller simply never gets here and the spawned
+                    // task runs on regardless.
+                    crate::backends::shared::join_commit_callbacks(callbacks).await;
+                    outcome
+                }
                 Err(join_err) => Err(Error::Other(if join_err.is_panic() {
                     format!("commit task panicked: {join_err}")
                 } else {
@@ -466,12 +491,14 @@ impl Txn for RocksDbTxn {
                         "Failed to commit RocksDB batch"
                     );
                 }
-                CallbackManager::execute_callbacks(self.callbacks.take_error());
-                CallbackManager::execute_async_callbacks(self.callbacks.take_error_async()).await;
                 return Err(e);
             }
+
+            self.committed.store(true, Ordering::Release);
+            return Ok(());
         }
 
+        // Nothing was written, so there is no commit task to carry them.
         self.committed.store(true, Ordering::Release);
 
         CallbackManager::execute_callbacks(self.callbacks.take_success());

--- a/crates/storage/src/backends/shared.rs
+++ b/crates/storage/src/backends/shared.rs
@@ -427,6 +427,103 @@ impl ConflictTracker {
     }
 }
 
+/// Await spawned commit callbacks, re-raising a panic from one of them in the
+/// caller.
+///
+/// Callbacks run in a spawned task so they survive a cancelled commit future,
+/// which also isolates their panics. `commit()` is contractually required to
+/// propagate a panicking callback (see `test_suite::callbacks`), so the panic
+/// is resumed here. A caller that is already gone never reaches this, and the
+/// spawned task's panic is reported by the runtime instead.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) async fn join_commit_callbacks(handle: tokio::task::JoinHandle<()>) {
+    if let Err(join_error) = handle.await {
+        if join_error.is_panic() {
+            std::panic::resume_unwind(join_error.into_panic());
+        }
+    }
+}
+
+/// A transaction's callback sets, drained before its commit is handed to the
+/// blocking task that performs the write.
+///
+/// The write runs on a `spawn_blocking` thread, which keeps running after the
+/// caller's commit future is dropped. Selecting and starting the callbacks
+/// from the async side after that await would skip them for a write that
+/// still lands, silently losing the subscription and P2P Update events
+/// registered through `on_success_async` (#1185).
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    any(
+        feature = "redb",
+        feature = "fjall",
+        feature = "rocksdb",
+        feature = "lark"
+    )
+))]
+pub(crate) struct CommitCallbacks {
+    success: Vec<TxnCallback>,
+    success_async: Vec<AsyncTxnCallback>,
+    error: Vec<TxnCallback>,
+    error_async: Vec<AsyncTxnCallback>,
+    handle: tokio::runtime::Handle,
+}
+
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    any(
+        feature = "redb",
+        feature = "fjall",
+        feature = "rocksdb",
+        feature = "lark"
+    )
+))]
+impl CommitCallbacks {
+    /// Drain every set. Called from the async side, which is where the
+    /// runtime handle comes from.
+    pub(crate) fn drain(callbacks: &CallbackManager) -> Self {
+        Self {
+            success: callbacks.take_success(),
+            success_async: callbacks.take_success_async(),
+            error: callbacks.take_error(),
+            error_async: callbacks.take_error_async(),
+            handle: tokio::runtime::Handle::current(),
+        }
+    }
+
+    /// Start the success or error set on the runtime, returning its handle.
+    ///
+    /// Called from the blocking commit task once the write outcome is known.
+    /// The work is spawned rather than run inline on that thread because
+    /// these callbacks do real async work — P2P broadcasts, `tokio::fs`
+    /// reads, arbitrary post-commit hooks — and `tokio::fs` is itself backed
+    /// by the blocking pool, so occupying a pool thread while waiting on them
+    /// risks exhausting it. Spawning also detaches them from the caller,
+    /// which may already be gone.
+    ///
+    /// Callers await the returned handle on the normal path, preserving the
+    /// existing guarantee that callbacks finish before `commit()` returns.
+    #[must_use]
+    pub(crate) fn spawn(self, succeeded: bool) -> tokio::task::JoinHandle<()> {
+        let Self {
+            success,
+            success_async,
+            error,
+            error_async,
+            handle,
+        } = self;
+        handle.spawn(async move {
+            if succeeded {
+                CallbackManager::execute_callbacks(success);
+                CallbackManager::execute_async_callbacks(success_async).await;
+            } else {
+                CallbackManager::execute_callbacks(error);
+                CallbackManager::execute_async_callbacks(error_async).await;
+            }
+        })
+    }
+}
+
 /// Rolls back a `check_and_record` entry unless defused.
 ///
 /// Armed right after a successful `check_and_record` and defused only once


### PR DESCRIPTION
Closes #1185.

A commit's physical write runs on a `spawn_blocking` thread, which keeps running after the caller's future is dropped. The callbacks were selected and started on the async side *after* that await, so a cancelled commit — an HTTP client disconnecting mid-`tx_commit`, say — left a durable write whose callbacks never fired. Those callbacks are how subscription and P2P Update events get published (`db/src/event_emission.rs` registers them through `on_success_async`), so the write landed and the events were silently dropped.

Drain the callback sets before handing the commit to the blocking task and start them there, once the write outcome is known. Redb's group-commit path already worked this way — its callbacks live in `PendingCommit`, owned by the flush loop — so this brings the direct paths in line.

### Why spawned rather than run on the blocking thread

The obvious version, running the callbacks inline on the commit thread, is not safe here. These callbacks do real async work: P2P broadcasts (`broadcast_update`), `tokio::fs` reads (`add_lens`), and arbitrary post-commit ACP hooks. `tokio::fs` is itself backed by the blocking pool, so blocking a pool thread while waiting on them means waiting on work that needs a pool thread — a nested-pool deadlock under load, not merely pressure.

So `CommitCallbacks::spawn` puts them on the runtime and returns the handle. Callbacks run on workers where their own I/O behaves normally, they are detached from the caller (which may already be gone), and the caller awaits the handle on the normal path — preserving the existing guarantee that callbacks finish before `commit()` returns.

Two consequences worth calling out:

- **The gate covers only the write.** Callbacks start after the commit-gate write lock is released. A callback that opens a transaction would otherwise deadlock against the committing thread's own write lock, and holding the gate across arbitrary callback work would stall every new writer (undoing #1178/#1182's gate-hold-time work).
- **Panics still propagate.** Spawning isolates a panicking callback inside the task, but `commit()` is contractually required to propagate it (`test_suite::callbacks::test_callback_panic_propagates`). `join_commit_callbacks` resumes the panic in the caller. Without this, seven existing tests fail.

### Scope

All four `spawn_blocking` backends (rocksdb, fjall, lark, redb direct path), plus memory. Memory's gap is narrower — its mutation is synchronous and only the async-callback await is a cancellation point — and it has no blocking task to carry them, so it spawns and awaits directly, falling back to inline execution when there is no runtime. Empty commits keep running callbacks on the async side: no blocking task, and no durable write to lose.

### Validation

668 storage tests across all backends, db/datastore suites, wasm32 check, `clippy --all -D warnings`, the featureless `-p storage` pass, all five CI feature-gated clippy passes, fmt.

The new `cancelled_commit_still_runs_success_callbacks` is a discriminating regression test — verified by reverting the rocksdb change and re-running, where it fails with `callbacks never ran for a commit that landed (sync=false, async=false)`. It parks the commit's blocking task on the gate, aborts the caller's future, then asserts the write landed and both the sync and async success callbacks fired.
