### PR TITLE
fix(sync): browser-sync hardening follow-ups

### DIFF
--- a/crates/cli/src/browser_sync_adapter.rs
+++ b/crates/cli/src/browser_sync_adapter.rs
@@ -230,12 +230,25 @@ impl<S: Store + 'static> BrowserSyncAdapter<S> {
                 continue;
             }
 
-            let Some(document) = self
-                .engine
-                .load_document(&document_ref)
-                .await
-                .map_err(map_engine_error)?
-            else {
+            let loaded = match self.engine.load_document(&document_ref).await {
+                Ok(loaded) => loaded,
+                // A document whose DAG cannot fit in a sync payload can never
+                // be pulled. Failing the page would wedge this cursor
+                // position permanently — every retry re-reads the same
+                // document — so skip past it and keep the page moving.
+                Err(db_merge::browser_sync::BrowserSyncError::TooLarge(message)) => {
+                    tracing::warn!(
+                        doc_id = %document_ref.doc_id,
+                        collection_id = %document_ref.collection_id,
+                        %message,
+                        "browser sync skipped a document that exceeds the sync payload limit"
+                    );
+                    resume_cursor = Some(document_ref.doc_id);
+                    continue;
+                }
+                Err(error) => return Err(map_engine_error(error)),
+            };
+            let Some(document) = loaded else {
                 resume_cursor = Some(document_ref.doc_id);
                 continue;
             };

--- a/crates/cli/src/browser_sync_adapter_tests.rs
+++ b/crates/cli/src/browser_sync_adapter_tests.rs
@@ -94,6 +94,74 @@ async fn create_document(
     engine.load_document(&document_ref).await.unwrap().unwrap()
 }
 
+/// Create a document whose DAG cannot fit in a sync payload. Returns its
+/// doc id; it deliberately cannot be loaded through `load_document`.
+async fn create_oversized_document(database: &Arc<db::DB<MemoryStore>>) -> String {
+    let mut document = Document::new();
+    document.set(
+        "name",
+        "x".repeat(defra_core::browser_sync::MAX_SYNC_PAYLOAD_BYTES + 1024),
+    );
+    db::AutoCommitMutator::new(database.clone())
+        .create("Users", document)
+        .await
+        .unwrap()
+        .doc_id
+        .to_string()
+}
+
+/// A document too large to load must not fail the page it lands on. Before the
+/// per-document skip, every pull covering it returned 422 forever and the
+/// cursor could never advance past it, wedging the whole sync.
+#[tokio::test]
+async fn pull_skips_a_document_that_exceeds_the_payload_limit() {
+    let database = Arc::new(db::DB::new(MemoryStore::new()).unwrap());
+    database
+        .create_collection(users_schema(false))
+        .await
+        .unwrap();
+    let oversized = create_oversized_document(&database).await;
+    create_document(&database, "Alice").await;
+
+    let acp = Arc::new(LocalDocumentACP::new(Arc::new(MemoryAcpStore::new())));
+    let adapter = BrowserSyncAdapter::new_arc(database, acp);
+
+    let mut cursor = None;
+    let mut seen: Vec<String> = Vec::new();
+    for _ in 0..8 {
+        let page = adapter
+            .sync(
+                BrowserSyncRequest {
+                    documents: Vec::new(),
+                    pull: Some(BrowserSyncPull {
+                        doc_ids: Vec::new(),
+                        cursor: cursor.clone(),
+                        limit: Some(1),
+                    }),
+                },
+                None,
+                false,
+            )
+            .await
+            .expect("an oversized document must not fail the pull");
+        seen.extend(page.documents.iter().map(|doc| doc.doc_id.clone()));
+        match page.next_cursor {
+            Some(next) => cursor = Some(next),
+            None => break,
+        }
+    }
+
+    assert!(
+        !seen.contains(&oversized),
+        "oversized document should have been skipped, got {seen:?}"
+    );
+    assert_eq!(
+        seen.len(),
+        1,
+        "the loadable document should still be served, got {seen:?}"
+    );
+}
+
 #[tokio::test]
 async fn pull_uses_advancing_cursor_pages() {
     let database = Arc::new(db::DB::new(MemoryStore::new()).unwrap());

--- a/crates/http/src/handlers/browser_sync.rs
+++ b/crates/http/src/handlers/browser_sync.rs
@@ -37,6 +37,14 @@ pub async fn sync(
     if !request.documents.is_empty() {
         require_permission(&state, &identity, NodePermission::DocumentUpdate).await?;
     }
+    if request.pull.is_none() && request.documents.is_empty() {
+        // A request that neither pulls nor pushes still reaches the sync
+        // service below, whose "browser sync is not enabled" error would
+        // otherwise tell an unauthenticated caller whether the feature is on.
+        // Gate it on the weakest document permission so the probe answers
+        // the same way for callers that may not use sync at all.
+        require_permission(&state, &identity, NodePermission::DocumentRead).await?;
+    }
 
     let bypass_dac = resolve_dac_bypass(&state, &identity).await;
     let response = state

--- a/crates/http/src/handlers/browser_sync_tests.rs
+++ b/crates/http/src/handlers/browser_sync_tests.rs
@@ -12,10 +12,10 @@ use defra_core::browser_sync::{
     BrowserSyncRequest, BrowserSyncResponse, MAX_SYNC_DOCUMENTS_PER_REQUEST, MAX_SYNC_PULL_DOC_IDS,
 };
 
-use crate::mock::MockQueryExecutor;
+use crate::mock::{MockNodeAcpOperations, MockQueryExecutor};
 use crate::router::{
     create_router_with_state, create_router_with_state_and_sync_body_limit, AppStateBuilder,
-    BrowserSyncOperations, BrowserSyncResult,
+    BrowserSyncOperations, BrowserSyncResult, NodeAcpOperations,
 };
 
 #[derive(Default)]
@@ -45,6 +45,70 @@ fn router(sync: Arc<RecordingSync>) -> axum::Router {
         .with_browser_sync(sync)
         .build();
     create_router_with_state(state)
+}
+
+fn router_with_nac(sync: Arc<RecordingSync>, nac: Arc<MockNodeAcpOperations>) -> axum::Router {
+    let executor = Arc::new(MockQueryExecutor::new()) as Arc<dyn QueryExecutor>;
+    let state = AppStateBuilder::new(executor)
+        .with_browser_sync(sync)
+        .with_nac(nac as Arc<dyn NodeAcpOperations>)
+        .build();
+    create_router_with_state(state)
+}
+
+/// A request that neither pulls nor pushes still reaches the sync service,
+/// whose "not enabled" error would otherwise tell an unauthorized caller
+/// whether browser sync is turned on. It must be permission-checked like any
+/// other sync call.
+#[tokio::test]
+async fn empty_sync_request_is_permission_checked() {
+    let sync = Arc::new(RecordingSync::default());
+    let owner = identity::Did::new("did:key:owner").unwrap();
+    let nac = Arc::new(MockNodeAcpOperations::enabled_with_owner(owner));
+    let router = router_with_nac(sync.clone(), nac);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/v0/sync")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"documents":[]}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    assert_eq!(sync.calls.load(Ordering::Relaxed), 0);
+}
+
+/// The same request from a caller that does hold document-read still works,
+/// so gating the probe does not turn a no-op sync into a hard failure.
+#[tokio::test]
+async fn empty_sync_request_is_allowed_for_permitted_caller() {
+    let sync = Arc::new(RecordingSync::default());
+    let owner = identity::Did::new("did:key:owner").unwrap();
+    let nac = Arc::new(MockNodeAcpOperations::enabled_with_owner(owner).with_grant(
+        identity::Did::wildcard(),
+        crate::router::NodePermission::DocumentRead,
+    ));
+    let router = router_with_nac(sync.clone(), nac);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/v0/sync")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"documents":[]}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(sync.calls.load(Ordering::Relaxed), 1);
 }
 
 #[tokio::test]

--- a/crates/wasm/src/sync/session.rs
+++ b/crates/wasm/src/sync/session.rs
@@ -192,13 +192,18 @@ impl SyncSession {
             .await
             .map_err(engine_error)?
         {
-            if let Some(document) = self
-                .engine
-                .load_document(&document_ref)
-                .await
-                .map_err(engine_error)?
-            {
-                documents.push(document);
+            // Nothing to push for an over-large document, but the pull below
+            // still applies. Failing here would fall back to a full sync on
+            // every single update touching this document.
+            match self.engine.load_document(&document_ref).await {
+                Ok(Some(document)) => documents.push(document),
+                Ok(None) => {}
+                Err(db_merge::browser_sync::BrowserSyncError::TooLarge(message)) => {
+                    warn(&format!(
+                        "browser sync skipped document {doc_id} because it exceeds the sync payload limit: {message}"
+                    ));
+                }
+                Err(error) => return Err(engine_error(error)),
             }
         }
         self.exchange(BrowserSyncRequest {

--- a/crates/wasm/src/sync/session.rs
+++ b/crates/wasm/src/sync/session.rs
@@ -103,12 +103,21 @@ impl SyncSession {
         let mut documents = Vec::new();
         let mut serialized_size = EMPTY_PUSH_REQUEST_BYTES;
         for document_ref in refs {
-            let Some(document) = self
-                .engine
-                .load_document(&document_ref)
-                .await
-                .map_err(engine_error)?
-            else {
+            let loaded = match self.engine.load_document(&document_ref).await {
+                Ok(loaded) => loaded,
+                // Too large to even load, so it can never be pushed. Failing
+                // here would abort the whole push and leave recover_full_sync
+                // retrying forever; skip it like the request-size check below.
+                Err(db_merge::browser_sync::BrowserSyncError::TooLarge(message)) => {
+                    warn(&format!(
+                        "browser sync skipped document {} because it exceeds the sync payload limit: {message}",
+                        document_ref.doc_id
+                    ));
+                    continue;
+                }
+                Err(error) => return Err(engine_error(error)),
+            };
+            let Some(document) = loaded else {
                 continue;
             };
 


### PR DESCRIPTION
Closes #1181.

Two of the three follow-ups from the #1177 review. The third is addressed below with reasons for not doing it.

## Oversized documents no longer wedge sync

`load_document` returns `TooLarge` for a document whose DAG exceeds `MAX_SYNC_PAYLOAD_BYTES`. Both callers propagated it, which turned one bad document into a permanent stall:

- Server pull failed the entire page, and because the cursor only advances on documents it managed to load, every retry re-read the same document and failed again. Sync could never get past it.
- Browser push aborted `push_all_documents`, so `full_sync` failed, so `recover_full_sync` retried it forever with backoff.

Both now skip the document and carry on. The server also advances `resume_cursor` past it so pagination moves. This mirrors the size check already in `push_all_documents`, which skips over-large documents rather than failing the push.

## Empty sync requests are permission-checked

A request with no `pull` and no `documents` matched neither permission check but still reached the sync service, whose "browser sync is not enabled" error told an unauthenticated caller whether the feature is on. It is now gated on `DocumentRead`, the weakest of the two permissions the endpoint already uses, so a caller that can use sync at all is unaffected.

## Not done: a create-level permission check

The issue also suggested gating pushes of previously unseen documents on a create permission. There isn't one: `NodePermission` has read/update/delete for documents and no create variant, and this matches Go — `acp/types/types.go` defines `read-document`, `update-document` and `delete-document` only. Creates elsewhere in the codebase are gated on `DocumentUpdate` (`auto_commit_mutator/create.rs`), which is what sync already requires. Adding a new permission would diverge from Go and would reject callers holding policies that grant everything Go's model can express, so it needs an upstream decision rather than a local patch.

## Verification

Both fixes have tests, and each was checked to fail without its fix — the quarantine test errors with `InvalidInput("document bae-8fe2... exceeds 16777216 bytes")` on the unpatched adapter, and the probe test returns 200 instead of 401.

- `cargo fmt --all -- --check` clean
- `cargo clippy --all --all-targets -- -D warnings` exit 0, zero warnings
- `cargo check -p defra-wasm --target wasm32-unknown-unknown` compiles (`session.rs` is wasm-only)
- `cargo test -p cli -p defra-http -p db-merge` — 14 binaries, all green

The wasm-side push skip has no test: that would need a mock `SyncHttpClient`, which does not exist, and the code is `wasm32`-only. The server-side change is the same shape and is covered.
