### PR TITLE
fix: make the wasm32 build clippy-clean

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
+          components: clippy
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -76,6 +77,9 @@ jobs:
 
       - name: Exclude tools with private deps from workspace
         run: sed -i '/"tools\/integration-test"/d; /"tools\/ffi-test"/d' Cargo.toml
+
+      - name: Clippy (wasm32)
+        run: cargo clippy -p defra-wasm --target wasm32-unknown-unknown --all-targets -- -D warnings
 
       - name: Install wasm-pack
         run: cargo install wasm-pack --locked

--- a/crates/acp/src/lib.rs
+++ b/crates/acp/src/lib.rs
@@ -32,6 +32,9 @@ mod identity;
 mod local;
 pub mod nac;
 mod permission;
+// Both persistent stores require `S: Store + Send + Sync`, which the wasm
+// LevelDB store cannot satisfy, so they are native-only.
+#[cfg(not(target_arch = "wasm32"))]
 mod persistent;
 pub mod policy_yaml;
 pub mod read_access;
@@ -47,6 +50,7 @@ pub use error::{Error, Result};
 pub use identity::Identity;
 pub use local::{LocalDocumentACP, MemoryAcpStore};
 pub use permission::DocumentPermission;
+#[cfg(not(target_arch = "wasm32"))]
 pub use persistent::PersistentAcpStore;
 pub use read_access::{check_doc_read_access, DirectChecker, DocAccess, ObjectAccessChecker};
 pub use relation::{
@@ -57,6 +61,7 @@ pub use target_subject::parse_target_subject;
 pub use validation::{validate_resource_interface, REQUIRED_DOCUMENT_PERMISSIONS};
 
 // Re-export key zanzibar engine types from the standalone zanzibar crate
+#[cfg(not(target_arch = "wasm32"))]
 pub use zanzibar::PersistentZanzibarStore;
 pub use zanzibar::ZanzibarDocumentACP;
 

--- a/crates/acp/src/persistent.rs
+++ b/crates/acp/src/persistent.rs
@@ -11,9 +11,9 @@ use std::sync::Arc;
 use storage::corekv::{IterOptions, Reader, Store, Writer};
 use storage::namespace::{Namespace, NamespacedStore};
 
-#[cfg(all(not(target_arch = "wasm32"), feature = "redb"))]
+#[cfg(feature = "redb")]
 use std::path::Path;
-#[cfg(all(not(target_arch = "wasm32"), feature = "redb"))]
+#[cfg(feature = "redb")]
 use storage::RedbStore;
 
 use crate::error::{Error, Result};
@@ -74,7 +74,7 @@ impl<S: Store> PersistentAcpStore<S> {
     }
 }
 
-#[cfg(all(not(target_arch = "wasm32"), feature = "redb"))]
+#[cfg(feature = "redb")]
 impl PersistentAcpStore<RedbStore> {
     /// Open a persistent ACP store at the given directory path.
     ///
@@ -156,9 +156,7 @@ impl PersistentAcpStore<RedbStore> {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[async_trait]
 impl<S: Store + Send + Sync> AcpStore for PersistentAcpStore<S> {
     async fn put_tuple(&self, tuple: &RelationTuple) -> Result<()> {
         let mut txn = self

--- a/crates/acp/src/zanzibar/mod.rs
+++ b/crates/acp/src/zanzibar/mod.rs
@@ -11,4 +11,5 @@ mod acp;
 pub mod store;
 
 pub use acp::ZanzibarDocumentACP;
+#[cfg(not(target_arch = "wasm32"))]
 pub use store::PersistentZanzibarStore;

--- a/crates/acp/src/zanzibar/store/mod.rs
+++ b/crates/acp/src/zanzibar/store/mod.rs
@@ -1,5 +1,9 @@
 //! Defradb-specific Zanzibar store implementations.
 
+// Requires `S: Store + Send + Sync`, which the wasm LevelDB store cannot
+// satisfy, so this store is native-only.
+#[cfg(not(target_arch = "wasm32"))]
 mod persistent;
 
+#[cfg(not(target_arch = "wasm32"))]
 pub use persistent::PersistentZanzibarStore;

--- a/crates/acp/src/zanzibar/store/persistent.rs
+++ b/crates/acp/src/zanzibar/store/persistent.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use storage::corekv::{IterOptions, Reader, Store, Writer};
 use storage::namespace::{Namespace, NamespacedStore};
-#[cfg(all(not(target_arch = "wasm32"), feature = "redb"))]
+#[cfg(feature = "redb")]
 use storage::RedbStore;
 
 use identity::Did;
@@ -27,7 +27,7 @@ impl<S: Store> PersistentZanzibarStore<S> {
     }
 }
 
-#[cfg(all(not(target_arch = "wasm32"), feature = "redb"))]
+#[cfg(feature = "redb")]
 impl PersistentZanzibarStore<RedbStore> {
     /// Open a persistent store at the given path.
     pub fn open(path: &std::path::Path) -> Result<Self> {
@@ -62,9 +62,7 @@ impl<S: Store> PersistentZanzibarStore<S> {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[async_trait]
 impl<S: Store + Send + Sync> ZanzibarStore for PersistentZanzibarStore<S> {
     async fn store_policy(&self, policy: &Policy) -> Result<()> {
         let mut txn = self.store.new_txn(false).await.map_err(|e| {

--- a/crates/datastore/src/multistore.rs
+++ b/crates/datastore/src/multistore.rs
@@ -16,6 +16,11 @@ pub struct SharedTxn {
 
 impl SharedTxn {
     /// Create a new shared transaction.
+    // `Txn` drops its `Send + Sync` bounds on wasm32 (see `MaybeSendSync`), so
+    // there the Arc wraps a non-Send value. That is sound in the
+    // single-threaded browser runtime, and the return type has to stay `Arc`
+    // for native callers that share it across threads.
+    #[cfg_attr(target_arch = "wasm32", allow(clippy::arc_with_non_send_sync))]
     pub fn new(txn: Box<dyn Txn>) -> Arc<Self> {
         Arc::new(Self {
             txn: RwLock::new(txn),

--- a/crates/db-merge/src/acp_merge_handler.rs
+++ b/crates/db-merge/src/acp_merge_handler.rs
@@ -214,6 +214,9 @@ impl<S: Store, B: blockstore::Blockstore> AcpMergeHandler<S, B> {
             .db
             .node_identity()
             .and_then(|identity| identity.did().ok().map(Identity::from));
+        // Non-Send on wasm32, where the ACP traits it holds drop their `Send`
+        // bounds for the single-threaded browser runtime.
+        #[cfg_attr(target_arch = "wasm32", allow(clippy::arc_with_non_send_sync))]
         let hook = Arc::new(AcpCompositeMergeHook::new(local_identity));
         inner.set_composite_merge_hook(hook.clone());
         Self { inner, hook }

--- a/crates/db/src/downsample/execute.rs
+++ b/crates/db/src/downsample/execute.rs
@@ -434,6 +434,8 @@ impl<S: Store + 'static> crate::database::DB<S> {
         Ok(())
     }
 
+    // Only the downsample task drives this, and that task is native-only.
+    #[cfg(not(target_arch = "wasm32"))]
     pub(super) async fn process_downsample_update(
         self: &Arc<Self>,
         collection_id: &str,

--- a/crates/db/src/txn_registry.rs
+++ b/crates/db/src/txn_registry.rs
@@ -937,6 +937,9 @@ impl<S: Store + 'static> TransactionRegistry for DbTransactionRegistry<S> {
             .new_txn(readonly)
             .await
             .map_err(|e| TransactionError::execution(format!("storage error: {}", e)))?;
+        // Non-Send on wasm32, where the callbacks it holds drop their `Send`
+        // bounds for the single-threaded browser runtime.
+        #[cfg_attr(target_arch = "wasm32", allow(clippy::arc_with_non_send_sync))]
         let deferred_acp_mutations = Arc::new(DeferredAcpMutations::new());
         let deferred_acp_mutations_for_commit = deferred_acp_mutations.clone();
         db_txn

--- a/crates/db/src/view_ops.rs
+++ b/crates/db/src/view_ops.rs
@@ -6,7 +6,9 @@
 use crate::error::{Error, Result};
 use datastore::NamespaceView;
 use schema::CollectionVersion;
+#[cfg(not(target_arch = "wasm32"))]
 use std::collections::{HashMap, HashSet};
+#[cfg(not(target_arch = "wasm32"))]
 use std::sync::Arc;
 use std::time::Duration;
 use storage::corekv::{IterOptions, Key, Store};

--- a/crates/query/src/runner/executor.rs
+++ b/crates/query/src/runner/executor.rs
@@ -441,11 +441,13 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
             }
         };
 
-        let deferred_acp_mutations = txn_ctx.deferred_acp_mutations();
-
         // If the transaction provides a collection provider or deferred ACP
         // projection, set them as task-local overrides so this execution sees
-        // the transaction's uncommitted schema and ACP state.
+        // the transaction's uncommitted schema and ACP state. The task-local
+        // scoping is native-only, so wasm32 skips both overrides.
+        #[cfg(not(target_arch = "wasm32"))]
+        let deferred_acp_mutations = txn_ctx.deferred_acp_mutations();
+
         #[cfg(not(target_arch = "wasm32"))]
         let result = if let Some(provider) = txn_provider {
             if let Some(deferred_acp_mutations) = deferred_acp_mutations {

--- a/crates/storage/src/backends/shared.rs
+++ b/crates/storage/src/backends/shared.rs
@@ -2,6 +2,7 @@ use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 #[cfg(not(target_arch = "wasm32"))]
 use std::collections::BTreeMap;
+#[cfg(not(target_arch = "wasm32"))]
 use std::collections::HashSet;
 #[cfg(not(target_arch = "wasm32"))]
 use std::sync::{
@@ -9,7 +10,9 @@ use std::sync::{
     Arc,
 };
 
-use crate::corekv::{AsyncTxnCallback, IterOptions, TxnCallback};
+#[cfg(not(target_arch = "wasm32"))]
+use crate::corekv::IterOptions;
+use crate::corekv::{AsyncTxnCallback, TxnCallback};
 
 /// Controls when data is flushed to disk after a commit.
 ///
@@ -179,12 +182,14 @@ impl CallbackCounts {
 /// writes data must conflict if another transaction committed after its snapshot
 /// and either wrote a key it read, or read a key/range it wrote. Tracking both
 /// point reads and iterator ranges gives the Rust backends the same behavior.
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Debug, Clone, Default)]
 pub(crate) struct ReadSet {
     keys: HashSet<Vec<u8>>,
     ranges: Vec<ReadRange>,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Debug, Clone)]
 enum ReadRange {
     Prefix(Vec<u8>),
@@ -194,6 +199,7 @@ enum ReadRange {
     },
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl ReadSet {
     pub(crate) fn record_key(&mut self, key: &[u8]) {
         self.keys.insert(key.to_vec());
@@ -218,6 +224,7 @@ impl ReadSet {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn is_document_collection_scan_prefix(prefix: &[u8]) -> bool {
     // Namespaced datastore document scans use `d/d/...`; root datastore scans
     // use `/d/...`. Go's SSI conflict in the relation tests comes from FK index
@@ -229,6 +236,7 @@ fn is_document_collection_scan_prefix(prefix: &[u8]) -> bool {
         || prefix.starts_with(b"/del/")
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl ReadRange {
     fn contains(&self, key: &[u8]) -> bool {
         match self {

--- a/crates/wasm/src/client.rs
+++ b/crates/wasm/src/client.rs
@@ -182,6 +182,11 @@ impl DefraClient {
 
 // Internal implementation methods
 impl DefraClient {
+    // The LevelDB-backed database and its mutator are not `Send`, since wasm
+    // drops those bounds for the single-threaded browser runtime. Sharing them
+    // by `Arc` is what the query runner expects, and there are no threads to
+    // send them across.
+    #[allow(clippy::arc_with_non_send_sync)]
     async fn new_impl(config: JsValue) -> Result<Self> {
         let config: ClientConfig = if config.is_undefined() || config.is_null() {
             ClientConfig::default()
@@ -444,7 +449,7 @@ mod tests {
 
     #[wasm_bindgen_test]
     async fn test_mutate_no_schema_fails() {
-        let mut client = DefraClient::create(test_config("test_mutate_no_schema"))
+        let client = DefraClient::create(test_config("test_mutate_no_schema"))
             .await
             .unwrap();
         let result = client
@@ -455,7 +460,7 @@ mod tests {
 
     #[wasm_bindgen_test]
     async fn test_empty_mutation_fails() {
-        let mut client = DefraClient::create(test_config("test_empty_mut"))
+        let client = DefraClient::create(test_config("test_empty_mut"))
             .await
             .unwrap();
         let result = client.mutate("").await;


### PR DESCRIPTION
Nothing enforced clippy on wasm32. CI's WASM job runs `wasm-pack build`, so warnings on that target never failed anything and quietly accumulated across seven crates. `cargo clippy -p defra-wasm --target wasm32-unknown-unknown --all-targets -- -D warnings` fails on main with 26 errors; it passes here.

## Native-only code that was never gated

- **storage**: `ReadSet`, `ReadRange` and their helpers were left ungated even though `ConflictTracker` — the only thing that consumes them — is already `not(target_arch = "wasm32")`. Whoever gated the tracker missed the types it is built on. The `HashSet` and `IterOptions` imports move with them.
- **acp**: both persistent stores require `S: Store + Send + Sync`, which the wasm LevelDB store cannot satisfy, so their trait impls were excluded on wasm32 — leaving the modules exporting a struct with no impl behind it. Gate the modules instead. Each also carried a `#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]` written to support wasm that the blanket cfg above it made permanently dead; those are removed rather than left implying support that cannot exist.
- **db**: `process_downsample_update`'s only caller is the downsample task, already native-only; `view_ops`' imports are used only inside its native-gated block.
- **query**: the executor fetched `deferred_acp_mutations` and dropped it on wasm32. The task-local scoping it feeds is native-only, and the getter is a side-effect-free `Arc` clone, so the binding is now gated — no behaviour change.

## False positives

`clippy::arc_with_non_send_sync` fires in four places because wasm32 deliberately drops `Send + Sync` (see `MaybeSendSync` in defra-core `thread_bounds`) for the single-threaded browser runtime. Those `Arc`s have no threads to cross, and `Rc` is not available since the surrounding types and public signatures are `Arc`. Allowed per-site, scoped to wasm32 where the crate also builds natively, each with the reason recorded.

## Preventing recurrence

The WASM job now runs clippy with `-D warnings` before `wasm-pack build`, and the toolchain step gains the `clippy` component. Without this the warnings just re-accumulate.

## Verification

The originally-failing command now exits 0.

No native regression:

- `cargo clippy --all --all-targets -- -D warnings` exit 0, zero warnings
- `cargo fmt --all -- --check` clean
- all five CI feature-gated clippy passes exit 0
- `cargo build -p defra-wasm --target wasm32-unknown-unknown --release` exit 0 (what `wasm-pack` wraps)
- `cargo test -p storage -p acp -p datastore -p db -p query -p db-merge` — 50 binaries, zero failures

The SSI conflict tests (`detects_write_to_committed_read_prefix`, `detects_read_of_committed_write_key`, `ignores_document_collection_scan_prefixes`) and the `RecordGuard` tests from #1183 all pass, confirming write-skew detection is untouched.

Gating the `query` binding revealed a real functional gap that this PR does not attempt to close — filed separately.
