### PR TITLE
fix(storage): lift the lark commit-gate and rollback exceptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,7 +608,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -619,7 +619,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3369,7 +3369,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4387,7 +4387,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4964,7 +4964,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
+ "windows-link 0.1.3",
  "windows-result 0.4.1",
 ]
 
@@ -6779,7 +6779,7 @@ dependencies = [
 [[package]]
 name = "lark-kv"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/lark.git?rev=ab924471c2e376591c1e3b3cd419655f9c7c6dc4#ab924471c2e376591c1e3b3cd419655f9c7c6dc4"
+source = "git+https://github.com/sourcenetwork/lark.git?rev=d1ec2e727bad6c160e6c1d71e2cbb163892b3a02#d1ec2e727bad6c160e6c1d71e2cbb163892b3a02"
 dependencies = [
  "crossbeam-skiplist",
  "lru 0.16.4",
@@ -8229,7 +8229,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10905,7 +10905,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10997,7 +10997,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11293,7 +11293,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11832,7 +11832,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12341,7 +12341,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13139,7 +13139,7 @@ checksum = "51b70b87d15e91f553711b40df3048faf27a7a04e01e0ddc0cf9309f0af7c2ca"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -14021,7 +14021,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ postcard = { version = "1.0", features = ["alloc"] }
 redb = "2.4"
 fjall = "3.1.4"
 rocksdb = "0.24.0"
-lark-kv = { git = "https://github.com/sourcenetwork/lark.git", rev = "ab924471c2e376591c1e3b3cd419655f9c7c6dc4" }
+lark-kv = { git = "https://github.com/sourcenetwork/lark.git", rev = "d1ec2e727bad6c160e6c1d71e2cbb163892b3a02" }
 
 # Cryptography
 ed25519-dalek = { version = "2.1", features = ["serde", "zeroize"] }

--- a/crates/storage/src/backends/lark/store.rs
+++ b/crates/storage/src/backends/lark/store.rs
@@ -98,13 +98,16 @@ impl Store for LarkStore {
         }
         let mut guard = NewTxnGuard(&self.active_txn_count, false);
 
-        // Unlike the other backends, read-only transactions must NOT skip
-        // the gate here: lark publishes `latest_seq` before applying batch
-        // ops to the memtable, so an ungated snapshot taken mid-commit can
-        // claim visibility of sequence numbers whose data has not landed
-        // (torn batch). The gate is what keeps snapshot acquisition atomic
-        // against in-flight commits until lark publishes after applying.
-        let _commit_guard = self.commit_gate.read().await;
+        // Pair the conflict version and lark snapshot without a commit
+        // becoming visible between them. Read-only transactions skip the
+        // gate: lark now publishes its read horizon only after a batch is
+        // applied, so an ungated snapshot can no longer observe a torn
+        // batch, and read-only transactions never conflict-check.
+        let _commit_guard = if readonly {
+            None
+        } else {
+            Some(self.commit_gate.read().await)
+        };
         let txn = LarkTxn::new(
             Arc::clone(&self.db),
             Arc::clone(&self.conflict_tracker),
@@ -265,30 +268,25 @@ mod pairing_tests {
     }
 
     #[tokio::test]
-    async fn readonly_txn_still_gated_against_torn_batches() {
+    async fn readonly_txn_skips_the_commit_gate() {
         let temp_dir = tempfile::TempDir::new().unwrap();
         let store = Arc::new(LarkStore::open(temp_dir.path()).unwrap());
         let gate = Arc::clone(&store.commit_gate);
         let commit_guard = gate.write().await;
 
-        // lark publishes its sequence counter before applying batch ops, so
-        // read-only snapshots must stay behind the gate (unlike the other
-        // backends) or they can observe a torn batch.
+        // lark now publishes its read horizon only after a batch is applied,
+        // so a read-only snapshot can no longer observe a torn batch and does
+        // not need the gate — matching rocksdb/redb/fjall/memory. It must
+        // acquire even while a writer holds the gate.
         let readonly_store = Arc::clone(&store);
-        let mut readonly_task = tokio::spawn(async move { readonly_store.new_txn(true).await });
-        assert!(
-            tokio::time::timeout(Duration::from_millis(25), &mut readonly_task)
-                .await
-                .is_err(),
-            "read-only transaction skipped the commit gate on lark"
-        );
-
-        drop(commit_guard);
+        let readonly_task = tokio::spawn(async move { readonly_store.new_txn(true).await });
         tokio::time::timeout(Duration::from_secs(1), readonly_task)
             .await
-            .expect("read-only transaction remained blocked after gate release")
+            .expect("read-only transaction blocked on the commit gate")
             .expect("readonly task panicked")
             .expect("read-only transaction failed");
+
+        drop(commit_guard);
     }
 
     #[tokio::test]

--- a/crates/storage/src/backends/lark/transaction.rs
+++ b/crates/storage/src/backends/lark/transaction.rs
@@ -465,17 +465,22 @@ impl Txn for LarkTxn {
             let write_result = tokio::task::spawn_blocking(move || -> Result<()> {
                 let _conflict_snapshot = conflict_snapshot;
                 let _commit_guard = commit_gate.blocking_write();
-                // Unlike the other backends, a lark write error must NOT
-                // unrecord: lark can fail AFTER the batch is WAL-durable and
-                // memtable-visible (rotate_memtable on the same call), so an
-                // error is indeterminate. Keeping the record risks a phantom
-                // conflict (spurious retry); dropping it risks missing a real
-                // conflict against landed data (lost update).
-                pending.check_and_record_conflicts(&conflict_tracker, read_version, &read_set)?;
+                let version = pending.check_and_record_conflicts(
+                    &conflict_tracker,
+                    read_version,
+                    &read_set,
+                )?;
+                // Unrecords on error before the write lands. lark now reports
+                // write errors determinately (a failed rotate happens before
+                // the batch is applied), so an error means the batch did not
+                // land and the phantom write-set must not survive it.
+                let record_guard =
+                    crate::backends::shared::RecordGuard::new(&conflict_tracker, version);
 
                 let batch = pending.into_write_batch();
                 db.write_with_durability(batch, durability)
                     .map_err(|error| Error::Backend(error.to_string()))?;
+                record_guard.defuse();
                 Ok(())
             })
             .await;


### PR DESCRIPTION
Closes #1184.

#1183 carried two lark-only exceptions because the lark engine published its sequence number before applying a batch: read-only transactions had to take the commit gate (unlike the other backends, #1182) or risk observing a torn batch, and a write error was indeterminate so a failed commit could not unrecord its conflict entry (#1179).

The lark engine now publishes its read horizon only after applying a write, and reports write errors determinately (rotation moved ahead of the write, so a rotate failure is surfaced before the batch is assigned a sequence or applied). See sourcenetwork/lark#162.

This bumps `lark-kv` to that revision and drops both workarounds:

- **Read-only transactions skip the commit gate.** An ungated snapshot can no longer observe a torn batch, and read-only transactions never conflict-check — matching rocksdb/redb/fjall/memory.
- **A failed write rolls back its conflict record via `RecordGuard`.** A determinate error means the batch did not land, so the phantom write-set must not survive it — again matching the other backends.

The `readonly_txn_still_gated_against_torn_batches` unit test is inverted to `readonly_txn_skips_the_commit_gate`.

## Validation

- `cargo test -p storage --features "lark,redb,fjall,rocksdb"` and `-p db` — all green.
- `cargo test -p storage --features lark` — 406 tests including the backend conformance suite.
- The `lark_crash_reopen` integration test (SIGKILL then WAL-replay reopen, verifying acknowledged writes survive) passes.
- `cargo clippy --all --all-targets -- -D warnings` exit 0; `cargo fmt --all -- --check` clean.

The upstream engine change is covered by a new `snapshot_never_observes_a_torn_batch` concurrency test in lark that catches the torn batch on the pre-fix code and passes deterministically on the fix.
