### PR TITLE
fix(wasm): scope transaction state during queries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
+          components: clippy
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -76,6 +77,9 @@ jobs:
 
       - name: Exclude tools with private deps from workspace
         run: sed -i '/"tools\/integration-test"/d; /"tools\/ffi-test"/d' Cargo.toml
+
+      - name: Clippy (wasm32)
+        run: cargo clippy -p defra-wasm --target wasm32-unknown-unknown --all-targets -- -D warnings
 
       - name: Install wasm-pack
         run: cargo install wasm-pack --locked

--- a/crates/acp/src/lib.rs
+++ b/crates/acp/src/lib.rs
@@ -32,6 +32,9 @@ mod identity;
 mod local;
 pub mod nac;
 mod permission;
+// Both persistent stores require `S: Store + Send + Sync`, which the wasm
+// LevelDB store cannot satisfy, so they are native-only.
+#[cfg(not(target_arch = "wasm32"))]
 mod persistent;
 pub mod policy_yaml;
 pub mod read_access;
@@ -47,6 +50,7 @@ pub use error::{Error, Result};
 pub use identity::Identity;
 pub use local::{LocalDocumentACP, MemoryAcpStore};
 pub use permission::DocumentPermission;
+#[cfg(not(target_arch = "wasm32"))]
 pub use persistent::PersistentAcpStore;
 pub use read_access::{check_doc_read_access, DirectChecker, DocAccess, ObjectAccessChecker};
 pub use relation::{
@@ -57,6 +61,7 @@ pub use target_subject::parse_target_subject;
 pub use validation::{validate_resource_interface, REQUIRED_DOCUMENT_PERMISSIONS};
 
 // Re-export key zanzibar engine types from the standalone zanzibar crate
+#[cfg(not(target_arch = "wasm32"))]
 pub use zanzibar::PersistentZanzibarStore;
 pub use zanzibar::ZanzibarDocumentACP;
 

--- a/crates/acp/src/persistent.rs
+++ b/crates/acp/src/persistent.rs
@@ -11,9 +11,9 @@ use std::sync::Arc;
 use storage::corekv::{IterOptions, Reader, Store, Writer};
 use storage::namespace::{Namespace, NamespacedStore};
 
-#[cfg(all(not(target_arch = "wasm32"), feature = "redb"))]
+#[cfg(feature = "redb")]
 use std::path::Path;
-#[cfg(all(not(target_arch = "wasm32"), feature = "redb"))]
+#[cfg(feature = "redb")]
 use storage::RedbStore;
 
 use crate::error::{Error, Result};
@@ -74,7 +74,7 @@ impl<S: Store> PersistentAcpStore<S> {
     }
 }
 
-#[cfg(all(not(target_arch = "wasm32"), feature = "redb"))]
+#[cfg(feature = "redb")]
 impl PersistentAcpStore<RedbStore> {
     /// Open a persistent ACP store at the given directory path.
     ///
@@ -156,9 +156,7 @@ impl PersistentAcpStore<RedbStore> {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[async_trait]
 impl<S: Store + Send + Sync> AcpStore for PersistentAcpStore<S> {
     async fn put_tuple(&self, tuple: &RelationTuple) -> Result<()> {
         let mut txn = self

--- a/crates/acp/src/zanzibar/mod.rs
+++ b/crates/acp/src/zanzibar/mod.rs
@@ -11,4 +11,5 @@ mod acp;
 pub mod store;
 
 pub use acp::ZanzibarDocumentACP;
+#[cfg(not(target_arch = "wasm32"))]
 pub use store::PersistentZanzibarStore;

--- a/crates/acp/src/zanzibar/store/mod.rs
+++ b/crates/acp/src/zanzibar/store/mod.rs
@@ -1,5 +1,9 @@
 //! Defradb-specific Zanzibar store implementations.
 
+// Requires `S: Store + Send + Sync`, which the wasm LevelDB store cannot
+// satisfy, so this store is native-only.
+#[cfg(not(target_arch = "wasm32"))]
 mod persistent;
 
+#[cfg(not(target_arch = "wasm32"))]
 pub use persistent::PersistentZanzibarStore;

--- a/crates/acp/src/zanzibar/store/persistent.rs
+++ b/crates/acp/src/zanzibar/store/persistent.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use storage::corekv::{IterOptions, Reader, Store, Writer};
 use storage::namespace::{Namespace, NamespacedStore};
-#[cfg(all(not(target_arch = "wasm32"), feature = "redb"))]
+#[cfg(feature = "redb")]
 use storage::RedbStore;
 
 use identity::Did;
@@ -27,7 +27,7 @@ impl<S: Store> PersistentZanzibarStore<S> {
     }
 }
 
-#[cfg(all(not(target_arch = "wasm32"), feature = "redb"))]
+#[cfg(feature = "redb")]
 impl PersistentZanzibarStore<RedbStore> {
     /// Open a persistent store at the given path.
     pub fn open(path: &std::path::Path) -> Result<Self> {
@@ -62,9 +62,7 @@ impl<S: Store> PersistentZanzibarStore<S> {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[async_trait]
 impl<S: Store + Send + Sync> ZanzibarStore for PersistentZanzibarStore<S> {
     async fn store_policy(&self, policy: &Policy) -> Result<()> {
         let mut txn = self.store.new_txn(false).await.map_err(|e| {

--- a/crates/datastore/src/multistore.rs
+++ b/crates/datastore/src/multistore.rs
@@ -16,6 +16,11 @@ pub struct SharedTxn {
 
 impl SharedTxn {
     /// Create a new shared transaction.
+    // `Txn` drops its `Send + Sync` bounds on wasm32 (see `MaybeSendSync`), so
+    // there the Arc wraps a non-Send value. That is sound in the
+    // single-threaded browser runtime, and the return type has to stay `Arc`
+    // for native callers that share it across threads.
+    #[cfg_attr(target_arch = "wasm32", allow(clippy::arc_with_non_send_sync))]
     pub fn new(txn: Box<dyn Txn>) -> Arc<Self> {
         Arc::new(Self {
             txn: RwLock::new(txn),

--- a/crates/db-merge/src/acp_merge_handler.rs
+++ b/crates/db-merge/src/acp_merge_handler.rs
@@ -214,6 +214,9 @@ impl<S: Store, B: blockstore::Blockstore> AcpMergeHandler<S, B> {
             .db
             .node_identity()
             .and_then(|identity| identity.did().ok().map(Identity::from));
+        // Non-Send on wasm32, where the ACP traits it holds drop their `Send`
+        // bounds for the single-threaded browser runtime.
+        #[cfg_attr(target_arch = "wasm32", allow(clippy::arc_with_non_send_sync))]
         let hook = Arc::new(AcpCompositeMergeHook::new(local_identity));
         inner.set_composite_merge_hook(hook.clone());
         Self { inner, hook }

--- a/crates/db/src/downsample/execute.rs
+++ b/crates/db/src/downsample/execute.rs
@@ -434,6 +434,8 @@ impl<S: Store + 'static> crate::database::DB<S> {
         Ok(())
     }
 
+    // Only the downsample task drives this, and that task is native-only.
+    #[cfg(not(target_arch = "wasm32"))]
     pub(super) async fn process_downsample_update(
         self: &Arc<Self>,
         collection_id: &str,

--- a/crates/db/src/txn_registry.rs
+++ b/crates/db/src/txn_registry.rs
@@ -937,6 +937,9 @@ impl<S: Store + 'static> TransactionRegistry for DbTransactionRegistry<S> {
             .new_txn(readonly)
             .await
             .map_err(|e| TransactionError::execution(format!("storage error: {}", e)))?;
+        // Non-Send on wasm32, where the callbacks it holds drop their `Send`
+        // bounds for the single-threaded browser runtime.
+        #[cfg_attr(target_arch = "wasm32", allow(clippy::arc_with_non_send_sync))]
         let deferred_acp_mutations = Arc::new(DeferredAcpMutations::new());
         let deferred_acp_mutations_for_commit = deferred_acp_mutations.clone();
         db_txn

--- a/crates/db/src/view_ops.rs
+++ b/crates/db/src/view_ops.rs
@@ -6,7 +6,9 @@
 use crate::error::{Error, Result};
 use datastore::NamespaceView;
 use schema::CollectionVersion;
+#[cfg(not(target_arch = "wasm32"))]
 use std::collections::{HashMap, HashSet};
+#[cfg(not(target_arch = "wasm32"))]
 use std::sync::Arc;
 use std::time::Duration;
 use storage::corekv::{IterOptions, Key, Store};

--- a/crates/query-plan/Cargo.toml
+++ b/crates/query-plan/Cargo.toml
@@ -26,6 +26,7 @@ lens = { path = "../lens", default-features = false }
 async-trait.workspace = true
 async-lock.workspace = true
 futures.workspace = true
+tokio = { version = "1.35", default-features = false, features = ["rt"] }
 
 # Serialization
 serde.workspace = true
@@ -51,9 +52,8 @@ bm25.workspace = true
 # Time handling
 chrono = { version = "0.4", features = ["serde"] }
 
-# Tokio task-local storage only on non-WASM (used by txn::context)
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { workspace = true, features = ["time"] }
+[dev-dependencies]
+tokio.workspace = true
 
 [lints]
 workspace = true

--- a/crates/query-plan/src/txn/context.rs
+++ b/crates/query-plan/src/txn/context.rs
@@ -17,7 +17,6 @@ use crate::fetcher::CollectionProvider;
 use crate::fetcher::DocFetcher;
 use crate::mutator::DocMutator;
 
-#[cfg(not(target_arch = "wasm32"))]
 tokio::task_local! {
     static TXN_DEFERRED_ACP_MUTATIONS: Arc<DeferredAcpMutations>;
 }
@@ -264,7 +263,6 @@ impl Drop for RequestBearerTokenGuard {
 }
 
 /// Execute a future with the given deferred ACP mutation projection in scope.
-#[cfg(not(target_arch = "wasm32"))]
 pub async fn scope_deferred_acp_mutations<Fut, T>(
     mutations: Arc<DeferredAcpMutations>,
     future: Fut,
@@ -275,31 +273,11 @@ where
     TXN_DEFERRED_ACP_MUTATIONS.scope(mutations, future).await
 }
 
-/// Execute a future with the given deferred ACP mutation projection in scope.
-#[cfg(target_arch = "wasm32")]
-pub async fn scope_deferred_acp_mutations<Fut, T>(
-    _mutations: Arc<DeferredAcpMutations>,
-    future: Fut,
-) -> T
-where
-    Fut: Future<Output = T>,
-{
-    future.await
-}
-
 /// Return the current transaction's deferred ACP projection, if any.
 pub fn current_deferred_acp_mutations() -> Option<Arc<DeferredAcpMutations>> {
-    #[cfg(not(target_arch = "wasm32"))]
-    {
-        TXN_DEFERRED_ACP_MUTATIONS
-            .try_with(|mutations| mutations.clone())
-            .ok()
-    }
-
-    #[cfg(target_arch = "wasm32")]
-    {
-        None
-    }
+    TXN_DEFERRED_ACP_MUTATIONS
+        .try_with(|mutations| mutations.clone())
+        .ok()
 }
 
 /// Check document registration while honoring any ACP mutations buffered in the current txn.

--- a/crates/query/Cargo.toml
+++ b/crates/query/Cargo.toml
@@ -26,6 +26,7 @@ lens = { path = "../lens", default-features = false }
 async-trait.workspace = true
 async-lock.workspace = true
 futures.workspace = true
+tokio = { version = "1.35", default-features = false, features = ["rt"] }
 
 # Serialization
 serde.workspace = true
@@ -60,9 +61,9 @@ regex = "1"
 # Time handling (for DateTime parsing in mutations)
 chrono = { version = "0.4", features = ["serde"] }
 
-# Tokio is only needed on non-WASM targets (for query timeouts)
+# Query timeouts are native-only.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { workspace = true, features = ["time"] }
+tokio = { version = "1.35", default-features = false, features = ["time"] }
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/query/src/runner/executor.rs
+++ b/crates/query/src/runner/executor.rs
@@ -441,11 +441,13 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
             }
         };
 
-        let deferred_acp_mutations = txn_ctx.deferred_acp_mutations();
-
         // If the transaction provides a collection provider or deferred ACP
         // projection, set them as task-local overrides so this execution sees
-        // the transaction's uncommitted schema and ACP state.
+        // the transaction's uncommitted schema and ACP state. The task-local
+        // scoping is native-only, so wasm32 skips both overrides.
+        #[cfg(not(target_arch = "wasm32"))]
+        let deferred_acp_mutations = txn_ctx.deferred_acp_mutations();
+
         #[cfg(not(target_arch = "wasm32"))]
         let result = if let Some(provider) = txn_provider {
             if let Some(deferred_acp_mutations) = deferred_acp_mutations {

--- a/crates/query/src/runner/executor.rs
+++ b/crates/query/src/runner/executor.rs
@@ -328,23 +328,17 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
             }
         };
 
-        #[cfg(not(target_arch = "wasm32"))]
         let txn_provider = txn_ctx.collection_provider();
 
         // Validate that all referenced collections exist before execution.
         // Use the transaction-scoped provider if available so uncommitted schemas are visible.
         {
-            #[cfg(not(target_arch = "wasm32"))]
             let validation_provider: &dyn crate::fetcher::CollectionProvider =
                 if let Some(ref p) = txn_provider {
                     p.as_ref()
                 } else {
                     self.collection_provider.as_ref()
                 };
-
-            #[cfg(target_arch = "wasm32")]
-            let validation_provider: &dyn crate::fetcher::CollectionProvider =
-                self.collection_provider.as_ref();
 
             if let Err(e) = validate_parsed_operation(&parsed, validation_provider).await {
                 return QueryResponse {
@@ -441,14 +435,10 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
             }
         };
 
-        // If the transaction provides a collection provider or deferred ACP
-        // projection, set them as task-local overrides so this execution sees
-        // the transaction's uncommitted schema and ACP state. The task-local
-        // scoping is native-only, so wasm32 skips both overrides.
-        #[cfg(not(target_arch = "wasm32"))]
         let deferred_acp_mutations = txn_ctx.deferred_acp_mutations();
 
-        #[cfg(not(target_arch = "wasm32"))]
+        // Scope both transaction overlays around execution so schema resolution
+        // and ACP checks see uncommitted state.
         let result = if let Some(provider) = txn_provider {
             if let Some(deferred_acp_mutations) = deferred_acp_mutations {
                 super::TXN_COLLECTION_PROVIDER
@@ -474,9 +464,6 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
         } else {
             await_with_timeout(execution, self.query_timeout).await
         };
-
-        #[cfg(target_arch = "wasm32")]
-        let result = await_with_timeout(execution, self.query_timeout).await;
 
         match result {
             Ok(data) => QueryResponse {

--- a/crates/query/src/runner/mod.rs
+++ b/crates/query/src/runner/mod.rs
@@ -58,7 +58,6 @@ use crate::mutator::DocMutator;
 use crate::planner::Doc;
 use crate::txn::{NoOpTransactionRegistry, TransactionRegistry};
 
-#[cfg(not(target_arch = "wasm32"))]
 tokio::task_local! {
     /// Per-request collection provider override for transaction-scoped schema resolution.
     ///
@@ -406,16 +405,10 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
     ///
     /// Returns the transaction-scoped provider if set (via task-local storage),
     /// otherwise returns the default process-wide provider.
-    #[cfg(not(target_arch = "wasm32"))]
     fn effective_provider(&self) -> Arc<dyn CollectionProvider> {
         TXN_COLLECTION_PROVIDER
             .try_with(|p| p.clone())
             .unwrap_or_else(|_| self.collection_provider.clone())
-    }
-
-    #[cfg(target_arch = "wasm32")]
-    fn effective_provider(&self) -> Arc<dyn CollectionProvider> {
-        self.collection_provider.clone()
     }
 
     /// Get the names of all collections.

--- a/crates/storage/src/backends/shared.rs
+++ b/crates/storage/src/backends/shared.rs
@@ -2,6 +2,7 @@ use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 #[cfg(not(target_arch = "wasm32"))]
 use std::collections::BTreeMap;
+#[cfg(not(target_arch = "wasm32"))]
 use std::collections::HashSet;
 #[cfg(not(target_arch = "wasm32"))]
 use std::sync::{
@@ -9,7 +10,9 @@ use std::sync::{
     Arc,
 };
 
-use crate::corekv::{AsyncTxnCallback, IterOptions, TxnCallback};
+#[cfg(not(target_arch = "wasm32"))]
+use crate::corekv::IterOptions;
+use crate::corekv::{AsyncTxnCallback, TxnCallback};
 
 /// Controls when data is flushed to disk after a commit.
 ///
@@ -179,12 +182,14 @@ impl CallbackCounts {
 /// writes data must conflict if another transaction committed after its snapshot
 /// and either wrote a key it read, or read a key/range it wrote. Tracking both
 /// point reads and iterator ranges gives the Rust backends the same behavior.
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Debug, Clone, Default)]
 pub(crate) struct ReadSet {
     keys: HashSet<Vec<u8>>,
     ranges: Vec<ReadRange>,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Debug, Clone)]
 enum ReadRange {
     Prefix(Vec<u8>),
@@ -194,6 +199,7 @@ enum ReadRange {
     },
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl ReadSet {
     pub(crate) fn record_key(&mut self, key: &[u8]) {
         self.keys.insert(key.to_vec());
@@ -218,6 +224,7 @@ impl ReadSet {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn is_document_collection_scan_prefix(prefix: &[u8]) -> bool {
     // Namespaced datastore document scans use `d/d/...`; root datastore scans
     // use `/d/...`. Go's SSI conflict in the relation tests comes from FK index
@@ -229,6 +236,7 @@ fn is_document_collection_scan_prefix(prefix: &[u8]) -> bool {
         || prefix.starts_with(b"/del/")
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl ReadRange {
     fn contains(&self, key: &[u8]) -> bool {
         match self {

--- a/crates/wasm/src/client.rs
+++ b/crates/wasm/src/client.rs
@@ -182,6 +182,11 @@ impl DefraClient {
 
 // Internal implementation methods
 impl DefraClient {
+    // The LevelDB-backed database and its mutator are not `Send`, since wasm
+    // drops those bounds for the single-threaded browser runtime. Sharing them
+    // by `Arc` is what the query runner expects, and there are no threads to
+    // send them across.
+    #[allow(clippy::arc_with_non_send_sync)]
     async fn new_impl(config: JsValue) -> Result<Self> {
         let config: ClientConfig = if config.is_undefined() || config.is_null() {
             ClientConfig::default()
@@ -444,7 +449,7 @@ mod tests {
 
     #[wasm_bindgen_test]
     async fn test_mutate_no_schema_fails() {
-        let mut client = DefraClient::create(test_config("test_mutate_no_schema"))
+        let client = DefraClient::create(test_config("test_mutate_no_schema"))
             .await
             .unwrap();
         let result = client
@@ -455,7 +460,7 @@ mod tests {
 
     #[wasm_bindgen_test]
     async fn test_empty_mutation_fails() {
-        let mut client = DefraClient::create(test_config("test_empty_mut"))
+        let client = DefraClient::create(test_config("test_empty_mut"))
             .await
             .unwrap();
         let result = client.mutate("").await;

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -60,6 +60,8 @@ pub mod error;
 mod storage_tests;
 #[cfg(target_arch = "wasm32")]
 mod sync;
+#[cfg(target_arch = "wasm32")]
+mod transaction_tests;
 pub mod verification;
 
 // Re-export the main client class

--- a/crates/wasm/src/transaction_tests.rs
+++ b/crates/wasm/src/transaction_tests.rs
@@ -1,0 +1,46 @@
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use db::{DbCollectionProvider, DbTransactionRegistry, LensedAutoCommitFetcher, DB};
+    use query::runner::QueryRunner;
+    use query::txn::TransactionRegistry;
+    use query::{QueryExecutor, QueryRequest};
+    use serde_json::json;
+    use storage::LevelDbStore;
+    use wasm_bindgen_test::*;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[wasm_bindgen_test]
+    #[allow(clippy::arc_with_non_send_sync)]
+    async fn query_in_txn_sees_uncommitted_schema() {
+        let store = LevelDbStore::open("test_query_in_txn_schema").unwrap();
+        let db = Arc::new(DB::new(store).unwrap());
+        let registry = Arc::new(DbTransactionRegistry::new(Arc::clone(&db)));
+        let handle = registry.begin(false).await.unwrap();
+
+        registry
+            .add_schema_in_txn(handle.as_str(), "type TxnOnly { value: Int }")
+            .await
+            .unwrap();
+
+        let runner = QueryRunner::with_arc_registry_and_provider(
+            LensedAutoCommitFetcher::new(Arc::clone(&db)),
+            DbCollectionProvider::new_arc(db),
+            Arc::clone(&registry),
+        );
+        let response = runner
+            .execute_in_txn(QueryRequest::new("{ TxnOnly { value } }"), &handle)
+            .await;
+
+        assert!(
+            !response.has_errors(),
+            "transaction query failed: {:?}",
+            response.errors
+        );
+        assert_eq!(response.data, Some(json!({ "TxnOnly": [] })));
+
+        registry.rollback(&handle).await.unwrap();
+    }
+}


### PR DESCRIPTION
Closes #1190.

Depends on #1189; its two commits will disappear from this PR after that lands.

## Problem

Queries executed inside a browser transaction bypassed the task-local overlays used by native builds. Schema validation and execution therefore resolved collections from committed state, while permission checks ignored deferred ACP mutations from the same transaction.

## What changed

- Enable the existing Tokio task-local transaction scopes on WASM with the minimal `rt` feature.
- Use the transaction-scoped collection provider for validation and execution on every target.
- Apply deferred ACP projections around WASM query execution just as native execution does.
- Add a browser regression that creates a collection inside a transaction and queries it before commit.

## Validation

- [x] `cargo test -p query-plan -p query`
- [x] `cargo test --workspace --exclude integration-test --exclude ffi-test --exclude conformance`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo clippy -p query -p query-plan --all-targets -- -D warnings`
- [x] `cargo clippy -p defra-wasm --target wasm32-unknown-unknown --all-targets -- -D warnings`
- [x] `cargo build -p defra-wasm --target wasm32-unknown-unknown --release`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`