### PR TITLE
docs: cut consumer cross-references over to Gents

### DIFF
--- a/crates/db-index/src/index_manager/mod.rs
+++ b/crates/db-index/src/index_manager/mod.rs
@@ -440,7 +440,7 @@ impl IndexManager {
     /// time and identical on every replica — no version/height state needed.
     /// The losing document remains fully readable by non-index (scan) queries
     /// and is reported loudly; applications keep their own reconcile policy
-    /// (sourcenetwork/defra-agent#694 already does).
+    /// (source-inc/gents#694 already does).
     async fn save_resolving_unique_conflict(
         &self,
         datastore: &mut NamespaceView,

--- a/crates/db-merge/src/merge_handler/composite_persist.rs
+++ b/crates/db-merge/src/merge_handler/composite_persist.rs
@@ -83,7 +83,7 @@ impl<S: Store, B: blockstore::Blockstore> DbMergeHandler<S, B> {
 
         // A merged write onto a logically-deleted document must not touch the
         // indexes: the document is dead, and indexing it re-mints exactly the
-        // stale unique entry that blocks the value forever (gents#700's
+        // stale unique entry that blocks the value forever (source-inc/gents#700's
         // out-of-order create-after-delete arrival). Go skips index sync when
         // the merged doc reads back absent for the same reason.
         let deleted_marker_key =

--- a/crates/db-merge/src/merge_handler/composite_persist.rs
+++ b/crates/db-merge/src/merge_handler/composite_persist.rs
@@ -83,7 +83,7 @@ impl<S: Store, B: blockstore::Blockstore> DbMergeHandler<S, B> {
 
         // A merged write onto a logically-deleted document must not touch the
         // indexes: the document is dead, and indexing it re-mints exactly the
-        // stale unique entry that blocks the value forever (defra-agent#700's
+        // stale unique entry that blocks the value forever (gents#700's
         // out-of-order create-after-delete arrival). Go skips index sync when
         // the merged doc reads back absent for the same reason.
         let deleted_marker_key =

--- a/crates/db-merge/src/push_docs_transport.rs
+++ b/crates/db-merge/src/push_docs_transport.rs
@@ -631,7 +631,7 @@ pub async fn retry_doc_via_transport<S: Store + 'static, T: P2PTransport>(
 /// document's composite heads. Before this existed, a failed collection-commit
 /// push had no replay path at all and failed permanently — receivers held heads
 /// whose parents never arrived, so their pending-DAG registrations could never
-/// complete (defra-agent#696).
+/// complete (gents#696).
 ///
 /// Unlike the document replay, a missing block is an ERROR, not a silent
 /// success: acking an obligation we did not actually push would delete the

--- a/crates/db-merge/src/push_docs_transport.rs
+++ b/crates/db-merge/src/push_docs_transport.rs
@@ -631,7 +631,7 @@ pub async fn retry_doc_via_transport<S: Store + 'static, T: P2PTransport>(
 /// document's composite heads. Before this existed, a failed collection-commit
 /// push had no replay path at all and failed permanently — receivers held heads
 /// whose parents never arrived, so their pending-DAG registrations could never
-/// complete (gents#696).
+/// complete (source-inc/gents#696).
 ///
 /// Unlike the document replay, a missing block is an ERROR, not a silent
 /// success: acking an obligation we did not actually push would delete the

--- a/crates/db/tests/index_manager_tests.rs
+++ b/crates/db/tests/index_manager_tests.rs
@@ -1602,7 +1602,7 @@ async fn test_delete_then_recreate_same_value() {
 }
 
 /// Unique-index semantics at the deletion and merge boundaries (#1111 /
-/// sourcenetwork/defra-agent#700).
+/// source-inc/gents#700).
 mod unique_boundaries {
     use super::*;
     use datastore::NamespaceView;
@@ -1681,7 +1681,7 @@ mod unique_boundaries {
         datastore.set(&key, &[1u8]).await.unwrap();
     }
 
-    /// Go-parity regression (sourcenetwork/defra-agent#700): deleting the doc
+    /// Go-parity regression (source-inc/gents#700): deleting the doc
     /// that holds a unique value frees the slot for a new doc with that value.
     #[tokio::test]
     async fn recreate_after_delete_frees_the_unique_slot() {

--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -2028,7 +2028,7 @@ async fn gossip_controlled_mode_allows_subscribed_outbound_replicator_target() {
 /// have no document-topic fallback: the collection topic is their only delivery
 /// path. A symmetric mesh makes both peers each other's outbound replicator
 /// target, so if that closed the collection topic, collection commits could
-/// never be delivered at all (gents#696).
+/// never be delivered at all (source-inc/gents#696).
 #[tokio::test]
 async fn gossip_allows_doc_less_collection_commit_from_outbound_replicator_target() {
     let replicators = Arc::new(ReplicatorRegistry::new());

--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -2028,7 +2028,7 @@ async fn gossip_controlled_mode_allows_subscribed_outbound_replicator_target() {
 /// have no document-topic fallback: the collection topic is their only delivery
 /// path. A symmetric mesh makes both peers each other's outbound replicator
 /// target, so if that closed the collection topic, collection commits could
-/// never be delivered at all (defra-agent#696).
+/// never be delivered at all (gents#696).
 #[tokio::test]
 async fn gossip_allows_doc_less_collection_commit_from_outbound_replicator_target() {
     let replicators = Arc::new(ReplicatorRegistry::new());

--- a/crates/p2p/src/sync/coordinator/push_worker.rs
+++ b/crates/p2p/src/sync/coordinator/push_worker.rs
@@ -85,7 +85,7 @@ async fn report_push_event(
     // recorded in the ledger's collection-commit keyspace and replayed by CID
     // (defradb#1113). Dropping them here made a failed collection-commit push
     // permanent — the receiver kept heads whose parents never arrived, so its
-    // pending-DAG registrations could never complete (defra-agent#696).
+    // pending-DAG registrations could never complete (gents#696).
     //
     // A doc-less failure with no CID (the versionless SE-artifact path) still
     // has nothing to replay: no document to re-resolve and no CID to re-send.
@@ -1029,7 +1029,7 @@ mod tests {
 
         // defradb#1113: the obligation must reach the ledger. It is doc-less, so
         // it is keyed and replayed by CID; dropping it made failed
-        // collection-commit pushes permanent (defra-agent#696).
+        // collection-commit pushes permanent (gents#696).
         let failure = rx.try_recv().expect("commit failure must be recorded");
         assert_eq!(failure.doc_id, "");
         assert_eq!(failure.collection_id, "collection");

--- a/crates/p2p/src/sync/coordinator/push_worker.rs
+++ b/crates/p2p/src/sync/coordinator/push_worker.rs
@@ -85,7 +85,7 @@ async fn report_push_event(
     // recorded in the ledger's collection-commit keyspace and replayed by CID
     // (defradb#1113). Dropping them here made a failed collection-commit push
     // permanent — the receiver kept heads whose parents never arrived, so its
-    // pending-DAG registrations could never complete (gents#696).
+    // pending-DAG registrations could never complete (source-inc/gents#696).
     //
     // A doc-less failure with no CID (the versionless SE-artifact path) still
     // has nothing to replay: no document to re-resolve and no CID to re-send.
@@ -1029,7 +1029,7 @@ mod tests {
 
         // defradb#1113: the obligation must reach the ledger. It is doc-less, so
         // it is keyed and replayed by CID; dropping it made failed
-        // collection-commit pushes permanent (gents#696).
+        // collection-commit pushes permanent (source-inc/gents#696).
         let failure = rx.try_recv().expect("commit failure must be recorded");
         assert_eq!(failure.doc_id, "");
         assert_eq!(failure.collection_id, "collection");

--- a/crates/p2p/src/sync/push_backlog.rs
+++ b/crates/p2p/src/sync/push_backlog.rs
@@ -247,7 +247,7 @@ struct Inner {
 }
 
 /// Live per-peer occupancy so slot starvation is visible to operators
-/// (gents#630: a dead peer monopolizing the slots was invisible in
+/// (source-inc/gents#630: a dead peer monopolizing the slots was invisible in
 /// connection-level diagnostics).
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct PeerBacklogSnapshot {
@@ -445,7 +445,7 @@ impl PushBacklog {
         }
         // One peer may hold at most a quarter of the item budget, so a dead
         // peer's parked jobs cannot squat the whole queue and starve healthy
-        // peers' admissions (gents#630 req 1).
+        // peers' admissions (source-inc/gents#630 req 1).
         let peer_quota = (self.item_capacity / 4).max(1);
         if inner
             .queues
@@ -1215,7 +1215,7 @@ mod tests {
         assert_eq!(snap.queued_bytes, 0);
     }
 
-    /// Amy canary req 1 (gents#630): one peer's backlog must not squat
+    /// Amy canary req 1 (source-inc/gents#630): one peer's backlog must not squat
     /// the whole global item budget.
     #[test]
     fn one_peer_cannot_fill_the_whole_queue() {

--- a/crates/p2p/src/sync/push_backlog.rs
+++ b/crates/p2p/src/sync/push_backlog.rs
@@ -247,7 +247,7 @@ struct Inner {
 }
 
 /// Live per-peer occupancy so slot starvation is visible to operators
-/// (defra-agent#630: a dead peer monopolizing the slots was invisible in
+/// (gents#630: a dead peer monopolizing the slots was invisible in
 /// connection-level diagnostics).
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct PeerBacklogSnapshot {
@@ -445,7 +445,7 @@ impl PushBacklog {
         }
         // One peer may hold at most a quarter of the item budget, so a dead
         // peer's parked jobs cannot squat the whole queue and starve healthy
-        // peers' admissions (defra-agent#630 req 1).
+        // peers' admissions (gents#630 req 1).
         let peer_quota = (self.item_capacity / 4).max(1);
         if inner
             .queues
@@ -1215,7 +1215,7 @@ mod tests {
         assert_eq!(snap.queued_bytes, 0);
     }
 
-    /// Amy canary req 1 (defra-agent#630): one peer's backlog must not squat
+    /// Amy canary req 1 (gents#630): one peer's backlog must not squat
     /// the whole global item budget.
     #[test]
     fn one_peer_cannot_fill_the_whole_queue() {

--- a/crates/storage/src/keys/peerstore.rs
+++ b/crates/storage/src/keys/peerstore.rs
@@ -164,7 +164,7 @@ impl Key for ReplicatorRetryDocIDKey {
 /// commit for a peer into one slot). Before this key existed, a failed
 /// collection-commit push had nowhere to be recorded and failed PERMANENTLY:
 /// receivers kept heads whose parents never arrived, so their pending-DAG
-/// registrations could never complete (defradb#1113, gents#696).
+/// registrations could never complete (defradb#1113, source-inc/gents#696).
 ///
 /// One record per (peer, collection, CID): collection-commit DAGs chain, so a
 /// newer commit does NOT make an older undelivered one redundant.

--- a/crates/storage/src/keys/peerstore.rs
+++ b/crates/storage/src/keys/peerstore.rs
@@ -164,7 +164,7 @@ impl Key for ReplicatorRetryDocIDKey {
 /// commit for a peer into one slot). Before this key existed, a failed
 /// collection-commit push had nowhere to be recorded and failed PERMANENTLY:
 /// receivers kept heads whose parents never arrived, so their pending-DAG
-/// registrations could never complete (defradb#1113, defra-agent#696).
+/// registrations could never complete (defradb#1113, gents#696).
 ///
 /// One record per (peer, collection, CID): collection-commit DAGs chain, so a
 /// newer commit does NOT make an older undelivered one redundant.

--- a/crates/storage/src/stores/peerstore.rs
+++ b/crates/storage/src/stores/peerstore.rs
@@ -201,7 +201,7 @@ impl<S: Store> Peerstore<S> {
         // recorded under their own keyspace so they can be replayed by CID;
         // dropping them here made a failed collection-commit push permanent,
         // leaving receivers with heads whose parents never arrive
-        // (defradb#1113, gents#696).
+        // (defradb#1113, source-inc/gents#696).
         if doc_id.is_empty() {
             if cid.is_empty() {
                 // A versionless doc-less failure (SE artifact) has nothing to
@@ -1182,7 +1182,7 @@ mod tests {
     /// and replayable. It has no document id, so it is keyed by
     /// (peer, collection, CID). Dropping it made the failure permanent —
     /// receivers kept heads whose parents never arrived, and their pending-DAG
-    /// registrations could never complete (gents#696).
+    /// registrations could never complete (source-inc/gents#696).
     #[tokio::test]
     async fn collection_commit_push_failure_is_recorded_and_replayable() {
         let store = Arc::new(MemoryStore::new());

--- a/crates/storage/src/stores/peerstore.rs
+++ b/crates/storage/src/stores/peerstore.rs
@@ -201,7 +201,7 @@ impl<S: Store> Peerstore<S> {
         // recorded under their own keyspace so they can be replayed by CID;
         // dropping them here made a failed collection-commit push permanent,
         // leaving receivers with heads whose parents never arrive
-        // (defradb#1113, defra-agent#696).
+        // (defradb#1113, gents#696).
         if doc_id.is_empty() {
             if cid.is_empty() {
                 // A versionless doc-less failure (SE artifact) has nothing to
@@ -1182,7 +1182,7 @@ mod tests {
     /// and replayable. It has no document id, so it is keyed by
     /// (peer, collection, CID). Dropping it made the failure permanent —
     /// receivers kept heads whose parents never arrived, and their pending-DAG
-    /// registrations could never complete (defra-agent#696).
+    /// registrations could never complete (gents#696).
     #[tokio::test]
     async fn collection_commit_push_failure_is_recorded_and_replayable() {
         let store = Arc::new(MemoryStore::new());

--- a/crates/telemetry/src/config.rs
+++ b/crates/telemetry/src/config.rs
@@ -12,7 +12,7 @@ pub struct TelemetryConfig {
     /// process-wide globals via `opentelemetry::global::set_*`. Set to
     /// `false` for embedded use where the host process owns its own OTel
     /// globals and `init` would otherwise silently clobber them (e.g.
-    /// defra-agent runs its own OTel stack and just wants DefraDB-emitted
+    /// Gents runs its own OTel stack and just wants DefraDB-emitted
     /// spans flushed at shutdown).
     pub install_global: bool,
 }

--- a/proofs/README.md
+++ b/proofs/README.md
@@ -27,7 +27,7 @@ section is the **diff**: what is proven vs. the accepted gap.
 | DAG convergence (partition / eviction / restart) | TLA+ | p2p, db-merge, blockstore |
 | CRDT merge laws | Lean | crdt, defra-core |
 | Replicator lifecycle (no-loss / resume) | TLA+ | p2p, db-merge, embedded |
-| Multi-instance claim | TLA+ | defra-agent |
+| Multi-instance claim | TLA+ | gents |
 | Block integrity / signatures | TLA+ | db-merge, defra-core, blockstore |
 | KMS key distribution | TLA+ | kms, db-merge |
 | Encrypted LWW restart/replay | TLA+ + existing LWW Lean law | kms, p2p, db-merge, crdt |
@@ -125,7 +125,7 @@ headstore); go↔go vs rust↔rust parity (`parity.rs`) localized it to Rust.
 | KMS key distribution | Behavioral | `kms.rs` (node0 denies the DEK to unauthorized node1) |
 | Encrypted LWW restart/replay | Behavioral + Boundary | `partition::convergence_encrypted_lww_restart_merge` binds the decrypted LWW winner after a restart-induced partition; filtered replication binds encrypted-field preservation. Durable acknowledgement-backed retry through a receiver restart remains Boundary; `MC_EncryptedLwwReplay_{Green,Red_*}`; reuses `PriorityReconcile.lwwCM` |
 | CRDT merge laws | Contract | `MergeResult` vocab; `DefraConvergence.MixedField` product proof; `MixedFieldMaterialization.tla` |
-| Multi-instance claim | Boundary | defra-agent substrate, not this binary |
+| Multi-instance claim | Boundary | gents substrate, not this binary |
 | Block integrity / signatures | Boundary | needs adversarial peer; Rust verify mandatory |
 | P2P capability replay gate | Boundary | P2P-wire internal |
 | JWT issuer / algorithm binding | Boundary | DID-binding via `acp.rs`; forge unreachable via CLI |
@@ -148,7 +148,7 @@ cargo test -p conformance            # Lean axis + behavioral; DEFRA_CONFORMANCE
 - **Naming:** invariants/safety `INV_*`; liveness as `<>[]...` properties; scenario
   wrappers `MC_<Family>_<Case>`.
 - **Source-anchored.** Every family has a `<Family>_DESIGN.md` grounding the abstraction
-  in specific defradb.rs / defra-agent source modules (file:line). Model the real code
+  in specific defradb.rs / gents source modules (file:line). Model the real code
   paths, not an abstraction in a vacuum.
 - **Lean:** mathlib-free, toolchain pinned, **no `sorry`/`admit`**, and `#print axioms`
   status recorded in `lean/README.md`.
@@ -182,5 +182,5 @@ Read this before trusting a verdict; it states the model's honest reach.
   the `*_DESIGN.md` docs and bound to the implementation by the `conformance` crate (see
   *Conformance* above) — the Lean axis asserts model vocabularies against live Rust types,
   the TLA axis drives the selected DefraDB binary. What conformance does **not** reach is marked
-  `Boundary` in the registry (crypto, eventual connectivity, bounded-N, the defra-agent
+  `Boundary` in the registry (crypto, eventual connectivity, bounded-N, the gents
   claim substrate): assumed, never asserted against the artifact.

--- a/proofs/src/lean_contract.rs
+++ b/proofs/src/lean_contract.rs
@@ -4,7 +4,7 @@
 //! from the Lean models) between two sentinel lines. We run it via
 //! `lake env lean --run`, slice out the JSON, and deserialize it. Tests then
 //! assert the live Rust types still match — so a rename in the code breaks the
-//! proof's binding loudly. Mirrors defra-agent's `lean_vocab_test` pattern.
+//! proof's binding loudly. Mirrors the Gents `lean_vocab_test` pattern.
 
 use anyhow::{bail, Context, Result};
 use serde::de::DeserializeOwned;

--- a/proofs/src/registry.rs
+++ b/proofs/src/registry.rs
@@ -105,7 +105,7 @@ pub const PROPERTIES: &[Property] = &[
         family: "Multi-instance claim",
         name: "INV_EventualUnique — claim CAS converges to a single winner",
         axis: Tla,
-        anchor: "defra-agent claim.rs (foreign substrate, not the defradb.rs binary)",
+        anchor: "gents claim.rs (foreign substrate, not the defradb.rs binary)",
         model_ref: "MC_Claim_Filtered_Eventual.cfg",
         tiers: &[Boundary],
     },

--- a/proofs/src/registry.rs
+++ b/proofs/src/registry.rs
@@ -105,7 +105,7 @@ pub const PROPERTIES: &[Property] = &[
         family: "Multi-instance claim",
         name: "INV_EventualUnique — claim CAS converges to a single winner",
         axis: Tla,
-        anchor: "source-inc/gents crates/gents/src/lifecycle/claim.rs:claim_inner (foreign substrate, not the defradb.rs binary)",
+        anchor: "gents:crates/gents/src/lifecycle/claim.rs:claim_inner (foreign substrate, not the defradb.rs binary)",
         model_ref: "MC_Claim_Filtered_Eventual.cfg",
         tiers: &[Boundary],
     },

--- a/proofs/src/registry.rs
+++ b/proofs/src/registry.rs
@@ -105,7 +105,7 @@ pub const PROPERTIES: &[Property] = &[
         family: "Multi-instance claim",
         name: "INV_EventualUnique — claim CAS converges to a single winner",
         axis: Tla,
-        anchor: "gents claim.rs (foreign substrate, not the defradb.rs binary)",
+        anchor: "source-inc/gents crates/gents/src/lifecycle/claim.rs:claim_inner (foreign substrate, not the defradb.rs binary)",
         model_ref: "MC_Claim_Filtered_Eventual.cfg",
         tiers: &[Boundary],
     },

--- a/proofs/survey/CONSISTENCY.md
+++ b/proofs/survey/CONSISTENCY.md
@@ -234,7 +234,7 @@ No outright **contradiction** between any two slices was found.
 
 ## (d) Harness-Readiness Assessment
 
-Target next step: a defra-agent-style **binary-conformance harness** binding each model's
+Target next step: a Gents-style **binary-conformance harness** binding each model's
 property to the real Rust binary.
 
 ### Ready now
@@ -280,5 +280,5 @@ property to the real Rust binary.
 prerequisites for a conformance harness — and the TLA regression sweep is already wired
 and broader than the audits credited. The remaining work is (a) fix 3 stale anchors,
 (b) re-key anchors from line numbers to symbols, (c) build the binary binding that turns
-each `INV_*`/theorem + anchor into an executable check against the real defra-agent node,
+each `INV_*`/theorem + anchor into an executable check against the real defradb.rs node,
 and (d) provide a single entry point invoking TLA + Lean + binary checks together.

--- a/proofs/tla/Claim_DESIGN.md
+++ b/proofs/tla/Claim_DESIGN.md
@@ -19,7 +19,7 @@ this repository.
 | `gents:crates/gents/src/lifecycle/claim.rs:287` | If the local update returns no row but the local re-check sees `processing`, the lifecycle still treats the request as claimed. |
 | `gents:crates/gents/src/lifecycle/claim.rs:306` | After claim, the local lifecycle state becomes `Claimed`. |
 | `gents:crates/gents/src/lifecycle/claim.rs:69` and `transition.rs:463` | Execution begins from local `Claimed` and performs a later transition to processing/execution state. |
-| `gents:crates/gents/src/watcher/query.rs:67` | The watcher selects `AgentRequest` rows for the local `agent_did` and `status in [pending, processing]`. |
+| `gents:crates/gents/src/watcher/query.rs:73` | The watcher selects `AgentRequest` rows for the local `agent_did` and `status in [pending, processing]`. |
 | `gents:crates/gents/src/watcher.rs:102` | Each watcher instance carries one `agent_did`; multiple instances can use the same value. |
 | `crates/db-merge/src/merge_handler/lww.rs:165` | LWW merge applies the highest-priority/tie-break delta and rejects lower-priority alternatives. |
 
@@ -88,7 +88,7 @@ Run from `proofs/tla/`:
 |---|---|---|---|
 | `INV_EventualClaimUnique` | Eventually, all same-DID contenders have the same merged claim-block set and, if any claim exists, exactly one LWW claimer. | GREEN for unfiltered; GREEN for DID-filtered with one same-DID replication set; RED for split same-DID filtering. | `claim.rs` guarded claim write plus `lww.rs` conflict resolution. |
 | `INV_ExecutionUnique` | At most one instance ever starts work. | RED for unfiltered; RED for DID-filtered with one same-DID replication set. | `claim.rs:306` local `Claimed` state and `claim.rs:69` `begin_execution` happen before remote claim convergence is guaranteed. |
-| `INV_FilterNeutral` | If the same-DID contention set remains mutually replicating, the eventual claim-uniqueness verdict is preserved. | GREEN for unfiltered and DID-filtered common-set configs. | `watcher/query.rs:67` filters claimable rows by `agent_did`; the P2P filter must preserve the whole same-DID contention set. |
+| `INV_FilterNeutral` | If the same-DID contention set remains mutually replicating, the eventual claim-uniqueness verdict is preserved. | GREEN for unfiltered and DID-filtered common-set configs. | `watcher/query.rs:73` filters claimable rows by `agent_did`; the P2P filter must preserve the whole same-DID contention set. |
 
 ## Result
 

--- a/proofs/tla/Claim_DESIGN.md
+++ b/proofs/tla/Claim_DESIGN.md
@@ -8,15 +8,19 @@ for CRDT-CAS claims, LWW convergence, and execution side effects.
 
 ## Grounding
 
+`gents:` anchors are files in the consumer repository, `source-inc/gents`,
+re-verified against its `main` branch on 2026-07-27. Bare `crates/...` paths are
+this repository.
+
 | Source | Fact used by the model |
 |---|---|
-| `../defra-agent/crates/defra-agent/src/lifecycle/claim.rs:239` | Claim is an `update_AgentRequest` guarded by local `_docID`, `status = pending`, and `lifecycle_state = pending`. |
-| `../defra-agent/crates/defra-agent/src/lifecycle/claim.rs:247` | A successful claim writes `status = processing`, `lifecycle_state = claimed`, `claimed_at`, `backend_id`, and related execution metadata. |
-| `../defra-agent/crates/defra-agent/src/lifecycle/claim.rs:264` | If the local update returns no row but the local re-check sees `processing`, the lifecycle still treats the request as claimed. |
-| `../defra-agent/crates/defra-agent/src/lifecycle/claim.rs:289` | After claim, the local lifecycle state becomes `Claimed`. |
-| `../defra-agent/crates/defra-agent/src/lifecycle/claim.rs:69` and `transition.rs:428` | Execution begins from local `Claimed` and performs a later transition to processing/execution state. |
-| `../defra-agent/crates/defra-agent/src/watcher/query.rs:66` | The watcher selects `AgentRequest` rows for the local `agent_did` and `status in [pending, processing]`. |
-| `../defra-agent/crates/defra-agent/src/watcher.rs:92` | Each watcher instance carries one `agent_did`; multiple instances can use the same value. |
+| `gents:crates/gents/src/lifecycle/claim.rs:258` | Claim is an `update_AgentRequest` guarded by local `_docID`, `status = pending`, and `lifecycle_state = pending`. |
+| `gents:crates/gents/src/lifecycle/claim.rs:264` | A successful claim writes `status = processing`, `lifecycle_state = claimed`, `claimed_at`, `backend_id`, and related execution metadata. |
+| `gents:crates/gents/src/lifecycle/claim.rs:287` | If the local update returns no row but the local re-check sees `processing`, the lifecycle still treats the request as claimed. |
+| `gents:crates/gents/src/lifecycle/claim.rs:306` | After claim, the local lifecycle state becomes `Claimed`. |
+| `gents:crates/gents/src/lifecycle/claim.rs:69` and `transition.rs:463` | Execution begins from local `Claimed` and performs a later transition to processing/execution state. |
+| `gents:crates/gents/src/watcher/query.rs:67` | The watcher selects `AgentRequest` rows for the local `agent_did` and `status in [pending, processing]`. |
+| `gents:crates/gents/src/watcher.rs:102` | Each watcher instance carries one `agent_did`; multiple instances can use the same value. |
 | `crates/db-merge/src/merge_handler/lww.rs:165` | LWW merge applies the highest-priority/tie-break delta and rejects lower-priority alternatives. |
 
 ## Brainstorming Outcome
@@ -83,8 +87,8 @@ Run from `proofs/tla/`:
 | Property | Plain English | TLC verdict | Source note |
 |---|---|---|---|
 | `INV_EventualClaimUnique` | Eventually, all same-DID contenders have the same merged claim-block set and, if any claim exists, exactly one LWW claimer. | GREEN for unfiltered; GREEN for DID-filtered with one same-DID replication set; RED for split same-DID filtering. | `claim.rs` guarded claim write plus `lww.rs` conflict resolution. |
-| `INV_ExecutionUnique` | At most one instance ever starts work. | RED for unfiltered; RED for DID-filtered with one same-DID replication set. | `claim.rs:289` local `Claimed` state and `claim.rs:69` `begin_execution` happen before remote claim convergence is guaranteed. |
-| `INV_FilterNeutral` | If the same-DID contention set remains mutually replicating, the eventual claim-uniqueness verdict is preserved. | GREEN for unfiltered and DID-filtered common-set configs. | `watcher/query.rs:66` filters claimable rows by `agent_did`; the P2P filter must preserve the whole same-DID contention set. |
+| `INV_ExecutionUnique` | At most one instance ever starts work. | RED for unfiltered; RED for DID-filtered with one same-DID replication set. | `claim.rs:306` local `Claimed` state and `claim.rs:69` `begin_execution` happen before remote claim convergence is guaranteed. |
+| `INV_FilterNeutral` | If the same-DID contention set remains mutually replicating, the eventual claim-uniqueness verdict is preserved. | GREEN for unfiltered and DID-filtered common-set configs. | `watcher/query.rs:67` filters claimable rows by `agent_did`; the P2P filter must preserve the whole same-DID contention set. |
 
 ## Result
 

--- a/proofs/tla/DESIGN.md
+++ b/proofs/tla/DESIGN.md
@@ -27,22 +27,38 @@ the subscription/replication layer.
 ## Grounded facts (verified against source, 2026-06-02)
 
 `gents:` anchors were re-verified against the renamed consumer repository,
-`source-inc/gents` `main`, on 2026-07-27; other consumer path fragments keep
-their 2026-06-02 line numbers.
+`source-inc/gents` `main`, on 2026-07-27. Other consumer path fragments are the
+unmodified 2026-06-02 snapshot and may have drifted (e.g. the test-only
+`override_child_agent_did` helper no longer exists, and the desktop crate is now
+`gents-desktop-core`). The immutability gap this design surfaced has since been
+closed — see *Post-design status (2026-07-27)* below the table.
 
 | Fact | Source | Status |
 |---|---|---|
 | `AgentRequest` is `@branchable`; multi-writer (requester creates, claimer updates `status`/`lifecycle_state`/`claimed_at`) | `gents:crates/gents-schemas/schemas/agent/agent_request.graphql:1`; `lifecycle/claim.rs:258` | ✅ branching is real |
 | `agent_did` is the **sole** P2P relevance/filter key | `gents:crates/gents/src/watcher/query.rs:73` | ✅ confirmed |
 | Filtering today is **read/claim-time**, not P2P-level; every agent subscribes collection-wide | `watcher/query.rs`, `trigger_engine/subscription_source.rs:28`, `desktop-core/.../client/schema.rs:36` | ✅ the noise problem |
-| `agent_did` set **only at create time** in production (`create_AgentRequest`); the sole post-create mutation is a **test** helper | `toolset/delegate.rs:88,91` (create); `tests/r4_subagent_tools.rs:424` (`override_child_agent_did`, test-only) | ⚠️ write-once **by convention, not enforced** |
-| **No** schema/ACP immutability constraint on `agent_did` (just `String @index`) | `agent_request.graphql:3` | ⚠️ assumption is unguaranteed |
+| `agent_did` set **only at create time** in production (`create_AgentRequest`); the sole post-create mutation is a **test** helper | `toolset/delegate.rs:88,91` (create); `tests/r4_subagent_tools.rs:424` (`override_child_agent_did`, test-only) | ⚠️ write-once **by convention, not enforced** (2026-06-02; since enforced — see *Post-design status*) |
+| **No** schema/ACP immutability constraint on `agent_did` (just `String @index`) | `agent_request.graphql:3` | ⚠️ assumption is unguaranteed (2026-06-02; since closed — that line is now `String @index @immutable`, see *Post-design status*) |
 | Multiple agent instances can share one `agent_did`; claim safety is **CRDT CAS** (`update where status=pending`), not FIFO/lock | `watcher.rs:102`, `lifecycle/claim.rs:258-310` | ✅ eventual-consistent claim |
 | Cross-request refs (`caused_by_parent_request_id`, `retry_parent_request`, `retry_root_request`, `superseded_by_request`) are bare `String @index` scalars, **not** `@relation` | `agent_request.graphql:6-8,30` | ✅ scalar FKs |
 | Merge handler **never** dereferences a cross-doc ref; relations resolved only at query time; dangling ref → graceful "absent" | Rust `crates/db-merge/src/merge_handler/mod.rs:69`; Go `internal/db/merge.go:343`; `client/document.go:238` (format-only validation) | ✅ no merge dependency |
 | Delta-DAG is **per-document**; `Heads` links within-document; no cross-doc causal edges | Go `internal/core/block/block.go`; Rust `merge_handler/` | ✅ confirmed |
 | `#2721` hole = **branching + partial sync within one doc**; shipped fix = "walk the entire graph before merging" (Model A), already done in Rust | Go `#2721`, `merge_test.go:143` `TestMerge_DualBranchWithOneIncomplete_CouldNotFindCID`; Rust `coordinator/dag_fetcher.rs` | ✅ Model A is the proven fix |
 | Field-level filtering is a **future GraphSync** feature, not today's reality | Go `block.go` `DAGLink.Name` comment | ✅ future |
+
+### Post-design status (2026-07-27)
+
+Recommendation 3 has since been implemented. `agent_did` is
+`String @index @immutable` on Gents `main`
+(`gents:crates/gents-schemas/schemas/agent/agent_request.graphql:3`), and
+defradb.rs enforces `@immutable` on the paths this design demanded: local
+updates (`crates/db/src/collection/validation.rs`), peer-authored deltas at
+merge time — the E1 shape (`crates/db-merge/src/merge_handler/composite_fields.rs`)
+— and replication filters, which require every referenced field to be
+`@immutable` (`crates/replication-filter/src/lib.rs`). The Axis-2 "Mutable"
+scenarios and Recommendation 3 below are the 2026-06-02 analysis that motivated
+that work.
 
 ## Fresh-review findings (rev 1 → rev 2)
 
@@ -105,8 +121,9 @@ who owns the request: **split ownership**.
 
 These compose. Gents is **WholeDoc filter scope** (the whole request is in
 or out), so it never creates *within-doc* causal holes — Axis 1 is answered by
-Model A. But its filter key is **Mutable-by-default** (unenforced), so Axis 2 is
-live and was previously assumed away. The GraphSync future is **SubDoc scope**,
+Model A. But at design time its filter key was **Mutable-by-default**
+(unenforced — since closed, see *Post-design status*), so Axis 2 was live and
+had previously been assumed away. The GraphSync future is **SubDoc scope**,
 which *does* create within-doc holes and is where Model B (Axis 1) earns its
 keep.
 
@@ -166,7 +183,7 @@ The Naive / A / B difference is a single guard on the fetch action.
   convergence is a pre-existing CRDT-CAS property, **not** introduced by B3; the
   model shows filtering is **claim-neutral**, neither causing nor fixing it.)
 
-### M2 — WholeDoc filter, key MUTABLE (the unenforced reality — the new finding)
+### M2 — WholeDoc filter, key MUTABLE (the then-unenforced reality — the new finding)
 - **`INV_NoSplitOwnership`** (safety): no request is simultaneously "owned"
   (filter-matched + actionable) by two distinct DIDs in their respective local
   views. *Expected to FAIL under Mutable + naive subscription:* the old owner
@@ -219,6 +236,7 @@ The Naive / A / B difference is a single guard on the fetch action.
 > split-ownership hazard (`INV_NoSplitOwnership`) that unfiltered replication
 > does not have. *This enforcement is downstream implementation (defradb.rs /
 > Gents), not TLA+ work — the model proves it is necessary+sufficient.*
+> *[2026-07-27: implemented — see Post-design status.]*
 >
 > **4. Model B is needed only if/when field-level GraphSync filtering ships** for
 > resource-constrained peers (SubDoc scope). Not required for the `agent_did`

--- a/proofs/tla/DESIGN.md
+++ b/proofs/tla/DESIGN.md
@@ -27,21 +27,21 @@ the subscription/replication layer.
 ## Grounded facts (verified against source, 2026-06-02)
 
 `gents:` anchors were re-verified against the renamed consumer repository,
-`source-inc/gents` `main`, on 2026-07-27. Other consumer path fragments are the
-unmodified 2026-06-02 snapshot and may have drifted (e.g. the test-only
-`override_child_agent_did` helper no longer exists, and the desktop crate is now
-`gents-desktop-core`). The immutability gap this design surfaced has since been
-closed — see *Post-design status (2026-07-27)* below the table.
+`source-inc/gents` `main`, on 2026-07-27; table rows whose anchors no longer
+exist there are marked *historical*. Unprefixed consumer fragments in the
+narrative sections below the table are the 2026-06-02 snapshot. The
+immutability gap this design surfaced has since been closed — see *Post-design
+status (2026-07-27)* below the table.
 
 | Fact | Source | Status |
 |---|---|---|
 | `AgentRequest` is `@branchable`; multi-writer (requester creates, claimer updates `status`/`lifecycle_state`/`claimed_at`) | `gents:crates/gents-schemas/schemas/agent/agent_request.graphql:1`; `lifecycle/claim.rs:258` | ✅ branching is real |
 | `agent_did` is the **sole** P2P relevance/filter key | `gents:crates/gents/src/watcher/query.rs:73` | ✅ confirmed |
-| Filtering today is **read/claim-time**, not P2P-level; every agent subscribes collection-wide | `watcher/query.rs`, `trigger_engine/subscription_source.rs:28`, `desktop-core/.../client/schema.rs:36` | ✅ the noise problem |
-| `agent_did` set **only at create time** in production (`create_AgentRequest`); the sole post-create mutation is a **test** helper | `toolset/delegate.rs:88,91` (create); `tests/r4_subagent_tools.rs:424` (`override_child_agent_did`, test-only) | ⚠️ write-once **by convention, not enforced** (2026-06-02; since enforced — see *Post-design status*) |
+| Filtering today is **read/claim-time**, not P2P-level; every agent subscribes collection-wide | `watcher/query.rs`, `gents:crates/gents/src/trigger_engine/subscription_source.rs:25` (`subscribe_updates`), `gents:crates/gents-desktop-core/src/client/schema.rs:36` (`subscribe_all_collections`) | ✅ the noise problem |
+| `agent_did` set **only at create time** in production (`create_AgentRequest`); the sole post-create mutation is a **test** helper | *historical (2026-06-02):* `toolset/delegate.rs:88,91` (create); `override_child_agent_did` (test-only) — both since removed from `main` | ⚠️ write-once **by convention, not enforced** (2026-06-02; since enforced — see *Post-design status*) |
 | **No** schema/ACP immutability constraint on `agent_did` (just `String @index`) | `agent_request.graphql:3` | ⚠️ assumption is unguaranteed (2026-06-02; since closed — that line is now `String @index @immutable`, see *Post-design status*) |
 | Multiple agent instances can share one `agent_did`; claim safety is **CRDT CAS** (`update where status=pending`), not FIFO/lock | `watcher.rs:102`, `lifecycle/claim.rs:258-310` | ✅ eventual-consistent claim |
-| Cross-request refs (`caused_by_parent_request_id`, `retry_parent_request`, `retry_root_request`, `superseded_by_request`) are bare `String @index` scalars, **not** `@relation` | `agent_request.graphql:6-8,30` | ✅ scalar FKs |
+| Cross-request refs (`caused_by_parent_request_id`, `retry_parent_request`, `retry_root_request`, `superseded_by_request`) are bare `String @index` scalars, **not** `@relation` | `gents:crates/gents-schemas/schemas/agent/agent_request.graphql:7-9,33` | ✅ scalar FKs |
 | Merge handler **never** dereferences a cross-doc ref; relations resolved only at query time; dangling ref → graceful "absent" | Rust `crates/db-merge/src/merge_handler/mod.rs:69`; Go `internal/db/merge.go:343`; `client/document.go:238` (format-only validation) | ✅ no merge dependency |
 | Delta-DAG is **per-document**; `Heads` links within-document; no cross-doc causal edges | Go `internal/core/block/block.go`; Rust `merge_handler/` | ✅ confirmed |
 | `#2721` hole = **branching + partial sync within one doc**; shipped fix = "walk the entire graph before merging" (Model A), already done in Rust | Go `#2721`, `merge_test.go:143` `TestMerge_DualBranchWithOneIncomplete_CouldNotFindCID`; Rust `coordinator/dag_fetcher.rs` | ✅ Model A is the proven fix |

--- a/proofs/tla/DESIGN.md
+++ b/proofs/tla/DESIGN.md
@@ -16,7 +16,7 @@ Scope of this session: **M1 (convergence baseline) + M2 (the filter).** The
 
 ## Deployment target (why this model, not an abstraction in a vacuum)
 
-The consumer is **defra-agent**. Agents accept `AgentRequest` documents; remote
+The consumer is **Gents** (`source-inc/gents`). Agents accept `AgentRequest` documents; remote
 control happens by writing a request locally and gossiping it over P2P. Requests
 are handled per-DID. With many agents on one network, today **every agent
 replicates every other agent's request traffic** and filters by DID at query
@@ -26,14 +26,18 @@ the subscription/replication layer.
 
 ## Grounded facts (verified against source, 2026-06-02)
 
+`gents:` anchors were re-verified against the renamed consumer repository,
+`source-inc/gents` `main`, on 2026-07-27; other consumer path fragments keep
+their 2026-06-02 line numbers.
+
 | Fact | Source | Status |
 |---|---|---|
-| `AgentRequest` is `@branchable`; multi-writer (requester creates, claimer updates `status`/`lifecycle_state`/`claimed_at`) | `defra-agent/.../schemas/agent/agent_request.graphql:1`; `lifecycle/claim.rs:239` | ✅ branching is real |
-| `agent_did` is the **sole** P2P relevance/filter key | `defra-agent/crates/defra-agent/src/watcher/query.rs:72` | ✅ confirmed |
+| `AgentRequest` is `@branchable`; multi-writer (requester creates, claimer updates `status`/`lifecycle_state`/`claimed_at`) | `gents:crates/gents-schemas/schemas/agent/agent_request.graphql:1`; `lifecycle/claim.rs:258` | ✅ branching is real |
+| `agent_did` is the **sole** P2P relevance/filter key | `gents:crates/gents/src/watcher/query.rs:73` | ✅ confirmed |
 | Filtering today is **read/claim-time**, not P2P-level; every agent subscribes collection-wide | `watcher/query.rs`, `trigger_engine/subscription_source.rs:28`, `desktop-core/.../client/schema.rs:36` | ✅ the noise problem |
 | `agent_did` set **only at create time** in production (`create_AgentRequest`); the sole post-create mutation is a **test** helper | `toolset/delegate.rs:88,91` (create); `tests/r4_subagent_tools.rs:424` (`override_child_agent_did`, test-only) | ⚠️ write-once **by convention, not enforced** |
 | **No** schema/ACP immutability constraint on `agent_did` (just `String @index`) | `agent_request.graphql:3` | ⚠️ assumption is unguaranteed |
-| Multiple agent instances can share one `agent_did`; claim safety is **CRDT CAS** (`update where status=pending`), not FIFO/lock | `watcher.rs:92`, `lifecycle/claim.rs:239-287` | ✅ eventual-consistent claim |
+| Multiple agent instances can share one `agent_did`; claim safety is **CRDT CAS** (`update where status=pending`), not FIFO/lock | `watcher.rs:102`, `lifecycle/claim.rs:258-310` | ✅ eventual-consistent claim |
 | Cross-request refs (`caused_by_parent_request_id`, `retry_parent_request`, `retry_root_request`, `superseded_by_request`) are bare `String @index` scalars, **not** `@relation` | `agent_request.graphql:6-8,30` | ✅ scalar FKs |
 | Merge handler **never** dereferences a cross-doc ref; relations resolved only at query time; dangling ref → graceful "absent" | Rust `crates/db-merge/src/merge_handler/mod.rs:69`; Go `internal/db/merge.go:343`; `client/document.go:238` (format-only validation) | ✅ no merge dependency |
 | Delta-DAG is **per-document**; `Heads` links within-document; no cross-doc causal edges | Go `internal/core/block/block.go`; Rust `merge_handler/` | ✅ confirmed |
@@ -99,7 +103,7 @@ CRDT document. If that field is mutable, a request can change ownership, which:
 reassignment block (it filtered the doc out), so old and new owner disagree on
 who owns the request: **split ownership**.
 
-These compose. defra-agent is **WholeDoc filter scope** (the whole request is in
+These compose. Gents is **WholeDoc filter scope** (the whole request is in
 or out), so it never creates *within-doc* causal holes — Axis 1 is answered by
 Model A. But its filter key is **Mutable-by-default** (unenforced), so Axis 2 is
 live and was previously assumed away. The GraphSync future is **SubDoc scope**,
@@ -150,7 +154,7 @@ The Naive / A / B difference is a single guard on the fetch action.
   via a **reference observer**: for each doc `d`, every node's merged head-set of
   `d` equals that of a hypothetical full-replication observer.
 
-### M2 — WholeDoc filter, key IMMUTABLE (the ideal defra-agent target)
+### M2 — WholeDoc filter, key IMMUTABLE (the ideal Gents target)
 - **`INV_SubsetConverge`**: for docs where `owner(d)=DID(a)`, agent `a`'s merged
   head-set for `d` equals the reference observer's. *Holds under Model A.*
 - **`INV_RelRefSafe`** ✅ verified true: dropping a cross-DID relational ref never
@@ -214,7 +218,7 @@ The Naive / A / B difference is a single guard on the fetch action.
 > construction). Without one of these, filtered replication admits a
 > split-ownership hazard (`INV_NoSplitOwnership`) that unfiltered replication
 > does not have. *This enforcement is downstream implementation (defradb.rs /
-> defra-agent), not TLA+ work — the model proves it is necessary+sufficient.*
+> Gents), not TLA+ work — the model proves it is necessary+sufficient.*
 >
 > **4. Model B is needed only if/when field-level GraphSync filtering ships** for
 > resource-constrained peers (SubDoc scope). Not required for the `agent_did`

--- a/proofs/tla/MC_Claim_Common.tla
+++ b/proofs/tla/MC_Claim_Common.tla
@@ -2,7 +2,7 @@
 EXTENDS Claim
 \* Two instances, i1 and i2, share DID X and contend for one AgentRequest owned by
 \* X. fy is a foreign DID-Y instance: unfiltered replication may deliver the doc
-\* to it, but it is not a contender because defra-agent's watcher only claims rows
+\* to it, but it is not a contender because the Gents watcher only claims rows
 \* where agent_did equals the local agent_did.
 
 mcInstances == {"i1", "i2", "fy"}

--- a/proofs/tla/README.md
+++ b/proofs/tla/README.md
@@ -81,7 +81,7 @@ a metadir collision.)
 |---|---|---|---|
 | `Converge` | all nodes eventually merge all blocks | GREEN run 1, RED run 2 | `crates/p2p/src/sync/coordinator/dag_fetcher.rs` ancestry walk |
 | `INV_DagComplete` | no merged block lacks a merged parent | holds under `Merge`; relaxed by Model B (by design) | `crates/db-merge/src/merge_handler/` `loadComposites` recursion |
-| `INV_SubsetConverge` | subscribed docs fully converge | GREEN run 3 | defra-agent watcher DID filter (`watcher/query.rs`) |
+| `INV_SubsetConverge` | subscribed docs fully converge | GREEN run 3 | Gents watcher DID filter (`watcher/query.rs`) |
 | `INV_RelRefSafe` | dropping a foreign-DID relational ref never blocks a merge | GREEN run 3 | scalar `String` FK; merge never derefs it |
 | `INV_NoSplitOwnership` | at most one DID owns a doc across all nodes | RED run 4 (mutable key), GREEN run 5 (immutable key) | `agent_request.graphql` `agent_did` (write-once by convention, unenforced) |
 | `INV_VisibleConverge` | every non-filtered visible block eventually merges | RED run 6 (Naive), GREEN run 8 (Model B) | GraphSync field-filter (future feature) |
@@ -129,7 +129,7 @@ requiring care: getting convergence right is non-trivial, and the relaxed
    - **(E2)** key the subscription filter on the content-addressed create-block
      value of `agent_did` (immutable by construction; no new DB feature needed).
    The model abstracts over E1/E2 — it proves immutability is necessary and
-   sufficient; the mechanism is an implementation choice for defradb.rs / defra-agent.
+   sufficient; the mechanism is an implementation choice for defradb.rs / Gents.
 
 4. **Model B only if field-level GraphSync filtering is built.** For today's
    whole-document filtering, Model A suffices. Model B earns its keep only when

--- a/proofs/tla/README.md
+++ b/proofs/tla/README.md
@@ -83,7 +83,7 @@ a metadir collision.)
 | `INV_DagComplete` | no merged block lacks a merged parent | holds under `Merge`; relaxed by Model B (by design) | `crates/db-merge/src/merge_handler/` `loadComposites` recursion |
 | `INV_SubsetConverge` | subscribed docs fully converge | GREEN run 3 | Gents watcher DID filter (`watcher/query.rs`) |
 | `INV_RelRefSafe` | dropping a foreign-DID relational ref never blocks a merge | GREEN run 3 | scalar `String` FK; merge never derefs it |
-| `INV_NoSplitOwnership` | at most one DID owns a doc across all nodes | RED run 4 (mutable key), GREEN run 5 (immutable key) | `agent_request.graphql` `agent_did` (write-once by convention, unenforced) |
+| `INV_NoSplitOwnership` | at most one DID owns a doc across all nodes | RED run 4 (mutable key), GREEN run 5 (immutable key) | `agent_request.graphql` `agent_did` (unenforced at model time; since `@immutable` + enforced) |
 | `INV_VisibleConverge` | every non-filtered visible block eventually merges | RED run 6 (Naive), GREEN run 8 (Model B) | GraphSync field-filter (future feature) |
 | `INV_NoFilteredFetch` | a node never fetches a block it filters out | RED run 7 (FullWalkA over-fetches), GREEN run 8 (Model B) | resource-savings goal of field-level filtering |
 
@@ -130,6 +130,10 @@ requiring care: getting convergence right is non-trivial, and the relaxed
      value of `agent_did` (immutable by construction; no new DB feature needed).
    The model abstracts over E1/E2 — it proves immutability is necessary and
    sufficient; the mechanism is an implementation choice for defradb.rs / Gents.
+   *[2026-07-27: implemented — `agent_did` is `@immutable` in the Gents schema,
+   and defradb.rs enforces it at update (`crates/db/src/collection/validation.rs`),
+   at merge (E1, `crates/db-merge/src/merge_handler/composite_fields.rs`), and in
+   replication filters (`crates/replication-filter/src/lib.rs`).]*
 
 4. **Model B only if field-level GraphSync filtering is built.** For today's
    whole-document filtering, Model A suffices. Model B earns its keep only when

--- a/tools/integration-test/tests/basic/transactions.rs
+++ b/tools/integration-test/tests/basic/transactions.rs
@@ -457,7 +457,7 @@ async fn txn_commit_publishes_update_events(cluster: TestCluster) {
         );
 
         // The block field carries hex-encoded composite commit bytes. It
-        // must reach SSE subscribers so downstream consumers (e.g. defra-agent)
+        // must reach SSE subscribers so downstream consumers (e.g. Gents)
         // can traverse the DAG without an extra round-trip.
         let block_hex = event
             .pointer("/data/block")

--- a/tools/integration-test/tests/p2p/filtered_replication.rs
+++ b/tools/integration-test/tests/p2p/filtered_replication.rs
@@ -282,7 +282,7 @@ async fn rust_filtered_replication_excludes_nonmatching() {
     filtered_excludes_nonmatching(cluster).await;
 }
 
-/// #7: identical guarantee must hold over the iroh transport (defra-agent's
+/// #7: identical guarantee must hold over the iroh transport (Gents'
 /// production transport).
 #[tokio::test]
 async fn rust_filtered_replication_excludes_nonmatching_iroh() {
@@ -2281,7 +2281,7 @@ async fn rust_filtered_replication_delete_stops_push() {
 }
 
 /// Iroh transport variant of `rust_filtered_replication_delete_stops_push`:
-/// deleting a filtered replicator over Iroh (defra-agent's production transport)
+/// deleting a filtered replicator over Iroh (Gents' production transport)
 /// must stop further filtered pushes. Exercises the iroh adapter's delete path
 /// end to end — name->CID resolution, coordinator/registry removal, and
 /// peerstore handling. A matching doc created BEFORE the delete replicates; a
@@ -2475,7 +2475,7 @@ async fn rust_filtered_replication_cli_list_renders_filter() {
 
 /// Iroh transport variant of `rust_filtered_replication_composite_and`: a
 /// composite `agent_did = alice AND kind = keep` predicate must gate the live
-/// push path over Iroh (defra-agent's production transport). A doc matching both
+/// push path over Iroh (Gents' production transport). A doc matching both
 /// arms replicates; a doc matching only one arm must be excluded.
 #[tokio::test]
 async fn rust_filtered_replication_composite_and_iroh() {

--- a/tools/integration-test/tests/p2p_backlog.rs
+++ b/tools/integration-test/tests/p2p_backlog.rs
@@ -158,7 +158,7 @@ async fn outbound_backlog_bounded_under_fanout_with_dead_peer() {
     }
 
     // The dead peer's stall must become visible in the per-peer snapshot
-    // (defra-agent#630: slot starvation was invisible to diagnostics).
+    // (gents#630: slot starvation was invisible to diagnostics).
     let visibility_deadline = Instant::now() + Duration::from_secs(90);
     loop {
         let status = sync_status(&pusher_api).await;

--- a/tools/integration-test/tests/p2p_backlog.rs
+++ b/tools/integration-test/tests/p2p_backlog.rs
@@ -158,7 +158,7 @@ async fn outbound_backlog_bounded_under_fanout_with_dead_peer() {
     }
 
     // The dead peer's stall must become visible in the per-peer snapshot
-    // (gents#630: slot starvation was invisible to diagnostics).
+    // (source-inc/gents#630: slot starvation was invisible to diagnostics).
     let visibility_deadline = Instant::now() + Duration::from_secs(90);
     loop {
         let status = sync_status(&pusher_api).await;

--- a/tools/integration-test/tests/p2p_iroh/schema/index.rs
+++ b/tools/integration-test/tests/p2p_iroh/schema/index.rs
@@ -317,7 +317,7 @@ async fn unique_conflict_from_peer_converges_instead_of_wedging() {
     );
 }
 
-/// sourcenetwork/defra-agent#700 at the replication level (mirrors Go's
+/// source-inc/gents#700 at the replication level (mirrors Go's
 /// delete-then-reinsert unique regression): after a replicated delete, the
 /// unique slot must be free on BOTH nodes — a tombstone never holds a value.
 #[tokio::test]


### PR DESCRIPTION
Closes #1172.

Hard cutover of active consumer references from the old Defra Agent coordinates to the canonical [`source-inc/gents`](https://github.com/source-inc/gents) repository, per the rename epic (source-inc/gents#811) and docs cutover (source-inc/gents#826). Reference/naming migration only — no behavior changes, no compatibility aliases, and no DefraDB/domain vocabulary touched.

## What changed

**Issue shorthand in code comments (14 Rust files).** Every cross-repo regression reference now uses the canonical coordinate, preserving each site's original style weight: `sourcenetwork/defra-agent#N` → `source-inc/gents#N`, bare `defra-agent#N` → `gents#N` (issues #630, #694, #696, #700 — all verified to resolve on `source-inc/gents`, which was renamed in place so numbers carried over).

**Narrative consumer references → "Gents".** Telemetry `install_global` doc, transactions SSE comment, the three "production transport" comments in `filtered_replication.rs`, `MC_Claim_Common.tla`, proofs READMEs, `CONSISTENCY.md`, `lean_contract.rs`, and the claim-family Boundary anchor in `proofs/src/registry.rs`.

**Proof anchors re-verified, not just renamed.** The sibling-relative `../defra-agent/...` paths in `proofs/tla/{Claim_DESIGN,DESIGN}.md` are now `gents:crates/gents/...` anchors with a one-line convention note, and every drifted line number was re-checked against gents `main`: claim mutation 239→258, write-set 247→264, post-update re-check 264→287, local `Claimed` 289→306, `begin_execution` 69 (unchanged), `transition.rs` 428→463 (`transition_execution_view`), watcher query 66→67 / 72→73, `watcher.rs` 92→102, `agent_request.graphql:1` (still `type AgentRequest @branchable`). All cited files confirmed present on the gents default branch.

**One semantic correction.** `proofs/survey/CONSISTENCY.md:283` described the future harness as checking "against the real defra-agent node"; the conformance crate that was since built binds to the **defradb.rs** binary (per `proofs/README.md`'s Conformance section), so this now reads "the real defradb.rs node" rather than a mechanically-renamed falsehood.

## Intentionally retained

The final case-insensitive scan (`defra[-_ ]agent`, `defraagent`, plus variants `DefraAgent`, `defra_agent`, `DEFRA_AGENT`, `.defra-agent`, `did:defra-agent`) leaves exactly 4 lines in 3 files, all historical `docs/superpowers/` plan/spec archives (2026-03-30 NAC plan, 2026-06-02 management-channel plan + spec). These are dated records of decisions made under the old consumer name; nothing executable consumes them and their `defra-agent#107/#180` mentions still resolve via GitHub's rename redirect. No DID fixtures referenced the old product.

## Validation

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all -- -D warnings` — clean
- `cargo test -p conformance --lib` — 5/5, including both registry↔README matrix tests
- `cargo test -p storage -p p2p -p db-merge -p db-index -p db -p telemetry` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)