### PR TITLE
fix(storage): don't conflict blind writes of identical content-addressed blocks

### DIFF
--- a/crates/storage/src/backends/shared.rs
+++ b/crates/storage/src/backends/shared.rs
@@ -218,6 +218,24 @@ impl ReadSet {
     }
 }
 
+/// Content-addressed blockstore keys: namespace byte `b` followed by raw CID
+/// bytes (0x01 for CIDv1, 0x12 for a CIDv0 sha2-256 multihash).
+///
+/// The key is the hash of the value, so any two writers of the same key write
+/// identical bytes — blind write-write overlap on these keys is not a
+/// serializability hazard, and Go's badger likewise never conflicts blind
+/// writes (it only checks reads against committed writes). Without this
+/// carve-out, concurrent updates to DIFFERENT documents that produce
+/// byte-identical field deltas (e.g. both rewrite `status: "streaming"`)
+/// collide on the shared delta block and spuriously abort (#1194).
+///
+/// Merge-tracking keys under the blockstore namespace (`b` + `m` + CID) do
+/// not match: their first payload byte is `m` (0x6d), and their presence is
+/// mutable state that must stay conflict-checked.
+fn is_content_addressed_block_key(key: &[u8]) -> bool {
+    key.len() >= 2 && key[0] == b'b' && matches!(key[1], 0x01 | 0x12)
+}
+
 fn is_document_collection_scan_prefix(prefix: &[u8]) -> bool {
     // Namespaced datastore document scans use `d/d/...`; root datastore scans
     // use `/d/...`. Go's SSI conflict in the relation tests comes from FK index
@@ -369,7 +387,9 @@ impl ConflictTracker {
         // Check for conflicts against transactions committed after our snapshot.
         for (_, committed_writes, committed_reads) in state.committed_after(read_version) {
             for write_key in &write_keys {
-                if committed_writes.contains(*write_key) || committed_reads.conflicts_key(write_key)
+                if (committed_writes.contains(*write_key)
+                    && !is_content_addressed_block_key(write_key))
+                    || committed_reads.conflicts_key(write_key)
                 {
                     return Err(crate::corekv::Error::TxnConflict);
                 }
@@ -574,6 +594,90 @@ mod tests {
             )
             .unwrap_err();
 
+        assert!(matches!(err, crate::corekv::Error::TxnConflict));
+    }
+
+    fn block_key(fill: u8) -> Vec<u8> {
+        // Namespace byte 'b' + CIDv1 marker + arbitrary CID payload.
+        let mut key = vec![b'b', 0x01, 0x71];
+        key.extend(std::iter::repeat_n(fill, 34));
+        key
+    }
+
+    #[test]
+    fn identical_block_writes_do_not_conflict() {
+        let tracker = Arc::new(ConflictTracker::new());
+        let first_snapshot = tracker.begin_snapshot();
+        let second_snapshot = tracker.begin_snapshot();
+
+        // Two overlapping transactions write the same content-addressed block
+        // (same CID => byte-identical value). Both must commit (#1194).
+        let writes = [block_key(0xaa)];
+        tracker
+            .check_and_record(first_snapshot.version(), writes.iter(), &ReadSet::default())
+            .unwrap();
+        drop(first_snapshot);
+
+        tracker
+            .check_and_record(
+                second_snapshot.version(),
+                writes.iter(),
+                &ReadSet::default(),
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn merge_index_writes_still_conflict() {
+        let tracker = Arc::new(ConflictTracker::new());
+        let first_snapshot = tracker.begin_snapshot();
+        let second_snapshot = tracker.begin_snapshot();
+
+        // Blockstore merge-tracking keys ('b' + 'm' + CID) are mutable state,
+        // not content-addressed data: write-write stays a conflict.
+        let mut merge_key = vec![b'b', b'm', 0x01, 0x71];
+        merge_key.extend(std::iter::repeat_n(0xaa, 34));
+        let writes = [merge_key];
+        tracker
+            .check_and_record(first_snapshot.version(), writes.iter(), &ReadSet::default())
+            .unwrap();
+        drop(first_snapshot);
+
+        let err = tracker
+            .check_and_record(
+                second_snapshot.version(),
+                writes.iter(),
+                &ReadSet::default(),
+            )
+            .unwrap_err();
+        assert!(matches!(err, crate::corekv::Error::TxnConflict));
+    }
+
+    #[test]
+    fn block_write_vs_committed_read_still_conflicts() {
+        let tracker = Arc::new(ConflictTracker::new());
+        let first_snapshot = tracker.begin_snapshot();
+        let second_snapshot = tracker.begin_snapshot();
+
+        // A committed transaction READ the block key; a later write to it is
+        // still an anti-dependency and must conflict.
+        let block = block_key(0xbb);
+        let mut first_reads = ReadSet::default();
+        first_reads.record_key(&block);
+        let first_writes = [b"d/d/books/other".to_vec()];
+        tracker
+            .check_and_record(first_snapshot.version(), first_writes.iter(), &first_reads)
+            .unwrap();
+        drop(first_snapshot);
+
+        let second_writes = [block];
+        let err = tracker
+            .check_and_record(
+                second_snapshot.version(),
+                second_writes.iter(),
+                &ReadSet::default(),
+            )
+            .unwrap_err();
         assert!(matches!(err, crate::corekv::Error::TxnConflict));
     }
 

--- a/crates/storage/src/backends/shared.rs
+++ b/crates/storage/src/backends/shared.rs
@@ -247,7 +247,7 @@ fn is_content_addressed_block_key(key: &[u8]) -> bool {
     };
     namespace == crate::namespace::Namespace::Blockstore.prefix()
         && !crate::keys::blockstore::ToMergeIndexKey::is_merge_key(cid_bytes)
-        && cid::Cid::try_from(cid_bytes).is_ok()
+        && cid::Cid::try_from(cid_bytes).is_ok_and(|cid| cid.encoded_len() == cid_bytes.len())
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -786,6 +786,33 @@ mod tests {
         bogus_key.extend(std::iter::repeat_n(0xaa, 34));
         assert!(cid::Cid::try_from(&bogus_key[1..]).is_err());
         let writes = [bogus_key];
+        tracker
+            .check_and_record(first_snapshot.version(), writes.iter(), &ReadSet::default())
+            .unwrap();
+        drop(first_snapshot);
+
+        let err = tracker
+            .check_and_record(
+                second_snapshot.version(),
+                writes.iter(),
+                &ReadSet::default(),
+            )
+            .unwrap_err();
+        assert!(matches!(err, crate::corekv::Error::TxnConflict));
+    }
+
+    #[test]
+    fn cid_with_trailing_bytes_still_conflicts() {
+        let tracker = Arc::new(ConflictTracker::new());
+        let first_snapshot = tracker.begin_snapshot();
+        let second_snapshot = tracker.begin_snapshot();
+
+        // CID parsing accepts a valid prefix, so require the entire payload to
+        // be one CID before treating the key as immutable content-addressed data.
+        let mut key = block_key(0xaa);
+        key.push(0xff);
+        assert!(cid::Cid::try_from(&key[1..]).is_ok());
+        let writes = [key];
         tracker
             .check_and_record(first_snapshot.version(), writes.iter(), &ReadSet::default())
             .unwrap();

--- a/crates/storage/src/backends/shared.rs
+++ b/crates/storage/src/backends/shared.rs
@@ -235,10 +235,10 @@ impl ReadSet {
 /// byte-identical field deltas (e.g. both rewrite `status: "streaming"`)
 /// collide on the shared delta block and spuriously abort (#1194).
 ///
-/// Merge-tracking keys under the blockstore namespace
-/// ([`ToMergeIndexKey`](crate::keys::blockstore::ToMergeIndexKey), `b` + `m`
-/// + CID) are explicitly excluded: their presence is mutable state that must
-/// stay conflict-checked. Only the write-write check consults this predicate;
+/// Merge-tracking keys under the blockstore namespace (`b` then `m` then
+/// CID, [`ToMergeIndexKey`](crate::keys::blockstore::ToMergeIndexKey)) are
+/// explicitly excluded: their presence is mutable state that must stay
+/// conflict-checked. Only the write-write check consults this predicate;
 /// read-vs-write conflicts apply to block keys like any other key.
 #[cfg(not(target_arch = "wasm32"))]
 fn is_content_addressed_block_key(key: &[u8]) -> bool {

--- a/tools/integration-test/Cargo.toml
+++ b/tools/integration-test/Cargo.toml
@@ -43,6 +43,10 @@ name = "issue1154_repro"
 path = "tests/issue1154_repro.rs"
 
 [[test]]
+name = "issue1194_repro"
+path = "tests/issue1194_repro.rs"
+
+[[test]]
 name = "p2p_backlog"
 path = "tests/p2p_backlog.rs"
 

--- a/tools/integration-test/tests/issue1194_repro.rs
+++ b/tools/integration-test/tests/issue1194_repro.rs
@@ -1,0 +1,338 @@
+//! Issue #1194 regression: concurrent `update_X` mutations against DISTINCT
+//! documents through the HTTP GraphQL API must not fail with
+//! `transaction conflict. Please retry`.
+//!
+//! Root cause: field-delta blocks are content-addressed (`b` + CID) and carry
+//! no document identity. Two documents whose updates produce byte-identical
+//! deltas (e.g. both rewrite `status: "streaming"` at the same chain depth)
+//! write the SAME blockstore key, and the conflict tracker treated that blind
+//! write-write overlap as a transaction conflict. Identical-content block
+//! writes are idempotent and must not conflict; true same-document conflicts
+//! must survive (see the control below).
+
+use std::sync::Arc;
+
+use integration_test::TestCluster;
+use serde_json::{json, Value};
+
+struct RoundStats {
+    ok: usize,
+    conflict: usize,
+    other: Vec<String>,
+}
+
+async fn gql(http: &reqwest::Client, url: &str, query: &str) -> Result<Value, String> {
+    let resp = http
+        .post(format!("{url}/api/v0/graphql"))
+        .json(&json!({ "query": query }))
+        .send()
+        .await
+        .map_err(|e| format!("http error: {e}"))?;
+    let body: Value = resp.json().await.map_err(|e| format!("bad json: {e}"))?;
+    if let Some(errors) = body.get("errors").and_then(|e| e.as_array()) {
+        if !errors.is_empty() {
+            return Err(errors
+                .iter()
+                .map(|e| e["message"].as_str().unwrap_or("?").to_string())
+                .collect::<Vec<_>>()
+                .join("; "));
+        }
+    }
+    Ok(body["data"].clone())
+}
+
+async fn run_workload(
+    api_url: &str,
+    collection: &str,
+    input_extra: &str,
+    doc_ids: &[String],
+    concurrency: usize,
+    rounds: usize,
+) -> RoundStats {
+    let http = reqwest::Client::new();
+    let barrier = Arc::new(tokio::sync::Barrier::new(concurrency));
+    let mut handles = Vec::new();
+    for (worker, doc_id) in doc_ids.iter().take(concurrency).enumerate() {
+        let http = http.clone();
+        let url = api_url.to_string();
+        let doc_id = doc_id.clone();
+        let collection = collection.to_string();
+        let input_extra = input_extra.to_string();
+        let barrier = Arc::clone(&barrier);
+        handles.push(tokio::spawn(async move {
+            let mut stats = RoundStats {
+                ok: 0,
+                conflict: 0,
+                other: Vec::new(),
+            };
+            for round in 0..rounds {
+                barrier.wait().await;
+                let mutation = format!(
+                    r#"mutation {{ update_{collection}(filter: {{_docID: {{_eq: "{doc_id}"}}, status: {{_eq: "streaming"}}}}, input: {{content: "w{worker}-r{round}"{input_extra}}}) {{ _docID }} }}"#
+                );
+                match gql(&http, &url, &mutation).await {
+                    Ok(data) => {
+                        let n = data[format!("update_{collection}")]
+                            .as_array()
+                            .map(|a| a.len())
+                            .unwrap_or(0);
+                        if n == 1 {
+                            stats.ok += 1;
+                        } else {
+                            stats.other.push(format!("updated {n} docs"));
+                        }
+                    }
+                    Err(msg) if msg.contains("transaction conflict") => {
+                        stats.conflict += 1;
+                    }
+                    Err(msg) => stats.other.push(msg),
+                }
+            }
+            stats
+        }));
+    }
+    let mut total = RoundStats {
+        ok: 0,
+        conflict: 0,
+        other: Vec::new(),
+    };
+    for h in handles {
+        let s = h.await.expect("worker panicked");
+        total.ok += s.ok;
+        total.conflict += s.conflict;
+        total.other.extend(s.other);
+    }
+    total
+}
+
+/// Eight docs, barrier-synchronized concurrent updates at concurrency 2/4/8.
+/// Every attempt must succeed on the first try: distinct documents may not
+/// leak transaction conflicts through the HTTP API.
+async fn run_scenario(schema: &str, collection: &str, input_extra: &str) {
+    let cluster = TestCluster::builder()
+        .rust_nodes(1)
+        .with_store("redb")
+        .build()
+        .await
+        .expect("build cluster");
+    let node = cluster.client(0);
+    let api_url = cluster.api_url(0).to_string();
+
+    node.schema_add(schema).expect("schema add");
+
+    let http = reqwest::Client::new();
+    let mut doc_ids = Vec::new();
+    for i in 0..8 {
+        let data = gql(
+            &http,
+            &api_url,
+            &format!(
+                r#"mutation {{ add_{collection}(input: {{status: "streaming", content: "init-{i}"}}) {{ _docID }} }}"#
+            ),
+        )
+        .await
+        .expect("create doc");
+        doc_ids.push(
+            data[format!("add_{collection}")][0]["_docID"]
+                .as_str()
+                .expect("docID")
+                .to_string(),
+        );
+    }
+
+    let rounds = 10;
+    for concurrency in [2usize, 4, 8] {
+        let stats = run_workload(
+            &api_url,
+            collection,
+            input_extra,
+            &doc_ids,
+            concurrency,
+            rounds,
+        )
+        .await;
+        let attempts = concurrency * rounds;
+        println!(
+            "[{collection}] concurrency={concurrency}: attempts={attempts} ok={} conflict={} other={:?}",
+            stats.ok, stats.conflict, stats.other
+        );
+        assert_eq!(
+            stats.conflict, 0,
+            "[{collection}] concurrency={concurrency}: transaction conflicts leaked for \
+             updates to distinct documents"
+        );
+        assert!(
+            stats.other.is_empty(),
+            "[{collection}] concurrency={concurrency}: unexpected errors: {:?}",
+            stats.other
+        );
+        assert_eq!(stats.ok, attempts);
+    }
+
+    // No writes lost, duplicated, or applied to the wrong document: each doc
+    // holds its own worker's final-round content.
+    for (worker, doc_id) in doc_ids.iter().enumerate() {
+        let data = gql(
+            &http,
+            &api_url,
+            &format!(r#"query {{ {collection}(docID: "{doc_id}") {{ content status }} }}"#),
+        )
+        .await
+        .expect("final read");
+        let last = rounds - 1;
+        assert_eq!(
+            data[collection][0]["content"],
+            json!(format!("w{worker}-r{last}")),
+            "doc {worker} final content"
+        );
+        assert_eq!(data[collection][0]["status"], json!("streaming"));
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn issue1194_unindexed_status() {
+    run_scenario(
+        "type AgentResponse { status: String  content: String }",
+        "AgentResponse",
+        "",
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn issue1194_indexed_status() {
+    run_scenario(
+        "type AgentResponseIdx { status: String @index  content: String }",
+        "AgentResponseIdx",
+        "",
+    )
+    .await;
+}
+
+/// The reported shape: the mutation input rewrites `status: "streaming"`
+/// unchanged on every flush, producing byte-identical field-delta blocks
+/// across documents. This was the failing variant.
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn issue1194_indexed_status_rewrite() {
+    run_scenario(
+        "type AgentResponseIdxRw { status: String @index  content: String }",
+        "AgentResponseIdxRw",
+        r#", status: "streaming""#,
+    )
+    .await;
+}
+
+/// Same as above without the index: proves the collision is on the shared
+/// content-addressed delta block, not on secondary-index keys.
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn issue1194_unindexed_status_rewrite() {
+    run_scenario(
+        "type AgentResponseRw { status: String  content: String }",
+        "AgentResponseRw",
+        r#", status: "streaming""#,
+    )
+    .await;
+}
+
+/// Deterministic core of #1194: two interactive transactions with overlapping
+/// snapshots update two DIFFERENT documents with a byte-identical field delta
+/// (same `status` value at the same CRDT chain depth => same block CID). Both
+/// commits must succeed. Before the fix the second commit always failed with
+/// a write-write conflict on the shared block key.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn issue1194_identical_delta_txn_pair_distinct_docs() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(1)
+        .with_store("redb")
+        .build()
+        .await
+        .expect("build cluster");
+    let node = cluster.client(0);
+
+    node.schema_add("type Snap { status: String  content: String }")
+        .expect("schema add");
+
+    let mut ids = Vec::new();
+    for i in 0..2 {
+        let data = node
+            .query(&format!(
+                r#"mutation {{ add_Snap(input: {{status: "streaming", content: "init-{i}"}}) {{ _docID }} }}"#
+            ))
+            .expect("create doc");
+        ids.push(data["add_Snap"][0]["_docID"].as_str().unwrap().to_string());
+    }
+
+    let tx1 = node.tx_create().expect("tx1 create");
+    let tx2 = node.tx_create().expect("tx2 create");
+
+    node.query_with_tx(
+        &format!(
+            r#"mutation {{ update_Snap(docID: "{}", input: {{status: "streaming"}}) {{ _docID }} }}"#,
+            ids[0]
+        ),
+        &tx1,
+    )
+    .expect("tx1 update doc0");
+    node.query_with_tx(
+        &format!(
+            r#"mutation {{ update_Snap(docID: "{}", input: {{status: "streaming"}}) {{ _docID }} }}"#,
+            ids[1]
+        ),
+        &tx2,
+    )
+    .expect("tx2 update doc1");
+
+    node.tx_commit(&tx1).expect("tx1 commit");
+    node.tx_commit(&tx2).expect(
+        "tx2 commit: identical-content block writes to distinct documents must not conflict",
+    );
+}
+
+/// Control: two interactive transactions updating the SAME document remain a
+/// genuine conflict — the second commit must abort.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn issue1194_same_doc_txn_pair_still_conflicts() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(1)
+        .with_store("redb")
+        .build()
+        .await
+        .expect("build cluster");
+    let node = cluster.client(0);
+
+    node.schema_add("type Snap { status: String  content: String }")
+        .expect("schema add");
+
+    let data = node
+        .query(r#"mutation { add_Snap(input: {status: "streaming", content: "init"}) { _docID } }"#)
+        .expect("create doc");
+    let id = data["add_Snap"][0]["_docID"].as_str().unwrap().to_string();
+
+    let tx1 = node.tx_create().expect("tx1 create");
+    let tx2 = node.tx_create().expect("tx2 create");
+
+    node.query_with_tx(
+        &format!(
+            r#"mutation {{ update_Snap(docID: "{id}", input: {{content: "a"}}) {{ _docID }} }}"#
+        ),
+        &tx1,
+    )
+    .expect("tx1 update");
+    node.query_with_tx(
+        &format!(
+            r#"mutation {{ update_Snap(docID: "{id}", input: {{content: "b"}}) {{ _docID }} }}"#
+        ),
+        &tx2,
+    )
+    .expect("tx2 update");
+
+    node.tx_commit(&tx1).expect("tx1 commit");
+    let err = node
+        .tx_commit(&tx2)
+        .expect_err("tx2 commit must conflict: same document, overlapping snapshots");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("transaction conflict"),
+        "expected a transaction conflict, got: {msg}"
+    );
+}

--- a/tools/integration-test/tests/issue1194_repro.rs
+++ b/tools/integration-test/tests/issue1194_repro.rs
@@ -1,6 +1,5 @@
 //! Issue #1194 regression: concurrent `update_X` mutations against DISTINCT
-//! documents through the HTTP GraphQL API must not fail with
-//! `transaction conflict. Please retry`.
+//! documents must not fail with `transaction conflict. Please retry`.
 //!
 //! Root cause: field-delta blocks are content-addressed (`b` + CID) and carry
 //! no document identity. Two documents whose updates produce byte-identical
@@ -15,10 +14,13 @@ use std::sync::Arc;
 use integration_test::TestCluster;
 use serde_json::{json, Value};
 
-struct RoundStats {
-    ok: usize,
-    conflict: usize,
-    other: Vec<String>,
+async fn build_cluster() -> TestCluster {
+    TestCluster::builder()
+        .rust_nodes(1)
+        .with_store("redb")
+        .build()
+        .await
+        .expect("build cluster")
 }
 
 async fn gql(http: &reqwest::Client, url: &str, query: &str) -> Result<Value, String> {
@@ -41,84 +43,19 @@ async fn gql(http: &reqwest::Client, url: &str, query: &str) -> Result<Value, St
     Ok(body["data"].clone())
 }
 
-async fn run_workload(
-    api_url: &str,
-    collection: &str,
-    input_extra: &str,
-    doc_ids: &[String],
-    concurrency: usize,
-    rounds: usize,
-) -> RoundStats {
-    let http = reqwest::Client::new();
-    let barrier = Arc::new(tokio::sync::Barrier::new(concurrency));
-    let mut handles = Vec::new();
-    for (worker, doc_id) in doc_ids.iter().take(concurrency).enumerate() {
-        let http = http.clone();
-        let url = api_url.to_string();
-        let doc_id = doc_id.clone();
-        let collection = collection.to_string();
-        let input_extra = input_extra.to_string();
-        let barrier = Arc::clone(&barrier);
-        handles.push(tokio::spawn(async move {
-            let mut stats = RoundStats {
-                ok: 0,
-                conflict: 0,
-                other: Vec::new(),
-            };
-            for round in 0..rounds {
-                barrier.wait().await;
-                let mutation = format!(
-                    r#"mutation {{ update_{collection}(filter: {{_docID: {{_eq: "{doc_id}"}}, status: {{_eq: "streaming"}}}}, input: {{content: "w{worker}-r{round}"{input_extra}}}) {{ _docID }} }}"#
-                );
-                match gql(&http, &url, &mutation).await {
-                    Ok(data) => {
-                        let n = data[format!("update_{collection}")]
-                            .as_array()
-                            .map(|a| a.len())
-                            .unwrap_or(0);
-                        if n == 1 {
-                            stats.ok += 1;
-                        } else {
-                            stats.other.push(format!("updated {n} docs"));
-                        }
-                    }
-                    Err(msg) if msg.contains("transaction conflict") => {
-                        stats.conflict += 1;
-                    }
-                    Err(msg) => stats.other.push(msg),
-                }
-            }
-            stats
-        }));
-    }
-    let mut total = RoundStats {
-        ok: 0,
-        conflict: 0,
-        other: Vec::new(),
-    };
-    for h in handles {
-        let s = h.await.expect("worker panicked");
-        total.ok += s.ok;
-        total.conflict += s.conflict;
-        total.other.extend(s.other);
-    }
-    total
-}
-
-/// Eight docs, barrier-synchronized concurrent updates at concurrency 2/4/8.
-/// Every attempt must succeed on the first try: distinct documents may not
-/// leak transaction conflicts through the HTTP API.
-async fn run_scenario(schema: &str, collection: &str, input_extra: &str) {
-    let cluster = TestCluster::builder()
-        .rust_nodes(1)
-        .with_store("redb")
-        .build()
-        .await
-        .expect("build cluster");
+/// The reported workload over HTTP GraphQL on redb: eight documents, eight
+/// barrier-synchronized writers, each round rewriting `status: "streaming"`
+/// unchanged (the snapshot-flush shape that makes delta blocks byte-identical
+/// across documents). Every attempt must succeed on the first try — no client
+/// retry budget.
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn issue1194_concurrent_distinct_doc_updates() {
+    let cluster = build_cluster().await;
     let node = cluster.client(0);
     let api_url = cluster.api_url(0).to_string();
 
-    node.schema_add(schema).expect("schema add");
+    node.schema_add("type AgentResponse { status: String  content: String }")
+        .expect("schema add");
 
     let http = reqwest::Client::new();
     let mut doc_ids = Vec::new();
@@ -127,13 +64,13 @@ async fn run_scenario(schema: &str, collection: &str, input_extra: &str) {
             &http,
             &api_url,
             &format!(
-                r#"mutation {{ add_{collection}(input: {{status: "streaming", content: "init-{i}"}}) {{ _docID }} }}"#
+                r#"mutation {{ add_AgentResponse(input: {{status: "streaming", content: "init-{i}"}}) {{ _docID }} }}"#
             ),
         )
         .await
         .expect("create doc");
         doc_ids.push(
-            data[format!("add_{collection}")][0]["_docID"]
+            data["add_AgentResponse"][0]["_docID"]
                 .as_str()
                 .expect("docID")
                 .to_string(),
@@ -141,97 +78,62 @@ async fn run_scenario(schema: &str, collection: &str, input_extra: &str) {
     }
 
     let rounds = 10;
-    for concurrency in [2usize, 4, 8] {
-        let stats = run_workload(
-            &api_url,
-            collection,
-            input_extra,
-            &doc_ids,
-            concurrency,
-            rounds,
-        )
-        .await;
-        let attempts = concurrency * rounds;
-        println!(
-            "[{collection}] concurrency={concurrency}: attempts={attempts} ok={} conflict={} other={:?}",
-            stats.ok, stats.conflict, stats.other
-        );
-        assert_eq!(
-            stats.conflict, 0,
-            "[{collection}] concurrency={concurrency}: transaction conflicts leaked for \
-             updates to distinct documents"
-        );
-        assert!(
-            stats.other.is_empty(),
-            "[{collection}] concurrency={concurrency}: unexpected errors: {:?}",
-            stats.other
-        );
-        assert_eq!(stats.ok, attempts);
+    let barrier = Arc::new(tokio::sync::Barrier::new(doc_ids.len()));
+    let mut handles = Vec::new();
+    for (worker, doc_id) in doc_ids.iter().enumerate() {
+        let http = http.clone();
+        let url = api_url.to_string();
+        let doc_id = doc_id.clone();
+        let barrier = Arc::clone(&barrier);
+        handles.push(tokio::spawn(async move {
+            let mut failures = Vec::new();
+            for round in 0..rounds {
+                barrier.wait().await;
+                let mutation = format!(
+                    r#"mutation {{ update_AgentResponse(filter: {{_docID: {{_eq: "{doc_id}"}}, status: {{_eq: "streaming"}}}}, input: {{content: "w{worker}-r{round}", status: "streaming"}}) {{ _docID }} }}"#
+                );
+                match gql(&http, &url, &mutation).await {
+                    Ok(data) => {
+                        let n = data["update_AgentResponse"]
+                            .as_array()
+                            .map(|a| a.len())
+                            .unwrap_or(0);
+                        if n != 1 {
+                            failures.push(format!("round {round}: updated {n} docs"));
+                        }
+                    }
+                    Err(msg) => failures.push(format!("round {round}: {msg}")),
+                }
+            }
+            failures
+        }));
     }
 
-    // No writes lost, duplicated, or applied to the wrong document: each doc
-    // holds its own worker's final-round content.
+    for (worker, handle) in handles.into_iter().enumerate() {
+        let failures = handle.await.expect("worker panicked");
+        assert!(
+            failures.is_empty(),
+            "worker {worker} updating its own document failed: {failures:?}"
+        );
+    }
+
+    // No writes lost, duplicated, or applied to the wrong document.
     for (worker, doc_id) in doc_ids.iter().enumerate() {
         let data = gql(
             &http,
             &api_url,
-            &format!(r#"query {{ {collection}(docID: "{doc_id}") {{ content status }} }}"#),
+            &format!(r#"query {{ AgentResponse(docID: "{doc_id}") {{ content status }} }}"#),
         )
         .await
         .expect("final read");
         let last = rounds - 1;
         assert_eq!(
-            data[collection][0]["content"],
+            data["AgentResponse"][0]["content"],
             json!(format!("w{worker}-r{last}")),
             "doc {worker} final content"
         );
-        assert_eq!(data[collection][0]["status"], json!("streaming"));
+        assert_eq!(data["AgentResponse"][0]["status"], json!("streaming"));
     }
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-async fn issue1194_unindexed_status() {
-    run_scenario(
-        "type AgentResponse { status: String  content: String }",
-        "AgentResponse",
-        "",
-    )
-    .await;
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-async fn issue1194_indexed_status() {
-    run_scenario(
-        "type AgentResponseIdx { status: String @index  content: String }",
-        "AgentResponseIdx",
-        "",
-    )
-    .await;
-}
-
-/// The reported shape: the mutation input rewrites `status: "streaming"`
-/// unchanged on every flush, producing byte-identical field-delta blocks
-/// across documents. This was the failing variant.
-#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-async fn issue1194_indexed_status_rewrite() {
-    run_scenario(
-        "type AgentResponseIdxRw { status: String @index  content: String }",
-        "AgentResponseIdxRw",
-        r#", status: "streaming""#,
-    )
-    .await;
-}
-
-/// Same as above without the index: proves the collision is on the shared
-/// content-addressed delta block, not on secondary-index keys.
-#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-async fn issue1194_unindexed_status_rewrite() {
-    run_scenario(
-        "type AgentResponseRw { status: String  content: String }",
-        "AgentResponseRw",
-        r#", status: "streaming""#,
-    )
-    .await;
 }
 
 /// Deterministic core of #1194: two interactive transactions with overlapping
@@ -241,12 +143,7 @@ async fn issue1194_unindexed_status_rewrite() {
 /// a write-write conflict on the shared block key.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn issue1194_identical_delta_txn_pair_distinct_docs() {
-    let cluster = TestCluster::builder()
-        .rust_nodes(1)
-        .with_store("redb")
-        .build()
-        .await
-        .expect("build cluster");
+    let cluster = build_cluster().await;
     let node = cluster.client(0);
 
     node.schema_add("type Snap { status: String  content: String }")
@@ -292,12 +189,7 @@ async fn issue1194_identical_delta_txn_pair_distinct_docs() {
 /// genuine conflict — the second commit must abort.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn issue1194_same_doc_txn_pair_still_conflicts() {
-    let cluster = TestCluster::builder()
-        .rust_nodes(1)
-        .with_store("redb")
-        .build()
-        .await
-        .expect("build cluster");
+    let cluster = build_cluster().await;
     let node = cluster.client(0);
 
     node.schema_add("type Snap { status: String  content: String }")


### PR DESCRIPTION
Fixes #1194 — chronic `transaction conflict. Please retry` failures when concurrent writers update **different** documents through the HTTP GraphQL API.

## Root cause

Field-delta blocks are content-addressed (blockstore key = `b` + CID) and contain no document identity — a delta is `{field_name, priority, schema_version_id, data}` plus prev-head links. Documents created with the same field value have byte-identical delta chains for that field, so when two documents both rewrite `status: "streaming"` at the same CRDT chain depth, their update transactions write the **same** blockstore key. `ConflictTracker::check_and_record` treated that blind write-write overlap as a `TxnConflict` and aborted the second committer.

Demonstrated with instrumentation on the reported workload shape (redb, HTTP GraphQL, `update_X` with `filter: {_docID: {_eq}, status: {_eq: "streaming"}}`, input rewriting `status`): every conflict at concurrency 8 was `our write hit a committed WRITE key` on a `b`+CID key shared across workers — never a document, index, head, or metadata key. Variants that don't produce identical deltas (content-only updates, indexed or not) showed **zero** conflicts on current `main`, i.e. the earlier conflict-retention/serialization fixes (f5930d67, fa594d56, 1b479d1c, 2450e0d8) removed the amplifiers, and this shared-block collision is the remaining defect.

## Fix

Exempt content-addressed block data keys from the **blind write-write** check only, in the shared `ConflictTracker` used by all five backends (redb, memory, fjall, rocksdb, lark). The predicate requires the blockstore namespace prefix, a non-merge-tracking payload, and fully valid CID bytes (`cid::Cid::try_from`). Writers of the same content-addressed key write identical bytes by construction, so the overlap is not a serializability hazard — Go's badger likewise only conflicts reads against writes and never blind write-write.

Still enforced:
- read-vs-write conflicts on block keys (anti-dependencies),
- blockstore merge-tracking keys (`ToMergeIndexKey`, mutable presence state) and blockstore-namespace keys that are not valid CIDs,
- every other same-key conflict (documents, versions, heads, indexes, metadata),
- SSI write-skew rejection (`conformance ssi_write_skew_prevented` passes).

## Regression coverage

`tools/integration-test/tests/issue1194_repro.rs` (redb, full stack over HTTP GraphQL):
- **Deterministic** core: two overlapping interactive transactions updating two *distinct* docs with identical deltas — both commits must succeed. Before the fix this failed 100% of runs with `HTTP 409 … transaction conflict. Please retry` (verified by neutralizing the carve-out).
- Control: two overlapping transactions updating the *same* doc — second commit must still conflict.
- Workload shape: 8 docs, 8 barrier-synchronized writers rewriting `status` unchanged for 10 rounds; asserts zero conflicts/errors and correct final per-document state (no lost/misapplied writes).
- Unit controls in `crates/storage/src/backends/shared.rs`: identical block write-write commits; merge-index write-write conflicts; non-CID blockstore-namespace write-write conflicts; block write vs committed read conflicts.

## Before / after (concurrency-8 barrier workload, status-rewrite variant)

| | attempts | conflicts |
|---|---|---|
| before | 80 | 6–8 per run (and 1–2 at concurrency 2/4); txn-pair repro fails deterministically |
| after | 80 | 0; txn-pair passes |

## Validation (re-run on the branch merged with current main)

- `cargo test -p storage` — pass
- `cargo test -p integration-test --test issue1194_repro -- --test-threads=1` — 3/3 pass
- `cargo test -p conformance --test tla_conformance -- ssi::` — pass
- `cargo test --workspace --exclude integration-test --exclude conformance --exclude ffi-test` — all pass (pre-merge); `cargo test -p integration-test --test basic`: all 24 `rust_*` pass, the 10 `go_*` failures are environmental (`Go defradb binary not available` locally)
- `cargo fmt --all --check` clean; `cargo clippy --all -- -D warnings` clean; `cargo clippy -p defra-wasm --target wasm32-unknown-unknown --all-targets -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)