### PR TITLE
fix(sync): complete the browser-sync wedge fix from #1188

### DIFF
--- a/crates/cli/src/browser_sync_adapter.rs
+++ b/crates/cli/src/browser_sync_adapter.rs
@@ -232,16 +232,20 @@ impl<S: Store + 'static> BrowserSyncAdapter<S> {
 
             let loaded = match self.engine.load_document(&document_ref).await {
                 Ok(loaded) => loaded,
-                // A document whose DAG cannot fit in a sync payload can never
-                // be pulled. Failing the page would wedge this cursor
-                // position permanently — every retry re-reads the same
-                // document — so skip past it and keep the page moving.
-                Err(db_merge::browser_sync::BrowserSyncError::TooLarge(message)) => {
+                // A document that cannot be represented as a sync payload can
+                // never be pulled, whether it exceeds the size limit or the
+                // block and root counts. Both are permanent properties of the
+                // stored DAG. Failing the page would wedge this cursor
+                // position — every retry re-reads the same document — so skip
+                // past it and keep the page moving. Storage errors are not
+                // included: those are transient and must still fail the page.
+                Err(error @ db_merge::browser_sync::BrowserSyncError::TooLarge(_))
+                | Err(error @ db_merge::browser_sync::BrowserSyncError::Invalid(_)) => {
                     tracing::warn!(
                         doc_id = %document_ref.doc_id,
                         collection_id = %document_ref.collection_id,
-                        %message,
-                        "browser sync skipped a document that exceeds the sync payload limit"
+                        %error,
+                        "browser sync skipped a document that cannot be represented as a sync payload"
                     );
                     resume_cursor = Some(document_ref.doc_id);
                     continue;
@@ -274,11 +278,17 @@ impl<S: Store + 'static> BrowserSyncAdapter<S> {
                 has_more = true;
                 break;
             }
+            // Alone on the page and still over the response limit, so no page
+            // can ever carry it. Skip it for the same reason as an unloadable
+            // document: erroring here would wedge this cursor position.
             if exceeds_limit {
-                return Err(BrowserSyncError::Internal(format!(
-                    "document {} exceeds the sync response limit",
-                    document.doc_id
-                )));
+                tracing::warn!(
+                    doc_id = %document.doc_id,
+                    collection_id = %document_ref.collection_id,
+                    "browser sync skipped a document that exceeds the sync response limit"
+                );
+                resume_cursor = Some(document_ref.doc_id);
+                continue;
             }
             payload_bytes = payload_bytes.saturating_add(document_bytes);
             wire_bytes = wire_bytes.saturating_add(document_wire_bytes + 1);

--- a/crates/cli/src/browser_sync_adapter.rs
+++ b/crates/cli/src/browser_sync_adapter.rs
@@ -239,8 +239,7 @@ impl<S: Store + 'static> BrowserSyncAdapter<S> {
                 // position — every retry re-reads the same document — so skip
                 // past it and keep the page moving. Storage errors are not
                 // included: those are transient and must still fail the page.
-                Err(error @ db_merge::browser_sync::BrowserSyncError::TooLarge(_))
-                | Err(error @ db_merge::browser_sync::BrowserSyncError::Invalid(_)) => {
+                Err(error @ db_merge::browser_sync::BrowserSyncError::TooLarge(_)) => {
                     tracing::warn!(
                         doc_id = %document_ref.doc_id,
                         collection_id = %document_ref.collection_id,

--- a/crates/cli/src/browser_sync_adapter_tests.rs
+++ b/crates/cli/src/browser_sync_adapter_tests.rs
@@ -601,12 +601,11 @@ async fn pull_reaches_documents_ordered_after_an_oversized_document() {
     assert!(!seen.contains(&oversized));
 }
 
-/// A DAG exceeding `MAX_SYNC_BLOCKS_PER_DOCUMENT` fails validation as
-/// `Invalid`, not `TooLarge`. Before this skip was widened it propagated and
-/// wedged the page exactly as the oversized case used to. Block count grows at
-/// 2 blocks per single-field update, so the 4096 limit is reached after ~2047
-/// updates while the payload is still under 1 MB — a more reachable trigger
-/// than the 16 MiB cap.
+/// A DAG exceeding `MAX_SYNC_BLOCKS_PER_DOCUMENT` must be classified as
+/// `TooLarge` so the permanent-document skip handles it instead of wedging the
+/// page. Block count grows at 2 blocks per single-field update, so the 4096
+/// limit is reached after ~2047 updates while the payload is still under 1 MB
+/// — a more reachable trigger than the 16 MiB cap.
 ///
 /// Ignored by default: building the DAG takes ~50s. Run with
 /// `cargo test -p cli --lib block_heavy_document -- --ignored`.
@@ -635,7 +634,7 @@ async fn pull_skips_a_block_heavy_document_and_keeps_paginating() {
     let heavy_ref = engine.document_ref(&heavy).await.unwrap().unwrap();
     let load_error = engine.load_document(&heavy_ref).await.unwrap_err();
     assert!(
-        matches!(load_error, db_merge::BrowserSyncError::Invalid(ref m) if m.contains("block count")),
+        matches!(load_error, db_merge::BrowserSyncError::TooLarge(ref m) if m.contains("block count")),
         "fixture must trip the block-count limit, got {load_error:?}"
     );
 

--- a/crates/cli/src/browser_sync_adapter_tests.rs
+++ b/crates/cli/src/browser_sync_adapter_tests.rs
@@ -535,3 +535,156 @@ async fn concurrent_changes_converge_through_push_pull_exchange() {
         );
     }
 }
+
+/// #1188 skips the oversized document, but the property that matters is that
+/// pagination still reaches documents ordered *after* it. Doc IDs are
+/// content-derived, so this fixture asserts the oversized document actually
+/// sits between two loadable ones before checking that both are served.
+#[tokio::test]
+async fn pull_reaches_documents_ordered_after_an_oversized_document() {
+    let database = Arc::new(db::DB::new(MemoryStore::new()).unwrap());
+    database
+        .create_collection(users_schema(false))
+        .await
+        .unwrap();
+
+    let oversized = create_oversized_document(&database).await;
+    let mut loadable = Vec::new();
+    for name in ["Alice", "Bob", "Carol", "Dave", "Erin", "Frank"] {
+        loadable.push(create_document(&database, name).await.doc_id);
+    }
+    let before: Vec<_> = loadable.iter().filter(|id| **id < oversized).collect();
+    let after: Vec<_> = loadable.iter().filter(|id| **id > oversized).collect();
+    assert!(
+        !before.is_empty() && !after.is_empty(),
+        "fixture must straddle the oversized document: before={before:?} after={after:?}"
+    );
+
+    let acp = Arc::new(LocalDocumentACP::new(Arc::new(MemoryAcpStore::new())));
+    let adapter = BrowserSyncAdapter::new_arc(database, acp);
+
+    let mut cursor = None;
+    let mut seen: Vec<String> = Vec::new();
+    for _ in 0..32 {
+        let page = adapter
+            .sync(
+                BrowserSyncRequest {
+                    documents: Vec::new(),
+                    pull: Some(BrowserSyncPull {
+                        doc_ids: Vec::new(),
+                        cursor: cursor.clone(),
+                        limit: Some(1),
+                    }),
+                },
+                None,
+                false,
+            )
+            .await
+            .expect("an oversized document must not fail the pull");
+        seen.extend(page.documents.iter().map(|doc| doc.doc_id.clone()));
+        match page.next_cursor {
+            Some(next) => {
+                assert_ne!(Some(&next), cursor.as_ref(), "cursor must advance");
+                cursor = Some(next);
+            }
+            None => break,
+        }
+    }
+
+    seen.sort();
+    let mut expected = loadable.clone();
+    expected.sort();
+    assert_eq!(
+        seen, expected,
+        "every loadable document must be served, including those after the oversized one"
+    );
+    assert!(!seen.contains(&oversized));
+}
+
+/// A DAG exceeding `MAX_SYNC_BLOCKS_PER_DOCUMENT` fails validation as
+/// `Invalid`, not `TooLarge`. Before this skip was widened it propagated and
+/// wedged the page exactly as the oversized case used to. Block count grows at
+/// 2 blocks per single-field update, so the 4096 limit is reached after ~2047
+/// updates while the payload is still under 1 MB — a more reachable trigger
+/// than the 16 MiB cap.
+///
+/// Ignored by default: building the DAG takes ~50s. Run with
+/// `cargo test -p cli --lib block_heavy_document -- --ignored`.
+#[tokio::test]
+#[ignore]
+async fn pull_skips_a_block_heavy_document_and_keeps_paginating() {
+    let database = Arc::new(db::DB::new(MemoryStore::new()).unwrap());
+    database
+        .create_collection(users_schema(false))
+        .await
+        .unwrap();
+
+    let mut document = Document::new();
+    document.set("name", "seed");
+    let heavy = db::AutoCommitMutator::new(database.clone())
+        .create("Users", document)
+        .await
+        .unwrap()
+        .doc_id
+        .to_string();
+    for index in 0..2_100 {
+        update_document(&database, &heavy, "name", &format!("v{index}")).await;
+    }
+
+    let engine = db_merge::BrowserSyncEngine::new(database.clone());
+    let heavy_ref = engine.document_ref(&heavy).await.unwrap().unwrap();
+    let load_error = engine.load_document(&heavy_ref).await.unwrap_err();
+    assert!(
+        matches!(load_error, db_merge::BrowserSyncError::Invalid(ref m) if m.contains("block count")),
+        "fixture must trip the block-count limit, got {load_error:?}"
+    );
+
+    let mut loadable = Vec::new();
+    for name in ["Alice", "Bob", "Carol", "Dave", "Erin", "Frank"] {
+        loadable.push(create_document(&database, name).await.doc_id);
+    }
+    assert!(
+        loadable.iter().any(|id| *id > heavy),
+        "fixture needs a document ordered after the block-heavy one"
+    );
+
+    let acp = Arc::new(LocalDocumentACP::new(Arc::new(MemoryAcpStore::new())));
+    let adapter = BrowserSyncAdapter::new_arc(database, acp);
+
+    let mut cursor: Option<String> = None;
+    let mut seen: Vec<String> = Vec::new();
+    for _ in 0..32 {
+        let page = adapter
+            .sync(
+                BrowserSyncRequest {
+                    documents: Vec::new(),
+                    pull: Some(BrowserSyncPull {
+                        doc_ids: Vec::new(),
+                        cursor: cursor.clone(),
+                        limit: Some(1),
+                    }),
+                },
+                None,
+                false,
+            )
+            .await
+            .expect("a block-heavy document must not fail the pull");
+        seen.extend(page.documents.iter().map(|doc| doc.doc_id.clone()));
+        match page.next_cursor {
+            Some(next) => {
+                assert_ne!(Some(&next), cursor.as_ref(), "cursor must advance");
+                cursor = Some(next);
+            }
+            None => break,
+        }
+    }
+
+    seen.sort();
+    let mut expected = loadable.clone();
+    expected.sort();
+    assert_eq!(
+        seen, expected,
+        "every loadable document must be served, including those after the block-heavy one"
+    );
+    assert!(!seen.contains(&heavy));
+}

--- a/crates/db-merge/src/browser_sync/tests.rs
+++ b/crates/db-merge/src/browser_sync/tests.rs
@@ -2,7 +2,10 @@ use std::sync::Arc;
 
 use cid::Cid;
 use defra_core::block::generate_cid_from_bytes;
-use defra_core::browser_sync::{BrowserSyncBlock, BrowserSyncDocument};
+use defra_core::browser_sync::{
+    BrowserSyncBlock, BrowserSyncDocument, MAX_SYNC_BLOCKS_PER_DOCUMENT,
+    MAX_SYNC_ROOTS_PER_DOCUMENT,
+};
 use defra_core::{Block, CrdtDelta, Signature, SignatureHeader, SignatureType};
 use document::{DocID, Document, NormalValue};
 use query::mutator::DocMutator;
@@ -55,6 +58,46 @@ fn replace_wire_block(document: &mut BrowserSyncDocument, old_cid: &str, block: 
     wire_block.cid = cid.to_string();
     wire_block.data = hex::encode(data);
     cid
+}
+
+#[test]
+fn validation_distinguishes_empty_and_over_limit_counts() {
+    let database = Arc::new(db::DB::new(MemoryStore::new()).unwrap());
+    let sync = BrowserSyncEngine::new(database);
+    let block = BrowserSyncBlock {
+        cid: "cid".into(),
+        data: "data".into(),
+    };
+
+    let empty_roots = BrowserSyncDocument {
+        doc_id: "doc".into(),
+        collection_id: "collection".into(),
+        roots: Vec::new(),
+        blocks: vec![block.clone()],
+    };
+    assert!(matches!(
+        sync.validate_document(&empty_roots),
+        Err(BrowserSyncError::Invalid(_))
+    ));
+
+    let too_many_roots = BrowserSyncDocument {
+        roots: vec!["root".into(); MAX_SYNC_ROOTS_PER_DOCUMENT + 1],
+        ..empty_roots.clone()
+    };
+    assert!(matches!(
+        sync.validate_document(&too_many_roots),
+        Err(BrowserSyncError::TooLarge(_))
+    ));
+
+    let too_many_blocks = BrowserSyncDocument {
+        roots: vec!["root".into()],
+        blocks: vec![block; MAX_SYNC_BLOCKS_PER_DOCUMENT + 1],
+        ..empty_roots
+    };
+    assert!(matches!(
+        sync.validate_document(&too_many_blocks),
+        Err(BrowserSyncError::TooLarge(_))
+    ));
 }
 
 #[tokio::test]

--- a/crates/db-merge/src/browser_sync/validation.rs
+++ b/crates/db-merge/src/browser_sync/validation.rs
@@ -29,18 +29,34 @@ impl<S: Store + 'static> BrowserSyncEngine<S> {
     ) -> Result<ValidatedBrowserSyncDocument, BrowserSyncError> {
         validate_id("doc_id", &document.doc_id)?;
         validate_id("collection_id", &document.collection_id)?;
-        if document.roots.is_empty() || document.roots.len() > MAX_SYNC_ROOTS_PER_DOCUMENT {
+        if document.roots.is_empty() {
             return Err(BrowserSyncError::Invalid(format!(
                 "document {} has invalid root count {}",
                 document.doc_id,
                 document.roots.len()
             )));
         }
-        if document.blocks.is_empty() || document.blocks.len() > MAX_SYNC_BLOCKS_PER_DOCUMENT {
+        if document.roots.len() > MAX_SYNC_ROOTS_PER_DOCUMENT {
+            return Err(BrowserSyncError::TooLarge(format!(
+                "document {} root count {} exceeds {}",
+                document.doc_id,
+                document.roots.len(),
+                MAX_SYNC_ROOTS_PER_DOCUMENT
+            )));
+        }
+        if document.blocks.is_empty() {
             return Err(BrowserSyncError::Invalid(format!(
                 "document {} has invalid block count {}",
                 document.doc_id,
                 document.blocks.len()
+            )));
+        }
+        if document.blocks.len() > MAX_SYNC_BLOCKS_PER_DOCUMENT {
+            return Err(BrowserSyncError::TooLarge(format!(
+                "document {} block count {} exceeds {}",
+                document.doc_id,
+                document.blocks.len(),
+                MAX_SYNC_BLOCKS_PER_DOCUMENT
             )));
         }
 

--- a/crates/http/src/handlers/browser_sync_tests.rs
+++ b/crates/http/src/handlers/browser_sync_tests.rs
@@ -219,3 +219,132 @@ async fn sync_honors_stricter_body_limit() {
     assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
     assert_eq!(sync.calls.load(Ordering::Relaxed), 0);
 }
+
+// =============================================================================
+// Contract coverage for the #1188 authorization gate (issue #1181).
+//
+// The tests above build the router without the global auth middleware and only
+// exercise anonymous callers. These add the three properties that pin the
+// deployed contract: the gate works for a real authenticated identity, it is
+// inert when NAC is disabled, and pushes that create documents are gated by
+// `DocumentUpdate` because no create permission exists in the model.
+// =============================================================================
+
+/// A bearer token that passes JWT verification against a `Host: localhost`
+/// audience, so tests can exercise the production middleware path.
+fn authenticated_caller() -> (identity::Did, String) {
+    let private_key = crypto::generate_ed25519().unwrap();
+    let raw = identity::RawIdentity::from_private_key(private_key).unwrap();
+    let did = identity::Identity::did(&raw).unwrap();
+    let token = identity::new_token(
+        &raw,
+        std::time::Duration::from_secs(3600),
+        Some("localhost".to_string()),
+        None,
+    )
+    .unwrap();
+    (did, format!("Bearer {}", String::from_utf8(token).unwrap()))
+}
+
+/// Mirrors `server.rs`: the auth middleware is applied via `route_layer`, so
+/// these tests prove what the middleware does and does not enforce for the
+/// Dynamic `/sync` route.
+fn router_with_middleware(
+    sync: Option<Arc<RecordingSync>>,
+    nac: Option<Arc<MockNodeAcpOperations>>,
+) -> axum::Router {
+    let executor = Arc::new(MockQueryExecutor::new()) as Arc<dyn QueryExecutor>;
+    let mut builder = AppStateBuilder::new(executor);
+    if let Some(sync) = sync {
+        builder = builder.with_browser_sync(sync);
+    }
+    if let Some(nac) = nac {
+        builder = builder.with_nac(nac as Arc<dyn NodeAcpOperations>);
+    }
+    let state = builder.build();
+    create_router_with_state(state.clone()).route_layer(axum::middleware::from_fn_with_state(
+        state,
+        crate::auth_middleware::auth_middleware,
+    ))
+}
+
+fn empty_sync_request(bearer: Option<&str>) -> Request<Body> {
+    let mut builder = Request::builder()
+        .method(Method::POST)
+        .uri("/api/v1/sync")
+        .header("content-type", "application/json")
+        .header("host", "localhost");
+    if let Some(bearer) = bearer {
+        builder = builder.header("authorization", bearer);
+    }
+    builder.body(Body::from(r#"{"documents":[]}"#)).unwrap()
+}
+
+/// The gate holds for a real authenticated identity on the production
+/// middleware path, not just for the anonymous wildcard fallback.
+#[tokio::test]
+async fn empty_sync_request_is_rejected_for_authenticated_caller_without_permission() {
+    let (owner, _) = authenticated_caller();
+    let (_, stranger_bearer) = authenticated_caller();
+    let nac = Arc::new(MockNodeAcpOperations::enabled_with_owner(owner));
+    let sync = Arc::new(RecordingSync::default());
+    let router = router_with_middleware(Some(sync.clone()), Some(nac));
+
+    let response = router
+        .oneshot(empty_sync_request(Some(&stranger_bearer)))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    assert_eq!(sync.calls.load(Ordering::Relaxed), 0);
+}
+
+/// Known limit of the gate: `require_permission` is a no-op when NAC is not
+/// configured, so an empty request still distinguishes a node with browser
+/// sync enabled (200) from one without it (503). Acceptable because a node
+/// without NAC exposes its whole API unauthenticated anyway; this test exists
+/// so that reasoning stays explicit rather than assumed.
+#[tokio::test]
+async fn empty_sync_request_still_reveals_availability_without_nac() {
+    let sync = Arc::new(RecordingSync::default());
+    let enabled = router_with_middleware(Some(sync.clone()), None);
+    let response = enabled.oneshot(empty_sync_request(None)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(sync.calls.load(Ordering::Relaxed), 1);
+
+    let disabled = router_with_middleware(None, None);
+    let response = disabled.oneshot(empty_sync_request(None)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+}
+
+/// Pushing a document the server has never seen is a create, and it is
+/// authorized by the same `DocumentUpdate` permission as an update: the NAC
+/// model has no create variant, matching Go. Pinned so that adding one becomes
+/// a deliberate, Go-diverging decision rather than an accident.
+#[tokio::test]
+async fn push_creating_a_new_document_is_gated_by_document_update() {
+    let (owner, _) = authenticated_caller();
+    let (writer, writer_bearer) = authenticated_caller();
+    let nac = Arc::new(
+        MockNodeAcpOperations::enabled_with_owner(owner)
+            .with_grant(writer, crate::router::NodePermission::DocumentUpdate),
+    );
+    let sync = Arc::new(RecordingSync::default());
+    let router = router_with_middleware(Some(sync.clone()), Some(nac));
+
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri("/api/v1/sync")
+        .header("content-type", "application/json")
+        .header("host", "localhost")
+        .header("authorization", &writer_bearer)
+        .body(Body::from(
+            r#"{"documents":[{"doc_id":"bae-new","collection_id":"c","roots":[],"blocks":[]}]}"#,
+        ))
+        .unwrap();
+    let response = router.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(sync.calls.load(Ordering::Relaxed), 1);
+    assert!(crate::router::NodePermission::parse("create-document").is_none());
+}

--- a/crates/wasm/src/sync/session.rs
+++ b/crates/wasm/src/sync/session.rs
@@ -105,12 +105,14 @@ impl SyncSession {
         for document_ref in refs {
             let loaded = match self.engine.load_document(&document_ref).await {
                 Ok(loaded) => loaded,
-                // Too large to even load, so it can never be pushed. Failing
+                // Cannot be represented as a sync payload — too large, or too
+                // many blocks or roots — so it can never be pushed. Failing
                 // here would abort the whole push and leave recover_full_sync
                 // retrying forever; skip it like the request-size check below.
-                Err(db_merge::browser_sync::BrowserSyncError::TooLarge(message)) => {
+                Err(error @ db_merge::browser_sync::BrowserSyncError::TooLarge(_))
+                | Err(error @ db_merge::browser_sync::BrowserSyncError::Invalid(_)) => {
                     warn(&format!(
-                        "browser sync skipped document {} because it exceeds the sync payload limit: {message}",
+                        "browser sync skipped document {} because it cannot be represented as a sync payload: {error}",
                         document_ref.doc_id
                     ));
                     continue;
@@ -198,9 +200,10 @@ impl SyncSession {
             match self.engine.load_document(&document_ref).await {
                 Ok(Some(document)) => documents.push(document),
                 Ok(None) => {}
-                Err(db_merge::browser_sync::BrowserSyncError::TooLarge(message)) => {
+                Err(error @ db_merge::browser_sync::BrowserSyncError::TooLarge(_))
+                | Err(error @ db_merge::browser_sync::BrowserSyncError::Invalid(_)) => {
                     warn(&format!(
-                        "browser sync skipped document {doc_id} because it exceeds the sync payload limit: {message}"
+                        "browser sync skipped document {doc_id} because it cannot be represented as a sync payload: {error}"
                     ));
                 }
                 Err(error) => return Err(engine_error(error)),

--- a/crates/wasm/src/sync/session.rs
+++ b/crates/wasm/src/sync/session.rs
@@ -109,8 +109,7 @@ impl SyncSession {
                 // many blocks or roots — so it can never be pushed. Failing
                 // here would abort the whole push and leave recover_full_sync
                 // retrying forever; skip it like the request-size check below.
-                Err(error @ db_merge::browser_sync::BrowserSyncError::TooLarge(_))
-                | Err(error @ db_merge::browser_sync::BrowserSyncError::Invalid(_)) => {
+                Err(error @ db_merge::browser_sync::BrowserSyncError::TooLarge(_)) => {
                     warn(&format!(
                         "browser sync skipped document {} because it cannot be represented as a sync payload: {error}",
                         document_ref.doc_id
@@ -200,8 +199,7 @@ impl SyncSession {
             match self.engine.load_document(&document_ref).await {
                 Ok(Some(document)) => documents.push(document),
                 Ok(None) => {}
-                Err(error @ db_merge::browser_sync::BrowserSyncError::TooLarge(_))
-                | Err(error @ db_merge::browser_sync::BrowserSyncError::Invalid(_)) => {
+                Err(error @ db_merge::browser_sync::BrowserSyncError::TooLarge(_)) => {
                     warn(&format!(
                         "browser sync skipped document {doc_id} because it cannot be represented as a sync payload: {error}"
                     ));


### PR DESCRIPTION
Follow-up to #1188, which closed #1181. Reviewing that PR against the full issue turned up an incomplete fix and two findings it did not cover.

## The wedge is only half fixed, and the unfixed half is more reachable

#1188 skips a document whose DAG exceeds `MAX_SYNC_PAYLOAD_BYTES` instead of failing the page. It matches `BrowserSyncError::TooLarge` — but `load_document` ended by calling `validate_document`, which misclassified a DAG over `MAX_SYNC_BLOCKS_PER_DOCUMENT` (4096) or `MAX_SYNC_ROOTS_PER_DOCUMENT` (16) as **`Invalid`**. That error still propagated, giving exactly the behaviour #1188 set out to remove: the page 422s, the cursor never advances past the document, and every document ordered after it is unreachable.

The block-count limit is the easier of the two to hit. Measured on this branch, a DAG grows by **exactly 2 blocks per single-field update**, so 4096 is passed after roughly **2047 updates** while the payload is still under 1 MB — far short of the 16 MiB cap. Because bytes are checked while blocks are collected but the count only at the end, an ordinary frequently-updated document (a counter, a status flag, a cursor) trips the count *first*. The 16 MiB cap is reached first only when field values are large.

The same gap existed on the browser side, where `Invalid` aborted `push_all_documents` and left `recover_full_sync` retrying forever — the original #1181 symptom.

This PR classifies over-limit root and block counts as `TooLarge`, so the existing permanent-document skip handles them on the server pull path and both browser call sites. Empty or malformed DAGs remain `Invalid` and continue to fail rather than being silently skipped. `Storage` errors also keep failing the page: they are transient and must not be treated as a permanent property of the document.

It also converts one remaining hard failure with the same shape — a document that loads but cannot fit in a response body even alone on a page returned `Internal` (500) without advancing the cursor.

## Verification

- `pull_skips_a_block_heavy_document_and_keeps_paginating` builds a 4202-block DAG and asserts the fixture actually trips the block-count limit, then that every loadable document is served and the cursor advances. It fails on `main` with `InvalidInput("... invalid block count ...")`. `#[ignore]` because building the DAG takes ~15s.
- `pull_reaches_documents_ordered_after_an_oversized_document` strengthens #1188's own coverage. That test creates a single loadable document alongside the oversized one, and since doc IDs are content-derived it does not control the ordering — it can pass even if everything sorting after the oversized document were dropped. This version asserts the fixture straddles the oversized document before checking that both sides are served.

Commands, all from this branch:

- `cargo test -p cli --lib browser_sync` — 10 passed, 1 ignored
- `cargo test -p cli --lib block_heavy_document -- --ignored` — 1 passed (13.55s)
- `cargo test -p defra-http browser_sync` — 9 passed
- `cargo check -p defra-wasm --target wasm32-unknown-unknown` — clean (`session.rs` is wasm-only)
- `cargo clippy -p cli -p defra-http --all-targets -- -D warnings` and `cargo clippy -p defra-wasm --target wasm32-unknown-unknown -- -D warnings` — both exit 0
- `cargo fmt --all -- --check` — clean

## Second commit: authorization contract coverage

#1188's NAC tests build the router without the global auth middleware and only exercise anonymous callers, so the deployed path was untested. The second commit adds three properties: the gate holds for a real authenticated identity through the production middleware; it is **inert when NAC is unconfigured**, so an empty request still distinguishes a node with browser sync enabled (200) from one without it (503); and a push creating a previously unseen document is authorized by `DocumentUpdate`, since the NAC model has no create variant — matching Go, and pinned so that adding one becomes a deliberate decision.

The NAC-disabled residual is recorded rather than fixed. A node without NAC serves its whole API unauthenticated, so the response reveals nothing that is not already reachable from `/api/v1/collections`. Rejecting empty requests with 400 would close it unconditionally and is arguably the better contract — no client ever sends that shape — but it would make #1188's `DocumentRead` check dead code, so it is a deliberate either/or rather than an addition. Happy to switch if preferred.

## Not addressed here

Three findings from #1181 remain open and are unchanged on current `main`; each wants its own PR:

1. **No fetch timeout or SSE staleness detection.** No `AbortController` anywhere in `crates/wasm/src/sync`, and `exchange` holds `exchange_lock` across the fetch await, so one half-dead connection stalls all sync. The server sends no SSE heartbeat (`Sse::keep_alive` is unused), so client-side idle detection needs a server change too.
2. **Batch application is not atomic.** `sync()` validates every document then applies sequentially, so a mid-batch failure leaves earlier documents applied while the request errors. Convergence-safe and idempotent on retry, but transient OCC conflict exhaustion is currently reported as 422.
3. **`document_refs` is recomputed per page**, giving O(N x pages) work with the cursor applied in memory. The systemstore `/d/p/<doc_id>` index is already in cursor order and would allow a seek with no wire change.

Skipped documents are still only visible in logs — the response has no `skipped` field, so a browser cannot tell "absent" from "present but unsendable". Adding one is additive and safe in both skew directions; worth a follow-up alongside client-side handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
