### PR TITLE
fix(db): prevent stale auto-commit updates

### DIFF
--- a/crates/db-merge/src/broadcast_mutator/mod.rs
+++ b/crates/db-merge/src/broadcast_mutator/mod.rs
@@ -254,6 +254,143 @@ impl<S: Store + 'static, B: Blockstore + 'static, T: P2PTransport> SeArtifactRep
     }
 }
 
+impl<S: Store + 'static, B: Blockstore + 'static, T: P2PTransport> BroadcastMutator<S, B, T> {
+    async fn broadcast_update_result(
+        &self,
+        collection_name: &str,
+        se_fields: Vec<String>,
+        result: UpdateResult,
+    ) -> query::error::Result<UpdateResult> {
+        let collection = self
+            .db
+            .get_collection(collection_name)
+            .map_err(|e| query::error::QueryError::execution(e.to_string()))?
+            .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?;
+        let collection_id = collection.collection_id().to_string();
+
+        let doc_id_for_broadcast = result
+            .document
+            .id()
+            .map(|id| id.to_string())
+            .unwrap_or_default();
+        let (cid, block, doc_id_str) =
+            if let (Some(cid), Some(block)) = (result.commit_cid, result.commit_block.as_ref()) {
+                (cid, block.clone(), doc_id_for_broadcast)
+            } else {
+                match read_latest_composite_block(&self.db, &doc_id_for_broadcast).await {
+                    Ok(br) => (br.cid, br.block, br.doc_id),
+                    Err(e) => {
+                        tracing::error!(
+                            doc_id = %doc_id_for_broadcast,
+                            collection = %collection_name,
+                            error = %e,
+                            "Failed to read composite block for P2P broadcast"
+                        );
+                        return Ok(UpdateResult::with_broadcast(
+                            result.document,
+                            result.fields_modified,
+                            BroadcastStatus::Failed(format!("Block read failed: {}", e)),
+                        ));
+                    }
+                }
+            };
+
+        let block_result = BlockResult {
+            cid,
+            block,
+            doc_id: doc_id_str,
+            field_cids: vec![],
+            encryption_cids: vec![],
+        };
+        let creator_did = defra_core::signing::get_broadcast_creator_did();
+        let branchable_data = if let (Some(col_cid), Some(col_block)) =
+            (result.broadcast_cid, result.broadcast_block.as_ref())
+        {
+            Some(BlockResult {
+                cid: col_cid,
+                block: col_block.clone(),
+                doc_id: String::new(),
+                field_cids: vec![],
+                encryption_cids: vec![],
+            })
+        } else {
+            None
+        };
+        let se_artifacts = self.generate_se_artifacts(
+            collection.schema(),
+            &block_result.doc_id,
+            &result.document,
+            &se_fields,
+        );
+        let document_json = serde_json::Value::Object(
+            result
+                .document
+                .to_map()
+                .unwrap_or_default()
+                .into_iter()
+                .collect(),
+        );
+        let sync = self.sync.clone();
+        let collection_name_owned = collection_name.to_string();
+
+        tokio::spawn(async move {
+            let creator_ref = creator_did.as_deref();
+            sync.push_document_to_replicators_with_creator(
+                &block_result.cid,
+                &block_result.block,
+                &block_result.doc_id,
+                &collection_id,
+                &document_json,
+                creator_ref,
+            )
+            .await;
+            sync.push_se_artifacts_to_replicators_for_document(
+                &collection_id,
+                se_artifacts,
+                &document_json,
+            )
+            .await;
+            log_broadcast_failure(
+                &broadcast_with_retry_with_creator(
+                    &sync,
+                    &block_result,
+                    &collection_id,
+                    &collection_name_owned,
+                    creator_ref,
+                )
+                .await,
+            );
+
+            if let Some(col_block_result) = branchable_data {
+                sync.push_to_replicators_with_creator(
+                    &col_block_result.cid,
+                    &col_block_result.block,
+                    &col_block_result.doc_id,
+                    &collection_id,
+                    creator_ref,
+                )
+                .await;
+                log_broadcast_failure(
+                    &broadcast_with_retry_with_creator(
+                        &sync,
+                        &col_block_result,
+                        &collection_id,
+                        &collection_name_owned,
+                        creator_ref,
+                    )
+                    .await,
+                );
+            }
+        });
+
+        Ok(UpdateResult::with_broadcast(
+            result.document,
+            result.fields_modified,
+            BroadcastStatus::Pending,
+        ))
+    }
+}
+
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl<S: Store + 'static, B: Blockstore + 'static, T: P2PTransport> DocMutator
@@ -624,158 +761,29 @@ impl<S: Store + 'static, B: Blockstore + 'static, T: P2PTransport> DocMutator
         doc: Document,
         modified_fields: std::collections::HashSet<String>,
     ) -> query::error::Result<UpdateResult> {
-        // Get collection ID for broadcast
-        let collection = self
-            .db
-            .get_collection(collection_name)
-            .map_err(|e| query::error::QueryError::execution(e.to_string()))?
-            .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?;
-        let collection_id = collection.collection_id().to_string();
         let se_fields: Vec<String> = modified_fields.iter().cloned().collect();
-
-        // Execute the update mutation
         let result = self
             .inner
             .update(collection_name, doc, modified_fields)
             .await?;
+        self.broadcast_update_result(collection_name, se_fields, result)
+            .await
+    }
 
-        // Use the committed block directly when available (from ffi/query),
-        // falling back to reading from storage.
-        let doc_id_for_broadcast = result
-            .document
-            .id()
-            .map(|id| id.to_string())
-            .unwrap_or_default();
-        let (cid, block, doc_id_str) =
-            if let (Some(cid), Some(block)) = (result.commit_cid, result.commit_block.as_ref()) {
-                (cid, block.clone(), doc_id_for_broadcast)
-            } else {
-                // Fallback: read committed composite block from storage
-                match read_latest_composite_block(&self.db, &doc_id_for_broadcast).await {
-                    Ok(br) => (br.cid, br.block, br.doc_id),
-                    Err(e) => {
-                        tracing::error!(
-                            doc_id = %doc_id_for_broadcast,
-                            collection = %collection_name,
-                            error = %e,
-                            "Failed to read composite block for P2P broadcast"
-                        );
-                        return Ok(UpdateResult::with_broadcast(
-                            result.document,
-                            result.fields_modified,
-                            BroadcastStatus::Failed(format!("Block read failed: {}", e)),
-                        ));
-                    }
-                }
-            };
-
-        let block_result = BlockResult {
-            cid,
-            block,
-            doc_id: doc_id_str,
-            field_cids: vec![],
-            encryption_cids: vec![],
-        };
-
-        // Read broadcast creator DID before spawning (reads thread-local state).
-        let creator_did = defra_core::signing::get_broadcast_creator_did();
-
-        // Capture branchable collection broadcast data before spawning.
-        let branchable_data = if let (Some(col_cid), Some(col_block)) =
-            (result.broadcast_cid, result.broadcast_block.as_ref())
-        {
-            Some(BlockResult {
-                cid: col_cid,
-                block: col_block.clone(),
-                doc_id: String::new(),
-                field_cids: vec![],
-                encryption_cids: vec![],
-            })
-        } else {
-            None
-        };
-        let se_artifacts = self.generate_se_artifacts(
-            collection.schema(),
-            &block_result.doc_id,
-            &result.document,
-            &se_fields,
-        );
-        let document_json = serde_json::Value::Object(
-            result
-                .document
-                .to_map()
-                .unwrap_or_default()
-                .into_iter()
-                .collect(),
-        );
-
-        // Capture everything for the spawned task by value.
-        let sync = self.sync.clone();
-        let collection_name_owned = collection_name.to_string();
-
-        // Spawn broadcast work as a detached task -- the local transaction
-        // is already committed, so we return immediately.
-        tokio::spawn(async move {
-            let creator_ref = creator_did.as_deref();
-
-            // Match Go DefraDB's live replicator model: push the new head block
-            // and let the receiver resolve any missing links via DAG sync.
-            sync.push_document_to_replicators_with_creator(
-                &block_result.cid,
-                &block_result.block,
-                &block_result.doc_id,
-                &collection_id,
-                &document_json,
-                creator_ref,
-            )
-            .await;
-            sync.push_se_artifacts_to_replicators_for_document(
-                &collection_id,
-                se_artifacts,
-                &document_json,
-            )
-            .await;
-
-            // Broadcast composite via GossipSub with retry for InsufficientPeers
-            log_broadcast_failure(
-                &broadcast_with_retry_with_creator(
-                    &sync,
-                    &block_result,
-                    &collection_id,
-                    &collection_name_owned,
-                    creator_ref,
-                )
-                .await,
-            );
-
-            // For branchable collections, also broadcast the collection block.
-            if let Some(col_block_result) = branchable_data {
-                sync.push_to_replicators_with_creator(
-                    &col_block_result.cid,
-                    &col_block_result.block,
-                    &col_block_result.doc_id,
-                    &collection_id,
-                    creator_ref,
-                )
-                .await;
-                log_broadcast_failure(
-                    &broadcast_with_retry_with_creator(
-                        &sync,
-                        &col_block_result,
-                        &collection_id,
-                        &collection_name_owned,
-                        creator_ref,
-                    )
-                    .await,
-                );
-            }
-        });
-
-        Ok(UpdateResult::with_broadcast(
-            result.document,
-            result.fields_modified,
-            BroadcastStatus::Pending,
-        ))
+    async fn update_if_unchanged(
+        &self,
+        collection_name: &str,
+        expected: Document,
+        doc: Document,
+        modified_fields: std::collections::HashSet<String>,
+    ) -> query::error::Result<UpdateResult> {
+        let se_fields: Vec<String> = modified_fields.iter().cloned().collect();
+        let result = self
+            .inner
+            .update_if_unchanged(collection_name, expected, doc, modified_fields)
+            .await?;
+        self.broadcast_update_result(collection_name, se_fields, result)
+            .await
     }
 
     async fn delete(

--- a/crates/db/src/auto_commit_mutator/mod.rs
+++ b/crates/db/src/auto_commit_mutator/mod.rs
@@ -102,7 +102,18 @@ impl<S: Store + 'static> DocMutator for AutoCommitMutator<S> {
         doc: Document,
         modified_fields: std::collections::HashSet<String>,
     ) -> query::error::Result<UpdateResult> {
-        self.update_impl(collection_name, doc, modified_fields)
+        self.update_impl(collection_name, None, doc, modified_fields)
+            .await
+    }
+
+    async fn update_if_unchanged(
+        &self,
+        collection_name: &str,
+        expected: Document,
+        doc: Document,
+        modified_fields: std::collections::HashSet<String>,
+    ) -> query::error::Result<UpdateResult> {
+        self.update_impl(collection_name, Some(expected), doc, modified_fields)
             .await
     }
 

--- a/crates/db/src/auto_commit_mutator/update.rs
+++ b/crates/db/src/auto_commit_mutator/update.rs
@@ -4,6 +4,7 @@ use super::helpers::{
 use super::*;
 
 use db_blocks::DocStorageIdentity;
+use query::runner::DocFetcher;
 
 #[allow(clippy::type_complexity)]
 impl<S: Store + 'static> AutoCommitMutator<S> {
@@ -86,6 +87,34 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
             .acquire(&canonical_lock_id.to_string())
             .await;
 
+        // The query plan materializes `doc` before this mutator acquires the
+        // per-document write guard. A concurrent update can commit while this
+        // call is waiting, leaving `doc` stale. Reload through the lensed
+        // fetcher under the guard and rebase only the caller's declared patch;
+        // otherwise an unrelated field from the concurrent update is silently
+        // replaced by the stale snapshot.
+        let fresh_fetcher = crate::LensedAutoCommitFetcher::new(Arc::clone(&self.db));
+        let canonical_id = canonical_lock_id.to_string();
+        let mut current_doc = fresh_fetcher
+            .get_by_ids(collection_name, std::slice::from_ref(&canonical_id))
+            .await?
+            .into_docs()
+            .into_iter()
+            .next()
+            .ok_or_else(|| query::error::QueryError::document_not_found(canonical_id))?;
+        for field_name in &modified_fields {
+            if let Some(delta) = doc.get_counter_delta(field_name).cloned() {
+                // Counter inputs are deltas computed from the stale
+                // materialization. Carry the delta, not its provisional
+                // accumulated value; `write_local_update` applies it to the
+                // authoritative value below.
+                current_doc.set_counter_delta(field_name.clone(), delta);
+            } else if let Some(value) = doc.get(field_name).cloned() {
+                current_doc.set(field_name.clone(), value);
+            }
+        }
+        doc = current_doc;
+
         // Create a write transaction
         let txn = self.db.new_txn(false).await.map_err(|e| {
             query::error::QueryError::execution(format!("failed to create txn: {}", e))
@@ -114,17 +143,6 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                     ))
                 })?;
 
-            self.db
-                .validate_downsample_write(
-                    &datastore,
-                    &systemstore,
-                    collection.schema(),
-                    &doc,
-                    Some(&modified_fields),
-                )
-                .await
-                .map_err(|e| query::error::QueryError::execution(e.to_string()))?;
-
             let (doc_short_id, canonical_doc_id) = collection
                 .require_doc_identity(&systemstore, &input_doc_id)
                 .await
@@ -135,6 +153,17 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                     other => query::error::QueryError::execution(other.to_string()),
                 })?;
             doc.set_id(canonical_doc_id);
+
+            self.db
+                .validate_downsample_write(
+                    &datastore,
+                    &systemstore,
+                    collection.schema(),
+                    &doc,
+                    Some(&modified_fields),
+                )
+                .await
+                .map_err(|e| query::error::QueryError::execution(e.to_string()))?;
 
             // Bundle the counter RMW (#1021) with the doc blob + index write so
             // the authoritative CRDT accumulation store always advances before the
@@ -324,5 +353,76 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                 Err(e)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::sync::Arc;
+
+    use document::{Document, NormalValue};
+    use query::mutator::DocMutator;
+    use schema::{CollectionVersion, FieldDescription, FieldKind};
+    use storage::backends::MemoryStore;
+
+    use super::*;
+
+    fn test_collection() -> CollectionVersion {
+        CollectionVersion::new(
+            "Patch",
+            "v1",
+            "col-patch",
+            vec![
+                FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                FieldDescription::new("2", "left", FieldKind::int()),
+                FieldDescription::new("3", "right", FieldKind::int()),
+            ],
+        )
+    }
+
+    /// A query plan materializes the document before entering the auto-commit
+    /// mutator. Two concurrent plans can therefore hand the mutator separate
+    /// stale copies of the same document. `modified_fields` is the patch
+    /// boundary: applying the second copy must not replace an unrelated field
+    /// written by the first update.
+    #[tokio::test]
+    async fn stale_disjoint_field_update_preserves_committed_fields() {
+        let db = Arc::new(DB::new(MemoryStore::new()).expect("create db"));
+        db.create_collection(test_collection())
+            .await
+            .expect("schema");
+        let mutator = AutoCommitMutator::new(Arc::clone(&db));
+
+        let initial =
+            Document::from_json_str(r#"{"left": 0, "right": 0}"#).expect("initial document");
+        let created = mutator.create("Patch", initial).await.expect("create");
+
+        let mut stale_left = mutator
+            .get_for_update("Patch", &created.doc_id)
+            .await
+            .expect("fetch left copy")
+            .expect("left copy");
+        let mut stale_right = stale_left.clone();
+
+        stale_left.set("left", NormalValue::Int(1));
+        mutator
+            .update("Patch", stale_left, HashSet::from(["left".to_string()]))
+            .await
+            .expect("update left");
+
+        stale_right.set("right", NormalValue::Int(1));
+        mutator
+            .update("Patch", stale_right, HashSet::from(["right".to_string()]))
+            .await
+            .expect("update right");
+
+        let final_doc = mutator
+            .get_for_update("Patch", &created.doc_id)
+            .await
+            .expect("fetch final")
+            .expect("final document");
+        assert_eq!(final_doc.get("left"), Some(&NormalValue::Int(1)));
+        assert_eq!(final_doc.get("right"), Some(&NormalValue::Int(1)));
     }
 }

--- a/crates/db/src/auto_commit_mutator/update.rs
+++ b/crates/db/src/auto_commit_mutator/update.rs
@@ -11,6 +11,7 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
     pub(super) async fn update_impl(
         &self,
         collection_name: &str,
+        expected: Option<Document>,
         doc: Document,
         modified_fields: std::collections::HashSet<String>,
     ) -> query::error::Result<UpdateResult> {
@@ -102,6 +103,23 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
             .into_iter()
             .next()
             .ok_or_else(|| query::error::QueryError::document_not_found(canonical_id))?;
+        if let Some(expected) = expected {
+            let values_unchanged = expected.values().len() == current_doc.values().len()
+                && expected
+                    .values()
+                    .iter()
+                    .all(|(field_name, expected_value)| {
+                        current_doc.get(field_name) == Some(expected_value.value())
+                    });
+            if expected.id() != current_doc.id()
+                || expected.is_deleted() != current_doc.is_deleted()
+                || !values_unchanged
+            {
+                return Err(query::error::QueryError::execution(
+                    "transaction conflict. Please retry",
+                ));
+            }
+        }
         for field_name in &modified_fields {
             if let Some(delta) = doc.get_counter_delta(field_name).cloned() {
                 // Counter inputs are deltas computed from the stale
@@ -387,7 +405,7 @@ mod tests {
     /// boundary: applying the second copy must not replace an unrelated field
     /// written by the first update.
     #[tokio::test]
-    async fn stale_disjoint_field_update_preserves_committed_fields() {
+    async fn stale_disjoint_field_update_without_precondition_preserves_committed_fields() {
         let db = Arc::new(DB::new(MemoryStore::new()).expect("create db"));
         db.create_collection(test_collection())
             .await
@@ -424,5 +442,59 @@ mod tests {
             .expect("final document");
         assert_eq!(final_doc.get("left"), Some(&NormalValue::Int(1)));
         assert_eq!(final_doc.get("right"), Some(&NormalValue::Int(1)));
+    }
+
+    /// Query mutations carry the snapshot against which their filter was
+    /// validated. If that snapshot changes while the update waits for the
+    /// per-document guard, the mutation must conflict instead of applying a
+    /// predicate that is no longer known to hold.
+    #[tokio::test]
+    async fn stale_conditional_update_returns_conflict() {
+        let db = Arc::new(DB::new(MemoryStore::new()).expect("create db"));
+        db.create_collection(test_collection())
+            .await
+            .expect("schema");
+        let mutator = AutoCommitMutator::new(Arc::clone(&db));
+
+        let initial =
+            Document::from_json_str(r#"{"left": 0, "right": 0}"#).expect("initial document");
+        let created = mutator.create("Patch", initial).await.expect("create");
+
+        let mut first = mutator
+            .get_for_update("Patch", &created.doc_id)
+            .await
+            .expect("fetch first copy")
+            .expect("first copy");
+        let expected_second = first.clone();
+        let mut second = first.clone();
+
+        first.set("left", NormalValue::Int(1));
+        mutator
+            .update("Patch", first, HashSet::from(["left".to_string()]))
+            .await
+            .expect("update left");
+
+        second.set("right", NormalValue::Int(1));
+        let error = mutator
+            .update_if_unchanged(
+                "Patch",
+                expected_second,
+                second,
+                HashSet::from(["right".to_string()]),
+            )
+            .await
+            .expect_err("stale conditional update must conflict");
+        assert!(
+            error.to_string().contains("transaction conflict"),
+            "unexpected error: {error}"
+        );
+
+        let final_doc = mutator
+            .get_for_update("Patch", &created.doc_id)
+            .await
+            .expect("fetch final")
+            .expect("final document");
+        assert_eq!(final_doc.get("left"), Some(&NormalValue::Int(1)));
+        assert_eq!(final_doc.get("right"), Some(&NormalValue::Int(0)));
     }
 }

--- a/crates/query-plan/src/mutator.rs
+++ b/crates/query-plan/src/mutator.rs
@@ -436,6 +436,24 @@ pub trait DocMutator: MaybeSendSync {
         modified_fields: std::collections::HashSet<String>,
     ) -> Result<UpdateResult>;
 
+    /// Update a document only if its persisted state still matches the
+    /// snapshot used to select and materialize the mutation.
+    ///
+    /// Transaction-scoped mutators already read and write through one
+    /// snapshot, so the default delegates to [`Self::update`]. Auto-commit
+    /// mutators should override this method and validate `expected` after
+    /// acquiring their per-document serialization guard.
+    async fn update_if_unchanged(
+        &self,
+        collection_name: &str,
+        expected: Document,
+        doc: Document,
+        modified_fields: std::collections::HashSet<String>,
+    ) -> Result<UpdateResult> {
+        let _ = expected;
+        self.update(collection_name, doc, modified_fields).await
+    }
+
     /// Delete a document by ID.
     ///
     /// # Arguments

--- a/crates/query-plan/src/plan/mutation/update.rs
+++ b/crates/query-plan/src/plan/mutation/update.rs
@@ -387,6 +387,27 @@ impl PlanNode for UpdateNode {
                 let doc_opt = fetch_result.into_docs().into_iter().next();
 
                 if let Some(mut doc) = doc_opt {
+                    // Filter resolution and this point-in-time fetch can be
+                    // separated by permission checks and other async work.
+                    // Revalidate against the exact snapshot used for the
+                    // update so a document that stopped matching is skipped.
+                    if let Some(ref filter) = self.filter {
+                        let filter_mapping = if let Some(collection) = &self.collection {
+                            let mut mapping = DocumentMapping::new();
+                            for (index, field) in collection.fields.iter().enumerate() {
+                                mapping.add(index, &field.name);
+                            }
+                            mapping
+                        } else {
+                            self.document_mapping.clone()
+                        };
+                        let plan_doc = document_to_plan_doc(&doc, &filter_mapping)?;
+                        if !filter.matches(plan_doc.fields(), &filter_mapping)? {
+                            continue;
+                        }
+                    }
+                    let expected = doc.clone();
+
                     // Apply update input with schema-aware coercion and request time
                     self.input.apply_to_with_time(
                         &mut doc,
@@ -401,7 +422,7 @@ impl PlanNode for UpdateNode {
                     // Persist update with modified field tracking
                     let result = self
                         .mutator
-                        .update(&self.collection_name, doc, modified_fields)
+                        .update_if_unchanged(&self.collection_name, expected, doc, modified_fields)
                         .await?;
 
                     // Convert to plan Doc

--- a/crates/query/src/runner/mutation.rs
+++ b/crates/query/src/runner/mutation.rs
@@ -560,13 +560,12 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                     node = node.with_doc_ids(doc_ids.clone());
                 }
 
-                // Pass the filter only when the node still needs to resolve it.
-                // If it was already resolved to doc IDs above, the filter must
-                // not be applied again to post-update document state.
-                if resolved_doc_ids.is_none() && mutation.doc_ids.is_none() {
-                    if let Some(ref filter) = mutation.filter {
-                        node = node.with_filter(filter.clone());
-                    }
+                // Keep the filter even when it was already resolved to IDs.
+                // UpdateNode revalidates it against the document snapshot that
+                // is passed to the mutator, closing the selection/write race
+                // without filtering the post-update result.
+                if let Some(ref filter) = mutation.filter {
+                    node = node.with_filter(filter.clone());
                 }
 
                 Box::new(node)

--- a/tools/integration-test/tests/issue1194_repro.rs
+++ b/tools/integration-test/tests/issue1194_repro.rs
@@ -228,3 +228,49 @@ async fn issue1194_same_doc_txn_pair_still_conflicts() {
         "expected a transaction conflict, got: {msg}"
     );
 }
+
+/// Regression control for the same-document case when the concurrent updates
+/// touch different fields. The document body is a single stored value, so both
+/// mutations still write from overlapping snapshots and the second commit must
+/// abort instead of silently replacing the first update.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn issue1194_same_doc_disjoint_field_txn_pair_still_conflicts() {
+    let cluster = build_cluster().await;
+    let node = cluster.client(0);
+
+    node.schema_add("type Snap { status: String  content: String }")
+        .expect("schema add");
+
+    let data = node
+        .query(r#"mutation { add_Snap(input: {status: "streaming", content: "init"}) { _docID } }"#)
+        .expect("create doc");
+    let id = data["add_Snap"][0]["_docID"].as_str().unwrap().to_string();
+
+    let tx1 = node.tx_create().expect("tx1 create");
+    let tx2 = node.tx_create().expect("tx2 create");
+
+    node.query_with_tx(
+        &format!(
+            r#"mutation {{ update_Snap(docID: "{id}", input: {{content: "first"}}) {{ _docID }} }}"#
+        ),
+        &tx1,
+    )
+    .expect("tx1 update content");
+    node.query_with_tx(
+        &format!(
+            r#"mutation {{ update_Snap(docID: "{id}", input: {{status: "claimed"}}) {{ _docID }} }}"#
+        ),
+        &tx2,
+    )
+    .expect("tx2 update status");
+
+    node.tx_commit(&tx1).expect("tx1 commit");
+    let err = node
+        .tx_commit(&tx2)
+        .expect_err("tx2 commit must conflict: same document, overlapping snapshots");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("transaction conflict"),
+        "expected a transaction conflict, got: {msg}"
+    );
+}


### PR DESCRIPTION
## Summary

- reload the latest lensed document after acquiring the per-document write guard and rebase only declared modified fields
- revalidate update filters against the exact document snapshot handed to the mutator
- add an optimistic snapshot precondition for auto-commit query updates, returning a retryable conflict instead of applying a stale predicate
- carry counter deltas instead of stale provisional counter values
- preserve the concurrent distinct-document path fixed by #1194

This was exposed while validating Gents against v0.17.0. The #1194 content-addressed block fix correctly removed a false conflict that had accidentally forced retries, revealing two latent auto-commit races: a stale materialized document could replace an unrelated field, and a filter that matched before waiting on the document guard could update a document after that predicate stopped being true.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p query-plan -p query -p db -p db-merge --all-targets -- -D warnings`
- `cargo test -p query-plan -p query -p db -p db-merge`
- `cargo test -p integration-test --test issue1194_repro`
- Gents focused streaming and parent-terminal subagent regressions (consumer validation)

The stale-copy and conditional-conflict tests were verified against the affected behavior. The Redb suite covers both concurrent distinct-document success and same-document conflict controls.