### PR TITLE
fix(ci): isolate Ubuntu APT sources

### DIFF
--- a/.github/scripts/apt-update-without-nodesource.sh
+++ b/.github/scripts/apt-update-without-nodesource.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Self-hosted runners may have NodeSource configured for operator-managed Node
+# upgrades. That third-party repository is not needed by DefraDB builds, and a
+# stale or unavailable NodeSource endpoint must not prevent Ubuntu packages
+# from being refreshed. Build a request-local source set instead of mutating
+# the runner's global APT configuration.
+filtered_root="$(mktemp -d)"
+trap 'rm -rf "${filtered_root}"' EXIT
+mkdir -p "${filtered_root}/sources.list.d"
+
+if [[ -f /etc/apt/sources.list ]]; then
+  grep -Fv "deb.nodesource.com" /etc/apt/sources.list \
+    >"${filtered_root}/sources.list" || true
+else
+  : >"${filtered_root}/sources.list"
+fi
+
+shopt -s nullglob
+for source_file in /etc/apt/sources.list.d/*; do
+  case "${source_file}" in
+    *.list | *.sources) ;;
+    *) continue ;;
+  esac
+  if grep -Fq "deb.nodesource.com" "${source_file}"; then
+    echo "Skipping unavailable NodeSource APT source: ${source_file}"
+    continue
+  fi
+  cp "${source_file}" "${filtered_root}/sources.list.d/"
+done
+
+sudo apt-get "$@" \
+  -o "Dir::Etc::sourcelist=${filtered_root}/sources.list" \
+  -o "Dir::Etc::sourceparts=${filtered_root}/sources.list.d" \
+  update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,9 @@ jobs:
         # clang is needed because lz4-sys (transitive C dep) builds
         # wasm-shim C sources via cc-rs when the target is wasm32.
         # protoc is needed by prost-build.
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler clang
+        run: |
+          bash .github/scripts/apt-update-without-nodesource.sh
+          sudo apt-get install -y protobuf-compiler clang
 
       - name: Exclude tools with private deps from workspace
         run: sed -i '/"tools\/integration-test"/d; /"tools\/ffi-test"/d' Cargo.toml
@@ -538,7 +540,9 @@ jobs:
       - name: Install system dependencies
         # protobuf-compiler: prost-build. clang/libclang-dev: bindgen (rocksdb).
         # cmake: librocksdb-sys. libdbus-1-dev: keyring secret-service backend.
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends protobuf-compiler clang libclang-dev cmake pkg-config libssl-dev libdbus-1-dev
+        run: |
+          bash .github/scripts/apt-update-without-nodesource.sh
+          sudo apt-get install -y --no-install-recommends protobuf-compiler clang libclang-dev cmake pkg-config libssl-dev libdbus-1-dev
 
       # Build both the standard and iroh-enabled binaries — the p2p suite's
       # `rust_*_iroh` filtered-replication tests spawn iroh-transport nodes via

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
             APT_ARGS=(-o APT::Architecture=arm64 -o APT::Architectures=arm64)
           fi
 
-          sudo apt-get "${APT_ARGS[@]}" update
+          bash .github/scripts/apt-update-without-nodesource.sh "${APT_ARGS[@]}"
           sudo apt-get "${APT_ARGS[@]}" install -y libssl-dev pkg-config protobuf-compiler libdbus-1-dev
           if [ "${{ matrix.variant }}" = "rocksdb" ]; then
             sudo apt-get "${APT_ARGS[@]}" install -y libclang-dev
@@ -163,7 +163,9 @@ jobs:
           shared-key: "wasm32"
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+        run: |
+          bash .github/scripts/apt-update-without-nodesource.sh
+          sudo apt-get install -y protobuf-compiler
 
       - name: Exclude workspace members with private deps
         run: sed -i '/"tools\/integration-test"/d; /"tools\/ffi-test"/d; /"proofs"/d' Cargo.toml
@@ -283,7 +285,7 @@ jobs:
             APT_ARGS=(-o APT::Architecture=arm64 -o APT::Architectures=arm64)
           fi
 
-          sudo apt-get "${APT_ARGS[@]}" update
+          bash .github/scripts/apt-update-without-nodesource.sh "${APT_ARGS[@]}"
           sudo apt-get "${APT_ARGS[@]}" install -y libssl-dev pkg-config protobuf-compiler libdbus-1-dev
           if [ "${{ matrix.variant }}" = "rocksdb" ]; then
             sudo apt-get "${APT_ARGS[@]}" install -y libclang-dev


### PR DESCRIPTION
## Summary
- build a request-local APT source set for CI/release Linux jobs
- exclude only the unavailable deb.nodesource.com source without mutating self-hosted runner configuration
- preserve Ubuntu and other healthy package sources

## Context
Post-merge CI run 30311932756 failed before compilation because the NodeSource node_22.x/nodistro InRelease endpoint returned HTTP 403. The fully green PR run had completed the same code jobs immediately beforehand.

## Validation
- bash -n .github/scripts/apt-update-without-nodesource.sh
- git diff --check