### PR TITLE
Remove redundant tests and strengthen coverage

### DIFF
--- a/crates/db/src/commits_fetcher/tests.rs
+++ b/crates/db/src/commits_fetcher/tests.rs
@@ -16,33 +16,6 @@ mod unit_tests {
 
 #[cfg(test)]
 mod additional_tests {
-    use cid::Cid;
-    use std::str::FromStr;
-
-    #[test]
-    fn test_invalid_cid_parsing() {
-        let result = Cid::from_str("fhbnjfahfhfhanfhga");
-        assert!(result.is_err(), "Invalid CID should fail to parse");
-    }
-
-    #[test]
-    fn test_valid_cid_parsing() {
-        let result = Cid::from_str("bafyreiajq6jmyblg2b6vupjdapzkaodbt7kkwqp4fijekdvydnyxvr4y7q");
-        assert!(result.is_ok(), "Valid CID should parse");
-    }
-
-    #[test]
-    fn test_unknown_cid_parsing() {
-        let result = Cid::from_str("bafybeid57gpbwi4i6bg7g35hhhhhhhhhhhhhhhhhhhhhhhdoesnotexist");
-        let _ = result;
-    }
-
-    #[test]
-    fn test_truly_invalid_cid_parsing() {
-        let result = Cid::from_str("fhbnjfahfhfhanfhga");
-        assert!(result.is_err(), "Truly invalid CID should fail to parse");
-    }
-
     #[test]
     fn test_looks_like_cidv1() {
         use crate::commits_fetcher::CommitsFetcher;

--- a/crates/document/tests/encoding_tests.rs
+++ b/crates/document/tests/encoding_tests.rs
@@ -130,14 +130,6 @@ fn test_to_map_nan_error() {
 }
 
 #[test]
-fn test_to_map_infinity_error() {
-    let mut doc = document::Document::new();
-    doc.set("value", f64::INFINITY);
-    let result = doc.to_map();
-    assert!(result.is_err());
-}
-
-#[test]
 fn test_to_map_neg_infinity_error() {
     let mut doc = document::Document::new();
     doc.set("value", f64::NEG_INFINITY);

--- a/crates/ffi/src/acp/dac.rs
+++ b/crates/ffi/src/acp/dac.rs
@@ -559,15 +559,13 @@ mod tests {
     }
 
     #[test]
-    fn test_dac_actor_relationship() {
+    fn test_dac_actor_relationship_missing_collection_returns_error() {
         assert!(crate::runtime::init_runtime());
 
-        let options = NodeInitOptions::default();
-        let result = new_node(options);
-        assert_eq!(result.status, 0);
+        let result = new_node(NodeInitOptions::default());
+        assert_eq!(result.status, 0, "new_node should succeed");
         let node = result.node_ptr;
 
-        // Add DAC relationship (no document registered, but we test the API)
         let requestor_did = CString::new(test_did()).unwrap();
         let target_did = CString::new(test_did2()).unwrap();
         let collection_id = CString::new("test-collection").unwrap();
@@ -584,21 +582,21 @@ mod tests {
                 relation.as_ptr(),
             )
         };
-        // This may fail because the document isn't registered - but it tests the API
-        // The status code indicates the FFI function was called correctly
-        if result.status == 0 {
-            let value = unsafe { CStr::from_ptr(result.value).to_string_lossy() };
-            assert!(
-                value.contains("added"),
-                "should have added field in response"
-            );
-            unsafe { crate::types::defra_free_string(result.value) };
-        } else {
-            // Expected - document not registered
-            unsafe { crate::types::defra_free_string(result.error) };
-        }
+        assert_eq!(result.status, 1, "missing collection should be an error");
+        assert!(
+            result.value.is_null(),
+            "error result should not contain a value"
+        );
+        assert!(
+            !result.error.is_null(),
+            "error result should contain a message"
+        );
+        let error = unsafe { CStr::from_ptr(result.error).to_string_lossy() };
+        assert_eq!(error, "collection 'test-collection' does not exist");
+        unsafe { crate::types::defra_free_string(result.error) };
 
-        node_close(node);
+        let close_result = node_close(node);
+        assert_eq!(close_result.status, 0, "node_close should succeed");
     }
 
     #[test]

--- a/crates/query-types/src/error.rs
+++ b/crates/query-types/src/error.rs
@@ -333,14 +333,6 @@ mod tests {
     }
 
     #[test]
-    fn test_error_constructors() {
-        let _ = QueryError::invalid_filter("bad condition");
-        let _ = QueryError::collection_not_found("users");
-        let _ = QueryError::execution("plan failed");
-        let _ = QueryError::internal("unexpected state");
-    }
-
-    #[test]
     fn test_transaction_error_is_retryable() {
         // NotFound is NOT retryable - the transaction doesn't exist
         assert!(

--- a/crates/query/src/lib.rs
+++ b/crates/query/src/lib.rs
@@ -83,15 +83,3 @@ pub use txn::{
     GetTransactionResult, NoOpTransactionRegistry, TransactionContext, TransactionGuard,
     TransactionHandle, TransactionRegistry,
 };
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_crate_compiles() {
-        // Basic smoke test that the crate compiles
-        let mapping = DocumentMapping::new();
-        assert_eq!(mapping.next_index(), 0);
-    }
-}

--- a/tools/integration-test/tests/p2p_iroh/replication/collection_sub.rs
+++ b/tools/integration-test/tests/p2p_iroh/replication/collection_sub.rs
@@ -3,7 +3,7 @@
 //! Ported from Go: tests/integration/net/simple/peer/ (collection subscription tests)
 //!
 //! Run with:
-//!   cargo test -p integration-test --test p2p_iroh_collection_sub -- --ignored
+//!   cargo test -p integration-test --test p2p_iroh replication::collection_sub
 
 use std::time::Duration;
 
@@ -214,25 +214,24 @@ async fn collection_add_erroneous_id() {
     );
 }
 
-/// Port: TestP2PCollectionAddValidAndErroneousCollectionID
-/// Mix of valid and erroneous IDs: behavior depends on implementation.
+/// A mixed batch returns an error after preserving subscriptions completed
+/// before the invalid collection was encountered.
 #[tokio::test]
 #[serial]
-async fn collection_add_valid_and_erroneous() {
+async fn collection_add_mixed_batch_preserves_prior_subscription() {
     let cluster = setup_iroh_node().await;
     let node = cluster.client(0);
 
     let result = node.p2p_collection_add(&["Users", "NonExistent"]);
-    // The entire call may fail or partially succeed.
-    // In Go, this is atomic (neither added). In Rust, it may be non-atomic
-    // (Users gets added even though NonExistent fails).
-    if result.is_err() {
-        let cols = node.p2p_collection_list().expect("list");
-        let arr = cols.as_array().expect("not array");
-        if !arr.is_empty() {
-            eprintln!("NOTE: non-atomic collection_add — valid collection was added despite error");
-        }
-    }
+    assert!(result.is_err(), "mixed valid/invalid batch should error");
+
+    let cols = node.p2p_collection_list().expect("list");
+    let arr = cols.as_array().expect("not array");
+    assert_eq!(
+        arr.len(),
+        1,
+        "the valid collection subscribed before the error should remain"
+    );
 }
 
 /// Port: TestP2PCollectionAddValidThenErroneousCollectionID


### PR DESCRIPTION
## Summary

- remove seven tests that were exact duplicates, assertion-free compile smoke tests, or direct tests of an upstream CID parser
- replace two false-green tests with deterministic assertions instead of deleting their unique paths
- correct the touched Iroh module's stale test command

Net change: 30 insertions, 88 deletions.

## Deletion evidence

- four `Cid::from_str` tests exercised only the upstream `cid` crate; two were duplicates and one discarded its result, while repository-specific CID classification coverage remains
- positive infinity encoding is asserted identically in `document_tests.rs`
- the assertion-free `QueryError` constructor smoke test is superseded by assertion-bearing conversion/use tests
- the query crate compilation smoke test duplicated `query-types`' stronger `DocumentMapping::new` test; query re-export compilation remains covered by benchmarks
- none of the deleted tests had `should_panic`, a `Result`-based assertion, special cfg/Miri/sanitizer behavior, unique cleanup, or a unique repository input path

## Preserved and strengthened coverage

- the DAC missing-collection FFI path now requires status 1, null value, a non-null exact error message, correct string cleanup, and successful node close
- the Iroh mixed valid/invalid batch now requires an error and asserts the existing one-entry partial side effect, covering the implementation's sequential subscription behavior
- an independent review rejected deleting these two paths and approved the amended tests

## Validation

- affected crate suites: 0 failures
- exact FFI missing-collection test: 1 passed, 150 filtered
- exact Iroh mixed-batch test: 1 passed, 230 filtered
- `cargo fmt --all -- --check`
- `git diff --check`
