### PR TITLE
Remove dead internal helpers

### DIFF
--- a/crates/crdt/src/lib.rs
+++ b/crates/crdt/src/lib.rs
@@ -21,9 +21,6 @@ pub mod lww;
 pub mod priority;
 pub mod traits;
 
-#[cfg(test)]
-mod test_utils;
-
 pub use composite::{CompositeDAG, CompositeDelta, STATUS_ACTIVE, STATUS_DELETED};
 pub use counter::{Counter, CounterDelta, NumericKind};
 pub use lww::{Lww, LwwDelta};

--- a/crates/crdt/src/test_utils.rs
+++ b/crates/crdt/src/test_utils.rs
@@ -1,6 +1,0 @@
-//! Test utilities for CRDT testing
-//!
-//! Re-exports storage::MemoryStore for use in tests.
-
-#[allow(unused_imports)]
-pub use storage::MemoryStore;

--- a/crates/query-parse/src/sdl_parse/helpers.rs
+++ b/crates/query-parse/src/sdl_parse/helpers.rs
@@ -3,7 +3,7 @@
 //! Module-level helper functions used during SDL parsing:
 //! - Preprocessing: `preprocess_empty_types()`
 //! - Type parsing: `parse_graphql_type()`, `graphql_to_scalar_kind()`
-//! - ID generation: `generate_collection_id()`, `generate_field_id()`, `generate_version_id()`
+//! - ID generation: `generate_collection_id()`, `generate_field_id()`
 //! - Formatting: `format_graphql_value()`, `graphql_schema_value_to_json()`
 //! - Hashing: `hash_to_hex()`
 
@@ -390,16 +390,6 @@ pub(super) fn generate_field_id(field_name: &str, kind: &FieldKind, crdt_type: C
             format!("field_{}", hash_to_hex(&hasher.finalize()))
         }
     }
-}
-
-/// Generate a deterministic version ID from collection name and fields.
-///
-/// Uses the same CID format as Go DefraDB for interoperability.
-/// In Go, for a new schema the VersionID equals the CollectionID.
-#[allow(dead_code)]
-pub(super) fn generate_version_id(name: &str, fields: &[FieldDescription]) -> String {
-    // Version ID uses the same logic as collection ID (Go behavior for new schemas)
-    generate_collection_id(name, fields, &HashMap::new())
 }
 
 /// Generate a relation name following Go DefraDB conventions.


### PR DESCRIPTION
## Summary

- remove CRDT's private, test-only `test_utils` module, which only re-exported an unused `MemoryStore`
- remove query-parse's unused private `generate_version_id` helper and its stale module-doc mention

No public API, manifest, lockfile, or runtime behavior changes.

## Reachability evidence

- workspace-wide history searches find `crdt::test_utils` only in its private `#[cfg(test)] mod` declaration and six-line file
- every CRDT integration test and benchmark imports `storage::MemoryStore` directly
- the module had no path/include, macro, generated-template, script, doc, feature, or manifest consumer
- `generate_version_id` occurred only in its own `#[allow(dead_code)] pub(super)` definition and the module-doc list
- query-parse's builder and tests explicitly import other helpers, never this function
- both crates expose empty Cargo feature maps and have no build scripts
- independent review approved the reachability analysis

## Validation

- `cargo test -p crdt -p query-parse --all-targets`: 262 tests passed plus CRDT benchmark smoke cases
- `cargo clippy -p crdt -p query-parse --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
