### PR TITLE
Correct stale module documentation

### DIFF
--- a/crates/query-parse/src/sdl_parse/mod.rs
+++ b/crates/query-parse/src/sdl_parse/mod.rs
@@ -3,15 +3,17 @@
 //! This module parses GraphQL Schema Definition Language (SDL) and converts
 //! type definitions into DefraDB CollectionVersion schemas.
 //!
-//! # Module Organization (planned)
+//! # Module Organization
 //!
 //! - `parser`: Main SdlParser struct and parse logic
 //! - `directives`: Directive parsing
 //! - `warnings`: Warning types
-//! - `fields`: Field parsing utilities (placeholder)
-//! - `validation`: Schema validation (placeholder)
-//! - `builder`: Collection building (placeholder)
-//! - `helpers`: Helper utilities (placeholder)
+//! - `fields`: Field and directive parsing
+//! - `validation`: Schema validation
+//! - `builder`: Collection building
+//! - `builder_cycles`: Circular relation detection
+//! - `builder_field_kinds`: Field kind resolution
+//! - `helpers`: Shared parsing utilities
 
 mod builder;
 mod builder_cycles;

--- a/crates/query-plan/src/planner/mod.rs
+++ b/crates/query-plan/src/planner/mod.rs
@@ -4,10 +4,11 @@
 //! - `builder`: Main Planner struct and plan building logic
 //! - `index_selection`: Index selection algorithms
 //! - `traits`: PlanNode trait and related types
-//! - `mapping`: Document mapping utilities (placeholder for extraction)
-//! - `aggregates`: Aggregate node building (placeholder for extraction)
-//! - `joins`: Join planning utilities (placeholder for extraction)
-//! - `views`: View planning utilities (placeholder for extraction)
+//! - `mapping`: Document mapping utilities
+//! - `aggregates`: Aggregate and similarity node building
+//! - `joins`: Join planning utilities
+//! - `cached_view_builder`: Materialized-view planning
+//! - `view_builder`: Non-materialized-view planning
 
 mod aggregates;
 mod builder;

--- a/crates/query/src/runner/mod.rs
+++ b/crates/query/src/runner/mod.rs
@@ -17,8 +17,8 @@
 //! - `mutation`: Mutation execution
 //! - `plan`: Plan execution utilities
 //! - `query`: Main query execution logic
-//! - `explain`: Explain functionality (placeholder for extraction)
-//! - `commits`: Commits query handling (placeholder for extraction)
+//! - `explain`: Explain query execution
+//! - `commits`: Commits query handling
 
 mod commits;
 mod commits_height;

--- a/proofs/src/lean_contract.rs
+++ b/proofs/src/lean_contract.rs
@@ -1,4 +1,4 @@
-//! Auto-generated Lean conformance vectors.
+//! Lean-generated conformance contract loader.
 //!
 //! `proofs/lean/Conformance.lean` emits a JSON contract (vocabularies derived
 //! from the Lean models) between two sentinel lines. We run it via

--- a/proofs/tests/lean_conformance.rs
+++ b/proofs/tests/lean_conformance.rs
@@ -1,4 +1,4 @@
-//! Lean axis: assert the auto-generated Lean contract still matches the live
+//! Lean axis: assert the Lean-generated contract still matches the live
 //! Rust types. A drift in either side fails here. No binary needed.
 
 use conformance::lean_contract::{load_contract, ContractSnapshot};


### PR DESCRIPTION
## Summary

- remove obsolete “planned” and “placeholder for extraction” labels from modules that are already split and implemented
- list the current SDL builder submodules and planner view builders by their real names
- describe the handwritten Rust Lean-contract code as a loader for Lean-generated JSON, rather than as generated Rust

This is a documentation-only correction with no API or runtime changes.

## Accuracy evidence

- every named SDL, planner, and runner module exists and its description matches the module's current implementation/header
- the planner list now covers all declared planner modules, including separate materialized and non-materialized view builders
- `proofs/lean/Conformance.lean` generates the JSON contract; `proofs/src/lean_contract.rs` is handwritten code that invokes Lean, extracts the sentinel-delimited JSON, and deserializes it
- an independent review confirmed every changed line is `//!` module documentation and found no stale or false replacement text

## Validation

- `cargo check -p query -p query-parse -p query-plan -p conformance --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`
