### PR TITLE
fix(storage): preserve concurrent branchable collection heads

### DIFF
--- a/crates/datastore/src/multistore.rs
+++ b/crates/datastore/src/multistore.rs
@@ -267,6 +267,9 @@ fn prefix_iter_options(namespace: Namespace, opts: IterOptions) -> IterOptions {
     prefixed_opts = prefixed_opts
         .with_reverse(opts.reverse())
         .with_keys_only(opts.keys_only());
+    if opts.commutative_set() {
+        prefixed_opts = prefixed_opts.with_commutative_set();
+    }
 
     prefixed_opts
 }

--- a/crates/db-blocks/src/collection.rs
+++ b/crates/db-blocks/src/collection.rs
@@ -19,7 +19,9 @@ pub async fn write_collection_block(
 
     // Get existing collection head (if any)
     let col_prefix = HeadstoreColKey::collection_prefix(collection_short_id);
-    let opts = IterOptions::new().with_prefix(col_prefix);
+    let opts = IterOptions::new()
+        .with_prefix(col_prefix)
+        .with_commutative_set();
 
     let mut iter = headstore
         .iterator(opts)
@@ -119,4 +121,142 @@ pub async fn write_collection_block(
     }
 
     Ok((collection_cid, collection_bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use datastore::SharedTxn;
+    use storage::backends::MemoryStore;
+    use storage::corekv::{IterOptions, Store};
+    use storage::namespace::Namespace;
+
+    use super::*;
+
+    fn test_cid(value: &[u8]) -> Cid {
+        generate_cid_from_bytes(value).unwrap()
+    }
+
+    fn views(shared: &Arc<SharedTxn>) -> (NamespaceView, NamespaceView) {
+        (
+            NamespaceView::new(Arc::clone(shared), Namespace::Blockstore),
+            NamespaceView::new(Arc::clone(shared), Namespace::Headstore),
+        )
+    }
+
+    async fn commit(shared: Arc<SharedTxn>) {
+        Arc::try_unwrap(shared)
+            .ok()
+            .expect("transaction views dropped")
+            .into_txn()
+            .commit()
+            .await
+            .unwrap();
+    }
+
+    async fn collection_heads(store: &MemoryStore, collection_id: u32) -> Vec<Cid> {
+        let shared = SharedTxn::new(store.new_txn(true).await.unwrap());
+        let (_, headstore) = views(&shared);
+        let mut iterator = headstore
+            .iterator(
+                IterOptions::new().with_prefix(HeadstoreColKey::collection_prefix(collection_id)),
+            )
+            .await
+            .unwrap();
+        let mut heads = Vec::new();
+        while let Some(pair) = iterator.next().await.unwrap() {
+            let cid = String::from_utf8(pair.key)
+                .unwrap()
+                .rsplit('/')
+                .next()
+                .unwrap()
+                .parse()
+                .unwrap();
+            heads.push(cid);
+        }
+        iterator.close().await.unwrap();
+        heads.sort_by_cached_key(Cid::to_string);
+        heads
+    }
+
+    #[tokio::test]
+    async fn concurrent_collection_transitions_preserve_and_merge_sibling_heads() {
+        const COLLECTION_ID: u32 = 7;
+
+        let store = MemoryStore::new();
+        let seed_txn = SharedTxn::new(store.new_txn(false).await.unwrap());
+        let (seed_blocks, seed_heads) = views(&seed_txn);
+        write_collection_block(
+            &seed_blocks,
+            &seed_heads,
+            COLLECTION_ID,
+            "schema-v1",
+            test_cid(b"seed document"),
+            None,
+        )
+        .await
+        .unwrap();
+        drop((seed_blocks, seed_heads));
+        commit(seed_txn).await;
+
+        let first_txn = SharedTxn::new(store.new_txn(false).await.unwrap());
+        let second_txn = SharedTxn::new(store.new_txn(false).await.unwrap());
+        let (first_blocks, first_heads) = views(&first_txn);
+        let (second_blocks, second_heads) = views(&second_txn);
+
+        let (first_cid, _) = write_collection_block(
+            &first_blocks,
+            &first_heads,
+            COLLECTION_ID,
+            "schema-v1",
+            test_cid(b"first document"),
+            None,
+        )
+        .await
+        .unwrap();
+        let (second_cid, _) = write_collection_block(
+            &second_blocks,
+            &second_heads,
+            COLLECTION_ID,
+            "schema-v1",
+            test_cid(b"second document"),
+            None,
+        )
+        .await
+        .unwrap();
+        drop((first_blocks, first_heads, second_blocks, second_heads));
+
+        commit(first_txn).await;
+        commit(second_txn).await;
+
+        let mut expected_siblings = vec![first_cid, second_cid];
+        expected_siblings.sort_by_cached_key(Cid::to_string);
+        assert_eq!(
+            collection_heads(&store, COLLECTION_ID).await,
+            expected_siblings
+        );
+
+        let merge_txn = SharedTxn::new(store.new_txn(false).await.unwrap());
+        let (merge_blocks, merge_heads) = views(&merge_txn);
+        let (merged_cid, merged_bytes) = write_collection_block(
+            &merge_blocks,
+            &merge_heads,
+            COLLECTION_ID,
+            "schema-v1",
+            test_cid(b"merge document"),
+            None,
+        )
+        .await
+        .unwrap();
+        let merged_block = Block::from_dag_cbor(&merged_bytes).unwrap();
+        assert_eq!(merged_block.heads, Some(expected_siblings));
+        drop((merge_blocks, merge_heads));
+        commit(merge_txn).await;
+
+        assert_eq!(
+            collection_heads(&store, COLLECTION_ID).await,
+            vec![merged_cid]
+        );
+    }
 }

--- a/crates/storage/src/backends/shared.rs
+++ b/crates/storage/src/backends/shared.rs
@@ -192,7 +192,10 @@ pub(crate) struct ReadSet {
 #[cfg(not(target_arch = "wasm32"))]
 #[derive(Debug, Clone)]
 enum ReadRange {
-    Prefix(Vec<u8>),
+    Prefix {
+        prefix: Vec<u8>,
+        commutative_set: bool,
+    },
     Range {
         start: Option<Vec<u8>>,
         end: Option<Vec<u8>>,
@@ -210,7 +213,10 @@ impl ReadSet {
             if is_document_collection_scan_prefix(prefix) {
                 return;
             }
-            self.ranges.push(ReadRange::Prefix(prefix.to_vec()));
+            self.ranges.push(ReadRange::Prefix {
+                prefix: prefix.to_vec(),
+                commutative_set: opts.commutative_set(),
+            });
         } else {
             self.ranges.push(ReadRange::Range {
                 start: opts.start().map(Vec::from),
@@ -219,8 +225,18 @@ impl ReadSet {
         }
     }
 
-    fn conflicts_key(&self, key: &[u8]) -> bool {
-        self.keys.contains(key) || self.ranges.iter().any(|range| range.contains(key))
+    fn has_commutative_range(&self, key: &[u8]) -> bool {
+        self.ranges
+            .iter()
+            .any(|range| range.commutative_set() && range.contains(key))
+    }
+
+    fn conflicts_key(&self, key: &[u8], other: &Self) -> bool {
+        self.keys.contains(key)
+            || self.ranges.iter().any(|range| {
+                range.contains(key)
+                    && (!range.commutative_set() || !other.has_commutative_range(key))
+            })
     }
 }
 
@@ -266,13 +282,23 @@ fn is_document_collection_scan_prefix(prefix: &[u8]) -> bool {
 impl ReadRange {
     fn contains(&self, key: &[u8]) -> bool {
         match self {
-            Self::Prefix(prefix) => key.starts_with(prefix),
+            Self::Prefix { prefix, .. } => key.starts_with(prefix),
             Self::Range { start, end } => {
                 let after_start = start.as_ref().is_none_or(|start| key >= start.as_slice());
                 let before_end = end.as_ref().is_none_or(|end| key < end.as_slice());
                 after_start && before_end
             }
         }
+    }
+
+    fn commutative_set(&self) -> bool {
+        matches!(
+            self,
+            Self::Prefix {
+                commutative_set: true,
+                ..
+            }
+        )
     }
 }
 
@@ -403,9 +429,12 @@ impl ConflictTracker {
         // Check for conflicts against transactions committed after our snapshot.
         for (_, committed_writes, committed_reads) in state.committed_after(read_version) {
             for write_key in &write_keys {
+                let commutative_overlap = read_set.has_commutative_range(write_key)
+                    && committed_reads.has_commutative_range(write_key);
                 if (committed_writes.contains(*write_key)
-                    && !is_content_addressed_block_key(write_key))
-                    || committed_reads.conflicts_key(write_key)
+                    && !is_content_addressed_block_key(write_key)
+                    && !commutative_overlap)
+                    || committed_reads.conflicts_key(write_key, read_set)
                 {
                     return Err(crate::corekv::Error::TxnConflict);
                 }
@@ -413,7 +442,7 @@ impl ConflictTracker {
 
             if committed_writes
                 .iter()
-                .any(|committed_write| read_set.conflicts_key(committed_write))
+                .any(|committed_write| read_set.conflicts_key(committed_write, committed_reads))
             {
                 return Err(crate::corekv::Error::TxnConflict);
             }

--- a/crates/storage/src/backends/shared_tests.rs
+++ b/crates/storage/src/backends/shared_tests.rs
@@ -50,6 +50,96 @@ fn ignores_document_collection_scan_prefixes() {
         .unwrap();
 }
 
+fn collection_transition_reads() -> ReadSet {
+    let mut reads = ReadSet::default();
+    reads.record_iter_options(
+        &IterOptions::new()
+            .with_prefix(b"h/c/7/".to_vec())
+            .with_commutative_set(),
+    );
+    reads
+}
+
+#[test]
+fn commutative_set_transitions_do_not_conflict() {
+    let tracker = Arc::new(ConflictTracker::new());
+    let first_snapshot = tracker.begin_snapshot();
+    let second_snapshot = tracker.begin_snapshot();
+    let reads = collection_transition_reads();
+
+    let first_writes = [b"h/c/7/old".to_vec(), b"h/c/7/first".to_vec()];
+    tracker
+        .check_and_record(first_snapshot.version(), first_writes.iter(), &reads)
+        .unwrap();
+    drop(first_snapshot);
+
+    let second_writes = [b"h/c/7/old".to_vec(), b"h/c/7/second".to_vec()];
+    tracker
+        .check_and_record(second_snapshot.version(), second_writes.iter(), &reads)
+        .unwrap();
+}
+
+#[test]
+fn commutative_set_transition_conflicts_with_ordinary_scan_in_either_order() {
+    for ordinary_first in [false, true] {
+        let tracker = Arc::new(ConflictTracker::new());
+        let first_snapshot = tracker.begin_snapshot();
+        let second_snapshot = tracker.begin_snapshot();
+        let commutative_reads = collection_transition_reads();
+        let mut ordinary_reads = ReadSet::default();
+        ordinary_reads.record_iter_options(&IterOptions::new().with_prefix(b"h/c/7/".to_vec()));
+
+        let (first_reads, second_reads) = if ordinary_first {
+            (&ordinary_reads, &commutative_reads)
+        } else {
+            (&commutative_reads, &ordinary_reads)
+        };
+        let first_writes = [b"h/c/7/old".to_vec(), b"h/c/7/first".to_vec()];
+        tracker
+            .check_and_record(first_snapshot.version(), first_writes.iter(), first_reads)
+            .unwrap();
+        drop(first_snapshot);
+
+        let second_writes = [b"h/c/7/old".to_vec(), b"h/c/7/second".to_vec()];
+        let error = tracker
+            .check_and_record(
+                second_snapshot.version(),
+                second_writes.iter(),
+                second_reads,
+            )
+            .unwrap_err();
+        assert!(matches!(error, crate::corekv::Error::TxnConflict));
+    }
+}
+
+#[test]
+fn commutative_set_transition_does_not_hide_document_head_conflicts() {
+    let tracker = Arc::new(ConflictTracker::new());
+    let first_snapshot = tracker.begin_snapshot();
+    let second_snapshot = tracker.begin_snapshot();
+    let reads = collection_transition_reads();
+
+    let first_writes = [
+        b"h/c/7/old".to_vec(),
+        b"h/c/7/first".to_vec(),
+        b"h/d/1/C/old".to_vec(),
+    ];
+    tracker
+        .check_and_record(first_snapshot.version(), first_writes.iter(), &reads)
+        .unwrap();
+    drop(first_snapshot);
+
+    let second_writes = [
+        b"h/c/7/old".to_vec(),
+        b"h/c/7/second".to_vec(),
+        b"h/d/1/C/old".to_vec(),
+    ];
+    let error = tracker
+        .check_and_record(second_snapshot.version(), second_writes.iter(), &reads)
+        .unwrap_err();
+    assert!(matches!(error, crate::corekv::Error::TxnConflict));
+}
+
 #[test]
 fn detects_read_of_committed_write_key() {
     let tracker = Arc::new(ConflictTracker::new());

--- a/crates/storage/src/backends/test_suite/concurrency.rs
+++ b/crates/storage/src/backends/test_suite/concurrency.rs
@@ -1,4 +1,4 @@
-use crate::corekv::{Error, Store};
+use crate::corekv::{Error, IterOptions, Store, Txn};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
@@ -35,6 +35,58 @@ pub async fn test_concurrent_writes_different_keys<S: Store + 'static>(store: Ar
             i
         );
     }
+}
+
+async fn replace_collection_heads(txn: &mut Box<dyn Txn>, child: &[u8]) {
+    let mut iterator = txn
+        .iterator(
+            IterOptions::new()
+                .with_prefix(b"h/c/7/".to_vec())
+                .with_commutative_set(),
+        )
+        .await
+        .unwrap();
+    let mut old_heads = Vec::new();
+    while let Some(pair) = iterator.next().await.unwrap() {
+        old_heads.push(pair.key);
+    }
+    iterator.close().await.unwrap();
+
+    for old_head in old_heads {
+        txn.delete(&old_head).await.unwrap();
+    }
+    txn.set(child, b"2").await.unwrap();
+}
+
+/// Test concurrent observed-remove/add transitions on a shared set prefix.
+pub async fn test_commutative_set_transitions<S: Store + 'static>(store: Arc<S>) {
+    let mut seed = store.new_txn(false).await.unwrap();
+    seed.set(b"h/c/7/root", b"1").await.unwrap();
+    seed.commit().await.unwrap();
+
+    let mut first = store.new_txn(false).await.unwrap();
+    let mut second = store.new_txn(false).await.unwrap();
+    replace_collection_heads(&mut first, b"h/c/7/first").await;
+    replace_collection_heads(&mut second, b"h/c/7/second").await;
+
+    first.commit().await.unwrap();
+    second.commit().await.unwrap();
+
+    let read = store.new_txn(true).await.unwrap();
+    let mut iterator = read
+        .iterator(IterOptions::new().with_prefix(b"h/c/7/".to_vec()))
+        .await
+        .unwrap();
+    let mut heads = Vec::new();
+    while let Some(pair) = iterator.next().await.unwrap() {
+        heads.push(pair.key);
+    }
+    iterator.close().await.unwrap();
+    heads.sort();
+    assert_eq!(
+        heads,
+        vec![b"h/c/7/first".to_vec(), b"h/c/7/second".to_vec()]
+    );
 }
 
 /// Test concurrent writes to the SAME key (last writer wins)

--- a/crates/storage/src/backends/test_suite/macros.rs
+++ b/crates/storage/src/backends/test_suite/macros.rs
@@ -369,6 +369,12 @@ macro_rules! generate_backend_concurrency_tests {
         }
 
         #[tokio::test]
+        async fn shared_test_commutative_set_transitions() {
+            let store = $arc_store_fn().await;
+            test_suite::test_commutative_set_transitions(store).await;
+        }
+
+        #[tokio::test]
         async fn shared_test_concurrent_writes_same_key() {
             let store = $arc_store_fn().await;
             test_suite::test_concurrent_writes_same_key(store).await;

--- a/crates/storage/src/corekv/types.rs
+++ b/crates/storage/src/corekv/types.rs
@@ -86,6 +86,12 @@ pub struct IterOptions {
     /// When true, the iterator will not fetch values from storage,
     /// improving performance when only keys are needed.
     keys_only: bool,
+
+    /// Treat this prefix scan as an observed-remove/add set transition.
+    ///
+    /// The conflict tracker permits overlapping keys only when both
+    /// transactions mark a scan covering the key this way.
+    commutative_set: bool,
 }
 
 impl IterOptions {
@@ -124,6 +130,17 @@ impl IterOptions {
         self
     }
 
+    /// Mark this prefix scan as an observed-remove/add set transition.
+    ///
+    /// This is only meaningful for prefix scans. Callers must limit writes in
+    /// the prefix to removing keys observed by the scan and adding new keys;
+    /// otherwise allowing concurrent transitions could weaken serializability.
+    /// Overlap is permitted only when both transactions opt in.
+    pub fn with_commutative_set(mut self) -> Self {
+        self.commutative_set = true;
+        self
+    }
+
     /// Get the prefix filter, if set.
     pub fn prefix(&self) -> Option<&[u8]> {
         self.prefix.as_deref()
@@ -148,6 +165,11 @@ impl IterOptions {
     pub fn keys_only(&self) -> bool {
         self.keys_only
     }
+
+    /// Check whether this scan is a commutative set transition.
+    pub fn commutative_set(&self) -> bool {
+        self.commutative_set
+    }
 }
 
 impl fmt::Display for IterOptions {
@@ -164,8 +186,8 @@ impl fmt::Display for IterOptions {
         }
         write!(
             f,
-            "reverse: {}, keys_only: {} }}",
-            self.reverse, self.keys_only
+            "reverse: {}, keys_only: {}, commutative_set: {} }}",
+            self.reverse, self.keys_only, self.commutative_set
         )
     }
 }
@@ -181,13 +203,15 @@ mod tests {
             .with_start(b"a".to_vec())
             .with_end(b"z".to_vec())
             .with_reverse(true)
-            .with_keys_only(true);
+            .with_keys_only(true)
+            .with_commutative_set();
 
         assert_eq!(opts.prefix(), Some(b"test".as_slice()));
         assert_eq!(opts.start(), Some(b"a".as_slice()));
         assert_eq!(opts.end(), Some(b"z".as_slice()));
         assert!(opts.reverse());
         assert!(opts.keys_only());
+        assert!(opts.commutative_set());
     }
 
     #[test]

--- a/crates/storage/src/namespace.rs
+++ b/crates/storage/src/namespace.rs
@@ -187,6 +187,9 @@ impl Reader for NamespacedTxn {
         prefixed_opts = prefixed_opts
             .with_reverse(opts.reverse())
             .with_keys_only(opts.keys_only());
+        if opts.commutative_set() {
+            prefixed_opts = prefixed_opts.with_commutative_set();
+        }
 
         let iter = self.txn.iterator(prefixed_opts).await?;
         Ok(Box::new(NamespacedIterator {

--- a/tools/integration-test/Cargo.toml
+++ b/tools/integration-test/Cargo.toml
@@ -47,6 +47,10 @@ name = "issue1194_repro"
 path = "tests/issue1194_repro.rs"
 
 [[test]]
+name = "issue1211_repro"
+path = "tests/issue1211_repro.rs"
+
+[[test]]
 name = "p2p_backlog"
 path = "tests/p2p_backlog.rs"
 

--- a/tools/integration-test/tests/issue1211_repro.rs
+++ b/tools/integration-test/tests/issue1211_repro.rs
@@ -1,0 +1,161 @@
+//! Issue #1211 regression: concurrent updates to distinct documents in a
+//! branchable collection must not conflict through the collection head set.
+
+use std::sync::Arc;
+
+use integration_test::TestCluster;
+use serde_json::{json, Value};
+
+async fn gql(http: &reqwest::Client, url: &str, query: &str) -> Result<Value, String> {
+    let response = http
+        .post(format!("{url}/api/v0/graphql"))
+        .json(&json!({ "query": query }))
+        .send()
+        .await
+        .map_err(|error| format!("http error: {error}"))?;
+    let body: Value = response
+        .json()
+        .await
+        .map_err(|error| format!("bad json: {error}"))?;
+    if let Some(errors) = body.get("errors").and_then(Value::as_array) {
+        if !errors.is_empty() {
+            return Err(errors
+                .iter()
+                .map(|error| error["message"].as_str().unwrap_or("?").to_string())
+                .collect::<Vec<_>>()
+                .join("; "));
+        }
+    }
+    Ok(body["data"].clone())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 16)]
+async fn concurrent_distinct_branchable_doc_updates_do_not_conflict() {
+    const WRITERS: usize = 16;
+    const ROUNDS: usize = 20;
+
+    let cluster = TestCluster::builder()
+        .rust_nodes(1)
+        .with_store("redb")
+        .build()
+        .await
+        .expect("build cluster");
+    let node = cluster.client(0);
+    let api_url = cluster.api_url(0).to_string();
+
+    node.schema_add(
+        r#"
+        type AgentResponse @branchable {
+            response_key: String @index(unique: true)
+            status: String @index
+            content: String
+            reasoning: String
+            token_count: Int
+            reasoning_progress_seq: Int
+        }
+        "#,
+    )
+    .expect("schema add");
+
+    let http = reqwest::Client::new();
+    let mut doc_ids = Vec::with_capacity(WRITERS);
+    for writer in 0..WRITERS {
+        let data = gql(
+            &http,
+            &api_url,
+            &format!(
+                r#"mutation {{
+                    add_AgentResponse(input: {{
+                        response_key: "response-{writer}",
+                        status: "streaming",
+                        content: "initial",
+                        reasoning: "initial",
+                        token_count: 0,
+                        reasoning_progress_seq: 0
+                    }}) {{ _docID }}
+                }}"#
+            ),
+        )
+        .await
+        .expect("create document");
+        doc_ids.push(
+            data["add_AgentResponse"][0]["_docID"]
+                .as_str()
+                .expect("document ID")
+                .to_string(),
+        );
+    }
+
+    let barrier = Arc::new(tokio::sync::Barrier::new(WRITERS));
+    let mut tasks = Vec::with_capacity(WRITERS);
+    for (writer, doc_id) in doc_ids.iter().cloned().enumerate() {
+        let http = http.clone();
+        let api_url = api_url.clone();
+        let barrier = Arc::clone(&barrier);
+        tasks.push(tokio::spawn(async move {
+            for round in 0..ROUNDS {
+                barrier.wait().await;
+                gql(
+                    &http,
+                    &api_url,
+                    &format!(
+                        r#"mutation {{
+                            update_AgentResponse(
+                                filter: {{
+                                    _docID: {{_eq: "{doc_id}"}},
+                                    status: {{_eq: "streaming"}}
+                                }},
+                                input: {{
+                                    content: "writer-{writer}-round-{round}",
+                                    reasoning: "reasoning-{writer}-{round}",
+                                    token_count: {round},
+                                    reasoning_progress_seq: {round}
+                                }}
+                            ) {{ _docID }}
+                        }}"#
+                    ),
+                )
+                .await
+                .map_err(|error| format!("round {round}: {error}"))?;
+            }
+            Ok::<_, String>(())
+        }));
+    }
+
+    for (writer, task) in tasks.into_iter().enumerate() {
+        task.await
+            .expect("writer task panicked")
+            .unwrap_or_else(|error| panic!("writer {writer} failed: {error}"));
+    }
+
+    for (writer, doc_id) in doc_ids.iter().enumerate() {
+        let data = gql(
+            &http,
+            &api_url,
+            &format!(
+                r#"query {{
+                    AgentResponse(docID: "{doc_id}") {{
+                        content
+                        reasoning
+                        token_count
+                        reasoning_progress_seq
+                    }}
+                }}"#
+            ),
+        )
+        .await
+        .expect("read final document");
+        let expected_round = ROUNDS - 1;
+        let document = &data["AgentResponse"][0];
+        assert_eq!(
+            document["content"],
+            json!(format!("writer-{writer}-round-{expected_round}"))
+        );
+        assert_eq!(
+            document["reasoning"],
+            json!(format!("reasoning-{writer}-{expected_round}"))
+        );
+        assert_eq!(document["token_count"], json!(expected_round));
+        assert_eq!(document["reasoning_progress_seq"], json!(expected_round));
+    }
+}


### PR DESCRIPTION
Closes #1211.

## Problem

Every mutation in an `@branchable` collection also transitions the collection-wide head set. Concurrent transactions updating different documents can therefore scan the same `h/c/...` prefix, remove the same observed parent, and add different child heads.

The conflict tracker treated that valid observed-remove/add transition as a write conflict and aborted the second transaction. This made unrelated documents contend on shared collection metadata even though retaining both children as sibling heads is valid CRDT state.

## What changed

- Add an opt-in observed-remove/add set-transition marker to iterator conflict metadata and preserve it through namespaced stores.
- Allow overlapping keys to commute only when both transactions mark a covering prefix. Ordinary scans, point reads, collection truncation, unrelated writes, and same-document head updates remain conflict-checked.
- Mark branchable collection-head transitions so concurrent children are retained as siblings and the next mutation can merge the complete frontier.
- Add conflict-tracker controls, a deterministic sibling-retention and merge regression, backend-wide transactional coverage, and the reported 16-writer x 20-round HTTP workload.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo clippy -p storage --all-targets --features redb,fjall,rocksdb,lark -- -D warnings`
- [x] `cargo test --workspace --exclude integration-test --exclude ffi-test --exclude conformance`
- [x] `cargo test -p storage --features redb,fjall,rocksdb,lark`
- [x] `cargo test -p db-blocks`
- [x] `cargo test -p db`
- [x] `cargo test -p integration-test --test issue1211_repro --no-run`
- [x] `git diff --check`
