### PR TITLE
fix(db): complete Go lens migration parity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4535,6 +4535,7 @@ version = "0.5.0"
 dependencies = [
  "acp",
  "async-trait",
+ "base64 0.22.1",
  "blockstore",
  "cbindgen",
  "cid",
@@ -4563,6 +4564,7 @@ dependencies = [
  "sha2 0.10.9",
  "sourcehub",
  "storage",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/crates/db/src/auto_commit_mutator/mod.rs
+++ b/crates/db/src/auto_commit_mutator/mod.rs
@@ -64,7 +64,12 @@ impl<S: Store> AutoCommitMutator<S> {
         let txn = self.db.new_txn(false).await.map_err(|e| {
             query::error::QueryError::execution(format!("failed to create txn: {}", e))
         })?;
-        let fetcher = Arc::new(LensedDocFetcher::new(txn, self.db.lens_store.clone()));
+        let fetcher = Arc::new(LensedDocFetcher::new(
+            self.db.clone(),
+            txn,
+            self.db.lens_store.clone(),
+            false,
+        ));
         let batch = Arc::new(BatchMutator::new(self.db.clone(), fetcher.shared_txn()));
         Ok((batch, fetcher))
     }

--- a/crates/db/src/auto_commit_mutator/update.rs
+++ b/crates/db/src/auto_commit_mutator/update.rs
@@ -94,7 +94,8 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
         // fetcher under the guard and rebase only the caller's declared patch;
         // otherwise an unrelated field from the concurrent update is silently
         // replaced by the stale snapshot.
-        let fresh_fetcher = crate::LensedAutoCommitFetcher::new(Arc::clone(&self.db));
+        let fresh_fetcher =
+            crate::LensedAutoCommitFetcher::new_without_write_back(Arc::clone(&self.db));
         let canonical_id = canonical_lock_id.to_string();
         let mut current_doc = fresh_fetcher
             .get_by_ids(collection_name, std::slice::from_ref(&canonical_id))

--- a/crates/db/src/database.rs
+++ b/crates/db/src/database.rs
@@ -135,6 +135,13 @@ pub struct DB<S: Store> {
     options: DbOptions,
     /// Counter for generating unique transaction IDs.
     txn_id_counter: AtomicU64,
+    /// Generation of the committed migration graph.
+    ///
+    /// Lensed fetchers include this in their history-cache validity checks so
+    /// registering another transform invalidates both positive and negative
+    /// cached migration contexts, even when the active schema version does not
+    /// change.
+    migration_generation: AtomicU64,
     /// Whether the database has been closed.
     closed: AtomicBool,
     /// In-memory collection cache (name -> Collection).
@@ -204,6 +211,7 @@ impl<S: Store> DB<S> {
             store: Arc::new(store),
             options,
             txn_id_counter: AtomicU64::new(0),
+            migration_generation: AtomicU64::new(0),
             closed: AtomicBool::new(false),
             collections: RwLock::new(HashMap::new()),
             event_bus: None,
@@ -258,6 +266,7 @@ impl<S: Store> DB<S> {
             store,
             options,
             txn_id_counter: AtomicU64::new(0),
+            migration_generation: AtomicU64::new(0),
             closed: AtomicBool::new(false),
             collections: RwLock::new(HashMap::new()),
             event_bus: None,
@@ -308,6 +317,16 @@ impl<S: Store> DB<S> {
     /// document are mutually serialized (#1021).
     pub fn doc_write_queue(&self) -> Arc<crate::doc_write_queue::DocWriteQueue> {
         self.doc_write_queue.clone()
+    }
+
+    /// Return the generation of the committed migration graph.
+    pub(crate) fn migration_generation(&self) -> u64 {
+        self.migration_generation.load(Ordering::Acquire)
+    }
+
+    /// Invalidate migration-history caches after a migration commit.
+    pub(crate) fn bump_migration_generation(&self) {
+        self.migration_generation.fetch_add(1, Ordering::AcqRel);
     }
 
     /// Install the KMS service. First call wins (OnceLock); subsequent calls

--- a/crates/db/src/error.rs
+++ b/crates/db/src/error.rs
@@ -138,6 +138,15 @@ impl From<db_index::Error> for Error {
 }
 
 impl Error {
+    pub fn is_txn_conflict(&self) -> bool {
+        matches!(self, Error::Storage(source) if source.is_txn_conflict())
+            || matches!(
+                self,
+                Error::Datastore(datastore::Error::Storage(source))
+                    if source.is_txn_conflict()
+            )
+    }
+
     pub fn is_unique_constraint_violation(&self) -> bool {
         matches!(self, Error::Storage(source) if source.is_unique_constraint_violation())
     }

--- a/crates/db/src/lens_utils.rs
+++ b/crates/db/src/lens_utils.rs
@@ -206,3 +206,50 @@ pub fn build_collection_history(
 
     result
 }
+
+/// Return whether the targeted path from `source_version_id` crosses a transform.
+///
+/// The walk mirrors the lens pipeline's forward-first navigation and is used by reindexing to
+/// avoid stamping transform-less paths before an application has explicitly requested eager
+/// identity materialization.
+pub fn migration_path_has_transform(
+    history: &HashMap<String, TargetedHistoryLink>,
+    source_version_id: &str,
+    target_version_id: &str,
+) -> bool {
+    if source_version_id == target_version_id {
+        return false;
+    }
+
+    let mut current = source_version_id;
+    let mut visited = std::collections::HashSet::new();
+    visited.insert(current.to_string());
+    let mut has_transform = false;
+
+    while current != target_version_id {
+        let Some(link) = history.get(current) else {
+            return false;
+        };
+
+        if let Some(next) = link.next.as_deref().filter(|next| !visited.contains(*next)) {
+            let Some(next_link) = history.get(next) else {
+                return false;
+            };
+            has_transform |= next_link.transform.is_some();
+            current = next;
+        } else if let Some(previous) = link
+            .previous
+            .as_deref()
+            .filter(|previous| !visited.contains(*previous))
+        {
+            has_transform |= link.transform.is_some();
+            current = previous;
+        } else {
+            return false;
+        }
+
+        visited.insert(current.to_string());
+    }
+
+    has_transform
+}

--- a/crates/db/src/lensed_auto_commit_fetcher/fetcher.rs
+++ b/crates/db/src/lensed_auto_commit_fetcher/fetcher.rs
@@ -11,7 +11,12 @@ use crate::commits_fetcher::{CommitsFetcher, CommitsQueryOptions as DbCommitsOpt
 use crate::txn::DbTxn;
 use crate::versioned_fetcher::VersionedFetcher;
 
+use super::migration::MigrationWriteBack;
 use super::LensedAutoCommitFetcher;
+
+type ProcessedDocs = (Vec<Document>, Vec<MigrationWriteBack>);
+type ProcessedDocsWithStatus = (Vec<(Document, bool)>, Vec<MigrationWriteBack>);
+type ProcessedDocsById = (Vec<Document>, Vec<String>, Vec<MigrationWriteBack>);
 
 impl<S: Store + 'static> LensedAutoCommitFetcher<S> {
     pub(super) async fn get_all_impl(
@@ -24,7 +29,8 @@ impl<S: Store + 'static> LensedAutoCommitFetcher<S> {
             .map_err(|e| query::error::QueryError::execution(format!("db error: {}", e)))?
             .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?;
 
-        let (has_migrations, preloaded_history) = self.load_migration_context(&collection).await?;
+        let (migration_generation, has_migrations, preloaded_history) =
+            self.load_migration_context(&collection).await?;
 
         let target_version_id = &collection.schema().version_id;
 
@@ -36,7 +42,7 @@ impl<S: Store + 'static> LensedAutoCommitFetcher<S> {
             );
         }
 
-        let txn = self.db.new_txn(!has_migrations).await.map_err(|e| {
+        let txn = self.db.new_txn(true).await.map_err(|e| {
             query::error::QueryError::execution(format!("failed to create txn: {}", e))
         })?;
 
@@ -47,57 +53,56 @@ impl<S: Store + 'static> LensedAutoCommitFetcher<S> {
             query::error::QueryError::execution(format!("failed to get systemstore: {}", e))
         })?;
 
-        let docs = collection
-            .get_all_with_datastore(&datastore, &systemstore)
-            .await
-            .map_err(|e| query::error::QueryError::execution(format!("storage error: {}", e)))?;
+        let read_result: query::error::Result<ProcessedDocs> = async {
+            let docs = collection
+                .get_all_with_datastore(&datastore, &systemstore)
+                .await
+                .map_err(|e| {
+                    query::error::QueryError::execution(format!("storage error: {}", e))
+                })?;
 
-        let needs_migration_count = docs
-            .iter()
-            .filter(|doc| Self::doc_needs_migration(doc, target_version_id, has_migrations))
-            .count();
+            trace!(
+                collection = %collection_name,
+                doc_count = docs.len(),
+                "Fetched documents"
+            );
 
-        trace!(
-            collection = %collection_name,
-            doc_count = docs.len(),
-            needs_migration = needs_migration_count,
-            "Fetched documents"
-        );
-
-        let mut processed_docs = Vec::with_capacity(docs.len());
-        for doc in docs {
-            let processed = self
-                .process_document(
-                    doc,
-                    &collection,
-                    &datastore,
-                    &systemstore,
-                    has_migrations,
-                    &preloaded_history,
-                )
-                .await?;
-            processed_docs.push(processed);
+            let mut processed_docs = Vec::with_capacity(docs.len());
+            let mut write_backs = Vec::new();
+            for doc in docs {
+                let outcome = self
+                    .process_document(doc, &collection, has_migrations, &preloaded_history)
+                    .await?;
+                if let Some(source_document) = outcome.source_document {
+                    write_backs.push(MigrationWriteBack {
+                        source_document,
+                        migrated_document: outcome.document.clone(),
+                        migration_generation,
+                    });
+                }
+                processed_docs.push(outcome.document);
+            }
+            Ok((processed_docs, write_backs))
         }
+        .await;
 
         drop(datastore);
         drop(systemstore);
-        if has_migrations {
-            txn.commit().await
-        } else {
-            txn.discard()
-        }
-        .map_err(|e| {
+        txn.discard().map_err(|e| {
             query::error::QueryError::execution(format!(
-                "failed to finish lensed fetch transaction: {}",
+                "failed to discard lensed read transaction: {}",
                 e
             ))
         })?;
+        let (processed_docs, write_backs) = read_result?;
+        self.persist_migrated_documents(&collection, write_backs)
+            .await?;
 
-        if needs_migration_count > 0 {
+        if !processed_docs.is_empty() {
             debug!(
                 collection = %collection_name,
-                migrated = needs_migration_count,
-                "Documents migrated"
+                returned = processed_docs.len(),
+                "Lensed read completed"
             );
         }
 
@@ -115,9 +120,10 @@ impl<S: Store + 'static> LensedAutoCommitFetcher<S> {
             .map_err(|e| query::error::QueryError::execution(format!("db error: {}", e)))?
             .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?;
 
-        let (has_migrations, preloaded_history) = self.load_migration_context(&collection).await?;
+        let (migration_generation, has_migrations, preloaded_history) =
+            self.load_migration_context(&collection).await?;
 
-        let txn = self.db.new_txn(!has_migrations).await.map_err(|e| {
+        let txn = self.db.new_txn(true).await.map_err(|e| {
             query::error::QueryError::execution(format!("failed to create txn: {}", e))
         })?;
 
@@ -128,39 +134,44 @@ impl<S: Store + 'static> LensedAutoCommitFetcher<S> {
             query::error::QueryError::execution(format!("failed to get systemstore: {}", e))
         })?;
 
-        let docs_with_status = collection
-            .get_all_with_datastore_include_deleted(&datastore, &systemstore, show_deleted)
-            .await
-            .map_err(|e| query::error::QueryError::execution(format!("storage error: {}", e)))?;
+        let read_result: query::error::Result<ProcessedDocsWithStatus> = async {
+            let docs_with_status = collection
+                .get_all_with_datastore_include_deleted(&datastore, &systemstore, show_deleted)
+                .await
+                .map_err(|e| {
+                    query::error::QueryError::execution(format!("storage error: {}", e))
+                })?;
 
-        let mut processed_docs = Vec::with_capacity(docs_with_status.len());
-        for (doc, is_deleted) in docs_with_status {
-            let processed = self
-                .process_document(
-                    doc,
-                    &collection,
-                    &datastore,
-                    &systemstore,
-                    has_migrations,
-                    &preloaded_history,
-                )
-                .await?;
-            processed_docs.push((processed, is_deleted));
+            let mut processed_docs = Vec::with_capacity(docs_with_status.len());
+            let mut write_backs = Vec::new();
+            for (doc, is_deleted) in docs_with_status {
+                let outcome = self
+                    .process_document(doc, &collection, has_migrations, &preloaded_history)
+                    .await?;
+                if let Some(source_document) = outcome.source_document {
+                    write_backs.push(MigrationWriteBack {
+                        source_document,
+                        migrated_document: outcome.document.clone(),
+                        migration_generation,
+                    });
+                }
+                processed_docs.push((outcome.document, is_deleted));
+            }
+            Ok((processed_docs, write_backs))
         }
+        .await;
 
         drop(datastore);
         drop(systemstore);
-        if has_migrations {
-            txn.commit().await
-        } else {
-            txn.discard()
-        }
-        .map_err(|e| {
+        txn.discard().map_err(|e| {
             query::error::QueryError::execution(format!(
-                "failed to finish lensed fetch transaction: {}",
+                "failed to discard lensed read transaction: {}",
                 e
             ))
         })?;
+        let (processed_docs, write_backs) = read_result?;
+        self.persist_migrated_documents(&collection, write_backs)
+            .await?;
 
         Ok(processed_docs)
     }
@@ -176,9 +187,10 @@ impl<S: Store + 'static> LensedAutoCommitFetcher<S> {
             .map_err(|e| query::error::QueryError::execution(format!("db error: {}", e)))?
             .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?;
 
-        let (has_migrations, preloaded_history) = self.load_migration_context(&collection).await?;
+        let (migration_generation, has_migrations, preloaded_history) =
+            self.load_migration_context(&collection).await?;
 
-        let txn = self.db.new_txn(!has_migrations).await.map_err(|e| {
+        let txn = self.db.new_txn(true).await.map_err(|e| {
             query::error::QueryError::execution(format!("failed to create txn: {}", e))
         })?;
 
@@ -189,56 +201,60 @@ impl<S: Store + 'static> LensedAutoCommitFetcher<S> {
             query::error::QueryError::execution(format!("failed to get systemstore: {}", e))
         })?;
 
-        let mut docs = Vec::new();
-        let mut missing_ids = Vec::new();
+        let read_result: query::error::Result<ProcessedDocsById> = async {
+            let mut docs = Vec::new();
+            let mut missing_ids = Vec::new();
 
-        for id_str in doc_ids {
-            let doc_id = match document::DocID::from_string(id_str) {
-                Ok(id) => id,
-                Err(_) => {
-                    missing_ids.push(id_str.clone());
-                    continue;
+            for id_str in doc_ids {
+                let doc_id = match document::DocID::from_string(id_str) {
+                    Ok(id) => id,
+                    Err(_) => {
+                        missing_ids.push(id_str.clone());
+                        continue;
+                    }
+                };
+
+                match collection
+                    .get_by_doc_id(&datastore, &systemstore, &doc_id)
+                    .await
+                    .map_err(|e| {
+                        query::error::QueryError::execution(format!("storage error: {}", e))
+                    })? {
+                    Some(doc) => docs.push(doc),
+                    None => missing_ids.push(id_str.clone()),
                 }
-            };
-
-            match collection
-                .get_by_doc_id(&datastore, &systemstore, &doc_id)
-                .await
-                .map_err(|e| query::error::QueryError::execution(format!("storage error: {}", e)))?
-            {
-                Some(doc) => docs.push(doc),
-                None => missing_ids.push(id_str.clone()),
             }
-        }
 
-        let mut processed_docs = Vec::with_capacity(docs.len());
-        for doc in docs {
-            let processed = self
-                .process_document(
-                    doc,
-                    &collection,
-                    &datastore,
-                    &systemstore,
-                    has_migrations,
-                    &preloaded_history,
-                )
-                .await?;
-            processed_docs.push(processed);
+            let mut processed_docs = Vec::with_capacity(docs.len());
+            let mut write_backs = Vec::new();
+            for doc in docs {
+                let outcome = self
+                    .process_document(doc, &collection, has_migrations, &preloaded_history)
+                    .await?;
+                if let Some(source_document) = outcome.source_document {
+                    write_backs.push(MigrationWriteBack {
+                        source_document,
+                        migrated_document: outcome.document.clone(),
+                        migration_generation,
+                    });
+                }
+                processed_docs.push(outcome.document);
+            }
+            Ok((processed_docs, missing_ids, write_backs))
         }
+        .await;
 
         drop(datastore);
         drop(systemstore);
-        if has_migrations {
-            txn.commit().await
-        } else {
-            txn.discard()
-        }
-        .map_err(|e| {
+        txn.discard().map_err(|e| {
             query::error::QueryError::execution(format!(
-                "failed to finish lensed fetch transaction: {}",
+                "failed to discard lensed read transaction: {}",
                 e
             ))
         })?;
+        let (processed_docs, missing_ids, write_backs) = read_result?;
+        self.persist_migrated_documents(&collection, write_backs)
+            .await?;
 
         Ok(FetchByIdsResult::partial(processed_docs, missing_ids))
     }
@@ -255,9 +271,10 @@ impl<S: Store + 'static> LensedAutoCommitFetcher<S> {
             .map_err(|e| query::error::QueryError::execution(format!("db error: {}", e)))?
             .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?;
 
-        let (has_migrations, preloaded_history) = self.load_migration_context(&collection).await?;
+        let (migration_generation, has_migrations, preloaded_history) =
+            self.load_migration_context(&collection).await?;
 
-        let txn = self.db.new_txn(!has_migrations).await.map_err(|e| {
+        let txn = self.db.new_txn(true).await.map_err(|e| {
             query::error::QueryError::execution(format!("failed to create txn: {}", e))
         })?;
 
@@ -268,49 +285,51 @@ impl<S: Store + 'static> LensedAutoCommitFetcher<S> {
             query::error::QueryError::execution(format!("failed to get systemstore: {}", e))
         })?;
 
-        let all_docs = collection
-            .get_all_with_datastore(&datastore, &systemstore)
-            .await
-            .map_err(|e| query::error::QueryError::execution(format!("storage error: {}", e)))?;
+        let read_result: query::error::Result<ProcessedDocs> = async {
+            let all_docs = collection
+                .get_all_with_datastore(&datastore, &systemstore)
+                .await
+                .map_err(|e| {
+                    query::error::QueryError::execution(format!("storage error: {}", e))
+                })?;
 
-        let matching_docs: Vec<Document> = all_docs
-            .into_iter()
-            .filter(|doc| {
-                doc.get(field_name)
+            let mut processed_docs = Vec::new();
+            let mut write_backs = Vec::new();
+            for doc in all_docs {
+                let outcome = self
+                    .process_document(doc, &collection, has_migrations, &preloaded_history)
+                    .await?;
+                if let Some(source_document) = outcome.source_document {
+                    write_backs.push(MigrationWriteBack {
+                        source_document,
+                        migrated_document: outcome.document.clone(),
+                        migration_generation,
+                    });
+                }
+                let is_match = outcome
+                    .document
+                    .get(field_name)
                     .and_then(|v| v.as_str())
-                    .map(|v| v == value)
-                    .unwrap_or(false)
-            })
-            .collect();
-
-        let mut processed_docs = Vec::with_capacity(matching_docs.len());
-        for doc in matching_docs {
-            let processed = self
-                .process_document(
-                    doc,
-                    &collection,
-                    &datastore,
-                    &systemstore,
-                    has_migrations,
-                    &preloaded_history,
-                )
-                .await?;
-            processed_docs.push(processed);
+                    .is_some_and(|field_value| field_value == value);
+                if is_match {
+                    processed_docs.push(outcome.document);
+                }
+            }
+            Ok((processed_docs, write_backs))
         }
+        .await;
 
         drop(datastore);
         drop(systemstore);
-        if has_migrations {
-            txn.commit().await
-        } else {
-            txn.discard()
-        }
-        .map_err(|e| {
+        txn.discard().map_err(|e| {
             query::error::QueryError::execution(format!(
-                "failed to finish lensed fetch transaction: {}",
+                "failed to discard lensed read transaction: {}",
                 e
             ))
         })?;
+        let (processed_docs, write_backs) = read_result?;
+        self.persist_migrated_documents(&collection, write_backs)
+            .await?;
 
         Ok(processed_docs)
     }

--- a/crates/db/src/lensed_auto_commit_fetcher/fetcher.rs
+++ b/crates/db/src/lensed_auto_commit_fetcher/fetcher.rs
@@ -36,7 +36,7 @@ impl<S: Store + 'static> LensedAutoCommitFetcher<S> {
             );
         }
 
-        let txn = self.db.new_txn(true).await.map_err(|e| {
+        let txn = self.db.new_txn(!has_migrations).await.map_err(|e| {
             query::error::QueryError::execution(format!("failed to create txn: {}", e))
         })?;
 
@@ -51,8 +51,6 @@ impl<S: Store + 'static> LensedAutoCommitFetcher<S> {
             .get_all_with_datastore(&datastore, &systemstore)
             .await
             .map_err(|e| query::error::QueryError::execution(format!("storage error: {}", e)))?;
-
-        let _ = txn.discard();
 
         let needs_migration_count = docs
             .iter()
@@ -69,10 +67,31 @@ impl<S: Store + 'static> LensedAutoCommitFetcher<S> {
         let mut processed_docs = Vec::with_capacity(docs.len());
         for doc in docs {
             let processed = self
-                .process_document(doc, &collection, has_migrations, &preloaded_history)
+                .process_document(
+                    doc,
+                    &collection,
+                    &datastore,
+                    &systemstore,
+                    has_migrations,
+                    &preloaded_history,
+                )
                 .await?;
             processed_docs.push(processed);
         }
+
+        drop(datastore);
+        drop(systemstore);
+        if has_migrations {
+            txn.commit().await
+        } else {
+            txn.discard()
+        }
+        .map_err(|e| {
+            query::error::QueryError::execution(format!(
+                "failed to finish lensed fetch transaction: {}",
+                e
+            ))
+        })?;
 
         if needs_migration_count > 0 {
             debug!(
@@ -98,7 +117,7 @@ impl<S: Store + 'static> LensedAutoCommitFetcher<S> {
 
         let (has_migrations, preloaded_history) = self.load_migration_context(&collection).await?;
 
-        let txn = self.db.new_txn(true).await.map_err(|e| {
+        let txn = self.db.new_txn(!has_migrations).await.map_err(|e| {
             query::error::QueryError::execution(format!("failed to create txn: {}", e))
         })?;
 
@@ -114,15 +133,34 @@ impl<S: Store + 'static> LensedAutoCommitFetcher<S> {
             .await
             .map_err(|e| query::error::QueryError::execution(format!("storage error: {}", e)))?;
 
-        let _ = txn.discard();
-
         let mut processed_docs = Vec::with_capacity(docs_with_status.len());
         for (doc, is_deleted) in docs_with_status {
             let processed = self
-                .process_document(doc, &collection, has_migrations, &preloaded_history)
+                .process_document(
+                    doc,
+                    &collection,
+                    &datastore,
+                    &systemstore,
+                    has_migrations,
+                    &preloaded_history,
+                )
                 .await?;
             processed_docs.push((processed, is_deleted));
         }
+
+        drop(datastore);
+        drop(systemstore);
+        if has_migrations {
+            txn.commit().await
+        } else {
+            txn.discard()
+        }
+        .map_err(|e| {
+            query::error::QueryError::execution(format!(
+                "failed to finish lensed fetch transaction: {}",
+                e
+            ))
+        })?;
 
         Ok(processed_docs)
     }
@@ -140,7 +178,7 @@ impl<S: Store + 'static> LensedAutoCommitFetcher<S> {
 
         let (has_migrations, preloaded_history) = self.load_migration_context(&collection).await?;
 
-        let txn = self.db.new_txn(true).await.map_err(|e| {
+        let txn = self.db.new_txn(!has_migrations).await.map_err(|e| {
             query::error::QueryError::execution(format!("failed to create txn: {}", e))
         })?;
 
@@ -173,15 +211,34 @@ impl<S: Store + 'static> LensedAutoCommitFetcher<S> {
             }
         }
 
-        let _ = txn.discard();
-
         let mut processed_docs = Vec::with_capacity(docs.len());
         for doc in docs {
             let processed = self
-                .process_document(doc, &collection, has_migrations, &preloaded_history)
+                .process_document(
+                    doc,
+                    &collection,
+                    &datastore,
+                    &systemstore,
+                    has_migrations,
+                    &preloaded_history,
+                )
                 .await?;
             processed_docs.push(processed);
         }
+
+        drop(datastore);
+        drop(systemstore);
+        if has_migrations {
+            txn.commit().await
+        } else {
+            txn.discard()
+        }
+        .map_err(|e| {
+            query::error::QueryError::execution(format!(
+                "failed to finish lensed fetch transaction: {}",
+                e
+            ))
+        })?;
 
         Ok(FetchByIdsResult::partial(processed_docs, missing_ids))
     }
@@ -200,7 +257,7 @@ impl<S: Store + 'static> LensedAutoCommitFetcher<S> {
 
         let (has_migrations, preloaded_history) = self.load_migration_context(&collection).await?;
 
-        let txn = self.db.new_txn(true).await.map_err(|e| {
+        let txn = self.db.new_txn(!has_migrations).await.map_err(|e| {
             query::error::QueryError::execution(format!("failed to create txn: {}", e))
         })?;
 
@@ -216,8 +273,6 @@ impl<S: Store + 'static> LensedAutoCommitFetcher<S> {
             .await
             .map_err(|e| query::error::QueryError::execution(format!("storage error: {}", e)))?;
 
-        let _ = txn.discard();
-
         let matching_docs: Vec<Document> = all_docs
             .into_iter()
             .filter(|doc| {
@@ -231,10 +286,31 @@ impl<S: Store + 'static> LensedAutoCommitFetcher<S> {
         let mut processed_docs = Vec::with_capacity(matching_docs.len());
         for doc in matching_docs {
             let processed = self
-                .process_document(doc, &collection, has_migrations, &preloaded_history)
+                .process_document(
+                    doc,
+                    &collection,
+                    &datastore,
+                    &systemstore,
+                    has_migrations,
+                    &preloaded_history,
+                )
                 .await?;
             processed_docs.push(processed);
         }
+
+        drop(datastore);
+        drop(systemstore);
+        if has_migrations {
+            txn.commit().await
+        } else {
+            txn.discard()
+        }
+        .map_err(|e| {
+            query::error::QueryError::execution(format!(
+                "failed to finish lensed fetch transaction: {}",
+                e
+            ))
+        })?;
 
         Ok(processed_docs)
     }

--- a/crates/db/src/lensed_auto_commit_fetcher/migration.rs
+++ b/crates/db/src/lensed_auto_commit_fetcher/migration.rs
@@ -2,61 +2,75 @@
 
 use std::collections::HashMap;
 
-use datastore::NamespaceView;
 use document::Document;
 use lens::{build_targeted_history, CollectionHistoryLink, Lens, LensDoc, TargetedHistoryLink};
 use storage::corekv::Store;
 use tracing::{debug, trace, warn};
 
 use crate::collection::Collection;
-use crate::migration::helpers::{cache_migrated_document, lens_doc_to_document};
+use crate::migration::helpers::{cache_migrated_document_with_indexes, lens_doc_to_document};
 use crate::schema_loader::get_collections_by_collection_id;
 
 use super::LensedAutoCommitFetcher;
 
+pub(super) struct MigrationOutcome {
+    pub(super) document: Document,
+    pub(super) source_document: Option<Document>,
+}
+
+pub(crate) struct MigrationWriteBack {
+    pub(crate) source_document: Document,
+    pub(crate) migrated_document: Document,
+    pub(crate) migration_generation: u64,
+}
+
 impl<S: Store> LensedAutoCommitFetcher<S> {
     /// Load migration context for a collection, using cache when available.
     ///
-    /// Positive results are cached per collection and target version. Negative
-    /// results are reloaded because a transform can be registered in place.
+    /// Results are cached per collection, target version, and committed
+    /// migration-graph generation.
     pub(super) async fn load_migration_context(
         &self,
         collection: &Collection,
-    ) -> query::error::Result<(bool, Option<HashMap<String, TargetedHistoryLink>>)> {
+    ) -> query::error::Result<(u64, bool, Option<HashMap<String, TargetedHistoryLink>>)> {
         let collection_id = collection.schema().collection_id.clone();
         let target_version_id = &collection.schema().version_id;
 
-        // Check if cached entry is still valid: the cache key includes the target
-        // version ID so that when the active collection version changes (via
-        // set_active_collection_version or patch_collection), the stale entry is
-        // bypassed and a fresh migration context is computed.
         let cache_key = format!("{}:{}", collection_id, target_version_id);
-
-        if let Ok(cache) = self.migration_cache.lock() {
-            if let Some(cached) = cache.get(&cache_key) {
-                if cached.0 {
-                    return Ok(cached.clone());
+        loop {
+            let generation = self.db.migration_generation();
+            if let Ok(mut cache) = self.migration_cache.lock() {
+                if cache.generation != generation {
+                    cache.generation = generation;
+                    cache.contexts.clear();
+                }
+                if let Some(cached) = cache.contexts.get(&cache_key) {
+                    return Ok((generation, cached.0, cached.1.clone()));
                 }
             }
-        }
 
-        let history = self.load_collection_history(collection).await.ok();
+            let history = self.load_collection_history(collection).await.ok();
 
-        let has_migrations = history
-            .as_ref()
-            .is_some_and(|h| h.values().any(|link| link.transform.is_some()));
+            let has_migrations = history
+                .as_ref()
+                .is_some_and(|h| h.values().any(|link| link.transform.is_some()));
 
-        let result = (has_migrations, if has_migrations { history } else { None });
+            let result = (has_migrations, if has_migrations { history } else { None });
 
-        // A transform can be registered without changing the active version ID, so a negative
-        // result must not be cached. Positive entries remain version-scoped.
-        if has_migrations {
-            if let Ok(mut cache) = self.migration_cache.lock() {
-                cache.insert(cache_key, result.clone());
+            // A migration may have committed while history was being loaded.
+            // Never publish a context under the wrong generation.
+            if self.db.migration_generation() != generation {
+                continue;
             }
-        }
+            if let Ok(mut cache) = self.migration_cache.lock() {
+                if cache.generation != generation {
+                    continue;
+                }
+                cache.contexts.insert(cache_key.clone(), result.clone());
+            }
 
-        Ok(result)
+            return Ok((generation, result.0, result.1));
+        }
     }
 
     /// Check if a document needs migration.
@@ -228,11 +242,9 @@ impl<S: Store> LensedAutoCommitFetcher<S> {
         &self,
         doc: Document,
         collection: &Collection,
-        datastore: &NamespaceView,
-        systemstore: &NamespaceView,
         has_migrations: bool,
         preloaded_history: &Option<HashMap<String, TargetedHistoryLink>>,
-    ) -> query::error::Result<Document> {
+    ) -> query::error::Result<MigrationOutcome> {
         let target_version_id = &collection.schema().version_id;
 
         if !Self::doc_needs_migration(&doc, target_version_id, has_migrations) {
@@ -242,7 +254,10 @@ impl<S: Store> LensedAutoCommitFetcher<S> {
                 target_version = %target_version_id,
                 "Document does not need migration, returning as-is"
             );
-            return Ok(doc);
+            return Ok(MigrationOutcome {
+                document: doc,
+                source_document: None,
+            });
         }
 
         let doc_version = doc.schema_version_id().unwrap_or("unknown").to_string();
@@ -266,7 +281,10 @@ impl<S: Store> LensedAutoCommitFetcher<S> {
                 target_version = %target_version_id,
                 "Document version is unknown locally; returning it unchanged"
             );
-            return Ok(doc);
+            return Ok(MigrationOutcome {
+                document: doc,
+                source_document: None,
+            });
         }
 
         let original_lens_doc = Self::doc_to_lens_doc(&doc).ok_or_else(|| {
@@ -312,15 +330,197 @@ impl<S: Store> LensedAutoCommitFetcher<S> {
         );
 
         let migrated_doc = lens_doc_to_document(migrated_lens_doc, &doc, collection);
-        cache_migrated_document(datastore, systemstore, collection, &migrated_doc)
-            .await
-            .map_err(|e| {
+        Ok(MigrationOutcome {
+            document: migrated_doc,
+            source_document: Some(doc),
+        })
+    }
+
+    /// Persist documents that were transformed during a read.
+    ///
+    /// The initial query always uses a read-only transaction. Only documents
+    /// that actually traversed a lens path are escalated here. Per-document
+    /// write guards serialize this fresh re-read with local updates and P2P
+    /// merges, preventing a transform of a stale snapshot from overwriting a
+    /// concurrent mutation.
+    pub(crate) async fn persist_migrated_documents(
+        &self,
+        collection: &Collection,
+        candidates: Vec<MigrationWriteBack>,
+    ) -> query::error::Result<()> {
+        if !self.write_back_migrations || candidates.is_empty() {
+            return Ok(());
+        }
+
+        let mut candidates = candidates;
+        candidates.sort_by_key(|candidate| {
+            candidate
+                .source_document
+                .id()
+                .map(ToString::to_string)
+                .unwrap_or_default()
+        });
+        candidates.dedup_by(|left, right| left.source_document.id() == right.source_document.id());
+
+        let queue = self.db.doc_write_queue();
+        let batch_gate = if candidates.len() > 1 {
+            Some(queue.acquire_batch_gate().await)
+        } else {
+            None
+        };
+        let mut guards = Vec::with_capacity(candidates.len());
+        for candidate in &candidates {
+            if let Some(doc_id) = candidate.source_document.id() {
+                guards.push(queue.acquire(&doc_id.to_string()).await);
+            }
+        }
+        drop(batch_gate);
+
+        let max_retries = self.db.options().max_txn_retries.unwrap_or(3);
+        let mut retry = 0;
+        loop {
+            let active_collection = self.db.get_collection(collection.name()).map_err(|error| {
                 query::error::QueryError::execution(format!(
-                    "failed to cache migrated document: {}",
+                    "failed to inspect active collection before lens write-back: {}",
+                    error
+                ))
+            })?;
+            if active_collection
+                .as_ref()
+                .is_none_or(|active| active.version_id() != collection.version_id())
+            {
+                return Ok(());
+            }
+
+            let (generation, has_migrations, history) =
+                self.load_migration_context(collection).await?;
+            if !has_migrations {
+                return Ok(());
+            }
+
+            let txn = self.db.new_txn(false).await.map_err(|e| {
+                query::error::QueryError::execution(format!(
+                    "failed to create lens write-back transaction: {}",
+                    e
+                ))
+            })?;
+            let datastore = txn.datastore().map_err(|e| {
+                query::error::QueryError::execution(format!(
+                    "failed to get datastore for lens write-back: {}",
+                    e
+                ))
+            })?;
+            let systemstore = txn.systemstore().map_err(|e| {
+                query::error::QueryError::execution(format!(
+                    "failed to get systemstore for lens write-back: {}",
                     e
                 ))
             })?;
 
-        Ok(migrated_doc)
+            let write_result: query::error::Result<bool> = async {
+                let mut wrote = false;
+                for candidate in &candidates {
+                    let Some(doc_id) = candidate.source_document.id() else {
+                        continue;
+                    };
+                    let Some(current_doc) = collection
+                        .get_by_doc_id(&datastore, &systemstore, doc_id)
+                        .await
+                        .map_err(|e| {
+                            query::error::QueryError::execution(format!(
+                                "failed to re-read document for lens write-back: {}",
+                                e
+                            ))
+                        })?
+                    else {
+                        continue;
+                    };
+
+                    let unchanged_since_read = current_doc.schema_version_id()
+                        == candidate.source_document.schema_version_id()
+                        && current_doc.is_deleted() == candidate.source_document.is_deleted()
+                        && current_doc.values().len() == candidate.source_document.values().len()
+                        && candidate.source_document.values().iter().all(
+                            |(field_name, source_value)| {
+                                current_doc.get(field_name) == Some(source_value.value())
+                            },
+                        );
+
+                    let migrated_document =
+                        if unchanged_since_read && candidate.migration_generation == generation {
+                            candidate.migrated_document.clone()
+                        } else {
+                            let outcome = self
+                                .process_document(current_doc, collection, has_migrations, &history)
+                                .await?;
+                            let Some(_) = outcome.source_document else {
+                                continue;
+                            };
+                            outcome.document
+                        };
+
+                    wrote |= cache_migrated_document_with_indexes(
+                        &datastore,
+                        &systemstore,
+                        collection,
+                        &migrated_document,
+                    )
+                    .await
+                    .map_err(|e| {
+                        query::error::QueryError::execution(format!(
+                            "failed to cache migrated document and indexes: {}",
+                            e
+                        ))
+                    })?;
+                }
+                Ok(wrote)
+            }
+            .await;
+
+            drop(datastore);
+            drop(systemstore);
+
+            let wrote = match write_result {
+                Ok(wrote) => wrote,
+                Err(error) => {
+                    if let Err(discard_error) = txn.discard() {
+                        tracing::warn!(
+                            error = %discard_error,
+                            "failed to discard lens write-back transaction"
+                        );
+                    }
+                    return Err(error);
+                }
+            };
+
+            if !wrote {
+                txn.discard().map_err(|e| {
+                    query::error::QueryError::execution(format!(
+                        "failed to discard no-op lens write-back transaction: {}",
+                        e
+                    ))
+                })?;
+                return Ok(());
+            }
+
+            match txn.commit().await {
+                Ok(()) => return Ok(()),
+                Err(error) if error.is_txn_conflict() && retry < max_retries => {
+                    retry += 1;
+                    debug!(
+                        retry,
+                        max_retries,
+                        collection = %collection.name(),
+                        "Retrying conflicting lens write-back transaction"
+                    );
+                }
+                Err(error) => {
+                    return Err(query::error::QueryError::execution(format!(
+                        "failed to commit lens write-back transaction: {}",
+                        error
+                    )));
+                }
+            }
+        }
     }
 }

--- a/crates/db/src/lensed_auto_commit_fetcher/migration.rs
+++ b/crates/db/src/lensed_auto_commit_fetcher/migration.rs
@@ -260,7 +260,7 @@ impl<S: Store> LensedAutoCommitFetcher<S> {
         };
 
         if !history.contains_key(&doc_version) {
-            warn!(
+            debug!(
                 doc_id = %doc_id_str,
                 doc_version = %doc_version,
                 target_version = %target_version_id,

--- a/crates/db/src/lensed_auto_commit_fetcher/migration.rs
+++ b/crates/db/src/lensed_auto_commit_fetcher/migration.rs
@@ -2,14 +2,14 @@
 
 use std::collections::HashMap;
 
+use datastore::NamespaceView;
 use document::Document;
-use lens::{
-    build_targeted_history, CollectionHistoryLink, Lens, LensDoc, TargetedHistoryLink, DOC_ID_FIELD,
-};
+use lens::{build_targeted_history, CollectionHistoryLink, Lens, LensDoc, TargetedHistoryLink};
 use storage::corekv::Store;
 use tracing::{debug, trace, warn};
 
 use crate::collection::Collection;
+use crate::migration::helpers::{cache_migrated_document, lens_doc_to_document};
 use crate::schema_loader::get_collections_by_collection_id;
 
 use super::LensedAutoCommitFetcher;
@@ -17,9 +17,8 @@ use super::LensedAutoCommitFetcher;
 impl<S: Store> LensedAutoCommitFetcher<S> {
     /// Load migration context for a collection, using cache when available.
     ///
-    /// The result is cached per collection_id since schema migrations don't
-    /// change during normal runtime. This eliminates a read transaction +
-    /// systemstore scan on every fetch operation.
+    /// Positive results are cached per collection and target version. Negative
+    /// results are reloaded because a transform can be registered in place.
     pub(super) async fn load_migration_context(
         &self,
         collection: &Collection,
@@ -35,7 +34,9 @@ impl<S: Store> LensedAutoCommitFetcher<S> {
 
         if let Ok(cache) = self.migration_cache.lock() {
             if let Some(cached) = cache.get(&cache_key) {
-                return Ok(cached.clone());
+                if cached.0 {
+                    return Ok(cached.clone());
+                }
             }
         }
 
@@ -47,9 +48,12 @@ impl<S: Store> LensedAutoCommitFetcher<S> {
 
         let result = (has_migrations, if has_migrations { history } else { None });
 
-        // Store in cache using version-aware key
-        if let Ok(mut cache) = self.migration_cache.lock() {
-            cache.insert(cache_key, result.clone());
+        // A transform can be registered without changing the active version ID, so a negative
+        // result must not be cached. Positive entries remain version-scoped.
+        if has_migrations {
+            if let Ok(mut cache) = self.migration_cache.lock() {
+                cache.insert(cache_key, result.clone());
+            }
         }
 
         Ok(result)
@@ -75,37 +79,6 @@ impl<S: Store> LensedAutoCommitFetcher<S> {
             lens_doc.insert(key, value);
         }
         Some(lens_doc)
-    }
-
-    /// Convert a LensDoc back to a Document.
-    pub(super) fn lens_doc_to_doc(lens_doc: LensDoc, original_doc: &Document) -> Document {
-        use document::NormalValue;
-
-        let mut doc = Document::new();
-        if let Some(id) = original_doc.id() {
-            doc.set_id(id.clone());
-        }
-        for (field_name, value) in lens_doc {
-            if field_name != DOC_ID_FIELD {
-                let normal = match value {
-                    serde_json::Value::Null => NormalValue::Null,
-                    serde_json::Value::Bool(b) => NormalValue::Bool(b),
-                    serde_json::Value::Number(ref n) => {
-                        if let Some(i) = n.as_i64() {
-                            NormalValue::Int(i)
-                        } else if let Some(f) = n.as_f64() {
-                            NormalValue::Float64(f)
-                        } else {
-                            NormalValue::Json(value)
-                        }
-                    }
-                    serde_json::Value::String(s) => NormalValue::String(s),
-                    other => NormalValue::Json(other),
-                };
-                doc.set(&field_name, normal);
-            }
-        }
-        doc
     }
 
     /// Build collection history from versions.
@@ -255,6 +228,8 @@ impl<S: Store> LensedAutoCommitFetcher<S> {
         &self,
         doc: Document,
         collection: &Collection,
+        datastore: &NamespaceView,
+        systemstore: &NamespaceView,
         has_migrations: bool,
         preloaded_history: &Option<HashMap<String, TargetedHistoryLink>>,
     ) -> query::error::Result<Document> {
@@ -285,10 +260,13 @@ impl<S: Store> LensedAutoCommitFetcher<S> {
         };
 
         if !history.contains_key(&doc_version) {
-            return Err(query::error::QueryError::execution(format!(
-                "no migration path found for document {} from version {} to {}",
-                doc_id_str, doc_version, target_version_id
-            )));
+            warn!(
+                doc_id = %doc_id_str,
+                doc_version = %doc_version,
+                target_version = %target_version_id,
+                "Document version is unknown locally; returning it unchanged"
+            );
+            return Ok(doc);
         }
 
         let original_lens_doc = Self::doc_to_lens_doc(&doc).ok_or_else(|| {
@@ -333,8 +311,15 @@ impl<S: Store> LensedAutoCommitFetcher<S> {
             "Document migration completed"
         );
 
-        let mut migrated_doc = Self::lens_doc_to_doc(migrated_lens_doc, &doc);
-        migrated_doc.set_schema_version_id(target_version_id);
+        let migrated_doc = lens_doc_to_document(migrated_lens_doc, &doc, collection);
+        cache_migrated_document(datastore, systemstore, collection, &migrated_doc)
+            .await
+            .map_err(|e| {
+                query::error::QueryError::execution(format!(
+                    "failed to cache migrated document: {}",
+                    e
+                ))
+            })?;
 
         Ok(migrated_doc)
     }

--- a/crates/db/src/lensed_auto_commit_fetcher/mod.rs
+++ b/crates/db/src/lensed_auto_commit_fetcher/mod.rs
@@ -5,7 +5,7 @@
 
 mod fetcher;
 mod index_scan;
-mod migration;
+pub(crate) mod migration;
 
 #[cfg(test)]
 mod tests;
@@ -26,16 +26,23 @@ use crate::database::DB;
 /// Cached migration context for a collection.
 type MigrationContext = (bool, Option<HashMap<String, TargetedHistoryLink>>);
 
+#[derive(Default)]
+struct MigrationCache {
+    generation: u64,
+    contexts: HashMap<String, MigrationContext>,
+}
+
 /// Document fetcher that auto-commits and applies lens migrations.
 ///
 /// Combines the auto-commit behavior of AutoCommitFetcher with lens
 /// migration support from LensedDocFetcher.
 pub struct LensedAutoCommitFetcher<S: Store> {
     db: Arc<DB<S>>,
+    write_back_migrations: bool,
     /// Cache of migration contexts keyed by `"{collection_id}:{version_id}"`.
-    /// Only positive contexts are cached: a migration can be registered without
-    /// changing the active version ID, so negative entries would become stale.
-    migration_cache: Mutex<HashMap<String, MigrationContext>>,
+    /// The full cache is invalidated whenever the committed migration graph's
+    /// generation changes.
+    migration_cache: Mutex<MigrationCache>,
 }
 
 impl<S: Store> LensedAutoCommitFetcher<S> {
@@ -43,7 +50,22 @@ impl<S: Store> LensedAutoCommitFetcher<S> {
     pub fn new(db: Arc<DB<S>>) -> Self {
         Self {
             db,
-            migration_cache: Mutex::new(HashMap::new()),
+            write_back_migrations: true,
+            migration_cache: Mutex::new(MigrationCache::default()),
+        }
+    }
+
+    /// Create a lensed fetcher that returns transformed values without lazy
+    /// persistence.
+    ///
+    /// Used by mutation rebasing after the caller already holds the document's
+    /// write guard. The mutation itself persists the active-schema document,
+    /// and attempting lazy write-back here would recursively acquire that guard.
+    pub(crate) fn new_without_write_back(db: Arc<DB<S>>) -> Self {
+        Self {
+            db,
+            write_back_migrations: false,
+            migration_cache: Mutex::new(MigrationCache::default()),
         }
     }
 }

--- a/crates/db/src/lensed_auto_commit_fetcher/mod.rs
+++ b/crates/db/src/lensed_auto_commit_fetcher/mod.rs
@@ -7,6 +7,9 @@ mod fetcher;
 mod index_scan;
 mod migration;
 
+#[cfg(test)]
+mod tests;
+
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
@@ -30,9 +33,8 @@ type MigrationContext = (bool, Option<HashMap<String, TargetedHistoryLink>>);
 pub struct LensedAutoCommitFetcher<S: Store> {
     db: Arc<DB<S>>,
     /// Cache of migration contexts keyed by `"{collection_id}:{version_id}"`.
-    /// The version-aware key ensures the cache is automatically bypassed when
-    /// the active collection version changes (via set_active_collection_version
-    /// or patch_collection), avoiding stale `has_migrations=false` entries.
+    /// Only positive contexts are cached: a migration can be registered without
+    /// changing the active version ID, so negative entries would become stale.
     migration_cache: Mutex<HashMap<String, MigrationContext>>,
 }
 

--- a/crates/db/src/lensed_auto_commit_fetcher/tests.rs
+++ b/crates/db/src/lensed_auto_commit_fetcher/tests.rs
@@ -9,9 +9,6 @@ use super::LensedAutoCommitFetcher;
 async fn unknown_document_version_passes_through() {
     let db = Arc::new(crate::DB::new(storage::MemoryStore::new()).unwrap());
     let fetcher = LensedAutoCommitFetcher::new(db.clone());
-    let txn = db.new_txn(false).await.unwrap();
-    let datastore = txn.datastore().unwrap();
-    let systemstore = txn.systemstore().unwrap();
 
     let collection = crate::Collection::new(schema::CollectionVersion::new(
         "Users",
@@ -41,16 +38,16 @@ async fn unknown_document_version_passes_through() {
     doc.set_schema_version_id("foreign-v3");
 
     let returned = fetcher
-        .process_document(doc, &collection, &datastore, &systemstore, true, &history)
+        .process_document(doc, &collection, true, &history)
         .await
         .unwrap();
     assert_eq!(
-        returned.get("name").and_then(|value| value.as_str()),
+        returned
+            .document
+            .get("name")
+            .and_then(|value| value.as_str()),
         Some("Alice")
     );
-    assert_eq!(returned.schema_version_id(), Some("foreign-v3"));
-
-    drop(datastore);
-    drop(systemstore);
-    txn.discard().unwrap();
+    assert_eq!(returned.document.schema_version_id(), Some("foreign-v3"));
+    assert!(returned.source_document.is_none());
 }

--- a/crates/db/src/lensed_auto_commit_fetcher/tests.rs
+++ b/crates/db/src/lensed_auto_commit_fetcher/tests.rs
@@ -1,31 +1,17 @@
-use super::*;
-use document::Document;
-use lens::TargetedHistoryLink;
-use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-#[test]
-fn test_doc_to_lens_doc_conversion() {
-    let mut doc = Document::new();
-    doc.set("name", Value::String("Alice".to_string()));
-    doc.set("age", Value::Number(30.into()));
+use lens::TargetedHistoryLink;
 
-    let lens_doc = LensedDocFetcher::<storage::MemoryStore>::doc_to_lens_doc(&doc).unwrap();
-
-    assert_eq!(
-        lens_doc.get("name").unwrap(),
-        &Value::String("Alice".to_string())
-    );
-    assert_eq!(lens_doc.get("age").unwrap(), &Value::Number(30.into()));
-}
+use super::LensedAutoCommitFetcher;
 
 #[tokio::test]
 async fn unknown_document_version_passes_through() {
-    let db = crate::DB::new(storage::MemoryStore::new()).unwrap();
+    let db = Arc::new(crate::DB::new(storage::MemoryStore::new()).unwrap());
+    let fetcher = LensedAutoCommitFetcher::new(db.clone());
     let txn = db.new_txn(false).await.unwrap();
     let datastore = txn.datastore().unwrap();
-    let fetcher = LensedDocFetcher::new(txn, Arc::new(lens::MemoryTransformStore::new()));
+    let systemstore = txn.systemstore().unwrap();
 
     let collection = crate::Collection::new(schema::CollectionVersion::new(
         "Users",
@@ -37,7 +23,7 @@ async fn unknown_document_version_passes_through() {
             schema::FieldKind::string(),
         )],
     ));
-    let history = HashMap::from([
+    let history = Some(HashMap::from([
         (
             "v1".to_string(),
             TargetedHistoryLink::new("v1", "users-collection").with_next("v2"),
@@ -48,19 +34,14 @@ async fn unknown_document_version_passes_through() {
                 .with_transform(Some("transform-v1-v2".to_string()))
                 .with_previous("v1"),
         ),
-    ]);
-    fetcher
-        .history_cache
-        .write()
-        .await
-        .insert("users-collection".to_string(), history);
+    ]));
 
-    let mut doc = Document::new();
+    let mut doc = document::Document::new();
     doc.set("name", "Alice");
     doc.set_schema_version_id("foreign-v3");
 
     let returned = fetcher
-        .process_document(doc, &collection, &datastore, true)
+        .process_document(doc, &collection, &datastore, &systemstore, true, &history)
         .await
         .unwrap();
     assert_eq!(
@@ -70,5 +51,6 @@ async fn unknown_document_version_passes_through() {
     assert_eq!(returned.schema_version_id(), Some("foreign-v3"));
 
     drop(datastore);
-    fetcher.take_txn().await.unwrap().discard().unwrap();
+    drop(systemstore);
+    txn.discard().unwrap();
 }

--- a/crates/db/src/lensed_fetcher/fetcher.rs
+++ b/crates/db/src/lensed_fetcher/fetcher.rs
@@ -191,18 +191,8 @@ impl<S: Store + 'static> LensedDocFetcher<S> {
             .await
             .map_err(|e| query::error::QueryError::execution(format!("storage error: {}", e)))?;
 
-        let matching_docs: Vec<Document> = all_docs
-            .into_iter()
-            .filter(|doc| {
-                doc.get(field_name)
-                    .and_then(|v| v.as_str())
-                    .map(|v| v == value)
-                    .unwrap_or(false)
-            })
-            .collect();
-
         // Count documents needing migration for logging
-        let needs_migration_count = matching_docs
+        let needs_migration_count = all_docs
             .iter()
             .filter(|doc| Self::doc_needs_migration(doc, target_version_id, has_migrations))
             .count();
@@ -211,19 +201,26 @@ impl<S: Store + 'static> LensedDocFetcher<S> {
             collection = %collection_name,
             field = %field_name,
             value = %value,
-            matches = matching_docs.len(),
+            candidates = all_docs.len(),
             needs_migration = needs_migration_count,
             has_migrations = has_migrations,
             "Fetched documents by field value"
         );
 
-        // Process each document, applying migration if needed
-        let mut processed_docs = Vec::with_capacity(matching_docs.len());
-        for doc in matching_docs {
+        // Migrations may create or change the filtered field, so apply them
+        // before evaluating the field value.
+        let mut processed_docs = Vec::new();
+        for doc in all_docs {
             let processed = self
                 .process_document(doc, &collection, &datastore, has_migrations)
                 .await?;
-            processed_docs.push(processed);
+            let is_match = processed
+                .get(field_name)
+                .and_then(|v| v.as_str())
+                .is_some_and(|field_value| field_value == value);
+            if is_match {
+                processed_docs.push(processed);
+            }
         }
 
         if needs_migration_count > 0 {

--- a/crates/db/src/lensed_fetcher/migration.rs
+++ b/crates/db/src/lensed_fetcher/migration.rs
@@ -4,14 +4,13 @@ use std::collections::HashMap;
 
 use datastore::NamespaceView;
 use document::Document;
-use lens::{
-    build_targeted_history, CollectionHistoryLink, Lens, LensDoc, TargetedHistoryLink, DOC_ID_FIELD,
-};
+use lens::{build_targeted_history, CollectionHistoryLink, Lens, LensDoc, TargetedHistoryLink};
 use schema::CollectionVersion;
 use storage::corekv::Store;
 use tracing::{debug, trace, warn};
 
 use crate::collection::Collection;
+use crate::migration::helpers::{cache_migrated_document, lens_doc_to_document};
 use crate::schema_loader::get_collections_by_collection_id;
 
 use super::LensedDocFetcher;
@@ -203,43 +202,6 @@ impl<S: Store> LensedDocFetcher<S> {
         Some(lens_doc)
     }
 
-    /// Convert a LensDoc back to a Document.
-    #[allow(dead_code)]
-    fn lens_doc_to_doc(lens_doc: LensDoc, original_doc: &Document) -> Document {
-        use document::NormalValue;
-
-        let mut doc = Document::new();
-
-        // Preserve original ID
-        if let Some(id) = original_doc.id() {
-            doc.set_id(id.clone());
-        }
-
-        // Copy fields from lens doc, converting JSON primitives to native NormalValues
-        for (field_name, value) in lens_doc {
-            if field_name != DOC_ID_FIELD {
-                let normal = match value {
-                    serde_json::Value::Null => NormalValue::Null,
-                    serde_json::Value::Bool(b) => NormalValue::Bool(b),
-                    serde_json::Value::Number(ref n) => {
-                        if let Some(i) = n.as_i64() {
-                            NormalValue::Int(i)
-                        } else if let Some(f) = n.as_f64() {
-                            NormalValue::Float64(f)
-                        } else {
-                            NormalValue::Json(value)
-                        }
-                    }
-                    serde_json::Value::String(s) => NormalValue::String(s),
-                    other => NormalValue::Json(other),
-                };
-                doc.set(&field_name, normal);
-            }
-        }
-
-        doc
-    }
-
     /// Check if a document needs migration to the target version.
     pub(super) fn doc_needs_migration(
         doc: &Document,
@@ -286,10 +248,13 @@ impl<S: Store> LensedDocFetcher<S> {
 
         // Check if we have a migration path for this version
         if !history.contains_key(&doc_version) {
-            return Err(query::error::QueryError::execution(format!(
-                "no migration path found for document {} from version {} to {}",
-                doc_id_str, doc_version, target_version_id
-            )));
+            warn!(
+                doc_id = %doc_id_str,
+                doc_version = %doc_version,
+                target_version = %target_version_id,
+                "Document version is unknown locally; returning it unchanged"
+            );
+            return Ok(doc);
         }
 
         // Convert document to LensDoc
@@ -337,121 +302,56 @@ impl<S: Store> LensedDocFetcher<S> {
             "Document migration completed"
         );
 
-        // Convert back to Document
-        let mut migrated_doc = Self::lens_doc_to_doc(migrated_lens_doc.clone(), &doc);
-        migrated_doc.set_schema_version_id(target_version_id);
-
-        // Cache the migrated values in datastore
-        if let Err(e) = self
-            .update_datastore(
-                datastore,
-                &doc,
-                &original_lens_doc,
-                &migrated_lens_doc,
-                target_version_id,
-            )
-            .await
-        {
-            warn!(
-                doc_id = ?doc.id(),
-                error = %e,
-                "Failed to cache migrated document - migration still applied in memory"
-            );
-        }
+        let migrated_doc = lens_doc_to_document(migrated_lens_doc, &doc, collection);
+        self.update_datastore(datastore, collection, &migrated_doc)
+            .await?;
 
         Ok(migrated_doc)
     }
 
     /// Update the datastore with migrated document values.
     ///
-    /// This caches the migrated field values and updates the document's
-    /// schema version to the target version. Only modified fields are written.
+    /// Rust stores a document's fields in one CBOR blob, so this replaces that blob and updates
+    /// the real schema-version key in the caller's transaction.
     ///
     /// Matches Go's `updateDataStore` in internal/lens/fetcher.go.
     async fn update_datastore(
         &self,
         datastore: &NamespaceView,
-        doc: &Document,
-        original: &LensDoc,
-        migrated: &LensDoc,
-        target_version_id: &str,
+        collection: &Collection,
+        migrated_doc: &Document,
     ) -> query::error::Result<()> {
-        let doc_id = match doc.id() {
-            Some(id) => id.to_string(),
-            None => return Ok(()), // No ID, can't cache
-        };
-
-        // Find changed fields
-        let changed_fields: Vec<(&String, &serde_json::Value)> = migrated
-            .iter()
-            .filter(|(key, value)| {
-                // Skip special fields
-                if *key == DOC_ID_FIELD {
-                    return false;
-                }
-                // Include if field is new or value changed
-                match original.get(*key) {
-                    Some(orig_val) => orig_val != *value,
-                    None => true,
-                }
-            })
-            .collect();
-
-        if changed_fields.is_empty() && original.len() == migrated.len() {
-            // No changes, just update version
+        let txn_guard = self.txn.lock().await;
+        let txn = txn_guard.as_ref().ok_or_else(|| {
+            query::error::QueryError::execution("transaction not available for lens write-back")
+        })?;
+        if txn.is_readonly().map_err(|e| {
+            query::error::QueryError::execution(format!(
+                "failed to inspect lens write-back transaction: {}",
+                e
+            ))
+        })? {
             trace!(
-                doc_id = %doc_id,
-                "No field changes, updating version only"
+                doc_id = ?migrated_doc.id(),
+                "Skipping lens write-back in a read-only explicit transaction"
             );
-        } else {
-            trace!(
-                doc_id = %doc_id,
-                changed_count = changed_fields.len(),
-                "Caching migrated field values"
-            );
+            return Ok(());
         }
+        let systemstore = txn.systemstore().map_err(|e| {
+            query::error::QueryError::execution(format!(
+                "failed to get systemstore for lens write-back: {}",
+                e
+            ))
+        })?;
 
-        // Write changed fields to datastore
-        // Note: In a full implementation, we would use the collection's field keys
-        // For now, we just update the version to mark the document as migrated
-        for (field_name, value) in &changed_fields {
-            // Build field key: /d/<collection_short_id>/<doc_id>/<field_id>
-            // This is simplified - full implementation needs collection metadata
-            let value_bytes = serde_json::to_vec(value).map_err(|e| {
-                query::error::QueryError::execution(format!("failed to serialize field: {}", e))
-            })?;
-
-            // Log what would be written (actual field key construction needs collection info)
-            trace!(
-                doc_id = %doc_id,
-                field = %field_name,
-                value_len = value_bytes.len(),
-                "Would cache migrated field value"
-            );
-        }
-
-        // Update the version field
-        // Key format: /d/<collection_short_id>/<doc_id>/v
-        // We need the collection short ID to build the proper key
-        // For now, use a simplified approach that updates just the version marker
-        let version_bytes = target_version_id.as_bytes();
-
-        // Build version key - simplified, using doc_id as a marker
-        // In full implementation, this would use Collection::version_key()
-        let version_key = format!("/v/{}", doc_id);
-        datastore
-            .set(version_key.as_bytes(), version_bytes)
+        cache_migrated_document(datastore, &systemstore, collection, migrated_doc)
             .await
             .map_err(|e| {
-                query::error::QueryError::execution(format!("failed to update version: {}", e))
+                query::error::QueryError::execution(format!(
+                    "failed to cache migrated document: {}",
+                    e
+                ))
             })?;
-
-        debug!(
-            doc_id = %doc_id,
-            target_version = %target_version_id,
-            changed_fields = changed_fields.len(),
-            "Cached migrated document"
-        );
 
         Ok(())
     }

--- a/crates/db/src/lensed_fetcher/migration.rs
+++ b/crates/db/src/lensed_fetcher/migration.rs
@@ -10,10 +10,11 @@ use storage::corekv::Store;
 use tracing::{debug, trace};
 
 use crate::collection::Collection;
-use crate::migration::helpers::{cache_migrated_document, lens_doc_to_document};
+use crate::lensed_auto_commit_fetcher::migration::MigrationWriteBack;
+use crate::migration::helpers::{cache_migrated_document_with_indexes, lens_doc_to_document};
 use crate::schema_loader::get_collections_by_collection_id;
 
-use super::LensedDocFetcher;
+use super::{LensedDocFetcher, PendingMigrationWriteBack};
 
 impl<S: Store> LensedDocFetcher<S> {
     /// Check if any version in a list of collection versions has migrations registered.
@@ -151,11 +152,12 @@ impl<S: Store> LensedDocFetcher<S> {
     ) -> query::error::Result<HashMap<String, TargetedHistoryLink>> {
         let collection_id = &collection.schema().collection_id;
         let target_version_id = &collection.schema().version_id;
+        let cache_key = format!("{}:{}", collection_id, target_version_id);
 
         // First check if history is cached
         {
             let cache = self.history_cache.read().await;
-            if let Some(history) = cache.get(collection_id) {
+            if let Some(history) = cache.get(&cache_key) {
                 return Ok(history.clone());
             }
         }
@@ -182,7 +184,7 @@ impl<S: Store> LensedDocFetcher<S> {
         // Cache the history
         {
             let mut cache = self.history_cache.write().await;
-            cache.insert(collection_id.clone(), history.clone());
+            cache.insert(cache_key, history.clone());
         }
 
         Ok(history)
@@ -303,7 +305,7 @@ impl<S: Store> LensedDocFetcher<S> {
         );
 
         let migrated_doc = lens_doc_to_document(migrated_lens_doc, &doc, collection);
-        self.update_datastore(datastore, collection, &migrated_doc)
+        self.update_datastore(datastore, collection, &doc, &migrated_doc)
             .await?;
 
         Ok(migrated_doc)
@@ -319,6 +321,7 @@ impl<S: Store> LensedDocFetcher<S> {
         &self,
         datastore: &NamespaceView,
         collection: &Collection,
+        source_doc: &Document,
         migrated_doc: &Document,
     ) -> query::error::Result<()> {
         let txn_guard = self.txn.lock().await;
@@ -331,10 +334,24 @@ impl<S: Store> LensedDocFetcher<S> {
                 e
             ))
         })? {
-            trace!(
-                doc_id = ?migrated_doc.id(),
-                "Skipping lens write-back in a read-only explicit transaction"
-            );
+            if self.defer_readonly_write_back {
+                self.pending_write_backs
+                    .lock()
+                    .await
+                    .push(PendingMigrationWriteBack {
+                        collection_name: collection.name().to_string(),
+                        write_back: MigrationWriteBack {
+                            source_document: source_doc.clone(),
+                            migrated_document: migrated_doc.clone(),
+                            migration_generation: self.db.migration_generation(),
+                        },
+                    });
+            } else {
+                trace!(
+                    doc_id = ?migrated_doc.id(),
+                    "Skipping lens write-back in a read-only explicit transaction"
+                );
+            }
             return Ok(());
         }
         let systemstore = txn.systemstore().map_err(|e| {
@@ -344,7 +361,7 @@ impl<S: Store> LensedDocFetcher<S> {
             ))
         })?;
 
-        cache_migrated_document(datastore, &systemstore, collection, migrated_doc)
+        cache_migrated_document_with_indexes(datastore, &systemstore, collection, migrated_doc)
             .await
             .map_err(|e| {
                 query::error::QueryError::execution(format!(

--- a/crates/db/src/lensed_fetcher/migration.rs
+++ b/crates/db/src/lensed_fetcher/migration.rs
@@ -7,7 +7,7 @@ use document::Document;
 use lens::{build_targeted_history, CollectionHistoryLink, Lens, LensDoc, TargetedHistoryLink};
 use schema::CollectionVersion;
 use storage::corekv::Store;
-use tracing::{debug, trace, warn};
+use tracing::{debug, trace};
 
 use crate::collection::Collection;
 use crate::migration::helpers::{cache_migrated_document, lens_doc_to_document};
@@ -248,7 +248,7 @@ impl<S: Store> LensedDocFetcher<S> {
 
         // Check if we have a migration path for this version
         if !history.contains_key(&doc_version) {
-            warn!(
+            debug!(
                 doc_id = %doc_id_str,
                 doc_version = %doc_version,
                 target_version = %target_version_id,

--- a/crates/db/src/lensed_fetcher/mod.rs
+++ b/crates/db/src/lensed_fetcher/mod.rs
@@ -35,6 +35,12 @@ use query::runner::{DocFetcher, FetchByIdsResult};
 use storage::corekv::Store;
 
 use crate::txn::DbTxn;
+use crate::{database::DB, lensed_auto_commit_fetcher::migration::MigrationWriteBack};
+
+pub(crate) struct PendingMigrationWriteBack {
+    pub(crate) collection_name: String,
+    pub(crate) write_back: MigrationWriteBack,
+}
 
 /// Document fetcher that applies lens migrations to documents.
 ///
@@ -42,7 +48,10 @@ use crate::txn::DbTxn;
 /// transformed to the current (target) schema version using registered
 /// lens migrations.
 pub struct LensedDocFetcher<S: Store> {
+    db: Arc<DB<S>>,
     txn: Arc<TokioMutex<Option<DbTxn<S>>>>,
+    defer_readonly_write_back: bool,
+    pending_write_backs: TokioMutex<Vec<PendingMigrationWriteBack>>,
     #[allow(dead_code)]
     lens_store: Arc<dyn TransformStore>,
     /// Cache of collection version histories keyed by collection name.
@@ -58,9 +67,17 @@ impl<S: Store> LensedDocFetcher<S> {
     /// * `txn` - The database transaction
     /// * `lens_store` - The lens transform store for applying migrations
     #[allow(dead_code)]
-    pub(crate) fn new(txn: DbTxn<S>, lens_store: Arc<dyn TransformStore>) -> Self {
+    pub(crate) fn new(
+        db: Arc<DB<S>>,
+        txn: DbTxn<S>,
+        lens_store: Arc<dyn TransformStore>,
+        defer_readonly_write_back: bool,
+    ) -> Self {
         Self {
+            db,
             txn: Arc::new(TokioMutex::new(Some(txn))),
+            defer_readonly_write_back,
+            pending_write_backs: TokioMutex::new(Vec::new()),
             lens_store,
             history_cache: async_lock::RwLock::new(HashMap::new()),
         }
@@ -85,6 +102,14 @@ impl<S: Store> LensedDocFetcher<S> {
 
     pub(crate) fn lens_store(&self) -> Arc<dyn TransformStore> {
         self.lens_store.clone()
+    }
+
+    pub(crate) async fn invalidate_migration_cache(&self) {
+        self.history_cache.write().await.clear();
+    }
+
+    pub(crate) async fn take_pending_write_backs(&self) -> Vec<PendingMigrationWriteBack> {
+        std::mem::take(&mut *self.pending_write_backs.lock().await)
     }
 }
 

--- a/crates/db/src/lensed_fetcher/tests.rs
+++ b/crates/db/src/lensed_fetcher/tests.rs
@@ -22,10 +22,11 @@ fn test_doc_to_lens_doc_conversion() {
 
 #[tokio::test]
 async fn unknown_document_version_passes_through() {
-    let db = crate::DB::new(storage::MemoryStore::new()).unwrap();
+    let db = Arc::new(crate::DB::new(storage::MemoryStore::new()).unwrap());
     let txn = db.new_txn(false).await.unwrap();
     let datastore = txn.datastore().unwrap();
-    let fetcher = LensedDocFetcher::new(txn, Arc::new(lens::MemoryTransformStore::new()));
+    let fetcher =
+        LensedDocFetcher::new(db, txn, Arc::new(lens::MemoryTransformStore::new()), false);
 
     let collection = crate::Collection::new(schema::CollectionVersion::new(
         "Users",
@@ -53,7 +54,7 @@ async fn unknown_document_version_passes_through() {
         .history_cache
         .write()
         .await
-        .insert("users-collection".to_string(), history);
+        .insert("users-collection:v2".to_string(), history);
 
     let mut doc = Document::new();
     doc.set("name", "Alice");

--- a/crates/db/src/migration/helpers.rs
+++ b/crates/db/src/migration/helpers.rs
@@ -1,6 +1,12 @@
-//! Helper functions for migration placeholder creation and value conversion.
+//! Helper functions for migration placeholder creation and document materialization.
 
+use datastore::NamespaceView;
+use document::Document;
+use lens::{LensDoc, DOC_ID_FIELD};
 use schema::{CollectionVersion, FieldKind, ORPHAN_COLLECTION_ID};
+
+use crate::collection::Collection;
+use crate::error::{Error, Result};
 
 /// Create an orphan placeholder collection version.
 ///
@@ -50,11 +56,11 @@ pub(super) fn create_placeholder_with_source(
 /// This function converts them to the appropriate native type (Int, Float, Time, etc.)
 /// based on the field's declared type in the schema.
 ///
-/// The scalar coercion delegates to [`document::encoding::json_to_normal_value_for_kind`]
-/// — the same converter the mutation-create path uses — so reindexed index entries are
-/// byte-identical to freshly-written ones (notably DateTime → `Time`, not a raw string).
-/// Values that cannot be coerced to the declared kind fall back to a raw JSON value,
-/// preserving prior best-effort behavior.
+/// Scalar and scalar-array coercion delegates to the shared document converters, producing the
+/// same native representation as mutation writes. Reindexed entries are therefore byte-identical
+/// to freshly-written ones (notably DateTime → `Time`, and arrays → typed array variants rather
+/// than a JSON blob). Values that cannot be coerced fall back to raw JSON, preserving prior
+/// best-effort behavior.
 pub fn json_to_native_value(
     value: &serde_json::Value,
     field_name: &str,
@@ -70,13 +76,102 @@ pub fn json_to_native_value(
         .find(|f| f.name == field_name)
         .map(|f| &f.kind);
 
-    if let Some(FieldKind::Scalar(scalar)) = field_kind {
-        if let Some(nv) = document::encoding::json_to_normal_value_for_kind(value, scalar) {
-            return nv;
+    if let Some(field_kind) = field_kind {
+        match field_kind {
+            FieldKind::Scalar(scalar) => {
+                if let Some(nv) = document::encoding::json_to_normal_value_for_kind(value, scalar) {
+                    return nv;
+                }
+            }
+            FieldKind::ScalarArray(array) => {
+                if let Some(nv) =
+                    document::encoding::json_to_normal_value_for_array_kind(value, array)
+                {
+                    return nv;
+                }
+            }
+            _ => {}
         }
     }
 
     document::NormalValue::Json(value.clone())
+}
+
+/// Convert a transformed lens document to the active collection's storage representation.
+///
+/// Lens output is JSON-shaped, while document storage and indexes use schema-aware native
+/// values. Unknown output fields are ignored, matching Go's lensed fetcher.
+pub(crate) fn lens_doc_to_document(
+    mut lens_doc: LensDoc,
+    original_doc: &Document,
+    collection: &Collection,
+) -> Document {
+    let mut doc = Document::new();
+
+    if let Some(id) = original_doc.id() {
+        doc.set_id(id.clone());
+    }
+
+    for field in &collection.schema().fields {
+        if field.name == DOC_ID_FIELD {
+            continue;
+        }
+        if let Some(value) = lens_doc.remove(&field.name) {
+            doc.set(
+                &field.name,
+                json_to_native_value(&value, &field.name, collection.schema()),
+            );
+        }
+    }
+
+    doc.set_schema_version_id(collection.version_id());
+    doc
+}
+
+/// Persist a lensed document directly to the datastore without creating CRDT commits.
+///
+/// Rust stores document fields in one CBOR blob, so this is the current-layout equivalent of
+/// Go's per-field `updateDataStore`: replace the blob and update the real version key in the same
+/// transaction.
+pub(crate) async fn cache_migrated_document(
+    datastore: &NamespaceView,
+    systemstore: &NamespaceView,
+    collection: &Collection,
+    doc: &Document,
+) -> Result<bool> {
+    let Some(doc_id) = doc.id() else {
+        return Ok(false);
+    };
+    let Some(doc_short_id) = collection.resolve_doc_short_id(systemstore, doc_id).await? else {
+        return Ok(false);
+    };
+
+    let data = doc.to_cbor()?;
+    datastore
+        .set(&collection.doc_key(doc_short_id), &data)
+        .await
+        .map_err(Error::Storage)?;
+    collection.store_version(datastore, doc_short_id).await?;
+
+    Ok(true)
+}
+
+/// Advance only a document's stored schema version.
+pub(crate) async fn cache_document_version(
+    datastore: &NamespaceView,
+    systemstore: &NamespaceView,
+    collection: &Collection,
+    doc: &Document,
+) -> Result<bool> {
+    let Some(doc_id) = doc.id() else {
+        return Ok(false);
+    };
+    let Some(doc_short_id) = collection.resolve_doc_short_id(systemstore, doc_id).await? else {
+        return Ok(false);
+    };
+
+    collection.store_version(datastore, doc_short_id).await?;
+    Ok(true)
 }
 
 #[cfg(test)]
@@ -164,6 +259,68 @@ mod tests {
         assert_eq!(
             json_to_native_value(&serde_json::json!("hi"), "name", &coll),
             document::NormalValue::String("hi".to_string())
+        );
+    }
+
+    #[test]
+    fn scalar_arrays_reindex_to_native_values() {
+        let coll = CollectionVersion::new(
+            "test",
+            "v1",
+            "coll_test_001",
+            vec![
+                FieldDescription::new("1", "bools", FieldKind::bool_array()),
+                FieldDescription::new("2", "ints", FieldKind::int_array()),
+                FieldDescription::new("3", "float64s", FieldKind::float64_array()),
+                FieldDescription::new("4", "float32s", FieldKind::float32_array()),
+                FieldDescription::new("5", "strings", FieldKind::string_array()),
+                FieldDescription::new("6", "maybe_bools", FieldKind::nillable_bool_array()),
+                FieldDescription::new("7", "maybe_ints", FieldKind::nillable_int_array()),
+                FieldDescription::new("8", "maybe_float64s", FieldKind::nillable_float64_array()),
+                FieldDescription::new("9", "maybe_float32s", FieldKind::nillable_float32_array()),
+                FieldDescription::new("10", "maybe_strings", FieldKind::nillable_string_array()),
+            ],
+        );
+
+        assert_eq!(
+            json_to_native_value(&serde_json::json!([true, false]), "bools", &coll),
+            document::NormalValue::BoolArray(vec![true, false])
+        );
+        assert_eq!(
+            json_to_native_value(&serde_json::json!([1, 2]), "ints", &coll),
+            document::NormalValue::IntArray(vec![1, 2])
+        );
+        assert_eq!(
+            json_to_native_value(&serde_json::json!([1, 2.5]), "float64s", &coll),
+            document::NormalValue::Float64Array(vec![1.0, 2.5])
+        );
+        assert_eq!(
+            json_to_native_value(&serde_json::json!([1, 2.5]), "float32s", &coll),
+            document::NormalValue::Float32Array(vec![1.0, 2.5])
+        );
+        assert_eq!(
+            json_to_native_value(&serde_json::json!(["a", "b"]), "strings", &coll),
+            document::NormalValue::StringArray(vec!["a".to_string(), "b".to_string()])
+        );
+        assert_eq!(
+            json_to_native_value(&serde_json::json!([true, null]), "maybe_bools", &coll),
+            document::NormalValue::NillableBoolElementArray(vec![Some(true), None])
+        );
+        assert_eq!(
+            json_to_native_value(&serde_json::json!([1, null]), "maybe_ints", &coll),
+            document::NormalValue::NillableIntElementArray(vec![Some(1), None])
+        );
+        assert_eq!(
+            json_to_native_value(&serde_json::json!([1, null]), "maybe_float64s", &coll),
+            document::NormalValue::NillableFloat64ElementArray(vec![Some(1.0), None])
+        );
+        assert_eq!(
+            json_to_native_value(&serde_json::json!([1, null]), "maybe_float32s", &coll),
+            document::NormalValue::NillableFloat32ElementArray(vec![Some(1.0), None])
+        );
+        assert_eq!(
+            json_to_native_value(&serde_json::json!(["a", null]), "maybe_strings", &coll),
+            document::NormalValue::NillableStringElementArray(vec![Some("a".to_string()), None])
         );
     }
 }

--- a/crates/db/src/migration/helpers.rs
+++ b/crates/db/src/migration/helpers.rs
@@ -7,6 +7,7 @@ use schema::{CollectionVersion, FieldKind, ORPHAN_COLLECTION_ID};
 
 use crate::collection::Collection;
 use crate::error::{Error, Result};
+use crate::index_manager::IndexManager;
 
 /// Create an orphan placeholder collection version.
 ///
@@ -121,6 +122,12 @@ pub(crate) fn lens_doc_to_document(
                 &field.name,
                 json_to_native_value(&value, &field.name, collection.schema()),
             );
+        } else if original_doc.get(&field.name).is_some() {
+            // Go's updateDataStore treats a field removed by a lens as an
+            // explicit nil assignment. Rust omits nils from CBOR storage, but
+            // retaining Null in the returned in-memory document preserves the
+            // same clear semantics for the query that performed the migration.
+            doc.set(&field.name, document::NormalValue::Null);
         }
     }
 
@@ -152,6 +159,51 @@ pub(crate) async fn cache_migrated_document(
         .await
         .map_err(Error::Storage)?;
     collection.store_version(datastore, doc_short_id).await?;
+
+    Ok(true)
+}
+
+/// Persist a lazily migrated document and update its secondary indexes in the
+/// same transaction.
+///
+/// Unlike a user mutation, migration write-back deliberately creates no CRDT
+/// blocks or commits. It still has to remove index entries derived from the old
+/// stored blob and add entries derived from the migrated representation.
+pub(crate) async fn cache_migrated_document_with_indexes(
+    datastore: &NamespaceView,
+    systemstore: &NamespaceView,
+    collection: &Collection,
+    doc: &Document,
+) -> Result<bool> {
+    let Some(doc_id) = doc.id() else {
+        return Ok(false);
+    };
+    let Some(doc_short_id) = collection.resolve_doc_short_id(systemstore, doc_id).await? else {
+        return Ok(false);
+    };
+
+    let key = collection.doc_key(doc_short_id);
+    let Some(old_data) = datastore.get(&key).await.map_err(Error::Storage)? else {
+        return Ok(false);
+    };
+    let mut old_doc = Document::from_cbor(&old_data)?;
+    old_doc.set_id(doc_id.clone());
+
+    datastore
+        .set(&key, &doc.to_cbor()?)
+        .await
+        .map_err(Error::Storage)?;
+    collection.store_version(datastore, doc_short_id).await?;
+
+    // Deleted documents have already been removed from secondary indexes.
+    // Materializing their retained blob must not add those entries back.
+    if !collection.is_deleted(datastore, doc_short_id).await? {
+        let index_manager =
+            IndexManager::from_collection(collection.resolved_root_id(), collection.schema())?;
+        index_manager
+            .on_document_update(datastore, &old_doc, doc, doc_short_id, collection.schema())
+            .await?;
+    }
 
     Ok(true)
 }
@@ -259,6 +311,36 @@ mod tests {
         assert_eq!(
             json_to_native_value(&serde_json::json!("hi"), "name", &coll),
             document::NormalValue::String("hi".to_string())
+        );
+    }
+
+    #[test]
+    fn lens_removed_field_is_returned_as_explicit_null() {
+        let collection = Collection::new(CollectionVersion::new(
+            "Users",
+            "v2",
+            "users",
+            vec![
+                FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                FieldDescription::new("2", "name", FieldKind::string()),
+            ],
+        ));
+        let mut original = Document::new();
+        original.set("name", document::NormalValue::String("Alice".to_string()));
+
+        let migrated = lens_doc_to_document(LensDoc::new(), &original, &collection);
+
+        assert_eq!(
+            migrated.get("name"),
+            Some(&document::NormalValue::Null),
+            "a lens omission must be observable as a clear in the current query"
+        );
+        assert_eq!(
+            Document::from_cbor(&migrated.to_cbor().unwrap())
+                .unwrap()
+                .get("name"),
+            None,
+            "nil fields remain omitted from persisted CBOR, matching Go"
         );
     }
 

--- a/crates/db/src/migration/mod.rs
+++ b/crates/db/src/migration/mod.rs
@@ -9,6 +9,9 @@ pub(crate) mod helpers;
 mod reindex;
 mod set_migration;
 
+#[cfg(test)]
+mod tests;
+
 use std::sync::Arc;
 
 use lens::{LensConfig, TransformId, TransformStore};

--- a/crates/db/src/migration/reindex.rs
+++ b/crates/db/src/migration/reindex.rs
@@ -144,9 +144,11 @@ impl<S: Store> DB<S> {
                     if materialize_identity_paths {
                         let mut restamped = doc.clone();
                         restamped.set_schema_version_id(&target_version_id);
-                        cache_document_version(&datastore, &txn_systemstore, &collection, &doc)
-                            .await?;
-                        materialized_count += 1;
+                        if cache_document_version(&datastore, &txn_systemstore, &collection, &doc)
+                            .await?
+                        {
+                            materialized_count += 1;
+                        }
                         migrated_docs.push((doc_short_id, restamped));
                     } else {
                         migrated_docs.push((doc_short_id, doc));
@@ -177,11 +179,14 @@ impl<S: Store> DB<S> {
                 );
                 if !path_has_transform {
                     if materialize_identity_paths {
-                        cache_document_version(&datastore, &txn_systemstore, &collection, &doc)
-                            .await?;
+                        let cached =
+                            cache_document_version(&datastore, &txn_systemstore, &collection, &doc)
+                                .await?;
                         let mut restamped = doc;
                         restamped.set_schema_version_id(&target_version_id);
-                        materialized_count += 1;
+                        if cached {
+                            materialized_count += 1;
+                        }
                         migrated_docs.push((doc_short_id, restamped));
                     } else {
                         migrated_docs.push((doc_short_id, doc));
@@ -211,9 +216,11 @@ impl<S: Store> DB<S> {
                     })?
                     .map_err(|e| Error::Lens(e.to_string()))?;
                 let migrated = lens_doc_to_document(migrated_lens_doc, &doc, &collection);
-                cache_migrated_document(&datastore, &txn_systemstore, &collection, &migrated)
-                    .await?;
-                materialized_count += 1;
+                if cache_migrated_document(&datastore, &txn_systemstore, &collection, &migrated)
+                    .await?
+                {
+                    materialized_count += 1;
+                }
                 migrated_docs.push((doc_short_id, migrated));
             }
 

--- a/crates/db/src/migration/reindex.rs
+++ b/crates/db/src/migration/reindex.rs
@@ -1,12 +1,10 @@
-//! Reindexing after migration registration.
+//! Datastore materialization and reindexing after schema migration.
 
-use std::collections::HashMap;
-
-use lens::{build_targeted_history, CollectionHistoryLink, Lens, LensDoc, DOC_ID_FIELD};
+use lens::Lens;
 use storage::corekv::Store;
-use tracing::instrument;
+use tracing::{instrument, warn};
 
-use super::helpers::json_to_native_value;
+use super::helpers::{cache_document_version, cache_migrated_document, lens_doc_to_document};
 use crate::error::{Error, Result};
 use crate::index_manager::IndexManager;
 use crate::schema_loader::get_collections_by_collection_id;
@@ -80,14 +78,38 @@ impl<S: Store> DB<S> {
 
     /// Rebuild secondary indexes for a collection using lens-migrated documents.
     ///
-    /// Fetches all documents, applies lens migration to any that need it,
-    /// drops existing index entries, and rebuilds them with migrated values.
+    /// Documents that cross a registered transform are also written back to the
+    /// datastore so the rebuilt indexes and cached values cannot diverge.
     pub async fn reindex_collection_with_migrations(&self, collection_name: &str) -> Result<()> {
-        let collection = match self.get_collection(collection_name)? {
-            Some(c) => c,
-            None => return Ok(()),
-        };
+        if self.get_collection(collection_name)?.is_none() {
+            return Ok(());
+        }
+        self.materialize_collection_inner(collection_name, false)
+            .await
+            .map(|_| ())
+    }
 
+    /// Eagerly advance every known-version document in a collection to its active version.
+    ///
+    /// This writes only the datastore blob, version key, and secondary indexes. It does not
+    /// create CRDT commits, update heads, emit mutation events, or gossip data to peers.
+    ///
+    /// Returns the number of documents whose stored version was advanced.
+    pub async fn materialize_collection(&self, collection_name: &str) -> Result<usize> {
+        self.check_node_access(None, acp::nac::NodePermission::CollectionPatch)
+            .await?;
+        self.materialize_collection_inner(collection_name, true)
+            .await
+    }
+
+    async fn materialize_collection_inner(
+        &self,
+        collection_name: &str,
+        materialize_identity_paths: bool,
+    ) -> Result<usize> {
+        let collection = self
+            .get_collection(collection_name)?
+            .ok_or_else(|| Error::CollectionNotFound(collection_name.to_string()))?;
         let collection_id = collection.collection_id().to_string();
         let target_version_id = collection.version_id().to_string();
         let short_id = collection.resolved_root_id();
@@ -97,44 +119,16 @@ impl<S: Store> DB<S> {
         let versions = get_collections_by_collection_id(&systemstore, &collection_id).await?;
         let _ = read_txn.discard();
 
-        let history = {
-            let mut full_history: HashMap<String, CollectionHistoryLink> = HashMap::new();
-            for version in &versions {
-                let mut link =
-                    CollectionHistoryLink::new(&version.version_id, &version.collection_id);
-                if let Some(ref prev) = version.previous_version {
-                    link = link.with_previous(&prev.source_collection_id);
-                    if let Some(ref transform_id) = prev.transform {
-                        link = link.with_transform(transform_id);
-                    }
-                }
-                full_history.insert(version.version_id.clone(), link);
-            }
-
-            let reverse_links: Vec<(String, String)> = full_history
-                .values()
-                .flat_map(|link| {
-                    link.previous
-                        .iter()
-                        .map(|prev_id| (prev_id.clone(), link.version_id.clone()))
-                        .collect::<Vec<_>>()
-                })
-                .collect();
-            for (parent_id, child_id) in reverse_links {
-                if let Some(parent_link) = full_history.get_mut(&parent_id) {
-                    if !parent_link.next.contains(&child_id) {
-                        parent_link.next.push(child_id);
-                    }
-                }
-            }
-
-            match build_targeted_history(&full_history, &target_version_id) {
-                Some(h) => h,
-                None => return Ok(()),
-            }
-        };
+        let history = crate::lens_utils::build_collection_history(&versions, &target_version_id)
+            .ok_or_else(|| {
+                Error::Lens(format!(
+                    "failed to build migration history for collection '{}'",
+                    collection_name
+                ))
+            })?;
 
         let write_txn = self.new_txn(false).await?;
+        let mut materialized_count = 0usize;
 
         {
             let datastore = write_txn.datastore()?;
@@ -146,82 +140,118 @@ impl<S: Store> DB<S> {
 
             let mut migrated_docs = Vec::with_capacity(raw_docs.len());
             for (doc_short_id, doc, _) in raw_docs {
-                let doc_version = doc
-                    .schema_version_id()
-                    .unwrap_or(&target_version_id)
-                    .to_string();
+                let Some(doc_version) = doc.schema_version_id().map(str::to_string) else {
+                    if materialize_identity_paths {
+                        let mut restamped = doc.clone();
+                        restamped.set_schema_version_id(&target_version_id);
+                        cache_document_version(&datastore, &txn_systemstore, &collection, &doc)
+                            .await?;
+                        materialized_count += 1;
+                        migrated_docs.push((doc_short_id, restamped));
+                    } else {
+                        migrated_docs.push((doc_short_id, doc));
+                    }
+                    continue;
+                };
 
                 if doc_version == target_version_id {
                     migrated_docs.push((doc_short_id, doc));
                     continue;
                 }
 
-                if let Ok(map) = doc.to_map() {
-                    let mut lens_doc = LensDoc::new();
-                    for (key, value) in map {
-                        lens_doc.insert(key, value);
-                    }
-
-                    let mut lens =
-                        Lens::new(self.lens_store.clone(), &target_version_id, history.clone());
-
-                    if let Ok(()) = lens.put(&doc_version, lens_doc).await {
-                        if let Some(Ok(migrated_lens_doc)) = lens.next().await {
-                            let mut migrated = document::Document::new();
-                            if let Some(id) = doc.id() {
-                                migrated.set_id(id.clone());
-                            }
-                            for (field_name, value) in migrated_lens_doc {
-                                if field_name != DOC_ID_FIELD {
-                                    let native_value = json_to_native_value(
-                                        &value,
-                                        &field_name,
-                                        collection.schema(),
-                                    );
-                                    migrated.set(&field_name, native_value);
-                                }
-                            }
-                            migrated.set_schema_version_id(&target_version_id);
-                            migrated_docs.push((doc_short_id, migrated));
-                            continue;
-                        }
-                    }
+                if !history.contains_key(&doc_version) {
+                    warn!(
+                        doc_id = ?doc.id(),
+                        doc_version = %doc_version,
+                        target_version = %target_version_id,
+                        "Skipping materialization for a document version unknown locally"
+                    );
+                    migrated_docs.push((doc_short_id, doc));
+                    continue;
                 }
 
-                migrated_docs.push((doc_short_id, doc));
+                let path_has_transform = crate::lens_utils::migration_path_has_transform(
+                    &history,
+                    &doc_version,
+                    &target_version_id,
+                );
+                if !path_has_transform {
+                    if materialize_identity_paths {
+                        cache_document_version(&datastore, &txn_systemstore, &collection, &doc)
+                            .await?;
+                        let mut restamped = doc;
+                        restamped.set_schema_version_id(&target_version_id);
+                        materialized_count += 1;
+                        migrated_docs.push((doc_short_id, restamped));
+                    } else {
+                        migrated_docs.push((doc_short_id, doc));
+                    }
+                    continue;
+                }
+
+                let lens_doc = crate::lens_utils::doc_to_lens_doc(&doc).ok_or_else(|| {
+                    Error::Lens(format!(
+                        "failed to convert document {:?} for materialization",
+                        doc.id()
+                    ))
+                })?;
+                let mut lens =
+                    Lens::new(self.lens_store.clone(), &target_version_id, history.clone());
+                lens.put(&doc_version, lens_doc)
+                    .await
+                    .map_err(|e| Error::Lens(e.to_string()))?;
+                let migrated_lens_doc = lens
+                    .next()
+                    .await
+                    .ok_or_else(|| {
+                        Error::Lens(format!(
+                            "lens produced no document while materializing {:?}",
+                            doc.id()
+                        ))
+                    })?
+                    .map_err(|e| Error::Lens(e.to_string()))?;
+                let migrated = lens_doc_to_document(migrated_lens_doc, &doc, &collection);
+                cache_migrated_document(&datastore, &txn_systemstore, &collection, &migrated)
+                    .await?;
+                materialized_count += 1;
+                migrated_docs.push((doc_short_id, migrated));
             }
 
-            let index_manager = IndexManager::from_collection(short_id, collection.schema())
-                .map_err(|e| Error::Other(format!("failed to create index manager: {}", e)))?;
+            if !collection.get_indexes().is_empty() {
+                let index_manager = IndexManager::from_collection(short_id, collection.schema())
+                    .map_err(|e| Error::Other(format!("failed to create index manager: {}", e)))?;
 
-            for index_desc in collection.get_indexes() {
-                if let Some(index) = index_manager.get_index(&index_desc.name) {
-                    index
-                        .remove_all(&mut datastore.clone())
-                        .await
-                        .map_err(Error::Storage)?;
+                for index_desc in collection.get_indexes() {
+                    if let Some(index) = index_manager.get_index(&index_desc.name) {
+                        index
+                            .remove_all(&mut datastore.clone())
+                            .await
+                            .map_err(Error::Storage)?;
+                    }
+
+                    index_manager
+                        .bulk_index(
+                            &datastore,
+                            &index_desc.name,
+                            &migrated_docs,
+                            collection.schema(),
+                        )
+                        .await?;
                 }
-
-                index_manager
-                    .bulk_index(
-                        &datastore,
-                        &index_desc.name,
-                        &migrated_docs,
-                        collection.schema(),
-                    )
-                    .await?;
             }
 
             tracing::debug!(
                 collection = %collection_name,
                 doc_count = migrated_docs.len(),
+                materialized_count,
                 index_count = collection.get_indexes().len(),
-                "Rebuilt indexes after version switch"
+                materialize_identity_paths,
+                "Materialized collection datastore and rebuilt indexes"
             );
         }
 
         write_txn.commit().await?;
 
-        Ok(())
+        Ok(materialized_count)
     }
 }

--- a/crates/db/src/migration/set_migration.rs
+++ b/crates/db/src/migration/set_migration.rs
@@ -224,6 +224,7 @@ impl<S: Store> DB<S> {
                 .map_err(Error::Storage)?;
         }
         txn.commit().await?;
+        self.bump_migration_generation();
 
         if !collection_name.is_empty() {
             let mut cache = self.collections.write().map_err(|e| {

--- a/crates/db/src/migration/tests.rs
+++ b/crates/db/src/migration/tests.rs
@@ -708,6 +708,81 @@ async fn field_value_fetch_filters_after_lens_transform() {
 }
 
 #[tokio::test]
+async fn concurrent_lazy_reads_of_same_document_are_idempotent() {
+    let transform_store = Arc::new(BlockingVerifiedStore::default());
+    let mut raw_db = DB::new(MemoryStore::new()).unwrap();
+    raw_db.lens_store = transform_store.clone();
+    let db = Arc::new(raw_db);
+
+    db.create_collection(indexed_users_schema()).await.unwrap();
+    let v1 = db
+        .get_collection("Users")
+        .unwrap()
+        .unwrap()
+        .version_id()
+        .to_string();
+    let v2 = add_placeholder_version(&db, "placeholder").await;
+    db.set_migration(
+        LensConfig::new(
+            &v1,
+            &v2,
+            LensModule::from_bytes(b"\0asm\x01\0\0\0".to_vec()),
+        ),
+        None,
+    )
+    .await
+    .unwrap();
+    let doc_id = seed_old_user(&db, &v1, "Concurrent").await;
+
+    transform_store.arm();
+    let first_db = db.clone();
+    let first_doc_id = doc_id.to_string();
+    let first = tokio::spawn(async move {
+        crate::LensedAutoCommitFetcher::new(first_db)
+            .get_by_ids("Users", &[first_doc_id])
+            .await
+    });
+
+    tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        transform_store.entered.notified(),
+    )
+    .await
+    .expect("first lensed read reached the transform");
+
+    let second_docs = tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        crate::LensedAutoCommitFetcher::new(db.clone()).get_by_ids("Users", &[doc_id.to_string()]),
+    )
+    .await
+    .expect("second lensed read completed while the first was paused")
+    .unwrap()
+    .into_docs();
+
+    transform_store.release.notify_one();
+    let first_docs = first.await.unwrap().unwrap().into_docs();
+
+    for docs in [&first_docs, &second_docs] {
+        assert_eq!(
+            docs[0].get("verified"),
+            Some(&document::NormalValue::Bool(true))
+        );
+    }
+
+    let persisted = load_user(&db, &doc_id).await;
+    assert_eq!(
+        persisted.get("verified"),
+        Some(&document::NormalValue::Bool(true))
+    );
+    assert_eq!(persisted.schema_version_id(), Some(v2.as_str()));
+    assert_eq!(
+        verified_index_count(&db).await,
+        1,
+        "concurrent write-back must leave exactly one indexed document"
+    );
+}
+
+#[tokio::test]
 async fn concurrent_update_wins_over_stale_lazy_write_back() {
     let transform_store = Arc::new(BlockingVerifiedStore::default());
     let mut raw_db = DB::new(MemoryStore::new()).unwrap();

--- a/crates/db/src/migration/tests.rs
+++ b/crates/db/src/migration/tests.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 
 use async_trait::async_trait;
@@ -7,10 +7,13 @@ use futures::StreamExt;
 use lens::{
     LensConfig, LensDocResultStream, LensDocStream, LensModule, TransformId, TransformStore,
 };
-use query::{DocFetcher, DocMutator};
+use query::txn::{GetTransactionResult, TransactionRegistry};
+use query::{DocFetcher, DocMutator, QueryExecutor, QueryRequest};
 use schema::{CollectionVersion, FieldDescription, FieldKind};
 use storage::corekv::IterOptions;
+use storage::index::IndexIterator;
 use storage::MemoryStore;
+use tokio::sync::Notify;
 
 use crate::{AutoCommitMutator, DB};
 
@@ -66,6 +69,139 @@ impl TransformStore for SetVerifiedStore {
     }
 }
 
+#[derive(Default)]
+struct BlockingVerifiedStore {
+    transforms: RwLock<HashSet<TransformId>>,
+    armed: AtomicBool,
+    entered: Arc<Notify>,
+    release: Arc<Notify>,
+}
+
+impl BlockingVerifiedStore {
+    fn arm(&self) {
+        self.armed.store(true, Ordering::SeqCst);
+    }
+}
+
+#[async_trait]
+impl TransformStore for BlockingVerifiedStore {
+    async fn add(&self, config: LensConfig) -> lens::Result<TransformId> {
+        let id = TransformId::new(format!("blocking-transform-{}", config.lenses.len()));
+        self.transforms.write().unwrap().insert(id.clone());
+        Ok(id)
+    }
+
+    async fn add_with_id(&self, id: TransformId, _config: LensConfig) -> lens::Result<()> {
+        self.transforms.write().unwrap().insert(id);
+        Ok(())
+    }
+
+    async fn list(&self) -> lens::Result<HashMap<String, LensModule>> {
+        Ok(HashMap::new())
+    }
+
+    fn transform(
+        &self,
+        id: &TransformId,
+        docs: LensDocStream,
+    ) -> lens::Result<LensDocResultStream> {
+        if !self.has_transform(id) {
+            return Err(lens::Error::TransformNotFound(id.to_string()));
+        }
+        let should_block = self.armed.swap(false, Ordering::SeqCst);
+        let entered = self.entered.clone();
+        let release = self.release.clone();
+        Ok(Box::pin(docs.then(move |mut doc| {
+            let entered = entered.clone();
+            let release = release.clone();
+            async move {
+                if should_block {
+                    entered.notify_one();
+                    release.notified().await;
+                }
+                doc.insert("verified".to_string(), serde_json::Value::Bool(true));
+                Ok(doc)
+            }
+        })))
+    }
+
+    fn inverse(&self, id: &TransformId, docs: LensDocStream) -> lens::Result<LensDocResultStream> {
+        self.transform(id, docs)
+    }
+
+    fn has_transform(&self, id: &TransformId) -> bool {
+        self.transforms.read().unwrap().contains(id)
+    }
+
+    async fn remove(&self, id: &TransformId) -> lens::Result<()> {
+        self.transforms.write().unwrap().remove(id);
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct StepTransformStore {
+    next_id: AtomicUsize,
+    fields: RwLock<HashMap<TransformId, String>>,
+}
+
+#[async_trait]
+impl TransformStore for StepTransformStore {
+    async fn add(&self, _config: LensConfig) -> lens::Result<TransformId> {
+        let sequence = self.next_id.fetch_add(1, Ordering::SeqCst);
+        let id = TransformId::new(format!("step-transform-{sequence}"));
+        let field = if sequence == 0 { "latest" } else { "middle" };
+        self.fields
+            .write()
+            .unwrap()
+            .insert(id.clone(), field.to_string());
+        Ok(id)
+    }
+
+    async fn add_with_id(&self, id: TransformId, _config: LensConfig) -> lens::Result<()> {
+        self.fields
+            .write()
+            .unwrap()
+            .insert(id, "restored".to_string());
+        Ok(())
+    }
+
+    async fn list(&self) -> lens::Result<HashMap<String, LensModule>> {
+        Ok(HashMap::new())
+    }
+
+    fn transform(
+        &self,
+        id: &TransformId,
+        docs: LensDocStream,
+    ) -> lens::Result<LensDocResultStream> {
+        let field = self
+            .fields
+            .read()
+            .unwrap()
+            .get(id)
+            .cloned()
+            .ok_or_else(|| lens::Error::TransformNotFound(id.to_string()))?;
+        Ok(Box::pin(docs.map(move |mut doc| {
+            doc.insert(field.clone(), serde_json::Value::String("set".to_string()));
+            Ok(doc)
+        })))
+    }
+
+    fn inverse(&self, id: &TransformId, docs: LensDocStream) -> lens::Result<LensDocResultStream> {
+        self.transform(id, docs)
+    }
+
+    fn has_transform(&self, id: &TransformId) -> bool {
+        self.fields.read().unwrap().contains_key(id)
+    }
+
+    async fn remove(&self, id: &TransformId) -> lens::Result<()> {
+        self.fields.write().unwrap().remove(id);
+        Ok(())
+    }
+}
+
 fn users_schema() -> CollectionVersion {
     let mut schema = CollectionVersion::new(
         "Users",
@@ -76,6 +212,23 @@ fn users_schema() -> CollectionVersion {
             FieldDescription::new("2", "name", FieldKind::string()),
         ],
     );
+    schema.is_materialized = true;
+    schema
+}
+
+fn indexed_users_schema() -> CollectionVersion {
+    let mut schema = CollectionVersion::new(
+        "Users",
+        "users-v1",
+        "users-collection",
+        vec![
+            FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+            FieldDescription::new("2", "name", FieldKind::string()),
+            FieldDescription::new("3", "verified", FieldKind::bool()),
+        ],
+    );
+    schema.indexes =
+        vec![schema::IndexDescription::new("idx_verified").with_field("verified", false)];
     schema.is_materialized = true;
     schema
 }
@@ -99,6 +252,81 @@ async fn add_verified_version(db: &Arc<DB<MemoryStore>>) -> String {
     .await
     .unwrap()
     .version_id
+}
+
+async fn add_placeholder_version(db: &Arc<DB<MemoryStore>>, field_name: &str) -> String {
+    db.patch_collection(
+        "Users",
+        &format!(
+            r#"[{{"op":"add","path":"/Users/Fields/-","value":{{"Name":"{field_name}","Kind":"String"}}}}]"#
+        ),
+        None,
+    )
+    .await
+    .unwrap()
+    .version_id
+}
+
+async fn seed_old_user(db: &Arc<DB<MemoryStore>>, version_id: &str, name: &str) -> document::DocID {
+    let collection = db.get_collection("Users").unwrap().unwrap();
+    let index_manager = crate::index_manager::IndexManager::from_collection(
+        collection.resolved_root_id(),
+        collection.schema(),
+    )
+    .unwrap();
+    let mut doc = document::Document::new();
+    let seed = format!("late-{name}");
+    let doc_id = document::DocID::new_v0_from_seed(&seed);
+    doc.set_id(doc_id.clone());
+    doc.set("name", document::NormalValue::String(name.to_string()));
+    doc.set_schema_version_id(version_id);
+
+    let txn = db.new_txn(false).await.unwrap();
+    let datastore = txn.datastore().unwrap();
+    let systemstore = txn.systemstore().unwrap();
+    let doc_short_id = crate::doc_id_map::next_doc_short_id(&systemstore)
+        .await
+        .unwrap();
+    crate::doc_id_map::set_doc_id_mapping(
+        &systemstore,
+        collection.resolved_root_id(),
+        doc_short_id,
+        &doc_id.to_string(),
+    )
+    .await
+    .unwrap();
+    collection
+        .create_with_indexes(&datastore, &doc, doc_short_id, &index_manager)
+        .await
+        .unwrap();
+    collection
+        .save_with_datastore(&datastore, &doc, doc_short_id)
+        .await
+        .unwrap();
+    drop(datastore);
+    drop(systemstore);
+    txn.commit().await.unwrap();
+    doc_id
+}
+
+async fn verified_index_count(db: &Arc<DB<MemoryStore>>) -> usize {
+    let collection = db.get_collection("Users").unwrap().unwrap();
+    let index_manager = crate::index_manager::IndexManager::from_collection(
+        collection.resolved_root_id(),
+        collection.schema(),
+    )
+    .unwrap();
+    let index = index_manager.get_index("idx_verified").unwrap();
+    let txn = db.new_txn(true).await.unwrap();
+    let datastore = txn.datastore().unwrap();
+    let mut iter = index
+        .get(&datastore, &[document::NormalValue::Bool(true)])
+        .await
+        .unwrap();
+    let entries = iter.collect_all().await.unwrap();
+    drop(datastore);
+    txn.discard().unwrap();
+    entries.len()
 }
 
 async fn load_user(db: &Arc<DB<MemoryStore>>, doc_id: &document::DocID) -> document::Document {
@@ -257,4 +485,291 @@ async fn eager_materialize_restamps_transformless_paths() {
     );
     assert_eq!(db.materialize_collection("Users").await.unwrap(), 0);
     assert_eq!(namespace_counts(&db).await, before_counts);
+}
+
+#[tokio::test]
+async fn migration_context_cache_invalidates_when_graph_changes_without_version_change() {
+    let transform_store = Arc::new(StepTransformStore::default());
+    let mut raw_db = DB::new(MemoryStore::new()).unwrap();
+    raw_db.lens_store = transform_store;
+    let db = Arc::new(raw_db);
+
+    db.create_collection(users_schema()).await.unwrap();
+    let v1 = db
+        .get_collection("Users")
+        .unwrap()
+        .unwrap()
+        .version_id()
+        .to_string();
+    let v2 = add_placeholder_version(&db, "middle").await;
+    let v3 = add_placeholder_version(&db, "latest").await;
+
+    db.set_migration(
+        LensConfig::new(
+            &v2,
+            &v3,
+            LensModule::from_bytes(b"\0asm\x01\0\0\0".to_vec()),
+        ),
+        None,
+    )
+    .await
+    .unwrap();
+
+    let fetcher = crate::LensedAutoCommitFetcher::new(db.clone());
+    assert!(fetcher.get_all("Users").await.unwrap().is_empty());
+
+    db.set_migration(
+        LensConfig::new(
+            &v1,
+            &v2,
+            LensModule::from_bytes(b"\0asm\x01\0\0\0".to_vec()),
+        ),
+        None,
+    )
+    .await
+    .unwrap();
+
+    let doc_id = seed_old_user(&db, &v1, "CachedGraph").await;
+    let docs = fetcher
+        .get_by_ids("Users", &[doc_id.to_string()])
+        .await
+        .unwrap()
+        .into_docs();
+    assert_eq!(
+        docs[0].get("middle"),
+        Some(&document::NormalValue::String("set".to_string())),
+        "the newly registered v1→v2 transform must be present in refreshed history"
+    );
+    assert_eq!(
+        docs[0].get("latest"),
+        Some(&document::NormalValue::String("set".to_string())),
+        "the previously cached v2→v3 transform must remain in the complete history"
+    );
+}
+
+#[tokio::test]
+async fn lazy_write_back_updates_secondary_indexes_for_late_document() {
+    let transform_store = Arc::new(SetVerifiedStore::default());
+    let mut raw_db = DB::new(MemoryStore::new()).unwrap();
+    raw_db.lens_store = transform_store;
+    let db = Arc::new(raw_db);
+
+    db.create_collection(indexed_users_schema()).await.unwrap();
+    let v1 = db
+        .get_collection("Users")
+        .unwrap()
+        .unwrap()
+        .version_id()
+        .to_string();
+    let v2 = add_placeholder_version(&db, "placeholder").await;
+    db.set_migration(
+        LensConfig::new(
+            &v1,
+            &v2,
+            LensModule::from_bytes(b"\0asm\x01\0\0\0".to_vec()),
+        ),
+        None,
+    )
+    .await
+    .unwrap();
+
+    let doc_id = seed_old_user(&db, &v1, "Late").await;
+    assert_eq!(verified_index_count(&db).await, 0);
+
+    let fetcher = crate::LensedAutoCommitFetcher::new(db.clone());
+    let docs = fetcher
+        .get_by_ids("Users", &[doc_id.to_string()])
+        .await
+        .unwrap()
+        .into_docs();
+    assert_eq!(
+        docs[0].get("verified"),
+        Some(&document::NormalValue::Bool(true))
+    );
+    assert_eq!(
+        verified_index_count(&db).await,
+        1,
+        "lazy migration must atomically replace the document's index entries"
+    );
+}
+
+#[tokio::test]
+async fn implicit_query_flushes_lazy_migration_after_read_snapshot_closes() {
+    let transform_store = Arc::new(SetVerifiedStore::default());
+    let mut raw_db = DB::new(MemoryStore::new()).unwrap();
+    raw_db.lens_store = transform_store;
+    let db = Arc::new(raw_db);
+
+    db.create_collection(indexed_users_schema()).await.unwrap();
+    let v1 = db
+        .get_collection("Users")
+        .unwrap()
+        .unwrap()
+        .version_id()
+        .to_string();
+    let v2 = add_placeholder_version(&db, "placeholder").await;
+    db.set_migration(
+        LensConfig::new(
+            &v1,
+            &v2,
+            LensModule::from_bytes(b"\0asm\x01\0\0\0".to_vec()),
+        ),
+        None,
+    )
+    .await
+    .unwrap();
+    let doc_id = seed_old_user(&db, &v1, "Implicit").await;
+
+    let registry = Arc::new(crate::DbTransactionRegistry::new(db.clone()));
+
+    // A user-managed read-only transaction remains side-effect free.
+    let explicit = registry.begin(true).await.unwrap();
+    let explicit_ctx = match registry.get(&explicit) {
+        GetTransactionResult::Found(context) => context,
+        other => panic!("expected explicit transaction context, got {other:?}"),
+    };
+    let explicit_docs = explicit_ctx
+        .doc_fetcher()
+        .get_by_ids("Users", &[doc_id.to_string()])
+        .await
+        .unwrap()
+        .into_docs();
+    assert_eq!(
+        explicit_docs[0].get("verified"),
+        Some(&document::NormalValue::Bool(true))
+    );
+    registry.rollback(&explicit).await.unwrap();
+    assert_eq!(verified_index_count(&db).await, 0);
+
+    let fetcher = crate::LensedAutoCommitFetcher::new(db.clone());
+    let provider = crate::DbCollectionProvider::new_arc(db.clone());
+    let runner = query::QueryRunner::with_arc_registry_and_provider(fetcher, provider, registry);
+
+    let response = runner
+        .execute(QueryRequest::new(
+            "query { Users { name verified } }".to_string(),
+        ))
+        .await;
+    assert!(response.errors.is_empty(), "{:?}", response.errors);
+    assert_eq!(verified_index_count(&db).await, 1);
+
+    let indexed_response = runner
+        .execute(QueryRequest::new(
+            "query { Users(filter: {verified: {_eq: true}}) { name verified } }".to_string(),
+        ))
+        .await;
+    assert!(
+        indexed_response.errors.is_empty(),
+        "{:?}",
+        indexed_response.errors
+    );
+    assert_eq!(
+        indexed_response.data,
+        Some(serde_json::json!({
+            "Users": [{"name": "Implicit", "verified": true}]
+        }))
+    );
+}
+
+#[tokio::test]
+async fn field_value_fetch_filters_after_lens_transform() {
+    let transform_store = Arc::new(StepTransformStore::default());
+    let mut raw_db = DB::new(MemoryStore::new()).unwrap();
+    raw_db.lens_store = transform_store;
+    let db = Arc::new(raw_db);
+
+    db.create_collection(users_schema()).await.unwrap();
+    let v1 = db
+        .get_collection("Users")
+        .unwrap()
+        .unwrap()
+        .version_id()
+        .to_string();
+    let v2 = add_placeholder_version(&db, "latest").await;
+    db.set_migration(
+        LensConfig::new(
+            &v1,
+            &v2,
+            LensModule::from_bytes(b"\0asm\x01\0\0\0".to_vec()),
+        ),
+        None,
+    )
+    .await
+    .unwrap();
+    let doc_id = seed_old_user(&db, &v1, "Filter").await;
+
+    let docs = crate::LensedAutoCommitFetcher::new(db)
+        .get_by_field_value("Users", "latest", "set")
+        .await
+        .unwrap();
+
+    assert_eq!(docs.len(), 1);
+    assert_eq!(docs[0].id(), Some(&doc_id));
+}
+
+#[tokio::test]
+async fn concurrent_update_wins_over_stale_lazy_write_back() {
+    let transform_store = Arc::new(BlockingVerifiedStore::default());
+    let mut raw_db = DB::new(MemoryStore::new()).unwrap();
+    raw_db.lens_store = transform_store.clone();
+    let db = Arc::new(raw_db);
+
+    db.create_collection(indexed_users_schema()).await.unwrap();
+    let v1 = db
+        .get_collection("Users")
+        .unwrap()
+        .unwrap()
+        .version_id()
+        .to_string();
+    let v2 = add_placeholder_version(&db, "placeholder").await;
+    db.set_migration(
+        LensConfig::new(
+            &v1,
+            &v2,
+            LensModule::from_bytes(b"\0asm\x01\0\0\0".to_vec()),
+        ),
+        None,
+    )
+    .await
+    .unwrap();
+    let doc_id = seed_old_user(&db, &v1, "Alice").await;
+
+    transform_store.arm();
+    let query_db = db.clone();
+    let query_doc_id = doc_id.to_string();
+    let query = tokio::spawn(async move {
+        crate::LensedAutoCommitFetcher::new(query_db)
+            .get_by_ids("Users", &[query_doc_id])
+            .await
+    });
+
+    tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        transform_store.entered.notified(),
+    )
+    .await
+    .expect("lensed read reached the transform");
+
+    let mut update = document::Document::new();
+    update.set_id(doc_id.clone());
+    update.set("name", document::NormalValue::String("Bob".to_string()));
+    AutoCommitMutator::new(db.clone())
+        .update("Users", update, HashSet::from(["name".to_string()]))
+        .await
+        .unwrap();
+
+    transform_store.release.notify_one();
+    query.await.unwrap().unwrap();
+
+    let persisted = load_user(&db, &doc_id).await;
+    assert_eq!(
+        persisted.get("name"),
+        Some(&document::NormalValue::String("Bob".to_string())),
+        "lazy write-back must not overwrite a mutation committed after its read snapshot"
+    );
+    assert_eq!(
+        persisted.get("verified"),
+        Some(&document::NormalValue::Bool(true))
+    );
+    assert_eq!(persisted.schema_version_id(), Some(v2.as_str()));
 }

--- a/crates/db/src/migration/tests.rs
+++ b/crates/db/src/migration/tests.rs
@@ -1,0 +1,260 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, RwLock};
+
+use async_trait::async_trait;
+use futures::StreamExt;
+use lens::{
+    LensConfig, LensDocResultStream, LensDocStream, LensModule, TransformId, TransformStore,
+};
+use query::{DocFetcher, DocMutator};
+use schema::{CollectionVersion, FieldDescription, FieldKind};
+use storage::corekv::IterOptions;
+use storage::MemoryStore;
+
+use crate::{AutoCommitMutator, DB};
+
+#[derive(Default)]
+struct SetVerifiedStore {
+    transforms: RwLock<HashSet<TransformId>>,
+    transform_calls: AtomicUsize,
+}
+
+#[async_trait]
+impl TransformStore for SetVerifiedStore {
+    async fn add(&self, config: LensConfig) -> lens::Result<TransformId> {
+        let id = TransformId::new(format!("test-transform-{}", config.lenses.len()));
+        self.transforms.write().unwrap().insert(id.clone());
+        Ok(id)
+    }
+
+    async fn add_with_id(&self, id: TransformId, _config: LensConfig) -> lens::Result<()> {
+        self.transforms.write().unwrap().insert(id);
+        Ok(())
+    }
+
+    async fn list(&self) -> lens::Result<HashMap<String, LensModule>> {
+        Ok(HashMap::new())
+    }
+
+    fn transform(
+        &self,
+        id: &TransformId,
+        docs: LensDocStream,
+    ) -> lens::Result<LensDocResultStream> {
+        if !self.has_transform(id) {
+            return Err(lens::Error::TransformNotFound(id.to_string()));
+        }
+        self.transform_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(Box::pin(docs.map(|mut doc| {
+            doc.insert("verified".to_string(), serde_json::Value::Bool(true));
+            Ok(doc)
+        })))
+    }
+
+    fn inverse(&self, id: &TransformId, docs: LensDocStream) -> lens::Result<LensDocResultStream> {
+        self.transform(id, docs)
+    }
+
+    fn has_transform(&self, id: &TransformId) -> bool {
+        self.transforms.read().unwrap().contains(id)
+    }
+
+    async fn remove(&self, id: &TransformId) -> lens::Result<()> {
+        self.transforms.write().unwrap().remove(id);
+        Ok(())
+    }
+}
+
+fn users_schema() -> CollectionVersion {
+    let mut schema = CollectionVersion::new(
+        "Users",
+        "users-v1",
+        "users-collection",
+        vec![
+            FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+            FieldDescription::new("2", "name", FieldKind::string()),
+        ],
+    );
+    schema.is_materialized = true;
+    schema
+}
+
+async fn seed_user(db: &Arc<DB<MemoryStore>>) -> document::DocID {
+    let mut doc = document::Document::new();
+    doc.set("name", document::NormalValue::String("Alice".to_string()));
+    AutoCommitMutator::new(db.clone())
+        .create("Users", doc)
+        .await
+        .unwrap()
+        .doc_id
+}
+
+async fn add_verified_version(db: &Arc<DB<MemoryStore>>) -> String {
+    db.patch_collection(
+        "Users",
+        r#"[{"op":"add","path":"/Users/Fields/-","value":{"Name":"verified","Kind":"Boolean"}}]"#,
+        None,
+    )
+    .await
+    .unwrap()
+    .version_id
+}
+
+async fn load_user(db: &Arc<DB<MemoryStore>>, doc_id: &document::DocID) -> document::Document {
+    let collection = db.get_collection("Users").unwrap().unwrap();
+    let txn = db.new_txn(true).await.unwrap();
+    let doc = collection
+        .get_by_doc_id(
+            &txn.datastore().unwrap(),
+            &txn.systemstore().unwrap(),
+            doc_id,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    txn.discard().unwrap();
+    doc
+}
+
+async fn load_user_blob(db: &Arc<DB<MemoryStore>>, doc_id: &document::DocID) -> Vec<u8> {
+    let collection = db.get_collection("Users").unwrap().unwrap();
+    let txn = db.new_txn(true).await.unwrap();
+    let datastore = txn.datastore().unwrap();
+    let systemstore = txn.systemstore().unwrap();
+    let doc_short_id = collection
+        .resolve_doc_short_id(&systemstore, doc_id)
+        .await
+        .unwrap()
+        .unwrap();
+    let blob = datastore
+        .get(&collection.doc_key(doc_short_id))
+        .await
+        .unwrap()
+        .unwrap();
+    drop(datastore);
+    drop(systemstore);
+    txn.discard().unwrap();
+    blob
+}
+
+async fn namespace_counts(db: &Arc<DB<MemoryStore>>) -> (usize, usize, usize) {
+    async fn count(view: datastore::NamespaceView) -> usize {
+        let mut iter = view.iterator(IterOptions::new()).await.unwrap();
+        let mut count = 0;
+        while iter.next().await.unwrap().is_some() {
+            count += 1;
+        }
+        iter.close().await.unwrap();
+        count
+    }
+
+    let txn = db.new_txn(true).await.unwrap();
+    let counts = (
+        count(txn.blockstore().unwrap()).await,
+        count(txn.headstore().unwrap()).await,
+        count(txn.peerstore().unwrap()).await,
+    );
+    txn.discard().unwrap();
+    counts
+}
+
+#[tokio::test]
+async fn lazy_lensed_read_writes_back_without_new_commits() {
+    let store = Arc::new(MemoryStore::new());
+    let transform_store = Arc::new(SetVerifiedStore::default());
+    let mut raw_db = DB::from_arc(store.clone()).unwrap();
+    raw_db.lens_store = transform_store.clone();
+    let db = Arc::new(raw_db);
+
+    db.create_collection(users_schema()).await.unwrap();
+    let v1 = db
+        .get_collection("Users")
+        .unwrap()
+        .unwrap()
+        .version_id()
+        .to_string();
+    let doc_id = seed_user(&db).await;
+    let v2 = add_verified_version(&db).await;
+    let fetcher = crate::LensedAutoCommitFetcher::new(db.clone());
+    let before_migration = fetcher.get_all("Users").await.unwrap();
+    assert_eq!(before_migration[0].get("verified"), None);
+
+    db.set_migration(
+        LensConfig::new(
+            &v1,
+            &v2,
+            LensModule::from_bytes(b"\0asm\x01\0\0\0".to_vec()),
+        ),
+        None,
+    )
+    .await
+    .unwrap();
+
+    let before_counts = namespace_counts(&db).await;
+    let docs = fetcher.get_all("Users").await.unwrap();
+    assert_eq!(docs.len(), 1);
+    assert_eq!(
+        docs[0].get("verified"),
+        Some(&document::NormalValue::Bool(true))
+    );
+    assert_eq!(docs[0].schema_version_id(), Some(v2.as_str()));
+    assert_eq!(transform_store.transform_calls.load(Ordering::SeqCst), 1);
+
+    let persisted = load_user(&db, &doc_id).await;
+    assert_eq!(
+        persisted.get("verified"),
+        Some(&document::NormalValue::Bool(true))
+    );
+    assert_eq!(persisted.schema_version_id(), Some(v2.as_str()));
+    assert_eq!(namespace_counts(&db).await, before_counts);
+
+    fetcher.get_all("Users").await.unwrap();
+    assert_eq!(
+        transform_store.transform_calls.load(Ordering::SeqCst),
+        1,
+        "the cached version must bypass the lens on subsequent reads"
+    );
+
+    drop(fetcher);
+    drop(db);
+    let reopened = Arc::new(DB::open_from_arc(store).await.unwrap());
+    let persisted_after_restart = load_user(&reopened, &doc_id).await;
+    assert_eq!(
+        persisted_after_restart.get("verified"),
+        Some(&document::NormalValue::Bool(true))
+    );
+    assert_eq!(
+        persisted_after_restart.schema_version_id(),
+        Some(v2.as_str())
+    );
+}
+
+#[tokio::test]
+async fn eager_materialize_restamps_transformless_paths() {
+    let store = Arc::new(MemoryStore::new());
+    let db = Arc::new(DB::from_arc(store).unwrap());
+
+    db.create_collection(users_schema()).await.unwrap();
+    let doc_id = seed_user(&db).await;
+    let v2 = add_verified_version(&db).await;
+    assert_ne!(
+        load_user(&db, &doc_id).await.schema_version_id(),
+        Some(v2.as_str())
+    );
+
+    let before_counts = namespace_counts(&db).await;
+    let before_blob = load_user_blob(&db, &doc_id).await;
+    assert_eq!(db.materialize_collection("Users").await.unwrap(), 1);
+    assert_eq!(
+        load_user(&db, &doc_id).await.schema_version_id(),
+        Some(v2.as_str())
+    );
+    assert_eq!(
+        load_user_blob(&db, &doc_id).await,
+        before_blob,
+        "identity materialization must update only the version key"
+    );
+    assert_eq!(db.materialize_collection("Users").await.unwrap(), 0);
+    assert_eq!(namespace_counts(&db).await, before_counts);
+}

--- a/crates/db/src/txn_context.rs
+++ b/crates/db/src/txn_context.rs
@@ -4,6 +4,7 @@ use query::fetcher::CollectionProvider;
 use query::mutator::DocMutator;
 use query::runner::DocFetcher;
 use query::txn::{DeferredAcpMutations, TransactionContext};
+use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use storage::corekv::Store;
@@ -13,6 +14,7 @@ use crate::database::DB;
 use crate::doc_mutator::DbDocMutator;
 use crate::lensed_fetcher::LensedDocFetcher;
 use crate::txn::DbTxn;
+use crate::LensedAutoCommitFetcher;
 
 /// Transaction context for query execution.
 ///
@@ -104,6 +106,43 @@ impl<S: Store + 'static> DbTransactionContext<S> {
     pub async fn is_consumed(&self) -> bool {
         self.fetcher.is_consumed().await
     }
+
+    /// Persist lazy migrations collected by a successful implicit read.
+    ///
+    /// The caller must close the read snapshot first. Each collection is then
+    /// written through the same guarded, conflict-retrying path as direct
+    /// auto-commit reads.
+    pub(crate) async fn persist_pending_migrations(&self) -> query::error::Result<()> {
+        let mut by_collection = BTreeMap::new();
+        for pending in self.fetcher.take_pending_write_backs().await {
+            by_collection
+                .entry(pending.collection_name)
+                .or_insert_with(Vec::new)
+                .push(pending.write_back);
+        }
+
+        if by_collection.is_empty() {
+            return Ok(());
+        }
+
+        let fetcher = LensedAutoCommitFetcher::new(self.db.clone());
+        for (collection_name, write_backs) in by_collection {
+            let Some(collection) = self.db.get_collection(&collection_name).map_err(|error| {
+                query::error::QueryError::execution(format!(
+                    "failed to load collection for deferred lens write-back: {}",
+                    error
+                ))
+            })?
+            else {
+                continue;
+            };
+            fetcher
+                .persist_migrated_documents(&collection, write_backs)
+                .await?;
+        }
+
+        Ok(())
+    }
 }
 
 impl<S: Store + 'static> DbTransactionContext<S> {
@@ -134,6 +173,10 @@ impl<S: Store + 'static> DbTransactionContext<S> {
 
     pub(crate) fn lens_store(&self) -> Arc<dyn lens::TransformStore> {
         self.fetcher.lens_store()
+    }
+
+    pub(crate) async fn invalidate_migration_cache(&self) {
+        self.fetcher.invalidate_migration_cache().await;
     }
 
     pub(crate) fn action_lock(&self) -> Arc<async_lock::Mutex<()>> {

--- a/crates/db/src/txn_registry.rs
+++ b/crates/db/src/txn_registry.rs
@@ -451,6 +451,7 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
             .await?;
         let transform_id = outcome.transform_id.clone();
         let updated_destination = outcome.updated_destination.clone();
+        ctx.invalidate_migration_cache().await;
 
         let db = self.db.clone();
         let transform_id_for_commit = transform_id.clone();
@@ -462,6 +463,7 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
             let updated_destination = updated_destination.clone();
             let destination_version_id = destination_version_id.clone();
             Box::pin(async move {
+                db.bump_migration_generation();
                 if let Err(error) = db
                     .lens_store()
                     .add_with_id(transform_id.clone(), config)
@@ -921,14 +923,11 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
 
         Ok(())
     }
-}
 
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-impl<S: Store + 'static> TransactionRegistry for DbTransactionRegistry<S> {
-    async fn begin(
+    async fn begin_with_options(
         &self,
         readonly: bool,
+        defer_readonly_write_back: bool,
     ) -> std::result::Result<TransactionHandle, TransactionError> {
         let txn_id = self.id_counter.fetch_add(1, Ordering::SeqCst).to_string();
 
@@ -958,7 +957,6 @@ impl<S: Store + 'static> TransactionRegistry for DbTransactionRegistry<S> {
         // Transaction-scoped collection caching: collections are loaded lazily
         // from the SystemStore on first access within the transaction. Once loaded,
         // the collection metadata is cached for the transaction's duration.
-        // Use LensedDocFetcher to support lens migrations within transactions.
         let lens_store = Arc::new(TxnLensStore::new(self.db.lens_store().clone()).map_err(
             |e| {
                 TransactionError::execution(format!(
@@ -967,7 +965,12 @@ impl<S: Store + 'static> TransactionRegistry for DbTransactionRegistry<S> {
                 ))
             },
         )?);
-        let fetcher = Arc::new(LensedDocFetcher::new(db_txn, lens_store));
+        let fetcher = Arc::new(LensedDocFetcher::new(
+            self.db.clone(),
+            db_txn,
+            lens_store,
+            defer_readonly_write_back,
+        ));
         let ctx = Arc::new(DbTransactionContext::new_with_broadcaster(
             self.db.clone(),
             txn_id.clone(),
@@ -983,6 +986,23 @@ impl<S: Store + 'static> TransactionRegistry for DbTransactionRegistry<S> {
             .insert(txn_id.clone(), ctx);
 
         Ok(TransactionHandle::new(txn_id))
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<S: Store + 'static> TransactionRegistry for DbTransactionRegistry<S> {
+    async fn begin(
+        &self,
+        readonly: bool,
+    ) -> std::result::Result<TransactionHandle, TransactionError> {
+        self.begin_with_options(readonly, false).await
+    }
+
+    async fn begin_implicit_read(
+        &self,
+    ) -> std::result::Result<TransactionHandle, TransactionError> {
+        self.begin_with_options(true, true).await
     }
 
     fn get(&self, handle: &TransactionHandle) -> GetTransactionResult {
@@ -1068,6 +1088,52 @@ impl<S: Store + 'static> TransactionRegistry for DbTransactionRegistry<S> {
                 handle, e
             ))
         })
+    }
+
+    async fn finish_implicit_read(
+        &self,
+        handle: &TransactionHandle,
+        apply_read_effects: bool,
+    ) -> std::result::Result<(), TransactionError> {
+        let ctx = self
+            .transactions
+            .write()
+            .map_err(|_| {
+                TransactionError::lock_poisoned(format!(
+                    "failed to acquire write lock while finalizing implicit read '{}'",
+                    handle
+                ))
+            })?
+            .remove(handle.as_str())
+            .ok_or_else(|| {
+                TransactionError::not_found(format!("transaction '{}' not found", handle))
+            })?;
+        let action_lock = ctx.action_lock();
+        let _action_guard = action_lock.lock().await;
+
+        let txn = ctx.take_txn().await.ok_or_else(|| {
+            TransactionError::already_finalized(format!(
+                "transaction '{}' was already consumed",
+                handle
+            ))
+        })?;
+        txn.force_discard().map_err(|e| {
+            TransactionError::execution(format!(
+                "failed to close implicit read transaction '{}': {}",
+                handle, e
+            ))
+        })?;
+
+        if apply_read_effects {
+            ctx.persist_pending_migrations().await.map_err(|error| {
+                TransactionError::execution(format!(
+                    "deferred lens write-back failed for transaction '{}': {}",
+                    handle, error
+                ))
+            })?;
+        }
+
+        Ok(())
     }
 }
 

--- a/crates/defra-node/src/db_impls.rs
+++ b/crates/defra-node/src/db_impls.rs
@@ -176,6 +176,12 @@ impl<S: storage::corekv::Store + 'static> SchemaOps for DbSchemaOps<S> {
             .map_err(anyhow::Error::new)
     }
 
+    async fn materialize_collection(&self, collection_name: &str) -> anyhow::Result<usize> {
+        db::DB::materialize_collection(&self.database, collection_name)
+            .await
+            .map_err(anyhow::Error::new)
+    }
+
     fn list_collections(&self) -> anyhow::Result<Vec<String>> {
         db::DB::list_collections(&self.database).map_err(anyhow::Error::new)
     }

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -97,6 +97,7 @@ trait SchemaOps: Send + Sync {
     ) -> anyhow::Result<CollectionVersion>;
     async fn set_active_collection_version(&self, version_id: &str) -> anyhow::Result<()>;
     async fn set_migration(&self, config: LensConfig) -> anyhow::Result<TransformId>;
+    async fn materialize_collection(&self, collection_name: &str) -> anyhow::Result<usize>;
     fn list_collections(&self) -> anyhow::Result<Vec<String>>;
     fn get_collection(&self, name: &str) -> anyhow::Result<Option<CollectionVersion>>;
     async fn get_collection_by_version_id(
@@ -396,6 +397,15 @@ impl EmbeddedNode {
     /// yet materialized, allowing migrations to be registered ahead of patches.
     pub async fn set_migration(&self, config: LensConfig) -> anyhow::Result<TransformId> {
         self.as_node_identity(self.schema_ops.set_migration(config))
+            .await
+    }
+
+    /// Eagerly migrate and cache every known-version document in a collection.
+    ///
+    /// Returns the number of documents advanced to the active version. This is a
+    /// datastore-only operation and does not create or broadcast document commits.
+    pub async fn materialize_collection(&self, collection_name: &str) -> anyhow::Result<usize> {
+        self.as_node_identity(self.schema_ops.materialize_collection(collection_name))
             .await
     }
 

--- a/crates/defra-node/tests/issue_859_schema_migration.rs
+++ b/crates/defra-node/tests/issue_859_schema_migration.rs
@@ -218,6 +218,19 @@ async fn set_migration_registers_lens_between_versions() -> Result<()> {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn materialize_collection_is_exposed_on_embedded_node() -> Result<()> {
+    let node = EmbeddedNode::builder().build().await?;
+    node.add_schema(USER_SDL).await?;
+
+    let patch =
+        r#"[{"op":"add","path":"/User/Fields/-","value":{"Name":"email","Kind":"String"}}]"#;
+    node.patch_collection("User", patch).await?;
+
+    assert_eq!(node.materialize_collection("User").await?, 0);
+    Ok(())
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn introspection_supports_idempotent_schema_ensure() -> Result<()> {
     // Demonstrates the idempotent bootstrap pattern the issue calls out:
     // the application checks whether a collection exists before falling

--- a/crates/document/src/encoding.rs
+++ b/crates/document/src/encoding.rs
@@ -204,7 +204,7 @@ pub fn json_to_normal_value_for_array_kind(
             .iter()
             .map(|value| match value {
                 JsonValue::Bool(value) => Some(*value),
-                JsonValue::Null => Some(false),
+                JsonValue::Null => None,
                 _ => None,
             })
             .collect::<Option<Vec<_>>>()
@@ -222,7 +222,7 @@ pub fn json_to_normal_value_for_array_kind(
             .iter()
             .map(|value| match value {
                 JsonValue::Number(value) => value.as_i64(),
-                JsonValue::Null => Some(0),
+                JsonValue::Null => None,
                 _ => None,
             })
             .collect::<Option<Vec<_>>>()
@@ -240,7 +240,7 @@ pub fn json_to_normal_value_for_array_kind(
             .iter()
             .map(|value| match value {
                 JsonValue::Number(value) => value.as_f64(),
-                JsonValue::Null => Some(0.0),
+                JsonValue::Null => None,
                 _ => None,
             })
             .collect::<Option<Vec<_>>>()
@@ -258,7 +258,7 @@ pub fn json_to_normal_value_for_array_kind(
             .iter()
             .map(|value| match value {
                 JsonValue::Number(value) => value.as_f64().map(|value| value as f32),
-                JsonValue::Null => Some(0.0),
+                JsonValue::Null => None,
                 _ => None,
             })
             .collect::<Option<Vec<_>>>()
@@ -276,7 +276,7 @@ pub fn json_to_normal_value_for_array_kind(
             .iter()
             .map(|value| match value {
                 JsonValue::String(value) => Some(value.clone()),
-                JsonValue::Null => Some(String::new()),
+                JsonValue::Null => None,
                 _ => None,
             })
             .collect::<Option<Vec<_>>>()
@@ -430,7 +430,7 @@ pub fn canonical_cbor_key_order(a: &&str, b: &&str) -> std::cmp::Ordering {
 #[cfg(test)]
 mod json_to_normal_value_for_kind_tests {
     use super::*;
-    use schema::ScalarKind;
+    use schema::{ScalarArrayKind, ScalarKind};
     use serde_json::json;
 
     #[test]
@@ -473,6 +473,39 @@ mod json_to_normal_value_for_kind_tests {
         assert_eq!(
             json_to_normal_value_for_kind(&json!("hi"), &ScalarKind::String),
             Some(NormalValue::String("hi".to_string()))
+        );
+    }
+
+    #[test]
+    fn non_nillable_arrays_reject_null_elements() {
+        let cases = [
+            (json!([true, null]), ScalarArrayKind::BoolArray),
+            (json!([1, null]), ScalarArrayKind::IntArray),
+            (json!([1.5, null]), ScalarArrayKind::Float64Array),
+            (json!([1.5, null]), ScalarArrayKind::Float32Array),
+            (json!(["value", null]), ScalarArrayKind::StringArray),
+        ];
+
+        for (value, kind) in cases {
+            assert_eq!(
+                json_to_normal_value_for_array_kind(&value, &kind),
+                None,
+                "{kind:?} must not invent a default for a null element"
+            );
+        }
+    }
+
+    #[test]
+    fn nillable_array_preserves_null_elements() {
+        assert_eq!(
+            json_to_normal_value_for_array_kind(
+                &json!([true, null]),
+                &ScalarArrayKind::NillableBoolArray,
+            ),
+            Some(NormalValue::NillableBoolElementArray(vec![
+                Some(true),
+                None,
+            ]))
         );
     }
 

--- a/crates/document/src/encoding.rs
+++ b/crates/document/src/encoding.rs
@@ -185,6 +185,115 @@ pub fn json_to_normal_value_for_kind(
     }
 }
 
+/// Coerce a JSON array to a `NormalValue` according to its declared scalar-array kind.
+///
+/// This mirrors the mutation write path's array representation so materialized documents and
+/// rebuilt indexes do not fall back to `NormalValue::Json` and encode differently from fresh
+/// writes.
+pub fn json_to_normal_value_for_array_kind(
+    value: &serde_json::Value,
+    kind: &schema::ScalarArrayKind,
+) -> Option<NormalValue> {
+    use schema::ScalarArrayKind;
+    use serde_json::Value as JsonValue;
+
+    let values = value.as_array()?;
+
+    match kind {
+        ScalarArrayKind::BoolArray => values
+            .iter()
+            .map(|value| match value {
+                JsonValue::Bool(value) => Some(*value),
+                JsonValue::Null => Some(false),
+                _ => None,
+            })
+            .collect::<Option<Vec<_>>>()
+            .map(NormalValue::BoolArray),
+        ScalarArrayKind::NillableBoolArray => values
+            .iter()
+            .map(|value| match value {
+                JsonValue::Bool(value) => Some(Some(*value)),
+                JsonValue::Null => Some(None),
+                _ => None,
+            })
+            .collect::<Option<Vec<_>>>()
+            .map(NormalValue::NillableBoolElementArray),
+        ScalarArrayKind::IntArray => values
+            .iter()
+            .map(|value| match value {
+                JsonValue::Number(value) => value.as_i64(),
+                JsonValue::Null => Some(0),
+                _ => None,
+            })
+            .collect::<Option<Vec<_>>>()
+            .map(NormalValue::IntArray),
+        ScalarArrayKind::NillableIntArray => values
+            .iter()
+            .map(|value| match value {
+                JsonValue::Number(value) => value.as_i64().map(Some),
+                JsonValue::Null => Some(None),
+                _ => None,
+            })
+            .collect::<Option<Vec<_>>>()
+            .map(NormalValue::NillableIntElementArray),
+        ScalarArrayKind::Float64Array => values
+            .iter()
+            .map(|value| match value {
+                JsonValue::Number(value) => value.as_f64(),
+                JsonValue::Null => Some(0.0),
+                _ => None,
+            })
+            .collect::<Option<Vec<_>>>()
+            .map(NormalValue::Float64Array),
+        ScalarArrayKind::NillableFloat64Array => values
+            .iter()
+            .map(|value| match value {
+                JsonValue::Number(value) => value.as_f64().map(Some),
+                JsonValue::Null => Some(None),
+                _ => None,
+            })
+            .collect::<Option<Vec<_>>>()
+            .map(NormalValue::NillableFloat64ElementArray),
+        ScalarArrayKind::Float32Array => values
+            .iter()
+            .map(|value| match value {
+                JsonValue::Number(value) => value.as_f64().map(|value| value as f32),
+                JsonValue::Null => Some(0.0),
+                _ => None,
+            })
+            .collect::<Option<Vec<_>>>()
+            .map(NormalValue::Float32Array),
+        ScalarArrayKind::NillableFloat32Array => values
+            .iter()
+            .map(|value| match value {
+                JsonValue::Number(value) => value.as_f64().map(|value| Some(value as f32)),
+                JsonValue::Null => Some(None),
+                _ => None,
+            })
+            .collect::<Option<Vec<_>>>()
+            .map(NormalValue::NillableFloat32ElementArray),
+        ScalarArrayKind::StringArray => values
+            .iter()
+            .map(|value| match value {
+                JsonValue::String(value) => Some(value.clone()),
+                JsonValue::Null => Some(String::new()),
+                _ => None,
+            })
+            .collect::<Option<Vec<_>>>()
+            .map(NormalValue::StringArray),
+        ScalarArrayKind::NillableStringArray => values
+            .iter()
+            .map(|value| match value {
+                JsonValue::String(value) => Some(Some(value.clone())),
+                JsonValue::Null => Some(None),
+                _ => None,
+            })
+            .collect::<Option<Vec<_>>>()
+            .map(NormalValue::NillableStringElementArray),
+        _ => None,
+    }
+}
+
 /// Re-type a value read back from document storage against its declared scalar
 /// kind, repairing the schema-blind CBOR round-trip.
 ///

--- a/crates/embedded/src/node_tasks.rs
+++ b/crates/embedded/src/node_tasks.rs
@@ -7,18 +7,42 @@ use p2p::P2PTransport;
 use crate::node::EmbeddedMergeHandler;
 
 pub struct BackgroundTasks {
-    downsample_task: Option<tokio::task::JoinHandle<()>>,
+    downsample_task: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
 
 impl BackgroundTasks {
     pub(crate) fn new(downsample_task: Option<tokio::task::JoinHandle<()>>) -> Self {
-        Self { downsample_task }
+        Self {
+            downsample_task: std::sync::Mutex::new(downsample_task),
+        }
+    }
+
+    /// Stop and await all node-owned background tasks.
+    ///
+    /// Awaiting cancellation is important for persistent stores: an aborted
+    /// task can retain the final database handle until Tokio next polls it,
+    /// which otherwise leaves the on-disk database lock held after close.
+    pub async fn shutdown(&self) {
+        let task = self
+            .downsample_task
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
+        if let Some(task) = task {
+            task.abort();
+            let _ = task.await;
+        }
     }
 }
 
 impl Drop for BackgroundTasks {
     fn drop(&mut self) {
-        if let Some(task) = self.downsample_task.take() {
+        let task = self
+            .downsample_task
+            .get_mut()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
+        if let Some(task) = task {
             task.abort();
         }
     }

--- a/crates/ffi/Cargo.toml
+++ b/crates/ffi/Cargo.toml
@@ -39,6 +39,7 @@ serde_json.workspace = true
 serde_yaml = "0.9"
 serde_ipld_dagcbor.workspace = true
 serde_bytes.workspace = true
+base64.workspace = true
 
 # Memory zeroization for sensitive key material
 zeroize = "1"
@@ -89,6 +90,7 @@ cbindgen = "0.28"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tempfile = "3.17"
 
 [lints]
 workspace = true

--- a/crates/ffi/src/collection/migration.rs
+++ b/crates/ffi/src/collection/migration.rs
@@ -2,11 +2,55 @@ use std::ffi::c_char;
 
 use acp::nac::NodePermission;
 
+use crate::ffi_node_db_async_body;
 use crate::helpers::{get_node_database, get_rt, require_c_str};
 use crate::nac_check::check_nac_for_node;
 use crate::state::NODES;
 use crate::types::FfiResult;
 use crate::{ffi_async, ffi_entry, try_ffi, ERR_INVALID_NODE_HANDLE};
+
+/// Eagerly migrate and cache every known-version document in a collection.
+///
+/// This advances datastore values, stored document-version keys, and secondary
+/// indexes without creating or broadcasting document commits.
+///
+/// # Arguments
+///
+/// * `node_ptr` - Handle to the node
+/// * `identity_did` - Optional DID for permission checks (null for anonymous)
+/// * `collection_name` - Name of the collection to materialize
+///
+/// # Returns
+///
+/// - Status 0: Success (value contains the number of documents advanced)
+/// - Status 1: Error (error field contains message)
+///
+/// # Safety
+///
+/// `identity_did` and `collection_name` must be valid null-terminated UTF-8
+/// strings when non-null.
+#[no_mangle]
+pub unsafe extern "C" fn materialize_collection(
+    node_ptr: usize,
+    identity_did: *const c_char,
+    collection_name: *const c_char,
+) -> FfiResult {
+    ffi_node_db_async_body! {
+        node = node_ptr,
+        identity = identity_did,
+        database = database,
+        permission = NodePermission::CollectionPatch,
+        collection_name => collection_name_str: "collection_name";
+        {
+            let count = database
+                .materialize_collection(&collection_name_str)
+                .await
+                .map_err(|e| format!("failed to materialize collection: {}", e))?;
+
+            Ok(count.to_string())
+        }
+    }
+}
 
 /// Set migration for collection versions.
 ///

--- a/crates/ffi/src/collection/mod.rs
+++ b/crates/ffi/src/collection/mod.rs
@@ -13,7 +13,9 @@ mod read;
 mod view;
 mod write;
 
-pub use migration::{delete_collection_versions, set_migration, set_migration_in_txn};
+pub use migration::{
+    delete_collection_versions, materialize_collection, set_migration, set_migration_in_txn,
+};
 pub use purge::delete_documents;
 pub use read::{
     find_collection_by_id, get_collection_by_name, get_collection_by_version_id, has_collection,

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -244,8 +244,8 @@ pub use block::{block_verify_signature, block_verify_signature_in_txn};
 pub use collection::{
     add_view, delete_collection, delete_collection_versions, delete_documents,
     find_collection_by_id, gc_downsample_histories, get_collection_by_name,
-    get_collection_by_version_id, has_collection, patch_collection, refresh_views,
-    set_active_collection_version, set_migration, truncate_collection,
+    get_collection_by_version_id, has_collection, materialize_collection, patch_collection,
+    refresh_views, set_active_collection_version, set_migration, truncate_collection,
 };
 pub use document::{collection_create, is_json_array, parse_duration, parse_string_array};
 pub use encrypted_index::{

--- a/crates/ffi/src/node.rs
+++ b/crates/ffi/src/node.rs
@@ -307,6 +307,8 @@ pub extern "C" fn node_close(node_ptr: usize) -> FfiResult {
             None => return FfiResult::error(ERR_INVALID_NODE_HANDLE),
         };
 
+        rt.block_on(state.background_tasks.shutdown());
+
         if let Some(ref p2p) = state.p2p {
             rt.block_on(async { p2p.system.shutdown().await });
         }
@@ -323,6 +325,8 @@ pub extern "C" fn node_close(node_ptr: usize) -> FfiResult {
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::CString;
+
     use super::*;
 
     #[test]
@@ -365,5 +369,29 @@ mod tests {
 
         assert_eq!(node_close(result1.node_ptr).status, 0);
         assert_eq!(node_close(result2.node_ptr).status, 0);
+    }
+
+    #[cfg(feature = "lark")]
+    #[test]
+    fn test_persistent_node_can_reopen_after_close() {
+        assert!(crate::runtime::init_runtime());
+
+        let directory = tempfile::tempdir().unwrap();
+        let path = CString::new(directory.path().to_string_lossy().as_bytes()).unwrap();
+        let backend = CString::new("lark").unwrap();
+        let options = || NodeInitOptions {
+            db_path: path.as_ptr(),
+            in_memory: 0,
+            datastore_backend: backend.as_ptr(),
+            ..NodeInitOptions::default()
+        };
+
+        let first = new_node(options());
+        assert_eq!(first.status, 0);
+        assert_eq!(node_close(first.node_ptr).status, 0);
+
+        let second = new_node(options());
+        assert_eq!(second.status, 0);
+        assert_eq!(node_close(second.node_ptr).status, 0);
     }
 }

--- a/crates/ffi/src/subscription/create.rs
+++ b/crates/ffi/src/subscription/create.rs
@@ -1,5 +1,7 @@
 use std::ffi::c_char;
 
+use base64::Engine;
+
 use crate::ffi_entry;
 use crate::state::{SubscriptionState, NODES, SUBSCRIPTIONS};
 use crate::types::c_str_to_string;
@@ -98,6 +100,7 @@ pub(crate) fn message_to_json(message: &events::Message) -> String {
             "doc_id": update.doc_id,
             "cid": update.cid.to_string(),
             "collection_id": update.collection_id,
+            "block": base64::engine::general_purpose::STANDARD.encode(&update.block),
             "is_retry": update.is_retry,
             "is_relay": update.is_relay
         })

--- a/crates/ffi/src/subscription/create.rs
+++ b/crates/ffi/src/subscription/create.rs
@@ -92,6 +92,10 @@ pub extern "C" fn create_merge_complete_subscription(node_ptr: usize) -> CreateS
 }
 
 /// Convert an event message to JSON.
+///
+/// Update-event `block` bytes use standard padded base64. This is the encoding
+/// consumed by the Go rust-FFI bridge; it intentionally differs from the HTTP
+/// event surface's hex representation.
 pub(crate) fn message_to_json(message: &events::Message) -> String {
     // Check if this is an Update event with data
     if let Some(update) = message.as_update() {

--- a/crates/ffi/src/subscription/manage.rs
+++ b/crates/ffi/src/subscription/manage.rs
@@ -27,6 +27,7 @@ use super::{CloseSubscriptionResult, PollSubscriptionResult};
 ///     "type": "update",
 ///     "doc_id": "bae-...",
 ///     "collection_id": "...",
+///     "block": "<base64-encoded composite block>",
 ///     "is_relay": false
 /// }
 /// ```

--- a/crates/query-plan/src/txn/registry.rs
+++ b/crates/query-plan/src/txn/registry.rs
@@ -23,6 +23,16 @@ pub trait TransactionRegistry: MaybeSendSync {
         readonly: bool,
     ) -> std::result::Result<TransactionHandle, TransactionError>;
 
+    /// Begin the short-lived read-only transaction used for a standalone query.
+    ///
+    /// Registries that need to defer read side effects until the snapshot has
+    /// closed can override this separately from user-managed transactions.
+    async fn begin_implicit_read(
+        &self,
+    ) -> std::result::Result<TransactionHandle, TransactionError> {
+        self.begin(true).await
+    }
+
     /// Get an existing transaction by handle.
     ///
     /// Returns `Found(context)` if the transaction exists,
@@ -43,6 +53,18 @@ pub trait TransactionRegistry: MaybeSendSync {
         &self,
         handle: &TransactionHandle,
     ) -> std::result::Result<(), TransactionError>;
+
+    /// Close a standalone query's implicit read transaction.
+    ///
+    /// `apply_read_effects` is false when query execution failed. The default
+    /// implementation simply rolls the snapshot back.
+    async fn finish_implicit_read(
+        &self,
+        handle: &TransactionHandle,
+        _apply_read_effects: bool,
+    ) -> std::result::Result<(), TransactionError> {
+        self.rollback(handle).await
+    }
 }
 
 /// A no-op transaction registry that doesn't support transactions.

--- a/crates/query/src/runner/executor.rs
+++ b/crates/query/src/runner/executor.rs
@@ -130,10 +130,21 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
         };
 
         if matches!(&parsed, ParsedOperation::Query { .. }) {
-            match self.registry.begin(true).await {
+            match self.registry.begin_implicit_read().await {
                 Ok(handle) => {
                     let response = self.execute_in_txn(request.clone(), &handle).await;
-                    if let Err(error) = self.registry.rollback(&handle).await {
+                    let apply_read_effects = response.errors.is_empty();
+                    if let Err(error) = self
+                        .registry
+                        .finish_implicit_read(&handle, apply_read_effects)
+                        .await
+                    {
+                        if apply_read_effects {
+                            return QueryResponse::error(format!(
+                                "failed to finalize implicit read transaction: {}",
+                                error
+                            ));
+                        }
                         warn!(
                             txn_id = %handle,
                             error = %error,


### PR DESCRIPTION
## Summary

- persist lazily migrated documents and version keys without creating new commits
- rebuild migrated secondary indexes and preserve scalar-array representations
- add eager `materialize_collection` support through the DB, node, and C FFI layers
- pass documents with unknown/newer collection versions through unchanged on reads
- include update blocks in FFI subscriptions and await node background-task shutdown so persistent stores can immediately reopen

## Why

This completes the Rust parity work tracked by #1230 and #1231. Lazy migrations previously returned transformed values without fully writing the migrated datastore/index state back, while reads of versions outside the local collection history could fail instead of preserving replicated data from newer peers.

The FFI additions allow the Go `rust_ffi` harness to exercise eager materialization directly and run the existing Go migration suite against the Rust implementation.

## Compatibility note

Go's `updateDataStore` restamps the version key to the local target even when an unknown/newer document version is passed through unchanged. Rust intentionally preserves that foreign version marker so a document received from a newer peer is not mislabeled as the local version. Query results remain compatible with Go; the stored-marker difference is deliberate.

## Hardening included

- generation-keyed migration-context invalidation for positive and negative cache entries (#1233)
- conflict-safe, idempotent concurrent lazy write-back with guarded fresh re-reads (#1234)
- atomic secondary-index maintenance for late lazy migrations (#1235)
- read-only query snapshots with short, explicit write-back transactions only when documents were transformed

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p db -p document -p ffi --all-targets -- -D warnings`
- `cargo test -p db migration::tests -- --nocapture`
- `cargo test -p db unknown_document_version_passes_through -- --nocapture`
- `cargo test -p ffi -- --nocapture` (152 passed)
- focused concurrent dual-read regression: `concurrent_lazy_reads_of_same_document_are_idempotent`
- direct Go FFI eager-materialization test passes against current Go `develop` (`13c46ec9`, `v1.0.0-19`)
- 10 targeted existing Go migration tests pass through `ffi-test`, including migrated indexes, arrays, sparse and multi-step histories, restart, and both newer-version P2P pass-through cases

Closes #1230
Closes #1231
