### PR TITLE
Honor RocksDB options in embedded nodes

### DIFF
--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -512,6 +512,8 @@ pub struct NodeBuilder {
     data_path: Option<PathBuf>,
     storage_backend: StorageBackend,
     storage_durability: storage::backends::DurabilityMode,
+    #[cfg(feature = "rocksdb")]
+    rocksdb_options: Option<storage::RocksDbStoreOptions>,
     embedding_url: Option<String>,
     embedding_model: Option<String>,
     embedding_api_key: Option<String>,
@@ -588,6 +590,17 @@ impl NodeBuilder {
         durability: storage::backends::DurabilityMode,
     ) -> Self {
         self.storage_durability = durability;
+        self
+    }
+
+    /// Set options for the RocksDB persistent storage backend.
+    ///
+    /// When omitted, RocksDB options are loaded from the `ROCKS_*`
+    /// environment variables. [`NodeBuilder::with_storage_durability`] always
+    /// supplies the final durability mode.
+    #[cfg(feature = "rocksdb")]
+    pub fn with_rocksdb_options(mut self, options: storage::RocksDbStoreOptions) -> Self {
+        self.rocksdb_options = Some(options);
         self
     }
 
@@ -745,6 +758,9 @@ impl NodeBuilder {
         let query_timeout = self.query_timeout;
         let query_limits = self.query_limits;
         let node_acp_enabled = self.node_acp_enabled;
+        #[cfg(feature = "rocksdb")]
+        let rocksdb_options =
+            resolve_rocksdb_options(self.rocksdb_options, self.storage_durability);
 
         // Telemetry handle (if any) was moved into the builder via
         // `with_telemetry`. Threaded through `StoreBuildArgs` to the
@@ -836,11 +852,10 @@ impl NodeBuilder {
                     tracing::info!(
                         storage_backend = "rocksdb",
                         data_path = %path.display(),
+                        options = ?rocksdb_options,
                         "embedded node starting"
                     );
-                    let opts = storage::RocksDbStoreOptions::new()
-                        .with_durability(self.storage_durability);
-                    let store = storage::RocksDbStore::open_with_options(&path, opts)
+                    let store = storage::RocksDbStore::open_with_options(&path, rocksdb_options)
                         .map_err(|e| anyhow::anyhow!("failed to open rocksdb store: {}", e))?;
 
                     Self::build_with_persistent_store(
@@ -1186,6 +1201,16 @@ impl NodeBuilder {
     }
 }
 
+#[cfg(feature = "rocksdb")]
+fn resolve_rocksdb_options(
+    explicit: Option<storage::RocksDbStoreOptions>,
+    durability: storage::backends::DurabilityMode,
+) -> storage::RocksDbStoreOptions {
+    explicit
+        .unwrap_or_else(storage::RocksDbStoreOptions::from_env)
+        .with_durability(durability)
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -1204,6 +1229,9 @@ mod tests {
     use super::HttpConfig;
 
     static SIGNING_STORE_GUARD: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+    #[cfg(feature = "rocksdb")]
+    static ROCKS_ENV_GUARD: LazyLock<std::sync::Mutex<()>> =
+        LazyLock::new(|| std::sync::Mutex::new(()));
 
     #[cfg(feature = "http")]
     #[test]
@@ -1229,6 +1257,39 @@ mod tests {
         let builder = EmbeddedNode::builder().with_query_timeout(timeout);
 
         assert_eq!(builder.query_timeout, Some(timeout));
+    }
+
+    #[cfg(feature = "rocksdb")]
+    #[test]
+    fn node_builder_accepts_explicit_rocksdb_options() {
+        let options = storage::RocksDbStoreOptions::new().with_block_cache_size(8 * 1024 * 1024);
+        let builder = EmbeddedNode::builder().with_rocksdb_options(options);
+
+        assert_eq!(
+            builder
+                .rocksdb_options
+                .expect("explicit RocksDB options should be retained")
+                .block_cache_size(),
+            8 * 1024 * 1024
+        );
+    }
+
+    #[cfg(feature = "rocksdb")]
+    #[test]
+    fn embedded_rocksdb_options_load_environment_and_override_durability() {
+        use storage::backends::DurabilityMode;
+
+        let _guard = ROCKS_ENV_GUARD.lock().expect("environment guard poisoned");
+        let original = std::env::var_os("ROCKS_BLOCK_CACHE_MB");
+        std::env::set_var("ROCKS_BLOCK_CACHE_MB", "8192");
+        let options = super::resolve_rocksdb_options(None, DurabilityMode::Immediate);
+        match original {
+            Some(value) => std::env::set_var("ROCKS_BLOCK_CACHE_MB", value),
+            None => std::env::remove_var("ROCKS_BLOCK_CACHE_MB"),
+        }
+
+        assert_eq!(options.block_cache_size(), 8192 * 1024 * 1024);
+        assert_eq!(options.durability(), DurabilityMode::Immediate);
     }
 
     #[test]

--- a/crates/storage/src/backends/rocksdb/config.rs
+++ b/crates/storage/src/backends/rocksdb/config.rs
@@ -259,8 +259,8 @@ impl RocksDbStoreOptions {
     /// | `ROCKS_L0_STOP` | l0_stop_writes_trigger | 36 |
     /// | `ROCKS_TARGET_FILE_MB` | target_file_size_base | 64 |
     /// | `ROCKS_LEVEL_BASE_MB` | max_bytes_for_level_base | 256 |
-    /// | `ROCKS_BLOCK_SIZE_KB` | block_size | 4 |
-    /// | `ROCKS_COMPRESSION` | compression | snappy |
+    /// | `ROCKS_BLOCK_SIZE_KB` | block_size | 16 |
+    /// | `ROCKS_COMPRESSION` | compression | lz4 |
     /// | `ROCKS_COMPACTION_STYLE` | compaction_style | level |
     /// | `ROCKS_BLOB_FILES` | enable_blob_files | false |
     /// | `ROCKS_MIN_BLOB_SIZE` | min_blob_size | 256 |


### PR DESCRIPTION
## Summary

- add a `NodeBuilder::with_rocksdb_options` override for embedded RocksDB nodes
- load the existing `ROCKS_*` environment configuration when no explicit
  options are supplied
- preserve `with_storage_durability` as the final durability override
- log the effective RocksDB options at embedded-node startup
- correct the documented block-size and compression defaults

## Root cause

`RocksDbStoreOptions::from_env` already supports cache, write-buffer,
compaction, WAL, and parallelism controls. The CLI and FFI paths use it, but
`defra-node::NodeBuilder` constructed fresh default options and applied only
durability. Embedded services therefore silently ignored every existing
`ROCKS_*` tuning variable.

## Impact

Embedded deployments can tune RocksDB through the same environment variables
as other node entry points, or pass a fully constructed option set directly.
Existing deployments retain the same defaults when no variables or explicit
options are supplied.

## Validation

- `CARGO_INCREMENTAL=0 cargo test -p defra-node --features rocksdb --lib`
- `CARGO_INCREMENTAL=0 cargo clippy -p defra-node --features rocksdb --lib -- -D warnings`
- `cargo fmt --all`

Closes #1236.
