### PR TITLE
Expose RocksDB runtime statistics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3721,6 +3721,7 @@ dependencies = [
  "sourcehub",
  "storage",
  "telemetry",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/crates/defra-node/Cargo.toml
+++ b/crates/defra-node/Cargo.toml
@@ -63,6 +63,7 @@ telemetry = { path = "../telemetry", optional = true, default-features = false }
 axum.workspace = true
 crypto = { path = "../crypto" }
 hex.workspace = true
+tempfile = "3"
 
 [lints]
 workspace = true

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -108,6 +108,8 @@ pub struct EmbeddedNode {
     schema_ops: Arc<dyn SchemaOps>,
     embedding_config: db::EmbeddingClientConfig,
     node_identity_did: Option<String>,
+    #[cfg(feature = "rocksdb")]
+    rocksdb_stats: Option<storage::RocksDbStatsHandle>,
     #[cfg(feature = "http")]
     txn_cleanup_task: tokio::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
     #[cfg(feature = "p2p")]
@@ -303,6 +305,18 @@ impl EmbeddedNode {
     /// Access the resolved node-level embedding runtime config.
     pub fn embedding_config(&self) -> &db::EmbeddingClientConfig {
         &self.embedding_config
+    }
+
+    /// Capture RocksDB diagnostics when this node uses the RocksDB backend.
+    ///
+    /// Gauges are sampled at call time. Cumulative RocksDB counters are present
+    /// only when `ROCKS_STATISTICS=1` or explicit store options enable them.
+    #[cfg(feature = "rocksdb")]
+    pub fn rocksdb_stats(&self) -> storage::Result<Option<storage::RocksDbStatsSnapshot>> {
+        self.rocksdb_stats
+            .as_ref()
+            .map(storage::RocksDbStatsHandle::snapshot)
+            .transpose()
     }
 
     /// Access P2P operations (if P2P is enabled and configured).
@@ -857,13 +871,15 @@ impl NodeBuilder {
                     );
                     let store = storage::RocksDbStore::open_with_options(&path, rocksdb_options)
                         .map_err(|e| anyhow::anyhow!("failed to open rocksdb store: {}", e))?;
-
-                    Self::build_with_persistent_store(
+                    let stats = store.stats_handle();
+                    let mut node = Self::build_with_persistent_store(
                         store,
                         self.at_rest_encryption_key,
                         persistent_args,
                     )
-                    .await?
+                    .await?;
+                    node.rocksdb_stats = Some(stats);
+                    node
                 }
                 #[cfg(not(feature = "rocksdb"))]
                 StorageBackend::RocksDb => {
@@ -1189,6 +1205,8 @@ impl NodeBuilder {
             schema_ops,
             embedding_config,
             node_identity_did,
+            #[cfg(feature = "rocksdb")]
+            rocksdb_stats: None,
             #[cfg(feature = "http")]
             txn_cleanup_task: tokio::sync::Mutex::new(txn_cleanup_task),
             #[cfg(feature = "p2p")]
@@ -1281,15 +1299,49 @@ mod tests {
 
         let _guard = ROCKS_ENV_GUARD.lock().expect("environment guard poisoned");
         let original = std::env::var_os("ROCKS_BLOCK_CACHE_MB");
+        let original_statistics = std::env::var_os("ROCKS_STATISTICS");
         std::env::set_var("ROCKS_BLOCK_CACHE_MB", "8192");
+        std::env::set_var("ROCKS_STATISTICS", "true");
         let options = super::resolve_rocksdb_options(None, DurabilityMode::Immediate);
         match original {
             Some(value) => std::env::set_var("ROCKS_BLOCK_CACHE_MB", value),
             None => std::env::remove_var("ROCKS_BLOCK_CACHE_MB"),
         }
+        match original_statistics {
+            Some(value) => std::env::set_var("ROCKS_STATISTICS", value),
+            None => std::env::remove_var("ROCKS_STATISTICS"),
+        }
 
         assert_eq!(options.block_cache_size(), 8192 * 1024 * 1024);
+        assert!(options.statistics_enabled());
         assert_eq!(options.durability(), DurabilityMode::Immediate);
+    }
+
+    #[cfg(feature = "rocksdb")]
+    #[tokio::test]
+    async fn embedded_node_retains_rocksdb_stats_through_encryption_wrapper() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let node = EmbeddedNode::builder()
+            .data_path(temp_dir.path())
+            .with_storage_backend(super::StorageBackend::RocksDb)
+            .with_rocksdb_options(
+                storage::RocksDbStoreOptions::new()
+                    .with_block_cache_size(1024 * 1024)
+                    .with_statistics_enabled(true),
+            )
+            .with_at_rest_encryption_key([7; 32])
+            .build()
+            .await
+            .unwrap();
+
+        let stats = node
+            .rocksdb_stats()
+            .unwrap()
+            .expect("RocksDB node should expose a diagnostics snapshot");
+        assert_eq!(stats.block_cache.capacity_bytes, 1024 * 1024);
+        assert!(stats.counters.is_some());
+
+        node.shutdown().await;
     }
 
     #[test]

--- a/crates/storage/src/backends/mod.rs
+++ b/crates/storage/src/backends/mod.rs
@@ -91,7 +91,12 @@ pub use redb::{IntegrityReport, RedbStore, RedbStoreOptions};
 pub use fjall::{FjallStore, FjallStoreOptions};
 
 #[cfg(all(feature = "rocksdb", not(target_arch = "wasm32")))]
-pub use rocksdb::{RocksDbStore, RocksDbStoreOptions};
+pub use rocksdb::{
+    RocksDbBlockCacheCounters, RocksDbBlockCacheStats, RocksDbBloomFilterCounters,
+    RocksDbCompactionCounters, RocksDbCumulativeStats, RocksDbFlushCounters, RocksDbHistogramStats,
+    RocksDbIoCounters, RocksDbLsmStats, RocksDbStatsHandle, RocksDbStatsSnapshot, RocksDbStore,
+    RocksDbStoreOptions, RocksDbTransactionStats, RocksDbWriteStallCounters,
+};
 
 #[cfg(all(feature = "lark", not(target_arch = "wasm32")))]
 pub use lark::{LarkStore, LarkStoreOptions};

--- a/crates/storage/src/backends/rocksdb/config.rs
+++ b/crates/storage/src/backends/rocksdb/config.rs
@@ -70,6 +70,7 @@ pub struct RocksDbStoreOptions {
     compaction_style: CompactionStyle,
     enable_blob_files: bool,
     min_blob_size: u64,
+    statistics_enabled: bool,
     close_timeout: Duration,
     durability: DurabilityMode,
 }
@@ -91,6 +92,7 @@ impl Default for RocksDbStoreOptions {
             compaction_style: CompactionStyle::Level,
             enable_blob_files: false,
             min_blob_size: 256,
+            statistics_enabled: false,
             close_timeout: Duration::from_secs(DEFAULT_CLOSE_TIMEOUT_SECS),
             durability: DurabilityMode::Eventual,
         }
@@ -228,6 +230,18 @@ impl RocksDbStoreOptions {
         self.min_blob_size
     }
 
+    /// Enable cumulative RocksDB counters and histograms.
+    ///
+    /// Disabled by default because RocksDB updates these counters on hot paths.
+    pub fn with_statistics_enabled(mut self, enabled: bool) -> Self {
+        self.statistics_enabled = enabled;
+        self
+    }
+
+    pub fn statistics_enabled(&self) -> bool {
+        self.statistics_enabled
+    }
+
     pub fn with_close_timeout(mut self, timeout: Duration) -> Self {
         self.close_timeout = timeout;
         self
@@ -264,6 +278,7 @@ impl RocksDbStoreOptions {
     /// | `ROCKS_COMPACTION_STYLE` | compaction_style | level |
     /// | `ROCKS_BLOB_FILES` | enable_blob_files | false |
     /// | `ROCKS_MIN_BLOB_SIZE` | min_blob_size | 256 |
+    /// | `ROCKS_STATISTICS` | statistics_enabled | false |
     pub fn from_env() -> Self {
         let mut opts = Self::default();
 
@@ -318,6 +333,9 @@ impl RocksDbStoreOptions {
         }
         if let Some(v) = env_u64("ROCKS_MIN_BLOB_SIZE") {
             opts.min_blob_size = v;
+        }
+        if let Ok(v) = std::env::var("ROCKS_STATISTICS") {
+            opts.statistics_enabled = v == "1" || v.eq_ignore_ascii_case("true");
         }
 
         opts

--- a/crates/storage/src/backends/rocksdb/metrics.rs
+++ b/crates/storage/src/backends/rocksdb/metrics.rs
@@ -1,0 +1,332 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use rocksdb::statistics::{Histogram, Ticker};
+use serde::Serialize;
+
+use crate::corekv::{Error, Result};
+
+/// Point-in-time and process-lifetime diagnostics for a RocksDB store.
+///
+/// Cache and LSM fields are gauges sampled when [`RocksDbStatsHandle::snapshot`]
+/// is called. `counters` and `transactions` are cumulative from the time the
+/// current process opened the database; restarting the process resets them.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct RocksDbStatsSnapshot {
+    pub block_cache: RocksDbBlockCacheStats,
+    pub lsm: RocksDbLsmStats,
+    pub counters: Option<RocksDbCumulativeStats>,
+    pub transactions: RocksDbTransactionStats,
+}
+
+/// Current block-cache residency.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct RocksDbBlockCacheStats {
+    pub capacity_bytes: u64,
+    pub usage_bytes: u64,
+    pub pinned_usage_bytes: u64,
+}
+
+/// Current memtable, flush, compaction, and SST state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct RocksDbLsmStats {
+    pub l0_file_count: u64,
+    pub pending_compaction_bytes: u64,
+    pub compaction_pending: bool,
+    pub running_compactions: u64,
+    pub flush_pending: bool,
+    pub running_flushes: u64,
+    pub immutable_memtable_count: u64,
+    pub active_memtable_bytes: u64,
+    pub unflushed_memtable_bytes: u64,
+    pub total_memtable_bytes: u64,
+    pub table_reader_bytes: u64,
+    pub live_sst_bytes: u64,
+    pub delayed_write_rate_bytes_per_second: u64,
+    pub writes_stopped: bool,
+    pub background_errors: u64,
+}
+
+/// Cumulative RocksDB counters collected only when statistics are enabled.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct RocksDbCumulativeStats {
+    pub block_cache: RocksDbBlockCacheCounters,
+    pub bloom_filter: RocksDbBloomFilterCounters,
+    pub io: RocksDbIoCounters,
+    pub write_stalls: RocksDbWriteStallCounters,
+    pub flushes: RocksDbFlushCounters,
+    pub compactions: RocksDbCompactionCounters,
+}
+
+/// RocksDB exposes cache admissions but no exact general LRU-eviction ticker.
+/// Compare admissions and misses with the point-in-time usage gauges instead.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct RocksDbBlockCacheCounters {
+    pub hits: u64,
+    pub misses: u64,
+    pub data_hits: u64,
+    pub data_misses: u64,
+    pub index_hits: u64,
+    pub index_misses: u64,
+    pub filter_hits: u64,
+    pub filter_misses: u64,
+    pub admissions: u64,
+    pub admission_failures: u64,
+    pub bytes_read: u64,
+    pub bytes_written: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct RocksDbBloomFilterCounters {
+    pub useful: u64,
+    pub full_positive: u64,
+    pub full_true_positive: u64,
+    pub prefix_checked: u64,
+    pub prefix_useful: u64,
+    pub prefix_true_positive: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct RocksDbIoCounters {
+    pub keys_read: u64,
+    pub bytes_read: u64,
+    pub iterator_bytes_read: u64,
+    pub file_opens: u64,
+    pub file_errors: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct RocksDbWriteStallCounters {
+    pub total_micros: u64,
+    pub latency_micros: RocksDbHistogramStats,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct RocksDbFlushCounters {
+    pub bytes_written: u64,
+    pub latency_micros: RocksDbHistogramStats,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct RocksDbCompactionCounters {
+    pub bytes_read: u64,
+    pub bytes_written: u64,
+    pub cpu_micros: u64,
+    pub cancelled: u64,
+    pub latency_micros: RocksDbHistogramStats,
+}
+
+/// A cumulative RocksDB histogram summary.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct RocksDbHistogramStats {
+    pub count: u64,
+    pub sum: u64,
+    pub median: f64,
+    pub p95: f64,
+    pub p99: f64,
+    pub max: f64,
+}
+
+/// DefraDB transaction diagnostics not supplied by RocksDB itself.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct RocksDbTransactionStats {
+    pub conflicts: u64,
+    pub snapshot_gate_waits: u64,
+    pub snapshot_gate_wait_micros: u64,
+    pub snapshot_gate_wait_max_micros: u64,
+    pub commit_gate_waits: u64,
+    pub commit_gate_wait_micros: u64,
+    pub commit_gate_wait_max_micros: u64,
+}
+
+#[derive(Default)]
+pub(crate) struct RocksDbTransactionMetrics {
+    conflicts: AtomicU64,
+    snapshot_gate_waits: AtomicU64,
+    snapshot_gate_wait_micros: AtomicU64,
+    snapshot_gate_wait_max_micros: AtomicU64,
+    commit_gate_waits: AtomicU64,
+    commit_gate_wait_micros: AtomicU64,
+    commit_gate_wait_max_micros: AtomicU64,
+}
+
+impl RocksDbTransactionMetrics {
+    pub(crate) fn record_conflict(&self) {
+        self.conflicts.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_snapshot_gate_wait(&self, elapsed: Duration) {
+        record_wait(
+            elapsed,
+            &self.snapshot_gate_waits,
+            &self.snapshot_gate_wait_micros,
+            &self.snapshot_gate_wait_max_micros,
+        );
+    }
+
+    pub(crate) fn record_commit_gate_wait(&self, elapsed: Duration) {
+        record_wait(
+            elapsed,
+            &self.commit_gate_waits,
+            &self.commit_gate_wait_micros,
+            &self.commit_gate_wait_max_micros,
+        );
+    }
+
+    fn snapshot(&self) -> RocksDbTransactionStats {
+        RocksDbTransactionStats {
+            conflicts: self.conflicts.load(Ordering::Relaxed),
+            snapshot_gate_waits: self.snapshot_gate_waits.load(Ordering::Relaxed),
+            snapshot_gate_wait_micros: self.snapshot_gate_wait_micros.load(Ordering::Relaxed),
+            snapshot_gate_wait_max_micros: self
+                .snapshot_gate_wait_max_micros
+                .load(Ordering::Relaxed),
+            commit_gate_waits: self.commit_gate_waits.load(Ordering::Relaxed),
+            commit_gate_wait_micros: self.commit_gate_wait_micros.load(Ordering::Relaxed),
+            commit_gate_wait_max_micros: self.commit_gate_wait_max_micros.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// Cloneable access to a live RocksDB store's diagnostics.
+#[derive(Clone)]
+pub struct RocksDbStatsHandle {
+    db: Arc<rocksdb::OptimisticTransactionDB>,
+    cache: rocksdb::Cache,
+    statistics: Option<Arc<rocksdb::Options>>,
+    pub(crate) transactions: Arc<RocksDbTransactionMetrics>,
+}
+
+impl RocksDbStatsHandle {
+    pub(crate) fn new(
+        db: Arc<rocksdb::OptimisticTransactionDB>,
+        cache: rocksdb::Cache,
+        statistics: Option<Arc<rocksdb::Options>>,
+        transactions: Arc<RocksDbTransactionMetrics>,
+    ) -> Self {
+        Self {
+            db,
+            cache,
+            statistics,
+            transactions,
+        }
+    }
+
+    /// Capture current gauges and cumulative counters without reading user data.
+    pub fn snapshot(&self) -> Result<RocksDbStatsSnapshot> {
+        Ok(RocksDbStatsSnapshot {
+            block_cache: RocksDbBlockCacheStats {
+                capacity_bytes: self.property(rocksdb::properties::BLOCK_CACHE_CAPACITY)?,
+                usage_bytes: self.cache.get_usage() as u64,
+                pinned_usage_bytes: self.cache.get_pinned_usage() as u64,
+            },
+            lsm: RocksDbLsmStats {
+                l0_file_count: self.property(&rocksdb::properties::num_files_at_level(0))?,
+                pending_compaction_bytes: self
+                    .property(rocksdb::properties::ESTIMATE_PENDING_COMPACTION_BYTES)?,
+                compaction_pending: self.property(rocksdb::properties::COMPACTION_PENDING)? != 0,
+                running_compactions: self.property(rocksdb::properties::NUM_RUNNING_COMPACTIONS)?,
+                flush_pending: self.property(rocksdb::properties::MEM_TABLE_FLUSH_PENDING)? != 0,
+                running_flushes: self.property(rocksdb::properties::NUM_RUNNING_FLUSHES)?,
+                immutable_memtable_count: self
+                    .property(rocksdb::properties::NUM_IMMUTABLE_MEM_TABLE)?,
+                active_memtable_bytes: self
+                    .property(rocksdb::properties::CUR_SIZE_ACTIVE_MEM_TABLE)?,
+                unflushed_memtable_bytes: self
+                    .property(rocksdb::properties::CUR_SIZE_ALL_MEM_TABLES)?,
+                total_memtable_bytes: self.property(rocksdb::properties::SIZE_ALL_MEM_TABLES)?,
+                table_reader_bytes: self
+                    .property(rocksdb::properties::ESTIMATE_TABLE_READERS_MEM)?,
+                live_sst_bytes: self.property(rocksdb::properties::LIVE_SST_FILES_SIZE)?,
+                delayed_write_rate_bytes_per_second: self
+                    .property(rocksdb::properties::ACTUAL_DELAYED_WRITE_RATE)?,
+                writes_stopped: self.property(rocksdb::properties::IS_WRITE_STOPPED)? != 0,
+                background_errors: self.property(rocksdb::properties::BACKGROUND_ERRORS)?,
+            },
+            counters: self
+                .statistics
+                .as_ref()
+                .map(|statistics| RocksDbCumulativeStats {
+                    block_cache: RocksDbBlockCacheCounters {
+                        hits: ticker(statistics, Ticker::BlockCacheHit),
+                        misses: ticker(statistics, Ticker::BlockCacheMiss),
+                        data_hits: ticker(statistics, Ticker::BlockCacheDataHit),
+                        data_misses: ticker(statistics, Ticker::BlockCacheDataMiss),
+                        index_hits: ticker(statistics, Ticker::BlockCacheIndexHit),
+                        index_misses: ticker(statistics, Ticker::BlockCacheIndexMiss),
+                        filter_hits: ticker(statistics, Ticker::BlockCacheFilterHit),
+                        filter_misses: ticker(statistics, Ticker::BlockCacheFilterMiss),
+                        admissions: ticker(statistics, Ticker::BlockCacheAdd),
+                        admission_failures: ticker(statistics, Ticker::BlockCacheAddFailures),
+                        bytes_read: ticker(statistics, Ticker::BlockCacheBytesRead),
+                        bytes_written: ticker(statistics, Ticker::BlockCacheBytesWrite),
+                    },
+                    bloom_filter: RocksDbBloomFilterCounters {
+                        useful: ticker(statistics, Ticker::BloomFilterUseful),
+                        full_positive: ticker(statistics, Ticker::BloomFilterFullPositive),
+                        full_true_positive: ticker(statistics, Ticker::BloomFilterFullTruePositive),
+                        prefix_checked: ticker(statistics, Ticker::BloomFilterPrefixChecked),
+                        prefix_useful: ticker(statistics, Ticker::BloomFilterPrefixUseful),
+                        prefix_true_positive: ticker(
+                            statistics,
+                            Ticker::BloomFilterPrefixTruePositive,
+                        ),
+                    },
+                    io: RocksDbIoCounters {
+                        keys_read: ticker(statistics, Ticker::NumberKeysRead),
+                        bytes_read: ticker(statistics, Ticker::BytesRead),
+                        iterator_bytes_read: ticker(statistics, Ticker::IterBytesRead),
+                        file_opens: ticker(statistics, Ticker::NoFileOpens),
+                        file_errors: ticker(statistics, Ticker::NoFileErrors),
+                    },
+                    write_stalls: RocksDbWriteStallCounters {
+                        total_micros: ticker(statistics, Ticker::StallMicros),
+                        latency_micros: histogram(statistics, Histogram::WriteStall),
+                    },
+                    flushes: RocksDbFlushCounters {
+                        bytes_written: ticker(statistics, Ticker::FlushWriteBytes),
+                        latency_micros: histogram(statistics, Histogram::FlushTime),
+                    },
+                    compactions: RocksDbCompactionCounters {
+                        bytes_read: ticker(statistics, Ticker::CompactReadBytes),
+                        bytes_written: ticker(statistics, Ticker::CompactWriteBytes),
+                        cpu_micros: ticker(statistics, Ticker::CompactionCpuTotalTime),
+                        cancelled: ticker(statistics, Ticker::CompactionCancelled),
+                        latency_micros: histogram(statistics, Histogram::CompactionTime),
+                    },
+                }),
+            transactions: self.transactions.snapshot(),
+        })
+    }
+
+    fn property(&self, name: &rocksdb::properties::PropName) -> Result<u64> {
+        self.db
+            .property_int_value(name)
+            .map_err(Error::from)?
+            .ok_or_else(|| Error::Backend(format!("RocksDB property unavailable: {name}")))
+    }
+}
+
+fn ticker(statistics: &rocksdb::Options, ticker: Ticker) -> u64 {
+    statistics.get_ticker_count(ticker)
+}
+
+fn histogram(statistics: &rocksdb::Options, histogram: Histogram) -> RocksDbHistogramStats {
+    let data = statistics.get_histogram_data(histogram);
+    RocksDbHistogramStats {
+        count: data.count(),
+        sum: data.sum(),
+        median: data.median(),
+        p95: data.p95(),
+        p99: data.p99(),
+        max: data.max(),
+    }
+}
+
+fn record_wait(elapsed: Duration, count: &AtomicU64, total: &AtomicU64, max: &AtomicU64) {
+    let micros = elapsed.as_micros().min(u128::from(u64::MAX)) as u64;
+    count.fetch_add(1, Ordering::Relaxed);
+    total.fetch_add(micros, Ordering::Relaxed);
+    max.fetch_max(micros, Ordering::Relaxed);
+}

--- a/crates/storage/src/backends/rocksdb/mod.rs
+++ b/crates/storage/src/backends/rocksdb/mod.rs
@@ -1,6 +1,7 @@
 pub mod config;
 mod errors;
 mod iterator;
+mod metrics;
 mod store;
 mod transaction;
 
@@ -8,4 +9,10 @@ mod transaction;
 mod tests;
 
 pub use config::RocksDbStoreOptions;
+pub use metrics::{
+    RocksDbBlockCacheCounters, RocksDbBlockCacheStats, RocksDbBloomFilterCounters,
+    RocksDbCompactionCounters, RocksDbCumulativeStats, RocksDbFlushCounters, RocksDbHistogramStats,
+    RocksDbIoCounters, RocksDbLsmStats, RocksDbStatsHandle, RocksDbStatsSnapshot,
+    RocksDbTransactionStats, RocksDbWriteStallCounters,
+};
 pub use store::RocksDbStore;

--- a/crates/storage/src/backends/rocksdb/store.rs
+++ b/crates/storage/src/backends/rocksdb/store.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use super::config::RocksDbStoreOptions;
+use super::metrics::{RocksDbStatsHandle, RocksDbStatsSnapshot, RocksDbTransactionMetrics};
 use super::transaction::RocksDbTxn;
 use crate::backends::shared::ConflictTracker;
 use crate::corekv::{Dropable, Error, Result, Store, Txn};
@@ -21,6 +22,7 @@ pub struct RocksDbStore {
     active_txn_count: Arc<AtomicUsize>,
     close_timeout: std::time::Duration,
     durability: crate::backends::shared::DurabilityMode,
+    stats: RocksDbStatsHandle,
 }
 
 impl RocksDbStore {
@@ -59,6 +61,11 @@ impl RocksDbStore {
         db_opts.set_level_zero_stop_writes_trigger(opts.l0_stop_writes_trigger());
         db_opts.set_target_file_size_base(opts.target_file_size_base());
         db_opts.set_max_bytes_for_level_base(opts.max_bytes_for_level_base());
+        if opts.statistics_enabled() {
+            db_opts.enable_statistics();
+            db_opts.set_statistics_level(rocksdb::statistics::StatsLevel::ExceptDetailedTimers);
+            db_opts.set_stats_dump_period_sec(0);
+        }
 
         use super::config::{CompactionStyle, CompressionType};
         let rocksdb_compression = match opts.compression() {
@@ -120,9 +127,18 @@ impl RocksDbStore {
                 let err: Error = e.into();
                 err
             })?;
+        let db = Arc::new(db);
+        let statistics = opts.statistics_enabled().then(|| Arc::new(db_opts));
+        let transaction_metrics = Arc::new(RocksDbTransactionMetrics::default());
+        let stats = RocksDbStatsHandle::new(
+            Arc::clone(&db),
+            cache,
+            statistics,
+            Arc::clone(&transaction_metrics),
+        );
 
         Ok(Self {
-            db: Arc::new(db),
+            db,
             closed: AtomicBool::new(false),
             conflict_tracker: Arc::new(ConflictTracker::new()),
             commit_gate: Arc::new(tokio::sync::RwLock::new(())),
@@ -130,12 +146,23 @@ impl RocksDbStore {
             active_txn_count: Arc::new(AtomicUsize::new(0)),
             close_timeout: opts.close_timeout(),
             durability: opts.durability(),
+            stats,
         })
     }
 
     /// Get the database file path.
     pub fn db_path(&self) -> &std::path::Path {
         &self.db_path
+    }
+
+    /// Return a cloneable diagnostics handle that remains valid for this store's lifetime.
+    pub fn stats_handle(&self) -> RocksDbStatsHandle {
+        self.stats.clone()
+    }
+
+    /// Capture current RocksDB gauges and process-lifetime counters.
+    pub fn stats(&self) -> Result<RocksDbStatsSnapshot> {
+        self.stats.snapshot()
     }
 
     fn is_closed(&self) -> bool {
@@ -178,7 +205,12 @@ impl Store for RocksDbStore {
         let _commit_guard = if readonly {
             None
         } else {
-            Some(self.commit_gate.read().await)
+            let started = std::time::Instant::now();
+            let guard = self.commit_gate.read().await;
+            self.stats
+                .transactions
+                .record_snapshot_gate_wait(started.elapsed());
+            Some(guard)
         };
         let txn = RocksDbTxn::new(
             Arc::clone(&self.db),
@@ -187,6 +219,7 @@ impl Store for RocksDbStore {
             Arc::clone(&self.active_txn_count),
             readonly,
             self.durability,
+            Arc::clone(&self.stats.transactions),
         );
 
         // The transaction now owns the active-count decrement through Drop.
@@ -507,5 +540,75 @@ mod tests {
         }
         drop(commit_guard);
         assert_eq!(store.active_txn_count.load(Ordering::Acquire), 0);
+    }
+
+    #[tokio::test]
+    async fn stats_keep_expensive_rocksdb_counters_opt_in() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let store = RocksDbStore::open_with_options(
+            temp_dir.path(),
+            RocksDbStoreOptions::new().with_block_cache_size(1024 * 1024),
+        )
+        .unwrap();
+
+        let stats = store.stats().unwrap();
+        assert_eq!(stats.block_cache.capacity_bytes, 1024 * 1024);
+        assert!(stats.counters.is_none());
+        assert_eq!(stats.transactions.conflicts, 0);
+    }
+
+    #[tokio::test]
+    async fn stats_report_live_cache_and_cumulative_reads() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let store = RocksDbStore::open_with_options(
+            temp_dir.path(),
+            RocksDbStoreOptions::new()
+                .with_block_cache_size(1024 * 1024)
+                .with_statistics_enabled(true),
+        )
+        .unwrap();
+
+        store.db.put(b"stats-key", b"stats-value").unwrap();
+        store.db.flush().unwrap();
+        assert_eq!(
+            store.db.get(b"stats-key").unwrap(),
+            Some(b"stats-value".to_vec())
+        );
+        assert_eq!(
+            store.db.get(b"stats-key").unwrap(),
+            Some(b"stats-value".to_vec())
+        );
+
+        let stats = store.stats_handle().snapshot().unwrap();
+        let counters = stats
+            .counters
+            .as_ref()
+            .expect("explicitly enabled counters should be present");
+        assert!(counters.io.keys_read >= 2);
+        assert!(counters.block_cache.hits + counters.block_cache.misses >= 1);
+        assert!(stats.block_cache.usage_bytes <= stats.block_cache.capacity_bytes);
+        serde_json::to_value(stats).expect("diagnostics snapshot should serialize as JSON");
+    }
+
+    #[tokio::test]
+    async fn stats_count_gate_waits_and_transaction_conflicts() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let store = RocksDbStore::open(temp_dir.path()).unwrap();
+        let key = b"stats-conflict-key";
+
+        let mut stale = store.new_txn(false).await.unwrap();
+        stale.get(key).await.unwrap();
+        stale.set(key, b"stale").await.unwrap();
+
+        let mut winner = store.new_txn(false).await.unwrap();
+        winner.set(key, b"winner").await.unwrap();
+        winner.commit().await.unwrap();
+
+        assert!(matches!(stale.commit().await, Err(Error::TxnConflict)));
+
+        let stats = store.stats().unwrap().transactions;
+        assert_eq!(stats.conflicts, 1);
+        assert_eq!(stats.snapshot_gate_waits, 2);
+        assert_eq!(stats.commit_gate_waits, 2);
     }
 }

--- a/crates/storage/src/backends/rocksdb/transaction.rs
+++ b/crates/storage/src/backends/rocksdb/transaction.rs
@@ -6,6 +6,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use super::iterator::RocksDbMergingIterator;
+use super::metrics::RocksDbTransactionMetrics;
 use crate::backends::shared::DurabilityMode;
 use crate::backends::shared::{
     CallbackCounts, CallbackManager, ConflictSnapshot, ConflictTracker, ReadSet,
@@ -79,6 +80,7 @@ pub(crate) struct RocksDbTxn {
     pub(crate) committed: AtomicBool,
     pub(crate) callbacks: CallbackManager,
     pub(crate) durability: DurabilityMode,
+    pub(crate) metrics: Arc<RocksDbTransactionMetrics>,
 }
 
 impl Drop for RocksDbTxn {
@@ -118,6 +120,7 @@ impl RocksDbTxn {
         active_txn_count: Arc<AtomicUsize>,
         readonly: bool,
         durability: DurabilityMode,
+        metrics: Arc<RocksDbTransactionMetrics>,
     ) -> Self {
         let conflict_snapshot = (!readonly).then(|| conflict_tracker.begin_snapshot());
         let read_version = conflict_snapshot.as_ref().map_or_else(
@@ -141,6 +144,7 @@ impl RocksDbTxn {
             committed: AtomicBool::new(false),
             callbacks: CallbackManager::new(),
             durability,
+            metrics,
         }
     }
 
@@ -413,6 +417,7 @@ impl Txn for RocksDbTxn {
             let commit_gate = Arc::clone(&self.commit_gate);
             let read_version = self.read_version;
             let durability = self.durability;
+            let metrics = Arc::clone(&self.metrics);
             let conflict_snapshot = self._conflict_snapshot.take();
             let callbacks = crate::backends::shared::CommitCallbacks::drain(&self.callbacks);
 
@@ -424,7 +429,9 @@ impl Txn for RocksDbTxn {
                     // deadlock against this thread's write lock, and holding it
                     // across callback work would stall every new writer.
                     let outcome = {
+                        let wait_started = std::time::Instant::now();
                         let _commit_guard = commit_gate.blocking_write();
+                        metrics.record_commit_gate_wait(wait_started.elapsed());
                         (|| -> Result<()> {
                             let version = conflict_tracker.check_and_record(
                                 read_version,
@@ -461,6 +468,9 @@ impl Txn for RocksDbTxn {
                             Ok(())
                         })()
                     };
+                    if matches!(outcome, Err(Error::TxnConflict)) {
+                        metrics.record_conflict();
+                    }
                     let callbacks = callbacks.spawn(outcome.is_ok());
                     (outcome, callbacks)
                 },

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -120,7 +120,12 @@ pub use backends::{RedbStore, RedbStoreOptions};
 pub use backends::{FjallStore, FjallStoreOptions};
 
 #[cfg(all(feature = "rocksdb", not(target_arch = "wasm32")))]
-pub use backends::{RocksDbStore, RocksDbStoreOptions};
+pub use backends::{
+    RocksDbBlockCacheCounters, RocksDbBlockCacheStats, RocksDbBloomFilterCounters,
+    RocksDbCompactionCounters, RocksDbCumulativeStats, RocksDbFlushCounters, RocksDbHistogramStats,
+    RocksDbIoCounters, RocksDbLsmStats, RocksDbStatsHandle, RocksDbStatsSnapshot, RocksDbStore,
+    RocksDbStoreOptions, RocksDbTransactionStats, RocksDbWriteStallCounters,
+};
 
 #[cfg(all(feature = "lark", not(target_arch = "wasm32")))]
 pub use backends::{LarkStore, LarkStoreOptions};


### PR DESCRIPTION
## Summary

- expose typed RocksDB cache, LSM, I/O, stall, flush, compaction, and transaction snapshots
- keep detailed RocksDB statistics opt-in with `ROCKS_STATISTICS=1`
- retain always-on local transaction conflict and commit/snapshot gate-wait counters
- make the diagnostics handle available from embedded nodes, including through the encryption wrapper

## Semantics and overhead

Gauges are point-in-time values. Counters and histograms are cumulative for the lifetime of the process and reset when the process restarts. Detailed RocksDB statistics are disabled by default because RocksDB documents a measurable statistics overhead; the local transaction diagnostics remain enabled.

RocksDB does not expose an exact general LRU-eviction ticker. The snapshot therefore reports cache capacity, usage, pinned usage, hits, misses, admissions, and admission failures rather than presenting an inferred value as an eviction count.

## Validation

- `cargo test -p storage --features rocksdb`
- `cargo test -p defra-node --no-default-features --features rocksdb`
- `cargo clippy -p storage --features rocksdb --all-targets -- -D warnings`
- `cargo clippy -p defra-node --no-default-features --features rocksdb --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

Closes #1237
