### PR TITLE
chore(storage): scope futures to native tests

### DIFF
--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -17,7 +17,6 @@ chrono = { version = "0.4", features = ["serde"] }
 
 # Async runtime
 async-trait.workspace = true
-futures.workspace = true
 
 # Storage backends
 redb = { workspace = true, optional = true }
@@ -75,6 +74,9 @@ js-sys = { version = "0.3", optional = true }
 # Tokio is only available on non-WASM targets
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio.workspace = true
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+futures.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true


### PR DESCRIPTION
## Summary

Move Storage's direct `futures` dependency from unconditional normal
dependencies to native-only development dependencies:

```toml
[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
futures.workspace = true
```

The only direct `futures` use is `FutureExt::catch_unwind` in Storage's
native-only backend test suite. Production code, public callback types, and
WASM code do not use that crate edge.

Exact reviewed candidate: `ac2d6b71444204ea12c109e63afbb4c4e07f0e21`
over merged `main` at
`69bd4266089b4604bd598351861be1a6ec7d3330`.

This is a one-file dependency-ownership correction. It changes no source,
Cargo feature name, public API, runtime behavior, wire format, storage format,
serialization, error, logging, retry, or timeout behavior.

## Hidden-use and target proof

The only external `futures::` crate path under `crates/storage` is:

```text
crates/storage/src/backends/test_suite/callbacks.rs:2:use futures::FutureExt;
```

It supplies the existing sync/async callback panic-propagation assertions.
The entire owning module is compiled only under:

```rust
#[cfg(all(test, not(target_arch = "wasm32")))]
pub mod test_suite;
```

The backend-test macros run those assertions for memory, Redb, Fjall,
RocksDB, and Lark. The candidate retains `futures` for exactly that native
development boundary.

Direct target/source/API inspection also confirms:

- public callback and future types use `std::future::Future`;
- browser code uses the distinct `wasm-bindgen-futures` dependency;
- Storage has one library, seven integration-test targets, and a Criterion
  `transaction` benchmark requiring the retained `redb` feature;
- Storage has no example or `build.rs`;
- no public signature/reexport, macro, generated include, linker directive,
  registration side effect, doctest, integration test, or benchmark hides a
  production use of the direct `futures` edge.

Fresh Cargo metadata reports the exact transition:

| Tree | Dependency kind | Target |
|---|---|---|
| Base | normal | all targets |
| Candidate | dev | `cfg(not(target_arch = "wasm32"))` |

## Exact resolved-graph effect

All rows use Cargo 1.95 with locked/offline resolution. There are zero added
packages or feature edges in every modeled configuration.

| Storage configuration | Production packages | Activated feature edges | Dev packages |
|---|---:|---:|---:|
| Native default / no-default | 177 → 167 | 447 → 414 | 219 → 219 |
| Native all features | 237 → 227 | 573 → 540 | 268 → 268 |
| Native `redb` | 178 → 168 | 448 → 415 | 220 → 220 |
| Native `fjall` | 205 → 195 | 502 → 469 | 241 → 241 |
| Native `rocksdb` | 200 → 190 | 511 → 478 | 236 → 236 |
| Native `lark` | 192 → 182 | 473 → 440 | 230 → 230 |
| WASM default / no-default / `wasm` | 167 → 157 | 418 → 385 | 210 → 200 |
| WASM `leveldb` / `leveldb,wasm` | 172 → 166 | 424 → 399 | 215 → 209 |
| WASM all features | 230 → 224 | 548 → 523 | 263 → 257 |
| Cargo all-target, default | 226 → 216 | 516 → 483 | 280 → 280 |
| Cargo all-target, all features | 288 → 282 | 653 → 628 | 328 → 328 |

Normal-edge-only default resolution is native `170 → 160` and WASM
`162 → 152`. Native default/all/named-feature development package and feature
inventories are byte-identical, proving the test capability is retained.

WASM LevelDB/all-feature resolution keeps the Futures components needed
transitively by `rusty-leveldb`, which explains its smaller six-package,
25-feature-edge reduction.

## Compounding consumers and shipped roots

All 20 normal direct Storage consumers were modeled on native default
features. Three lower-level consumers inherit the full reduction:

| Consumer | Packages | Activated feature edges |
|---|---:|---:|
| `blockstore` | 197 → 187 | 473 → 440 |
| `crdt` | 178 → 168 | 448 → 415 |
| `query-types` | 178 → 168 | 448 → 415 |

The other 17 consumer graphs retain Futures through another path and are
unchanged. Sealed post-KMS A/B consumer metadata confirms identical normalized
closures for the shipped CLI, Defra Node, Embedded, FFI, and browser-WASM
roots. That comparison transfers to the post-Crypto tip because the root and
Storage inputs are object-identical across the Crypto merge and all 32
representative post-Crypto Storage inventories are byte-identical to the
reviewed post-KMS rows.

`defra-wasm` is exactly invariant in every modeled feature mode:

```text
default       301 → 301 packages, 693 → 693 feature edges
no-default    301 → 301 packages, 693 → 693 feature edges
all-features  301 → 301 packages, 693 → 693 feature edges
```

## Lockfile and transfer integrity

`Cargo.lock` is byte-identical before and after, with SHA-256:

```text
8c97c6373c05d404d2fad93ac4dd287678bc68f2b7e617f124c3900e615ad093
```

There is no lockfile diff: no package, version, source, checksum, or
dependency-array change.

The one-file patch has remained exact across recent merged runtime work:

- raw patch SHA-256:
  `9416f61bc8d5a76c225732f67094d4011ee58f1553867e53076d3024960ca66a`;
- stable patch ID:
  `dba4d4099b681c79b51cb5176c51db388c8f3e80`;
- current diff: one file, three insertions, one deletion;
- current branch: one clean commit directly on its base.

## Validation

The complete current-main matrix used isolated Studio Two worktrees/targets,
Rust/Cargo 1.95, explicit Protobuf 35.1, locked/offline Cargo,
`RUSTC_WRAPPER=` with no sccache, low scheduling priority, and aggregate
compiler accounting. Audit process trees were suspended while normal-priority
CI saturated the shared host.

Native candidate validation passed:

- Storage default, no-default, all-feature, and all-target/all-feature checks;
- individual Redb, Fjall, RocksDB, and Lark checks;
- default, Redb, Lark, serialized RocksDB, serialized Fjall, and serialized
  all-feature tests;
- sync and async callback panic-propagation filters for all five native
  backends;
- all-feature doctests;
- all-target/all-feature Clippy with `-D warnings`;
- Criterion `transaction` benchmark `--no-run`;
- `blockstore`, `crdt`, and `query-types` checks/tests;
- important runtime and all-current-direct-consumer checks.

Exact counts include:

- serialized all-feature library: 684 passed, 3 ignored, 0 failed;
- serialized Fjall: 407 passed;
- serialized RocksDB: 408 passed;
- sync callback filter: 5/5 passed;
- async callback filter: 5/5 passed.

The first parallel Fjall invocation hit the host's 256-descriptor limit with
an explicit `EMFILE` error in `lsm-tree`. The same candidate suite passes
serialized, both standalone and inside the all-feature run. This is recorded
as an infrastructure retry, not a candidate pass on the failed invocation.

WASM validation:

- exact base/candidate default, no-default, `wasm`, `leveldb`, and
  `leveldb,wasm` Storage checks pass;
- supported LevelDB+WASM Clippy with `-D warnings` passes;
- matched base/candidate all-feature and all-target/all-feature controls exit
  101 before Storage source in native compression/system-library build
  scripts; these are documented unsupported declarations, not passes or
  candidate regressions;
- candidate `defra-wasm` default, no-default, and all-feature checks pass;
- a real candidate release WASM build passes.

After KMS merged, a separate exact-tip gate reran 38 resolver/metadata
commands plus:

- serialized all-feature Storage tests: 684 passed, 3 ignored;
- all-target/all-feature Clippy with warnings denied;
- `blockstore`, `crdt`, and `query-types`;
- Storage WASM default and `leveldb,wasm`;
- `defra-wasm` all-feature WASM.

After Crypto PR #1244 subsequently merged, the patch was transferred again
onto the new exact `main`. Crypto's merge changes only `Cargo.lock` and
`crates/crypto/Cargo.toml`; the root/Storage manifests and all Storage
source/tests/benches are object-identical across that merge. On the exact
`966cf42b`/`55d59e0a` pair:

- raw/stable patch identity remains unchanged;
- the new base and candidate lockfiles are byte-identical;
- locked metadata and formatting pass;
- all 32 representative resolver commands exit zero;
- all 32 normalized before/after package/feature inventories are
  byte-identical to the reviewed post-KMS evidence;
- native all-feature Storage and default Storage WASM checks pass.

The final publication rebase adds merged DB migration fix PR #1243 and no
Storage, root-manifest, or lockfile change. On exact
`69bd4266`/`ac2d6b71`:

- the raw patch SHA and stable patch ID remain byte-for-byte unchanged;
- `Cargo.lock` remains byte-identical across the candidate;
- locked/offline workspace metadata succeeds;
- native production, native developer, WASM production, and WASM LevelDB
  Storage feature trees all resolve successfully;
- `git diff --check` and workspace formatting pass.

The full dynamic matrix transfers because the patch, Storage source/manifest
inputs, root manifest, and lockfile are unchanged since the post-Crypto gate.
PR CI is the fresh dynamic validation boundary for the exact pushed commit.

The full evidence seal verifies 1,223/1,223 files at
`22ba357d7a5e0acab885c55483df3231c57c336ba3b210f883d321a0f80e5623`.
The post-KMS gate seal verifies 213/213 files at
`2b49697a70002bca4de064eee461f8cc2fdf0a8a27667eaa9a71073b60ae1563`.
The final post-Crypto transfer seal verifies 178/178 files at
`ce3db244797c71fed1b970bf6cfe0dd52d7063c4e6005feb9534774369627d89`.
Independent reviews of the full matrix and post-KMS transfer pass with no
actionable finding; the exact post-Crypto seal/body are the final
pre-publication review boundary.

## Build-time and artifact-size claims

No build-time improvement is claimed. The host was shared and the audit
deliberately paused commands during external load; recorded wall times are
operational logs, not performance measurements.

No native binary or WASM size improvement is claimed. Storage ships no binary,
and shipped roots retain the relevant package set through other paths. The
recorded WASM output is link/boundary proof only, not an A/B size result.

The durable result is correct dependency ownership and smaller focused
production graphs for Storage, Blockstore, CRDT, and Query Types, while native
Storage test resolution is intentionally unchanged.

## Limitations

An early derived target-inventory script queried Cargo metadata's
`required_features` field, but the JSON key is `required-features`. The old
seal remains untouched. Its manifest, raw metadata, and successful Redb
benchmark compilation already prove the benchmark boundary; the fresh
post-KMS harness uses the correct key and confirms
`required-features = ["redb"]`.

Fresh local validation is macOS/aarch64 plus `wasm32-unknown-unknown`. Exact
PR CI remains the ready/merge gate for workspace tests and Clippy on the
macOS Studio runner, WASM Clippy/build, and Linux P2P integration.
`Release Artifacts` is expected to skip on a PR.

The final authoritative combined-`main` run remains a stack-level gate after
the dependency-cleanup queue merges.
