### PR TITLE
chore(telemetry): gate thiserror behind otlp

### DIFF
--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -14,6 +14,7 @@ default = []
 # runtime behavior is default-on (Go parity); use `--no-telemetry` to disable
 # at runtime.
 otlp = [
+    "dep:thiserror",
     "dep:opentelemetry",
     "dep:opentelemetry_sdk",
     "dep:opentelemetry-otlp",
@@ -34,7 +35,7 @@ otlp = [
 [dependencies]
 tracing.workspace = true
 tracing-subscriber = { version = "0.3", features = ["registry", "std"] }
-thiserror.workspace = true
+thiserror = { workspace = true, optional = true }
 
 opentelemetry = { version = "0.32", optional = true }
 # `experimental_async_runtime` (not `rt-tokio`) is all that's needed: with the


### PR DESCRIPTION
## Summary

Make Telemetry's direct `thiserror` dependency optional and enable it only
through the existing `otlp` feature.

The only Telemetry use is the derive for public `InitError` in `init.rs`. That
module and its re-export are already compiled only under
`cfg(feature = "otlp")`, so this corrects dependency ownership without
changing any public feature name, API, error text/source chain, logging
behavior, runtime behavior, or supported target.

Exact head: `edfe31c8a71cdb5f0c4506b731599d7c2cac52dd` over Storage-merged
main `8d58199e65dcb1eac73b998887a615c69ae97237`.

## Hidden-use and feature proof

- Direct source, macro, build-script, test, example, benchmark, doctest,
  generated-code, registration, and cfg inspection found no other Telemetry
  use.
- `dep:thiserror` is added to the existing `otlp` feature, preventing a new
  implicit public feature.
- Public feature keys remain exactly `default` and `otlp`; `default` remains
  empty.
- OTLP continues to enable the same `std` and `internal-logs` edges.
- `init.rs` and `lib.rs` are byte-identical across base/candidate, preserving
  the exact `InitError` variants, `Display`, `Error::source`, and re-export
  boundary.

## Exact graph evidence

All rows were resolved locked/offline with Rust/Cargo 1.95. Counts include
the Telemetry root.

| Target | Features | Base | Candidate | Exact effect |
|---|---:|---:|---:|---|
| native | default | 21 | 19 | removes `thiserror 2.0.18` and `thiserror-impl 2.0.18` |
| native | no-default | 21 | 19 | same two-package removal |
| native | `otlp` | 102 | 102 | exact invariant |
| native | all | 102 | 102 | exact invariant |
| bare WASM | default | 21 | 19 | same two-package removal |
| bare WASM | no-default | 21 | 19 | same two-package removal |
| bare WASM | `otlp` | 93 | 93 | exact invariant |
| bare WASM | all | 93 | 93 | exact invariant |

`syn`, `quote`, and `proc-macro2` remain reachable through other paths, so no
broader package-removal claim is made. CLI and `defra-node` directly depend
on `thiserror 2`, so their shipped-root package inventories do not lose those
packages; this is a focused standalone Telemetry closure and fan-in
improvement.

## Lockfile

`Cargo.lock` is byte-identical before/after, SHA-256:

`8c97c6373c05d404d2fad93ac4dd287678bc68f2b7e617f124c3900e615ad093`

No package, version, checksum, source, or dependency array changes.

## Validation

Workstation 1 used Rust/Cargo 1.95 on Linux with 12/48 CPUs, nice 15,
locked/offline Cargo, wrappers disabled, incremental compilation off, and
audit-owned isolated targets.

Passed on the reviewed patch:

- Telemetry native default, no-default, `otlp`, all-feature/all-target checks;
- Telemetry tests, doctests, and Clippy with warnings denied;
- bare-WASM default and no-default checks;
- CLI `otel` telemetry-dedup test and package check;
- `defra-node` `otel` package check;
- external base/candidate public-API fixture with byte-identical observed
  `InitError` display/source behavior;
- live negative-path OTLP smoke: operator hint exactly once; repeated raw
  exporter errors zero times.

The first Clippy attempt stopped before compilation because the host lacked
the standard component; installing it and rerunning the exact command passed.
Bare-WASM OTLP/all stop at `getrandom`'s existing unsupported-target guard;
the exact base has the same status and diagnostic, while supported
default/no-default WASM remains green.

After Storage #1245 merged, the patch transferred byte-for-byte (stable patch
ID `c3f2a62d138af6921647ca4de695c3ba1408ccae`). A fresh exact-main graph seal
reproduced every count/removal above; Telemetry guarded sources and lock
remain byte-identical.

Independent Codex, Grok, and Claude Opus reviews approve with no
semantic/API/feature/cfg/target/lock blocker. Their claim-scope corrections
are incorporated here.

## Build time and artifact size

No wall-time, CPU-time, binary-size, or WASM-size improvement is claimed.
Validation reused isolated targets and was not a repeated cold A/B. Shipped
roots retain `thiserror` through direct dependencies. The durable gain is a
smaller focused default/no-default Telemetry production graph and removal of
an unnecessary proc-macro edge.

## Limitations

- Exact-head PR CI is the final publication gate.
- Any timing or artifact-size claim would require separate repeated
  fresh-target A/B measurements.
- Unsupported bare-WASM OTLP/all remains pre-existing and out of scope.
