### PR TITLE
chore(keyring): scope tracing to Linux

### DIFF
--- a/crates/keyring/Cargo.toml
+++ b/crates/keyring/Cargo.toml
@@ -10,7 +10,6 @@ description = "Keyring and key management for DefraDB"
 
 [dependencies]
 thiserror.workspace = true
-tracing.workspace = true
 base64 = "0.22"
 zeroize = "1.8"
 
@@ -25,6 +24,7 @@ keyring_crate = { package = "keyring", version = "3", features = ["apple-native"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 keyring_crate = { package = "keyring", version = "3", features = ["sync-secret-service", "crypto-rust"] }
+tracing.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]
 keyring_crate = { package = "keyring", version = "3", features = ["windows-native"] }


### PR DESCRIPTION
## Summary

Move Keyring's direct `tracing` dependency from unconditional normal
dependencies into its existing Linux target dependency table.

This is a target-classification correction. All three Keyring tracing calls
are in the already Linux-only systemd-credentials implementation, so Linux
retains the same dependency and logging behavior while standalone non-Linux
Keyring builds stop activating an unreachable tracing closure.

No Rust source, public API, package-feature contract, profile, lockfile, log
call, runtime behavior, error, serialization, retry, or timeout changes.

## Exact reviewed change

- Audited base: `7e4ab4240bc6771144488a8ea15730a577dffc04`
- Audited candidate: `fa97e94e6e42ca5a65d0b3b8478b59e04f6c9f03`
- Candidate parent: exact audited base
- Candidate tree: `d4fea69dc8fdce9e3bc248996bf5314d5d60824e`
- Branch: `agent/gate-keyring-tracing-linux`
- Diff: one insertion and one deletion in `crates/keyring/Cargo.toml`
- Raw patch SHA-256:
  `9c0fdeb92eecdaf5129d725a02bb584826b48948cb8887407a023d8cec81e54b`
- Stable patch ID:
  `0461922309b84861584abe349c6ce3ead4086aec`
- `git diff --check`: clean
- Candidate worktree: clean

## Why the target-scoped dependency is correct

Direct source and macro inspection found exactly three Keyring uses of
`tracing`. All are unchanged `tracing::warn!` calls in
`crates/keyring/src/systemd_creds.rs`.

The module, its two public re-exports, and its integration test are all guarded
by `target_os = "linux"`. The Cargo target predicate now matches that exact
source predicate:

- Linux still compiles the module, dependency, and all three macro expansions.
- macOS, Windows, WASM, Android, and other non-Linux targets compile neither
  the module nor any Keyring tracing use.
- Cross-compilation selects the edge from the compilation target, not the
  build host.

Keyring has no build script, example, benchmark, generated-code use,
registration/linking side effect, package feature, public `tracing` type, or
other hidden use. Linux keeps the same workspace dependency specification and
byte-identical source, preserving the WARN level, default target
`keyring::systemd_creds`, structured fields, formatting, and messages.

## Dependency and feature graph evidence

Locked/offline Cargo metadata, package, activated-feature, direct, and inverse
graphs were collected for Linux, macOS, Windows, and bare WASM. Keyring
declares no package features, so default, no-default, and all-features have the
same effect.

Counts below are normalized unique packages in the resolved closure, including
the Keyring root. They are not Cargo build units or measured compilations.

| Target | Production base → candidate | Development base → candidate |
| --- | ---: | ---: |
| Linux x86-64 | 86 → 86 | 104 → 104 |
| macOS ARM | 61 → 57 | 80 → 77 |
| Windows MSVC | 61 → 57 | 82 → 79 |
| bare WASM/other | 57 → 53 | 73 → 70 |

Non-Linux production closures remove exactly:

- `tracing 0.1.44`
- `tracing-core 0.1.36`
- `tracing-attributes 0.1.31` (proc macro)
- `pin-project-lite 0.2.17`

Non-Linux dev closures retain `pin-project-lite` through another dev path and
remove the three tracing packages. Linux package and activated-feature sets
are exact base/candidate invariants.

The exact non-Linux activated-feature contraction is:

- production removes five rows and adds one: the four removed-package rows
  plus the old `syn 2.0.117` row containing `extra-traits` and `visit-mut`,
  replaced by the retained `syn` row without those two features;
- development removes four rows and adds that same contracted `syn` row:
  the three tracing-package rows plus the old `syn` row are replaced by the
  retained `syn` row.

The normalized production package **and activated-feature sets** for
higher-level workspace roots are exact base/candidate invariants:

| Root | Linux packages / feature rows | macOS packages / feature rows | bare-WASM packages / feature rows |
| --- | ---: | ---: | ---: |
| CLI | 836 / 871 | 828 / 864 | 754 / 788 |
| `defra-node` control | 752 / 782 | 746 / 777 | 630 / 661 |

CLI already activates tracing independently. `defra-node` does not depend on
Keyring and is an invariant control. The demonstrated gain is a standalone
non-Linux Keyring package/activated-feature reduction and cleaner dependency
fan-in, not a shipped CLI/node graph, timing, or binary-size reduction.

Reproduction shape:

```text
cargo tree --locked --offline -p keyring@0.5.0 \
  --target <target> -e normal,build
cargo tree --locked --offline -p keyring@0.5.0 \
  --target <target> -e normal,build,dev
```

The authoritative exact post-Telemetry packet:

- uses a new isolated base worktree at `7e4ab424`;
- records every command, environment, raw stdout/stderr, and exit;
- preserves exact raw source paths;
- strips only Cargo's terminal ` (*)` already-displayed marker;
- normalizes only the two exact worktree roots;
- stores package and activated-feature sets separately;
- records 110/110 zero-exit resolution commands;
- contains no compiler or `--no-dedupe` command.

Its first collector attempt is preserved but rejected as authoritative because
its final checker mistook ripgrep `-L` for `--files-without-match`. All 110
queries in that attempt exited zero; attempt 2 recollected every query with the
corrected checker. Older marker-inflated absolute counts are withdrawn and are
not used here.

## Lockfile effect

`Cargo.lock` is byte-identical before and after:

`8c97c6373c05d404d2fad93ac4dd287678bc68f2b7e617f124c3900e615ad093`

There are no package, version, source, checksum, or workspace-package edge
changes.

## Validation

### Linux

Workstation 1 validated the byte-identical pre-rebase
`69bd4266`/`a846275d` Keyring patch with Rust/Cargo 1.95, locked/offline Cargo,
isolated audit targets, wrappers disabled, incremental compilation disabled,
12/48 pinned CPUs, and `nice 15`. This is inherited patch/source/lock evidence,
not a whole-tree run labeled with `7e4ab424`/`fa97e94e`.

Passed:

- Keyring default, no-default, and all-feature/all-target checks
- full Keyring tests and doctests
- all-feature/all-target Clippy with warnings denied
- CLI check and `defra-node` control check
- two warning-contract tests covering the non-UTF-8 filename and invalid key
  paths

The warning fixture has an explicit limitation: the base lane built and ran
the artifact; the candidate row reused that shared artifact and compiled
nothing. Separate candidate checks and Clippy prove all three unchanged
warning macros compile, but no warning call was dynamically executed from a
candidate-built binary. The third availability-error warning has
byte-identical source and candidate compile proof only.

### macOS

Studio 2 validated the exact post-Storage/pre-Telemetry
`8d58199e`/`edc95169` pair with Rust/Cargo 1.97.1, locked/offline Cargo,
isolated targets, wrappers disabled, and incremental compilation disabled.
This is inherited patch/source/lock evidence, not a run labeled with
`7e4ab424`/`fa97e94e`.

Passed:

- separate base and candidate default checks
- candidate no-default and all-feature/all-target checks
- 44 unit/integration tests; seven OS-keychain tests remained intentionally
  ignored, and the Linux-gated systemd test binary contained zero tests
- doctests: one passed and one intentionally ignored
- all-feature/all-target Clippy with warnings denied
- CLI and `defra-node` checks

### Paired limitations

- The inherited pre-rebase base and candidate bare-WASM default/no-default
  checks both stop with status 101 in the same pre-Keyring `openssl-sys`
  cross-compilation guard. This is paired non-regression to that stopping
  point, not a successful WASM build.
- The inherited post-Storage candidate Windows GNU cross-check on macOS also
  stops in `openssl-sys` before Keyring because no Windows OpenSSL
  sysroot/pkg-config setup exists. Exact-current static Windows resolution is
  covered; native Windows compilation of `fa97e94e` is not claimed.

## Independent review

- Grok 4.5: conditional approve; no correctness, API, cfg, lockfile, or
  logging blocker. Report SHA-256:
  `6faa323a47421d1ef72ba00fb6bc230cbd71f2f3156acae3aa166f6639c0214e`.
- Claude Opus: conditional approve; no semantic, public-API, target-cfg,
  feature-unification, logging, lockfile, or source blocker. Report SHA-256:
  `35df4cc578ea239e8ecb5bf09c69cb99efa02332179ee3ce493da155939af5c3`.
- Independent Codex review: conditional approve with no static blocker.
  Report SHA-256:
  `ce5815747d7e1719afee220914781f85269312d626d3f4c9c1509aa787b24a1b`.

Their conditions are evidence and exact-tip gates, not identified candidate
defects. The provenance/asymmetry and unsupported-target limitations above
incorporate their findings. These review sessions predate `fa97e94e`; they
review the same byte-identical patch/source/lock boundary and remain
transferred evidence, not exact-current review sessions.

## Evidence integrity

- Authoritative exact post-Telemetry static packet:
  `/tmp/defradb-dep-audit/keyring-tracing-69bd/post-telemetry-transfer/`
- Static packet `SHA256SUMS` SHA-256:
  `a8f83da1f3c7d34fd15e1dd0c3fbb3ce86ecbc7d4ccde887cd9b5704145aea0b`
  (1,322/1,322 entries verified)
- Static packet report SHA-256:
  `2cebf4dfbcc9cd3393a6d9d665d3503b27bb4c5327636c61ff2b782aa1512aa4`
- Inherited pre-rebase Linux/WASM dynamic seal:
  `c14556b819991c9210a5009da171e542bdd13884a69e558217146d4681dde8d9`
- Inherited post-Storage/pre-Telemetry macOS dynamic seal:
  `819a36e846f309c71fc1aced97878bca85b24b5e25b5991f538869fa242243b8`
- Inherited post-Storage Windows cross-attempt seal:
  `12c99b53a5a07c286917a0d8e91763a12e98ce01e473e02161ae6321cf7a1261`

## Claim boundary and remaining gate

This PR does not claim a measured cold, warm, or incremental build-time
improvement; a Cargo-unit reduction; or a native/WASM artifact-size
improvement. Single-run timings and partial compilation logs are correctness
provenance only.

Remaining before merge:

- [ ] exact-tip PR CI

Known limitation: the repository's current CI matrix does not provide a
native Windows compiler runner. Exact Windows dependency resolution is sealed;
the attempted macOS cross-check stops in the pre-Keyring OpenSSL sysroot guard
and is not claimed as Windows compilation.
