### PR TITLE
chore(datastore): move futures to dev dependencies

### DIFF
--- a/crates/datastore/Cargo.toml
+++ b/crates/datastore/Cargo.toml
@@ -12,7 +12,6 @@ description = "Transaction wrapper for DefraDB providing multistore access and c
 # Async runtime
 async-trait.workspace = true
 async-lock.workspace = true
-futures.workspace = true
 
 # Error handling
 thiserror.workspace = true
@@ -31,6 +30,7 @@ tokio = { workspace = true, features = ["rt"] }
 
 [dev-dependencies]
 # Testing
+futures.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 [lints]


### PR DESCRIPTION
<!-- Suggested title: Move Datastore futures to dev dependencies -->

## Summary

Move Datastore's unchanged `futures.workspace = true` declaration from normal
dependencies to unconditional dev dependencies.

Datastore's only direct Futures import is in its integration tests. Production
callback APIs use standard-library `Future` and `Pin`, so the normal edge
overstates production ownership. The dev edge preserves the unchanged
panic-propagation tests while removing the Futures family from Datastore's
production package closure.

No Rust source, public API, feature, profile, lockfile, test, logging, error,
serialization, retry, timeout, or runtime behavior changes.

## Exact reviewed change

- Audited base:
  `fa96b12534d678c2de26f389aa9d34cb991be6b0`
- Base tree:
  `d4fea69dc8fdce9e3bc248996bf5314d5d60824e`
- Audited candidate:
  `3f77b866f0cda9f4662fbeeb04d20fbb26828fb0`
- Candidate tree:
  `11b2a7f4ca0734f5957845f06432a82f2e50c479`
- Branch:
  `agent/move-datastore-futures-to-dev`
- Candidate parent: exact audited base
- Diff: one insertion and one deletion in `crates/datastore/Cargo.toml`
- Raw patch SHA-256:
  `4185faf6efd5969117568227c8b6daf2a3f186a75e6b173e9ec78acfeca631e0`
- Stable patch ID:
  `fd76d9fb866564a9a632b9dc9c91b484a02aa7b9`
- `git diff --check`: clean
- Base and candidate worktrees: clean

The audited base includes merged Storage #1245, Telemetry #1246, and keyring
#1247. Storage ordering is load-bearing: Storage's former normal Futures edge
would otherwise mask Datastore's unique production-closure effect. The
Datastore patch has remained byte-for-byte and stable-patch identical through
each rebase.

## Use, API, and test-ownership proof

Inspection of every Datastore source and target found one direct crate import:

```text
crates/datastore/tests/txn_tests.rs:4:use futures::FutureExt;
```

The two async-wrapped panic-propagation assertions use
`FutureExt::catch_unwind`. The unconditional dev dependency continues to own
those unchanged tests on native and WASM resolution.

Production callback aliases use only `std::future::Future` and
`std::pin::Pin`. Their native `Send` bounds, WASM non-`Send` form, public
module path, and re-export behavior are unchanged.

Datastore has:

- an empty Cargo feature map;
- one library and one integration-test target;
- no build script, example, benchmark, or proc-macro target; and
- no public Futures crate type, re-export, macro-only use, generated-code
  role, registration/linking side effect, doctest use, or cfg-only production
  path.

Exact metadata changes only the Futures dependency kind from normal to dev.
Its version requirement, default-feature setting, optionality, requested
features, and target remain unchanged.

## Exact-current dependency and feature graphs

Locked/offline Cargo inventories were freshly captured on the exact
`fa96b125`/`3f77b866` pair with Rust/Cargo 1.95 for:

- macOS ARM;
- Linux x86-64; and
- bare WASM.

Default, no-default, and all-feature production and development views were
captured independently. They are equivalent within each side because
Datastore has no package features.

Counts include the Datastore root:

| Target | Production packages | Development packages | Production feature records | Development feature records |
| --- | ---: | ---: | ---: | ---: |
| macOS ARM | 184 -> 174 | 184 = 184 | 187 -> 176 | 187 = 187 |
| Linux x86-64 | 184 -> 174 | 184 = 184 | 187 -> 176 | 187 = 187 |
| bare WASM | 173 -> 163 | 176 = 176 | 176 -> 165 | 179 = 179 |

The feature metric is one normalized record per package identity and its
exact aggregate activated feature list. It is not a build-unit count,
rendered feature-edge count, or individually split package/feature-pair
count.

The production-only removed package set is exactly:

- `futures 0.3.32`
- `futures-channel 0.3.32`
- `futures-core 0.3.32`
- `futures-executor 0.3.32`
- `futures-io 0.3.32`
- `futures-macro 0.3.32` (proc macro)
- `futures-sink 0.3.32`
- `futures-task 0.3.32`
- `futures-util 0.3.32`
- `slab 0.4.12`

No package or aggregate feature record is added. The eleventh removed feature
record is `memchr`'s redundant `default` activation; `memchr` remains
reachable with `alloc,std`.

The candidate production inverse for Futures is empty on all three targets.
The candidate development inverse explicitly retains
`futures <- [dev-dependencies] datastore`, and every development inventory is
an exact base/candidate invariant.

## Consumer propagation

DB Index compounds the exact ten-package/eleven-feature-record reduction:

| Root | Target | Packages | Feature records |
| --- | --- | ---: | ---: |
| DB Index | macOS/Linux | 185 -> 175 | 188 -> 177 |
| DB Index | bare WASM | 174 -> 164 | 177 -> 166 |

DB Blocks remains exact because another legitimate production path retains
Futures:

| Target | Packages | Feature records |
| --- | ---: | ---: |
| macOS/Linux | 212 = 212 | 216 = 216 |
| bare WASM | 203 = 203 | 207 = 207 |

Default production package and aggregate-feature inventories are byte-identical
for every larger measured root:

| Root | macOS packages/features | Linux packages/features | WASM packages/features |
| --- | ---: | ---: | ---: |
| DB | 549 / 574 | 560 / 585 | 468 / 493 |
| DB Merge | 550 / 575 | 561 / 586 | 376 / 393 |
| CLI | 828 / 864 | 836 / 871 | 754 / 788 |
| `defra-node` | 746 / 777 | 752 / 782 | 630 / 661 |
| Embedded | 751 / 782 | 757 / 787 | 649 / 680 |
| FFI | 771 / 806 | 776 / 810 | 676 / 707 |

Those larger products already reach Futures through other legitimate owners.
This is a focused Datastore/DB Index production closure and dependency-fan-in
win, not a shipped binary-size result.

## Lockfile effect

`Cargo.lock` is byte-identical before and after:

`8c97c6373c05d404d2fad93ac4dd287678bc68f2b7e617f124c3900e615ad093`

No package stanza, version, source, checksum, or workspace-package dependency
list changes. Futures remains locked for Datastore's tests and other
legitimate workspace owners.

## Validation

### Exact-current static packet

The authoritative static packet is:

`/tmp/defradb-dep-audit/datastore-futures-fa96b125/`

It contains:

- 168 raw Cargo-tree stdout/stderr/command/status sets;
- 168 normalized package/feature inventories;
- 24 direct/inverse ownership command sets;
- bounded metadata, source/API, diff, history, environment, and lock
  provenance;
- 391 pre-verification exit-status sidecars, all zero;
- an 84-row comparison summary;
- a fail-closed `VERIFY.sh` and zero-exit `RESULT=PASS` transcript; and
- no compiler command and no `--no-dedupe`.

The three nonempty ownership stderrs are the expected zero-exit
`warning: nothing to print.` diagnostics for the candidate's empty production
Futures inverse on macOS, Linux, and WASM. Raw graph stderr is empty.

The final 1,412-entry `SHA256SUMS` manifest verifies completely and includes
the exact-current independent Codex review plus its sidecar. Its SHA-256 seal
is:

`32720377f66d9827eba449d0468b8cb3decb4e8e92855107222603bfc4c7dd7d`

### Inherited dynamic correctness matrix

The previously sealed Workstation 1 matrix used exact clean
`8d58199e`/`18815224` worktrees, distinct base/candidate target directories,
locked/offline Cargo, Rust/Cargo 1.95, and 12 pinned CPUs at `nice 15`.
All 15 lanes passed:

- Datastore default/no-default/all-feature checks;
- all 4 unit and 22 integration tests;
- all three callback panic-propagation tests;
- doctests and warnings-denied Clippy;
- bare-WASM default/no-default checks;
- DB Blocks, DB Index, DB Merge, and DB consumer checks; and
- 72 focused DB transaction tests plus two callback tests.

That is inherited semantic evidence because the Datastore source, manifest
patch, public surface, and lockfile transfer byte-for-byte. It is not labeled
as an exact `fa96b125`/`3f77b866` compilation. Exact-tip PR CI remains the
final gate.

The dynamic evidence manifest seal is:

`2628e4eff2e25978b96bceb5a723eb4449b1b2b358d545f48ab10bb42cba662e`

## Independent review

- Grok found no semantic/API/target/feature/macro/hidden-use blocker and
  required Storage ordering plus an exact-current re-seal. Both conditions
  are satisfied. Report SHA-256:
  `836cc0233a106e0020bd12bd1f9218ce7bdc100de3641227f90b3d4947ec9c3e`.
- Independent exact-current Codex review conditionally approved publication
  with no code, semantic, public-API, target/cfg, feature, hidden-use,
  test-ownership, lockfile, or history blocker. Its only remaining code gate
  is exact-head PR CI. Report SHA-256:
  `52e220d53b4a2946e6d3da5b4a91f5acf2824cfcfdd877ce30b19a4e0891180b`.
- Claude Opus approved the byte-identical reviewed patch with no semantic,
  public-API, feature, cfg/target, hidden-use, or test-ownership blocker.
  Report SHA-256:
  `5fa1a3ca8d6a22f3feaea478d6d08686d5d54e55718db6c566279a9d9294c1bf`.

## Claim boundary and remaining gate

This PR establishes corrected dependency ownership and exact Datastore/DB
Index production package and aggregate-feature reductions. It does not claim:

- workspace-wide removal of Futures;
- product-root package reduction;
- Cargo compilation-unit change;
- cold/warm/incremental build-time improvement;
- target-directory footprint reduction; or
- native/WASM artifact-size reduction.

Remaining before merge:

- [ ] exact-tip PR CI, including workspace, consumer, Clippy, and supported
      WASM lanes
