### PR TITLE
chore(document): correct dependency ownership

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3951,12 +3951,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab03c107fafeb3ee9f5925686dbb7a73bc76e3932abb0d2b365cb64b169cf04c"
 
 [[package]]
-name = "diff"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
-
-[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4071,12 +4065,10 @@ dependencies = [
  "chrono",
  "ciborium",
  "cid",
- "crypto",
  "defra-core",
  "multibase",
  "multicodec",
  "multihash",
- "pretty_assertions",
  "schema",
  "serde",
  "serde_json",
@@ -9485,16 +9477,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pretty_assertions"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
-dependencies = [
- "diff",
- "yansi",
-]
-
-[[package]]
 name = "prettyplease"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14835,12 +14817,6 @@ dependencies = [
  "static_assertions",
  "web-time",
 ]
-
-[[package]]
-name = "yansi"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yasna"

--- a/crates/document/Cargo.toml
+++ b/crates/document/Cargo.toml
@@ -11,7 +11,6 @@ description = "Runtime document types for DefraDB"
 [dependencies]
 # Internal dependencies
 schema = { path = "../schema" }
-crypto = { path = "../crypto" }
 defra-core = { path = "../defra-core" }
 
 # Serialization
@@ -21,9 +20,6 @@ ciborium = "0.2"
 
 # IPLD
 cid = { workspace = true }
-multihash = { workspace = true }
-multicodec = { workspace = true }
-sha2 = { workspace = true }
 
 # UUID for DocID
 uuid = { workspace = true, features = ["v5", "serde"] }
@@ -41,7 +37,9 @@ base64 = "0.22"
 thiserror = { workspace = true }
 
 [dev-dependencies]
-pretty_assertions = "1.4"
+multicodec = { workspace = true }
+multihash = { workspace = true }
+sha2 = { workspace = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
<!-- Suggested title: Correct Document dependency ownership -->

## Summary

Remove Document's unused normal `crypto` dependency and unused dev
`pretty_assertions` dependency. Move its direct `multicodec`, `multihash`, and
`sha2` declarations unchanged from normal dependencies to unconditional dev
dependencies, where their only direct Rust uses live.

This changes dependency ownership only. It does not change Rust source, public
APIs, feature names, runtime behavior, CID or serialization behavior, errors,
logging, retries, timeouts, profiles, tests, or supported targets.

## Exact reviewed change

- Audited base:
  `497479e915a395f456d8887ac2c787841d260a67`
- Base tree:
  `11b2a7f4ca0734f5957845f06432a82f2e50c479`
- Audited candidate:
  `d5a7a03ea88a4296b62f61604a667268c4018ccb`
- Candidate tree:
  `561af4df4cac822065e615c0f71398773c9d2645`
- Branch:
  `agent/prune-document-dependencies`
- Candidate parent: exact audited base
- Diff: 3 insertions and 29 deletions across `crates/document/Cargo.toml`
  and `Cargo.lock`
- Raw diff SHA-256:
  `c158439a51d3518cd3c97c9681d5be2993d79a2fec032bc60488012953402542`
- Stable patch ID:
  `22978edaab14572fee36547ab067ef031ebb5674`
- `git diff --check`: clean
- Base and candidate worktrees: clean

The base is current through merged Datastore PR #1248. This slice does not
reuse or broaden the rejected CLI behavioral work from PR #1229.

## Use, API, and hidden-use proof

Document has one library and three integration-test targets, an empty feature
map, and no binary, example, benchmark, build script, proc macro, or
target-specific dependency declaration.

The only direct Rust uses among the five changed dependencies are:

```text
crates/document/tests/doc_id_tests.rs:6:use multicodec::Codec;
crates/document/tests/doc_id_tests.rs:7:use multihash::Multihash;
crates/document/tests/doc_id_tests.rs:8:use sha2::{Digest, Sha256};
```

There is no `crypto` or `pretty_assertions` Rust use and no production use of
the three moved dependencies. Direct inspection found no changed dependency
in a public signature, public re-export, type alias, trait bound, macro or
derive path, cfg-only production path, generated-code input, build/link hook,
registration side effect, doctest, example, or benchmark.

`cargo-machete 0.9.2` corroborates the result: on the exact base it flags
exactly `crypto` and `pretty_assertions`; on the candidate it reports no
unused Document dependency. That analyzer is corroboration only—the source,
API, target, graph, lock, and dynamic evidence are the proof basis.

## Exact dependency and feature graphs

Locked/offline Cargo inventories were captured with Rust/Cargo 1.95 for:

- macOS ARM;
- Linux x86-64;
- bare WASM; and
- Cargo target `all`.

Default, no-default, and all-feature views were captured independently for
normal, production (`normal,build`), and development
(`normal,build,dev`) scopes. Document's three feature modes are identical
within each side because its package feature map is empty.

Three representations were compared:

1. package identities;
2. aggregate package/activated-feature-list records; and
3. individually split package/feature pairs.

Default-mode Document counts are:

| Target | Scope | Package identities | Split feature pairs |
| --- | --- | ---: | ---: |
| macOS ARM | normal | 135 -> 94 | 317 -> 190 |
| macOS ARM | production | 142 -> 99 | 321 -> 192 |
| macOS ARM | development | 145 -> 99 | 326 -> 192 |
| Linux x86-64 | normal | 135 -> 93 | 315 -> 188 |
| Linux x86-64 | production | 142 -> 98 | 319 -> 190 |
| Linux x86-64 | development | 145 -> 98 | 324 -> 190 |
| bare WASM | normal | 123 -> 85 | 288 -> 162 |
| bare WASM | production | 128 -> 88 | 290 -> 162 |
| bare WASM | development | 131 -> 88 | 295 -> 162 |
| target-all | normal | 182 -> 138 | 373 -> 245 |
| target-all | production | 191 -> 144 | 377 -> 247 |
| target-all | development | 194 -> 144 | 382 -> 247 |

There is no candidate-only package or split feature pair in any of the 36
target/mode/scope cells.

Each aggregate comparison does contain three candidate-only *records*:

```text
crypto-common v0.1.7|features=std
digest v0.10.7|features=alloc,block-buffer,core-api,default,std
generic-array v0.14.7|features=more_lengths
```

These are narrower surviving feature lists for packages already present on
both sides, not new packages or feature activations. The split-pair view
contains zero additions and is the authoritative no-new-activation result.

These are resolved package/feature records, not compiler units, build-time
measurements, or artifact-size measurements.

## Moved dependency ownership

The candidate normal depth-one tree no longer reports direct Document edges
to `multicodec`, `multihash`, or `sha2`; its dev tree reports all three under
`[dev-dependencies]`.

They remain legitimately reachable in the candidate's production graph:

- `multicodec` through `defra-core`;
- `multihash` through CID/IPLD and schema paths; and
- `sha2` through `defra-core` and `schema`.

Their production aggregate features and split pairs are identical
base/candidate. In particular, SHA-2 retains:

```text
sha2 v0.10.9|feature=asm
sha2 v0.10.9|feature=default
sha2 v0.10.9|feature=sha2-asm
sha2 v0.10.9|feature=std
```

The candidate-focused Crypto inverse is absent across normal, production, and
development views on all four target filters. Crypto remains used elsewhere
in the workspace and remains in the lockfile; this PR does not claim its
workspace-wide removal.

## Lockfile effect

- Base lock SHA-256:
  `8c97c6373c05d404d2fad93ac4dd287678bc68f2b7e617f124c3900e615ad093`
- Candidate lock SHA-256:
  `80482645975e8781fd911ed84877d9ae9f571fa5e45c5cb462e54ed2d583c226`

The lock inventory contracts from 1,268 to 1,265 package identities. It
removes exactly:

- `diff 0.1.13`;
- `pretty_assertions 1.4.1`; and
- `yansi 1.0.1`.

It adds nothing. There is no upgrade, downgrade, source, version, checksum, or
unrelated lockfile churn. The Document lock dependency array removes only
`crypto` and `pretty_assertions`; the three moved dependencies remain because
Cargo.lock does not encode normal-versus-dev ownership.

## Consumer propagation

Exact metadata reports the same 17 direct normal consumers on both sides.
Default production package, aggregate-feature, and split-pair inventories
were compared for each on all four target filters.

Sixteen of the 17 are invariant in every recorded representation and target,
including the priority DB Index, Storage, and DB boundaries and every examined
shipped/product consumer. Only `integration-test` compounds the cleanup:

| Target | Packages | Split feature pairs |
| --- | ---: | ---: |
| macOS ARM | 467 -> 453 (-14) | 1040 -> 998 (-42) |
| Linux x86-64 | 461 -> 447 (-14) | 990 -> 948 (-42) |
| bare WASM | 387 -> 377 (-10) | 885 -> 849 (-36) |
| target-all | 558 -> 548 (-10) | 1262 -> 1225 (-37) |

It adds no package or split feature pair. Its candidate-only aggregate
records are again narrower lists for retained packages, not new activations.

## Validation

### Static packet

The authoritative exact-current packet is:

`/tmp/defradb-dep-audit/document-497479e9/`

Its fail-closed verifier passes and covers:

- exact commits, trees, parent, patch, diff, and lock identities;
- 416 raw Cargo-tree outputs with empty graph stderr;
- 416 package/aggregate inventories;
- 208 split-pair inventories;
- 112 ownership outputs;
- all target/feature/scope counts and subset relations;
- exact metadata dependency kinds and all 17 consumers;
- moved-feature parity, source/API/hidden-use evidence, and lock delta;
- 1,196 scoped static status sidecars: 1,176 zero plus exactly 20 expected
  package-not-selected `101` statuses;
- no `--no-dedupe`; and
- no compiler invocation in the static collector.

The final 4,444-entry `SHA256SUMS` verifies completely. Its SHA-256 seal is:

`6ec9994cc696476c3ba86933a8f32e8d7c367887022d6fb2b5d50d270eac7385`

### Exact-current Studio-2 matrix

The focused Studio-2 run used exact detached base/candidate trees, isolated
targets, locked/offline Cargo, Rust/Cargo 1.95, no sccache,
`CARGO_INCREMENTAL=0`, and 16 jobs per side. All 26 commands passed—13 per
side—with identical normalized test inventories:

- Document production, no-default, and all-feature/all-target checks;
- 140 native unit/integration tests and one doctest per side;
- warnings-denied all-feature/all-target Document Clippy;
- DB Index and Storage native checks;
- supported bare-WASM Storage library checks;
- encoding, DB migration, and scalar-array reindex tests.

The report SHA-256 is:

`4bc9f7760caade86182f36ffeb2e80db223112498cb8f851e3746bb4e5b42a95`

Its 164-entry raw manifest verifies completely. The two sides ran concurrently
on an active host, so timestamps and Cargo durations are provenance only—not
performance measurements.

## Independent review

- Independent Codex review: PASS, draft-publication ready, merge after exact
  candidate-head CI. Report SHA-256:
  `274db18901fe2a1224721e09b870f8491f04cfeeb71ff2608bac3a4c2df77f04`.
- Grok 4.5 exact-current review: APPROVE, no blockers, same CI gate. A second
  exact-current retry independently reproduced the identities, lock delta,
  ownership, SHA-2/ASM parity, aggregate-versus-split metric distinction,
  16/17 consumer invariance, and `integration-test` contraction. Its
  transcript SHA-256:
  `eb42e185fb503e65346e9de614243a2c93610f5e06ee54cccac8b1c7a537f772`.

## Claim boundary and remaining gate

This PR establishes corrected dependency ownership, exact focused Document
package/feature contraction, exact three-package lock contraction, preserved
production feature activation, and the recorded integration-test graph
contraction.

It does not claim:

- workspace-wide removal of Crypto;
- fewer compiler units for every product or workspace operation;
- cold, warm, or incremental build-time improvement;
- target-directory footprint reduction;
- native binary/section-size reduction; or
- WASM artifact-size reduction.

Remaining before merge:

- [ ] exact candidate-head repository CI, including required workspace,
      formatting/lint, Linux/integration/P2P, shipped browser-WASM, and FFI
      lanes where applicable
