### PR TITLE
Scope storage backend dependencies by target

### DIFF
--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -18,14 +18,6 @@ chrono = { version = "0.4", features = ["serde"] }
 # Async runtime
 async-trait.workspace = true
 
-# Storage backends
-redb = { workspace = true, optional = true }
-fjall = { workspace = true, optional = true }
-rocksdb = { workspace = true, optional = true }
-lark-kv = { workspace = true, optional = true }
-# rusty-leveldb v4 has optional fs feature - we disable it for WASM
-rusty-leveldb = { version = "4", optional = true, default-features = false }
-
 # Serialization
 serde.workspace = true
 serde_cbor.workspace = true
@@ -66,6 +58,9 @@ wasm = []
 getrandom = { version = "0.2", features = ["js"] }
 uuid = { version = "1.0", features = ["v4", "js"] }
 
+# rusty-leveldb v4 has optional fs feature - we disable it for WASM
+rusty-leveldb = { version = "4", optional = true, default-features = false }
+
 # WASM interop dependencies (optional, pulled in by leveldb feature)
 wasm-bindgen = { version = "0.2", optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }
@@ -74,6 +69,12 @@ js-sys = { version = "0.3", optional = true }
 # Tokio is only available on non-WASM targets
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio.workspace = true
+
+# Native storage backends
+redb = { workspace = true, optional = true }
+fjall = { workspace = true, optional = true }
+rocksdb = { workspace = true, optional = true }
+lark-kv = { workspace = true, optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 futures.workspace = true


### PR DESCRIPTION
## Summary

Scope Storage's optional backend dependencies to the targets where their
source and public APIs already exist:

- `redb`, `fjall`, `rocksdb`, and `lark-kv`: non-WASM only
- `rusty-leveldb`: WASM32 only
- native-only Futures dev dependency: unchanged

This is a one-file manifest relocation (9 insertions, 8 deletions). It does
not change source, public APIs, feature names or forwarding arrays, runtime
behavior, tests, benchmark code, workspace forwarding, dependency versions,
or `Cargo.lock`.

## Why

Storage's source has long gated the native backends with
`not(target_arch = "wasm32")` and LevelDB/OPFS with
`target_arch = "wasm32"`, but its optional dependencies were target-agnostic.
As a result, opposite-target feature bits could pull large inapplicable
closures into resolver and compile work—most notably RocksDB's native
C/C++/Bindgen/compression toolchain into WASM all-feature work.

The manifest now expresses the same target policy as the existing source cfg.

## Exact graph evidence

The exact base/candidate audit covers Apple arm64, Linux x86-64, WASM32, and
Cargo `--target all`; default/no-default/all and seven named combinations;
production and dev scopes; package sets, aggregate feature records, normalized
package/feature pairs, expanded compatible trees, inverse ownership, all
direct Storage consumers, and named feature forwarders.

- 80 Storage target/selection/scope cells / 240 representation records
- 58 compatible expanded-tree comparisons
- 384 direct/inverse ownership captures
- 172 consumer recipe cells / 516 representation records
- zero candidate-only packages
- zero candidate-only normalized package/feature pairs
- every compatible expanded tree identical
- every Storage and consumer `--target all` inventory identical

Representative production cells:

| Target / selection | Packages | Split feature pairs |
| --- | ---: | ---: |
| Apple default | 167 → 167 | 349 → 349 |
| Apple all | 227 → 224 | 471 → 471 |
| Linux default | 167 → 167 | 347 → 347 |
| Linux all | 228 → 225 | 475 → 475 |
| WASM default | 157 → 157 | 326 → 326 |
| WASM LevelDB | 166 → 166 | 337 → 337 |
| WASM Redb bit | 158 → 157 | 326 → 326 |
| WASM Fjall bit | 183 → 157 | 368 → 326 |
| WASM RocksDB bit | 183 → 157 | 386 → 326 |
| WASM Lark bit | 170 → 157 | 350 → 326 |
| WASM all | 224 → 166 | 458 → 343 |
| Target-all all | 282 → 282 | 559 → 559 |

Native `leveldb` / `wasm,leveldb` selections remove exactly four inapplicable
packages: `rusty-leveldb`, `integer-encoding`, `crc32c`, and `snap`. Native
all-features removes the same closure except `snap`, which remains through
another owner.

WASM all-features removes 58 wrong-target production packages and 115 split
feature pairs, including `rocksdb`, `librocksdb-sys`, Bindgen/Clang support,
C/C++ build support, compression sys crates, `redb`, `fjall`, and `lark-kv`.
The shipped WASM LevelDB graph and valid native backend graphs are unchanged.

Six aggregate `{f}` cells show candidate-only *records* because retained
`libc`, `lock_api`, or `parking_lot` rows have narrower aggregate feature
lists after an owner disappears. No feature was added: normalized split
package/feature pairs have zero additions, and no compatible or target-all
cell loses a pair.

## Public API, feature, and lock effects

- All seven features are byte-identical:
  `default`, `redb`, `fjall`, `rocksdb`, `lark`, `leveldb`, `wasm`.
- Dependency versions, optional flags, default-feature settings, requested
  features, and registries are unchanged.
- `rusty-leveldb` remains a normal dependency on WASM, where
  `LevelDbStore::open_with_options` exposes `rusty_leveldb::Options`.
- Native backend and LevelDB module/reexport cfgs are unchanged.
- `Cargo.lock` is byte-identical:
  `80482645975e8781fd911ed84877d9ae9f571fa5e45c5cb462e54ed2d583c226`.
- No packages or versions were added to or removed from the lockfile.

## Dynamic validation

Studio-2 ran 47 exact lanes per side from detached clean clones with isolated
target directories, Rust/Cargo 1.95.0, locked/offline resolution, no sccache,
and no shared-cache clean.

Covered:

- metadata and formatting
- ten native Storage feature checks
- seven native Storage test suites
- doctest, warnings-denied clippy, benchmark compile
- ten WASM Storage library feature checks
- WASM all / `wasm,leveldb` clippy
- shipped `defra-wasm` clippy and `wasm-pack`
- datastore, db-index, DB/migration, CLI/Fjall, node/RocksDB, embedded, FFI,
  and integration lanes

The candidate passes every lane. Four base-only failures demonstrate the
intended repair: WASM Fjall, RocksDB, all-feature check, and all-feature clippy
reach native-only crates or system toolchains. Ten paired infrastructure
failures (file-descriptor limit, missing rustfmt, audit-local
`wasm-bindgen-cli`) were retained and replayed under controlled conditions;
10/10 replays pass. Test counts are identical between sides.

The exact paired Linux AArch64 seal also passes on the two Spark hosts:
locked/offline metadata, Storage RocksDB all-target check, test compile, full
tests/doctests, warnings-denied Clippy, and a downstream `defra-node`
no-default + RocksDB check. Both sides pass 510 Storage tests with 10 ignored
doctests. The candidate's preserved initial metadata status was an offline
cache miss for `jni-sys`; after a complete locked fetch, the identical offline
metadata replay passed on both sides. Both exact sources remained clean and
retained the same lock blob and SHA.

Repository CI is fully green for the exact candidate, including Build & Test,
all Rust/Go/Iroh/signed-doc integrations, Linux P2P/default-RocksDB CLI,
WASM Build Check, Lint, Lean Conformance, and Conformance. Release Artifacts is
the expected skipped job for this non-release PR.

## Artifact and timing result

The shipped `wasm-pack --release --target web` output is byte-for-byte
identical. `defra_wasm_bg.wasm` is 7,215,256 bytes with SHA-256
`23c144b98a2e19e7de2f8c1804e1a5ef651d9d4cc2ee7f1ac830a5e7f956cdd8`
on both sides.

No artifact-size improvement is claimed. No build-time improvement is claimed:
the acceptance matrix did not run repeated matched cold/warm medians. The
proven gain is resolver/build-input contraction for native all/LevelDB and
WASM wrong-native/all-feature developer workflows; default native and shipped
WASM graphs are unchanged.

## Independent review

- Fail-closed static verifier: 365 checks, 0 failures.
- Grok 0.2.114: conditional PASS on exact static evidence; its sole acceptance
  condition was the dynamic matrix, now satisfied.
- Claude Opus: PASS, no blockers.
- Independent Codex semantic/public-API review: PASS, no blockers.

## Known limitations / out of scope

- Pre-existing WASM `--all-targets` integration-test and benchmark cfg gaps
  remain; this PR validates the WASM library and shipped package boundaries.
- Future WASM64/WASI target policy is a separate decision.
- This does not remove backend crates workspace-wide or change their versions.
- This does not tune profiles, delete tests, change algorithms, or redesign
  APIs.

## Exact evidence anchors

- Base: `7aa90d5e0b682ed61806df784b439fd130494df1`
- Candidate: `1cf64ca518bf5a22a0563d2dea3b27c7d6bd1db8`
- Raw diff SHA-256:
  `8dfce70e878e87fb24b58d85d85d3829a79bc63dad0fc55ab89dc85f4bcec2b3`
- Stable patch ID:
  `39ab0cf029c48b0fa5bce5cb002594b20e202667`
- Static verifier: 365 PASS / 0 FAIL
- Studio-2 report SHA-256:
  `a9acf9e575d1ae2a847132d149ea02258d07200da5070be4efa96d4ddb2cac78`
- Studio-2 674-file evidence-manifest SHA-256:
  `5338cdac5a37d895949d1539098ae368ca776bf9f48fbd017f009cbed753d420`
- Spark Linux report SHA-256:
  `bef0fe70f6939c0c9b1c44c5ae41449ebb1c6fbba855eadd5ad3544d3b4c7f95`
- Spark Linux 152-file evidence-manifest SHA-256:
  `b9639e7be890977be67af261d285bcaa5d3acf1384b4587e757c94f4df27a19e`
- Independent Codex review SHA-256:
  `964bbfb646a79b5507d960b5b6bf47f235f76e8c9bb0cde7f485f7bda55c8d9a`
- Claude review SHA-256:
  `777516370ede6a9d99e81ac218f173ee94ec32b0db4f099b45879c4cc239b9b7`
