### PR TITLE
Prune unused ACP dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,8 +17,6 @@ dependencies = [
  "defra-core",
  "identity",
  "parking_lot 0.12.5",
- "proptest",
- "schema",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/crates/acp/Cargo.toml
+++ b/crates/acp/Cargo.toml
@@ -16,7 +16,6 @@ redb = ["storage/redb"]
 [dependencies]
 defra-core = { path = "../defra-core" }
 identity = { path = "../identity" }
-schema = { path = "../schema" }
 storage = { path = "../storage" }
 zanzibar = { path = "../zanzibar" }
 
@@ -31,7 +30,6 @@ sha2.workspace = true
 serde_yaml = "0.9"
 
 [dev-dependencies]
-proptest.workspace = true
 tempfile = "3"
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }
 


### PR DESCRIPTION
## Summary

Remove two unused direct dependencies from ACP:

- normal `schema`
- dev-only `proptest`

The corresponding ACP dependency-array entries are removed from `Cargo.lock`.
No Rust source, public API, feature, test, target, dependency version, package
stanza, profile, or workspace dependency declaration changes.

## Why

ACP has never referenced either crate in source, tests, doctests, macros,
derives, public signatures, cfg paths, generated code, or linking/registration
paths.

Schema remains in every ACP production graph through Storage, so removing the
redundant direct edge changes ownership but not production resolution.
Proptest is not used by ACP's tests; removing that false dev ownership drops
its focused property-test closure while other real workspace owners retain
Proptest globally.

## Exact change and lock effect

- Base: `1cf64ca518bf5a22a0563d2dea3b27c7d6bd1db8`
- Candidate: `425e4dd985c594e28e6ec63a34f467645931e98b`
- Changed files: `crates/acp/Cargo.toml`, `Cargo.lock`
- Diff: four deletions
- Stable patch ID:
  `5f92df29adfa6e743b870716182859d15282c1bd`
- Lock package stanzas: 1,265 → 1,265
- Lock changes: only `"schema"` and `"proptest"` leave ACP's dependency array

No version, source, checksum, package stanza, other package dependency array,
or root workspace declaration changes. Schema and Proptest remain in the
lockfile through legitimate owners.

## Dependency-graph evidence

Cargo 1.95 resolution covered macOS, Linux, WASM, and Cargo target inventory
mode; default, no-default, all-feature, and Redb selections; and production
plus dev-inclusive scopes.

- Every production package and split named package-feature-pair inventory is
  byte-identical.
- All 56 direct-consumer production cells are identical.
- Every dev cell adds zero packages and zero feature pairs.
- Native dev cells remove 13 packages.
- WASM and target-inventory dev cells remove 14 packages.
- Every dev cell removes exactly 31 split named package-feature pairs.

The common removed dev closure is:

```text
bit-set 0.8.0
bit-vec 0.8.0
getrandom 0.3.4
proptest 1.11.0
quick-error 1.2.3
rand 0.9.2
rand_chacha 0.9.0
rand_core 0.9.5
rand_xorshift 0.4.0
regex-syntax 0.8.10
rusty-fork 0.3.1
unarray 0.1.4
wait-timeout 0.2.1
```

WASM additionally loses an otherwise unreachable Bitflags identity; Cargo
target inventory additionally loses `r-efi`. No candidate-only replacement
edge appears.

All ACP feature names and arrays remain byte-identical:

```toml
default = ["native"]
native = []
redb = ["storage/redb"]
```

## Dynamic validation

Studio‑2 ran exact detached base/candidate clones concurrently with separate
target directories, 16 Cargo jobs per side, Rust/Cargo 1.95, locked/offline
resolution, no sccache, `CARGO_INCREMENTAL=0`, and no shared-cache clean.

All 44 lanes passed:

- metadata and formatting
- ACP default/no-default/Redb/all checks
- ACP default/no-default/Redb/all full tests
- doctests
- all-target/all-feature Clippy with warnings denied
- four ACP WASM library feature modes
- shipped `defra-wasm`
- Zanzibar tests
- all 14 direct normal consumers
- DB, DB NAC, and DB Merge feature-forwarding boundaries

Test inventories are exactly identical:

- ACP default/no-default: 296 passed, 2 ignored per side
- ACP Redb/all: 310 passed, 2 ignored per side
- ACP doctests: 2 existing ignored per side
- Zanzibar: 24 passed per side
- DB NAC: 7 passed per side

Evidence:

- Dynamic report SHA-256:
  `4d3e91f12fa3e75b5dcd74603aa6f425bef78fdf02a5a721549f7a2ad597cf63`
- 289-file raw manifest SHA-256:
  `4c2624e446f427a6fa04df1338f1c360851b930047193e6c9abcb2876fb2bb30`
- Independent exact review: PASS, no blockers
- Independent review SHA-256:
  `09d1b6211b6a1fc170300a37be14a9a22cc1afc34c384bfe2b12f6a9544c33b6`

The packet includes exact Linux resolver coverage but not a native Linux
compile lane. Normal repository CI remains the final supported-host gate.

## Impact and claim boundary

This is a focused ACP developer/test-graph reduction and direct-dependency
ownership cleanup. Production graphs are invariant, ACP ships no standalone
binary, and no shipped artifact-size change is claimed.

Historical controlled experiments on the same patch class showed fewer Cargo
compile units and build-script executions, but this exact-current acceptance
matrix was not a repeated timing experiment. This PR therefore makes no
exact-current build-time claim.
