### PR TITLE
Prune unused Lens dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6823,13 +6823,11 @@ dependencies = [
  "futures",
  "hex",
  "parking_lot 0.12.5",
- "proptest",
  "serde",
  "serde_json",
  "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
- "tokio-stream",
  "tracing",
  "wasmtime",
 ]

--- a/crates/lens/Cargo.toml
+++ b/crates/lens/Cargo.toml
@@ -10,7 +10,7 @@ description = "Lens schema migration support for DefraDB"
 
 [features]
 default = ["wasmtime-runtime"]
-wasmtime-runtime = ["dep:wasmtime", "dep:tokio", "dep:tokio-stream", "dep:parking_lot"]
+wasmtime-runtime = ["dep:wasmtime", "dep:tokio", "dep:parking_lot"]
 
 [dependencies]
 # Core
@@ -36,12 +36,8 @@ hex.workspace = true
 
 # Wasmtime runtime dependencies (optional for wasm32)
 tokio = { workspace = true, optional = true }
-tokio-stream = { workspace = true, optional = true }
 parking_lot = { workspace = true, optional = true }
 wasmtime = { version = "43.0.1", optional = true }
-
-[dev-dependencies]
-proptest.workspace = true
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary

Prune two unused Lens dependency edges:

- remove the unused optional `tokio-stream` dependency and its internal
  `dep:tokio-stream` edge from `wasmtime-runtime`;
- remove the unused `proptest` dev dependency.

The public `wasmtime-runtime` feature name remains and still enables every
dependency Lens uses: Wasmtime, Tokio, and Parking Lot. No Rust source, public
API, test, target, profile, dependency version, or workspace dependency
declaration changes.

## Why

Lens implements its stream surface with `futures::Stream`, Futures channels,
and Futures combinators. It has never imported or exposed Tokio Stream.
Its 29 unit tests contain no Proptest use.

Complete source/history inspection found no hidden macro, derive, generated
code, cfg, public-signature, linking, or registration use of either crate.
Because the manifest used `dep:tokio-stream`, Cargo never exposed a separate
public `lens/tokio-stream` feature.

## Exact change and lock effect

- Base: `425e4dd985c594e28e6ec63a34f467645931e98b`
- Candidate: `0a4ced8efb7cb8a049c09b9c2ae8abebfae18918`
- Changed files: `crates/lens/Cargo.toml`, `Cargo.lock`
- Diff: one insertion, seven deletions
- Stable patch ID:
  `a99a94652f8e4383701a3211dc3be221314d3efa`
- Lock package stanzas: 1,265 → 1,265
- Lock changes: only `"proptest"` and `"tokio-stream"` leave Lens's
  dependency array

Both packages remain globally locked through legitimate workspace owners. No
version, source, checksum, package stanza, other dependency array, or root
workspace declaration changes.

## Dependency-graph evidence

Locked Cargo 1.95 graphs cover native and WASM default, no-default,
all-feature, and explicit-runtime modes.

| Target / mode | Production packages | Dev packages |
| --- | ---: | ---: |
| Native runtime-enabled | 164 → 163 | 181 → 163 |
| Native no-default | 46 → 46 | 70 → 46 |
| WASM runtime-enabled | 158 → 157 | 175 → 157 |
| WASM no-default | 40 → 40 | 61 → 40 |

Every runtime-enabled production graph removes only Tokio Stream. Every
no-default production graph is exact. Dev graphs additionally remove only
the unused Proptest closure. No graph adds a package.

The only retained production feature-request change is
`futures-core/default`; `futures-core/std` and `alloc` remain enabled through
Lens's real Futures dependency, and `default` is an alias for `std`.
Effective Tokio features remain unchanged through the retained workspace
Tokio `full` selection.

Important downstream results:

- Lens Host: removes only Tokio Stream
- minimal DB runtime graph: removes only Tokio Stream
- CLI, Defra Node, default DB, HTTP, Embedded, FFI, P2P Adapter, Query,
  Query Plan, and shipped `defra-wasm`: invariant

## Dynamic validation

Studio‑2 ran exact detached base/candidate clones with separate targets,
16 Cargo jobs per side, Rust/Cargo 1.95, locked/offline resolution,
`CARGO_INCREMENTAL=0`, no sccache, and no shared-cache clean.

The packet contains 80 paired lane records:

- 70 green;
- 10 paired pre-existing invalid selections;
- zero status mismatch;
- zero candidate-only failure.

Supported coverage includes:

- Lens default/all/explicit-runtime checks and full 29-test suites
- supported no-default library, Clippy, doctest, and WASM paths
- warnings-denied Clippy
- Lens Host and all ten direct consumers
- shipped `defra-wasm`
- DB migration/lensed paths and Defra Node migration integration
- valid DB `native,wasmtime-runtime` and FFI
  `native,redb,wasmtime-runtime` forwarders
- Document, Query, Query Plan, FFI, and Embedded suites

Every successful test-result inventory is identical. Representative parity:

- Lens default/all/runtime: 29 passed per side
- DB lensed filters: 4 passed per side
- DB migration and node migration: 10 passed per side
- Document encoding: 22 passed per side
- Query: 68 passed per side
- Query Plan: 125 passed per side
- FFI: 152 passed per side
- Embedded: 11 passed, 1 ignored per side

## Paired pre-existing invalid selections

Five deliberately broad feature selections fail identically on both sides:

- full Lens no-default tests reference six optional Tokio test macros;
- DB runtime without its required `native` feature references Tokio;
- FFI runtime without required native/storage features lacks `RedbStore`.

The supported no-default library gates and corrective valid DB/FFI feature
combinations pass on both sides. These source-identical limitations are not
candidate regressions.

## Independent review and evidence

- Grok exact semantic review: PASS, no blockers
- Grok review SHA-256:
  `b4b63b350ca74727b88dccc71b4b140a76196927c8f887be7456564a36c9b847`
- Final report SHA-256:
  `b5f85960a280044ebc58579c711b6c6b432fff04f5cc091dcaaeab8b6a87cff5`
- Top-level evidence-manifest SHA-256:
  `e30e4637408447b3c03e4d03595f282d273e74c9c1fbcdc8885594576d0a65a7`
- 509-entry Studio‑2 raw-manifest SHA-256:
  `4fec8899e12b1b9af34176e07a9e11bc741e5dd3ed5a6f353c4ccc477e2dbb7f`

## Claim boundary

This establishes a one-package focused production reduction and removes
Lens's unused test closure. The acceptance run was not a repeated timing
experiment, so no build-time number is claimed. Shipped CLI, node, FFI
default, and browser-WASM graphs are unchanged, so no artifact-size
improvement is claimed.
