### PR TITLE
Prune unused Iroh blobs dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6823,13 +6823,11 @@ dependencies = [
  "futures",
  "hex",
  "parking_lot 0.12.5",
- "proptest",
  "serde",
  "serde_json",
  "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
- "tokio-stream",
  "tracing",
  "wasmtime",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,7 +872,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
 dependencies = [
- "asn1-rs-derive 0.5.1",
+ "asn1-rs-derive",
  "asn1-rs-impl",
  "displaydoc",
  "nom",
@@ -883,38 +883,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "asn1-rs"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
-dependencies = [
- "asn1-rs-derive 0.6.0",
- "asn1-rs-impl",
- "displaydoc",
- "nom",
- "num-traits",
- "rusticata-macros",
- "thiserror 2.0.18",
- "time",
-]
-
-[[package]]
 name = "asn1-rs-derive"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "synstructure 0.13.2",
-]
-
-[[package]]
-name = "asn1-rs-derive"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1368,25 +1340,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bao-tree"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06384416b1825e6e04fde63262fda2dc408f5b64c02d04e0d8b70ae72c17a52b"
-dependencies = [
- "blake3",
- "bytes",
- "futures-lite",
- "genawaiter",
- "iroh-io",
- "positioned-io",
- "range-collections",
- "self_cell",
- "serde",
- "smallvec",
- "tokio",
-]
-
-[[package]]
 name = "base-x"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1441,12 +1394,6 @@ dependencies = [
  "bytes",
  "smallvec",
 ]
-
-[[package]]
-name = "binary-merge"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597bb81c80a54b6a4381b23faba8d7774b144c94cbd1d6fe3f1329bd776554ab"
 
 [[package]]
 name = "bindgen"
@@ -3828,21 +3775,7 @@ version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
 dependencies = [
- "asn1-rs 0.6.2",
- "displaydoc",
- "nom",
- "num-bigint",
- "num-traits",
- "rusticata-macros",
-]
-
-[[package]]
-name = "der-parser"
-version = "10.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
-dependencies = [
- "asn1-rs 0.7.1",
+ "asn1-rs",
  "displaydoc",
  "nom",
  "num-bigint",
@@ -4909,37 +4842,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
-]
-
-[[package]]
-name = "genawaiter"
-version = "0.99.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c86bd0361bcbde39b13475e6e36cb24c329964aa2611be285289d1e4b751c1a0"
-dependencies = [
- "futures-core",
- "genawaiter-macro",
- "genawaiter-proc-macro",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "genawaiter-macro"
-version = "0.99.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b32dfe1fdfc0bbde1f22a5da25355514b5e450c33a6af6770884c8750aedfbc"
-
-[[package]]
-name = "genawaiter-proc-macro"
-version = "0.99.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784f84eebc366e15251c4a8c3acee82a6a6f427949776ecb88377362a9621738"
-dependencies = [
- "proc-macro-error",
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -6012,15 +5914,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inplace-vec-builder"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf64c2edc8226891a71f127587a2861b132d2b942310843814d5001d99a1d307"
-dependencies = [
- "smallvec",
-]
-
-[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6221,47 +6114,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iroh-blobs"
-version = "0.103.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be50b0e2d0a9ba65cee4e0dfb708b3704e02ad12bd4c14c6307e94245943126"
-dependencies = [
- "arrayvec",
- "bao-tree",
- "bytes",
- "cfg_aliases",
- "chrono",
- "constant_time_eq",
- "data-encoding",
- "derive_more",
- "genawaiter",
- "getrandom 0.4.2",
- "hex",
- "iroh",
- "iroh-base",
- "iroh-io",
- "iroh-metrics",
- "iroh-tickets",
- "iroh-util",
- "irpc",
- "n0-error",
- "n0-future",
- "nested_enum_utils",
- "noq",
- "postcard",
- "rand 0.10.1",
- "range-collections",
- "redb 4.1.0",
- "ref-cast",
- "reflink-copy",
- "self_cell",
- "serde",
- "smallvec",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "iroh-dns"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6310,19 +6162,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
-]
-
-[[package]]
-name = "iroh-io"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a5feb781017b983ff1b155cd1faf8174da2acafd807aa482876da2d7e6577a"
-dependencies = [
- "bytes",
- "futures-lite",
- "pin-project",
- "smallvec",
- "tokio",
 ]
 
 [[package]]
@@ -6413,36 +6252,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "iroh-util"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20e41eb982f15230c55f0a70a74a514360e1f565b07861924fd0e8db172b3d00"
-dependencies = [
- "derive_more",
- "iroh",
- "n0-error",
- "n0-future",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "irpc"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3623d6ff582b415904b29bbe6ebcb4a4f9a262ccdee05a45fdd003ef0950c386"
 dependencies = [
- "futures-buffered",
  "futures-util",
  "irpc-derive",
  "n0-error",
  "n0-future",
- "noq",
- "postcard",
- "rcgen 0.14.7",
- "rustls 0.23.37",
  "serde",
- "smallvec",
  "tokio",
  "tokio-util",
  "tracing",
@@ -7329,12 +7148,12 @@ dependencies = [
  "futures-rustls",
  "libp2p-core",
  "libp2p-identity",
- "rcgen 0.11.3",
+ "rcgen",
  "ring 0.17.14",
  "rustls 0.23.37",
  "rustls-webpki 0.101.7",
  "thiserror 1.0.69",
- "x509-parser 0.16.0",
+ "x509-parser",
  "yasna",
 ]
 
@@ -7953,18 +7772,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
-name = "nested_enum_utils"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d5475271bdd36a4a2769eac1ef88df0f99428ea43e52dfd8b0ee5cb674695f"
-dependencies = [
- "proc-macro-crate 3.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "netdev"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8526,16 +8333,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
 dependencies = [
- "asn1-rs 0.6.2",
-]
-
-[[package]]
-name = "oid-registry"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
-dependencies = [
- "asn1-rs 0.7.1",
+ "asn1-rs",
 ]
 
 [[package]]
@@ -8851,7 +8649,6 @@ dependencies = [
  "ipld-core",
  "iroh",
  "iroh-bitswap",
- "iroh-blobs",
  "iroh-gossip",
  "iroh-tickets",
  "kms",
@@ -8859,6 +8656,7 @@ dependencies = [
  "libp2p-stream",
  "multiaddr",
  "multihash-codetable",
+ "noq",
  "p2p",
  "parking_lot 0.12.5",
  "postcard",
@@ -9370,16 +9168,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "positioned-io"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4ec4b80060f033312b99b6874025d9503d2af87aef2dd4c516e253fbfcdada7"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "postcard"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9532,32 +9320,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "syn-mid",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9578,12 +9340,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -10208,19 +9964,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "range-collections"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "861706ea9c4aded7584c5cd1d241cec2ea7f5f50999f236c22b65409a1f1a0d0"
-dependencies = [
- "binary-merge",
- "inplace-vec-builder",
- "ref-cast",
- "serde",
- "smallvec",
-]
-
-[[package]]
 name = "rapidhash"
 version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10271,20 +10014,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rcgen"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b99e0098aa4082912d4c649628623db6aba77335e4f4569ff5083a6448b32e"
-dependencies = [
- "pem",
- "ring 0.17.14",
- "rustls-pki-types",
- "time",
- "x509-parser 0.18.1",
- "yasna",
-]
-
-[[package]]
 name = "readme-rustdocifier"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10315,15 +10044,6 @@ name = "redb"
 version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eca1e9d98d5a7e9002d0013e18d5a9b000aee942eb134883a82f06ebffb6c01"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "redb"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e925444704b5f17d32bf42f5b6e2df050bceebc3dcd6e71cc73dafe8092e839"
 dependencies = [
  "libc",
 ]
@@ -10387,18 +10107,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "reflink-copy"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13362233b147e57674c37b802d216b7c5e3dcccbed8967c84f0d8d223868ae27"
-dependencies = [
- "cfg-if",
- "libc",
- "rustix 1.1.4",
- "windows 0.62.2",
 ]
 
 [[package]]
@@ -12003,7 +11711,7 @@ dependencies = [
  "lark-kv",
  "parking_lot 0.12.5",
  "proptest",
- "redb 2.6.3",
+ "redb",
  "rocksdb",
  "rusty-leveldb",
  "schema",
@@ -12120,17 +11828,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "syn-mid"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea305d57546cc8cd04feb14b62ec84bf17f50e3f7b12560d7bfa9265f39d9ed"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -14723,32 +14420,14 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
 dependencies = [
- "asn1-rs 0.6.2",
+ "asn1-rs",
  "data-encoding",
- "der-parser 9.0.0",
+ "der-parser",
  "lazy_static",
  "nom",
- "oid-registry 0.7.1",
+ "oid-registry",
  "rusticata-macros",
  "thiserror 1.0.69",
- "time",
-]
-
-[[package]]
-name = "x509-parser"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
-dependencies = [
- "asn1-rs 0.7.1",
- "data-encoding",
- "der-parser 10.0.0",
- "lazy_static",
- "nom",
- "oid-registry 0.8.1",
- "ring 0.17.14",
- "rusticata-macros",
- "thiserror 2.0.18",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,6 @@ multiaddr = "0.18"
 # Iroh P2P transport (alternative to libp2p)
 iroh = "1.0.1"
 iroh-gossip = "0.101.0"
-iroh-blobs = "0.103.0"
 iroh-tickets = "1.0.0"
 postcard = { version = "1.0", features = ["alloc"] }
 

--- a/crates/lens/Cargo.toml
+++ b/crates/lens/Cargo.toml
@@ -10,7 +10,7 @@ description = "Lens schema migration support for DefraDB"
 
 [features]
 default = ["wasmtime-runtime"]
-wasmtime-runtime = ["dep:wasmtime", "dep:tokio", "dep:tokio-stream", "dep:parking_lot"]
+wasmtime-runtime = ["dep:wasmtime", "dep:tokio", "dep:parking_lot"]
 
 [dependencies]
 # Core
@@ -36,12 +36,8 @@ hex.workspace = true
 
 # Wasmtime runtime dependencies (optional for wasm32)
 tokio = { workspace = true, optional = true }
-tokio-stream = { workspace = true, optional = true }
 parking_lot = { workspace = true, optional = true }
 wasmtime = { version = "43.0.1", optional = true }
-
-[dev-dependencies]
-proptest.workspace = true
 
 [lints]
 workspace = true

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -74,8 +74,10 @@ void = { version = "1.0.2", optional = true }
 # Iroh transport (optional)
 iroh = { workspace = true, optional = true }
 iroh-gossip = { workspace = true, optional = true }
-iroh-blobs = { workspace = true, optional = true }
 iroh-tickets = { workspace = true, optional = true }
+# Preserve the noq defaults and feature aliases that iroh-blobs previously
+# enabled transitively, including the Iroh endpoint's bloom token log.
+noq = { version = "1.1", features = ["bloom", "rustls-ring"], optional = true }
 rand = { version = "0.9", optional = true }
 blake3 = { version = "1", optional = true }
 
@@ -91,11 +93,14 @@ libp2p-transport = [
     "dep:sysinfo",
     "dep:void",
 ]
-iroh-transport = ["dep:iroh", "dep:iroh-gossip", "dep:iroh-blobs", "dep:iroh-tickets", "dep:rand", "dep:blake3"]
+iroh-transport = ["dep:iroh", "dep:iroh-gossip", "dep:iroh-tickets", "dep:noq", "dep:rand", "dep:blake3"]
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }
 p2p = { path = ".", features = ["test-utils"] }
+
+[package.metadata.cargo-machete]
+ignored = ["noq"]
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary

- remove the source-unused optional `iroh-blobs` dependency from P2P;
- retain the behavior-bearing Noq defaults/features that `iroh-blobs` previously unified by declaring an optional `noq` feature activator with `bloom,rustls-ring`;
- remove the now-unreachable blob/RPC/storage/certificate closure from `Cargo.lock`.

Stacked dependency: this exact commit is based on #1262. Its current CI therefore validates the combined Lens + Iroh tree; merge #1262 first. Once #1262 lands, this PR will contain only the three Iroh dependency files.

## Dependency evidence

There is no `iroh_blobs` Rust path, public type, re-export, macro, generated-code use, doctest, example, benchmark, build-script use, linker side effect, registration hook, or blobs ALPN in DefraDB. P2P source is byte-identical across this change.

The direct `noq` dependency is intentionally source-invisible: it preserves the Noq defaults and `bloom,rustls-ring` activation previously supplied transitively. `cargo machete` is ignored only for this documented feature activator and is corroboration, not proof.

Across the exact target/feature matrix, non-Iroh graphs are identical and protected `noq`, `noq-proto`, `noq-udp`, `rustls-platform-verifier`, Apple fast-datapath, and `tracing/log` feature inventories are identical.

## Lockfile effects

- package stanzas: 1,265 -> 1,241 (-24);
- all-feature normalized package/version/feature pairs: 2,991 -> 2,927 (-64);
- added identities/features: 0;
- retained version/source/checksum changes: 0.

Removed identities are the `iroh-blobs 0.103.0` closure, including its blob store/RPC helpers, redundant `redb 4.1.0`, certificate parser/generator, and legacy proc-macro support. No dependency upgrade or version unification is included.

Representative P2P production graph reductions:

- macOS ARM64 Iroh-only: 436 -> 412 (-24);
- Linux x86_64 Iroh-only: 428 -> 402 (-26);
- Windows GNU Iroh-only: 445 -> 419 (-26);
- WASM Iroh-only: 397 -> 373 (-24);
- Apple iOS ARM64 Iroh-only: 433 -> 409 (-24).

## Validation

Completed on the exact base/candidate pair:

- full static native/WASM feature and inverse-tree matrix;
- Cargo metadata/tree/Machete corroboration and lock identity audit;
- P2P Iroh, libp2p, both, test-utils, all-feature checks and Clippy;
- P2P library/tests: 627 passed, 8 ignored on each side;
- semantic Bloom/platform-verifier/tracing-log runtime probe;
- six Iroh consumers;
- Spark `p2p_iroh` suite: 215 shared first-pass passes; all 16 environment-prerequisite cases replayed green on both sides after supplying identical CLI/WASM/Go fixtures;
- Studio2 `p2p_iroh`: 222 shared first-pass passes; all 9 missing-CLI prerequisite cases replayed green on both sides with side-specific exact artifacts;
- independent Codex PASS, Grok PASS, Claude Opus conditional static PASS.

WASM compilation reaches the same existing `mio` unsupported-target diagnostic on both sides. No Windows dynamic runner exists; Windows is covered by the exact static matrix.

## Artifact and measurement scope

No source, profile, stripping, LTO, panic, or debug-info setting changes. Default/libp2p and shipped browser-WASM dependency graphs are identical, so this PR makes no size claim for those artifacts.

Four alternating same-host crossover rounds ran on each Spark with fresh explicit targets, inverse order, 20 pinned CPUs, positive niceness, `CARGO_INCREMENTAL=0`, no compiler wrapper/sccache, and locked/offline resolution:

```text
cargo +1.95.0 check --locked --offline -p p2p \
  --target aarch64-unknown-linux-gnu \
  --no-default-features --features iroh-transport --timings
```

Cold check medians:

- Spark1: 38.025s -> 33.955s (-10.70%; per-round range -8.30% to -11.86%);
- Spark2: 38.020s -> 34.420s (-9.47%; per-round range -8.86% to -11.03%);
- user CPU: -9.34% and -9.61%;
- fresh target data: about 1.520 GB -> 1.352 GB on both hosts (-11.05%, about 168 MB).

Warm unchanged checks remained sub-second and effectively neutral. Peak RSS was noisy/higher, so no memory improvement is claimed. These results support a roughly 9-11% cold-check improvement only for isolated pure-Iroh P2P; they are not a whole-workspace, incremental-edit, release-link, or shipped-binary claim.

## Known limitations

There is no Windows dynamic CI lane; Windows is covered statically. Five Windows storage/IO feature pairs disappear with the unreachable reflink/blob closure. The exact lock currently contains one Noq 1.1 major; future Iroh/Noq major drift must keep the source-invisible activator aligned.
