### PR TITLE
fix(release): build distinct feature sets per published variant

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,27 +58,27 @@ jobs:
             platform: darwin_arm64
             runner: '["self-hosted", "macOS", "ARM64", "studio"]'
             features: "--no-default-features --features rocksdb,lark"
-          # redb (lark included: default runtime backend)
-          - variant: redb
+          # lark (minimal: single default-runtime backend)
+          - variant: lark
             target: x86_64-unknown-linux-gnu
             platform: linux_amd64
             runner: '["self-hosted", "Linux", "X64"]'
-            features: "--no-default-features --features redb,lark"
-          - variant: redb
+            features: "--no-default-features --features lark"
+          - variant: lark
             target: aarch64-unknown-linux-gnu
             platform: linux_arm64
             runner: '["self-hosted", "Linux", "ARM64"]'
-            features: "--no-default-features --features redb,lark"
-          - variant: redb
+            features: "--no-default-features --features lark"
+          - variant: lark
             target: x86_64-apple-darwin
             platform: darwin_amd64
             runner: '["self-hosted", "macOS", "ARM64", "studio"]'
-            features: "--no-default-features --features redb,lark,vendored-openssl"
-          - variant: redb
+            features: "--no-default-features --features lark,vendored-openssl"
+          - variant: lark
             target: aarch64-apple-darwin
             platform: darwin_arm64
             runner: '["self-hosted", "macOS", "ARM64", "studio"]'
-            features: "--no-default-features --features redb,lark"
+            features: "--no-default-features --features lark"
     steps:
       - uses: actions/checkout@v4
 
@@ -106,7 +106,7 @@ jobs:
           if ! command -v protoc >/dev/null 2>&1; then
             NEEDS_APT=1
           fi
-          if [ "${{ matrix.variant }}" != "redb" ] && ! command -v clang >/dev/null 2>&1; then
+          if [ "${{ matrix.variant }}" != "lark" ] && ! command -v clang >/dev/null 2>&1; then
             NEEDS_APT=1
           fi
 
@@ -122,7 +122,7 @@ jobs:
 
           bash .github/scripts/apt-update-without-nodesource.sh "${APT_ARGS[@]}"
           sudo apt-get "${APT_ARGS[@]}" install -y libssl-dev pkg-config protobuf-compiler libdbus-1-dev
-          if [ "${{ matrix.variant }}" != "redb" ]; then
+          if [ "${{ matrix.variant }}" != "lark" ]; then
             sudo apt-get "${APT_ARGS[@]}" install -y libclang-dev
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,48 +16,69 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # rocksdb (default storage backend)
-          - variant: rocksdb
+          # full (all default features: lark + rocksdb + redb)
+          - variant: full
             target: x86_64-unknown-linux-gnu
             platform: linux_amd64
             runner: '["self-hosted", "Linux", "X64"]'
             features: ""
-          - variant: rocksdb
+          - variant: full
             target: aarch64-unknown-linux-gnu
             platform: linux_arm64
             runner: '["self-hosted", "Linux", "ARM64"]'
             features: ""
-          - variant: rocksdb
+          - variant: full
             target: x86_64-apple-darwin
             platform: darwin_amd64
             runner: '["self-hosted", "macOS", "ARM64", "studio"]'
             features: "--features vendored-openssl"
-          - variant: rocksdb
+          - variant: full
             target: aarch64-apple-darwin
             platform: darwin_arm64
             runner: '["self-hosted", "macOS", "ARM64", "studio"]'
             features: ""
-          # redb
+          # rocksdb (lark included: default runtime backend)
+          - variant: rocksdb
+            target: x86_64-unknown-linux-gnu
+            platform: linux_amd64
+            runner: '["self-hosted", "Linux", "X64"]'
+            features: "--no-default-features --features rocksdb,lark"
+          - variant: rocksdb
+            target: aarch64-unknown-linux-gnu
+            platform: linux_arm64
+            runner: '["self-hosted", "Linux", "ARM64"]'
+            features: "--no-default-features --features rocksdb,lark"
+          - variant: rocksdb
+            target: x86_64-apple-darwin
+            platform: darwin_amd64
+            runner: '["self-hosted", "macOS", "ARM64", "studio"]'
+            features: "--no-default-features --features rocksdb,lark,vendored-openssl"
+          - variant: rocksdb
+            target: aarch64-apple-darwin
+            platform: darwin_arm64
+            runner: '["self-hosted", "macOS", "ARM64", "studio"]'
+            features: "--no-default-features --features rocksdb,lark"
+          # redb (lark included: default runtime backend)
           - variant: redb
             target: x86_64-unknown-linux-gnu
             platform: linux_amd64
             runner: '["self-hosted", "Linux", "X64"]'
-            features: "--features redb"
+            features: "--no-default-features --features redb,lark"
           - variant: redb
             target: aarch64-unknown-linux-gnu
             platform: linux_arm64
             runner: '["self-hosted", "Linux", "ARM64"]'
-            features: "--features redb"
+            features: "--no-default-features --features redb,lark"
           - variant: redb
             target: x86_64-apple-darwin
             platform: darwin_amd64
             runner: '["self-hosted", "macOS", "ARM64", "studio"]'
-            features: "--features redb,vendored-openssl"
+            features: "--no-default-features --features redb,lark,vendored-openssl"
           - variant: redb
             target: aarch64-apple-darwin
             platform: darwin_arm64
             runner: '["self-hosted", "macOS", "ARM64", "studio"]'
-            features: "--features redb"
+            features: "--no-default-features --features redb,lark"
     steps:
       - uses: actions/checkout@v4
 
@@ -85,7 +106,7 @@ jobs:
           if ! command -v protoc >/dev/null 2>&1; then
             NEEDS_APT=1
           fi
-          if [ "${{ matrix.variant }}" = "rocksdb" ] && ! command -v clang >/dev/null 2>&1; then
+          if [ "${{ matrix.variant }}" != "redb" ] && ! command -v clang >/dev/null 2>&1; then
             NEEDS_APT=1
           fi
 
@@ -101,7 +122,7 @@ jobs:
 
           bash .github/scripts/apt-update-without-nodesource.sh "${APT_ARGS[@]}"
           sudo apt-get "${APT_ARGS[@]}" install -y libssl-dev pkg-config protobuf-compiler libdbus-1-dev
-          if [ "${{ matrix.variant }}" = "rocksdb" ]; then
+          if [ "${{ matrix.variant }}" != "redb" ]; then
             sudo apt-get "${APT_ARGS[@]}" install -y libclang-dev
           fi
 
@@ -124,7 +145,7 @@ jobs:
         shell: bash
         run: |
           TAG="${GITHUB_REF_NAME}"
-          if [ "${{ matrix.variant }}" = "rocksdb" ]; then
+          if [ "${{ matrix.variant }}" = "full" ]; then
             ARCHIVE="defra_${TAG}_${{ matrix.platform }}.tar.gz"
           else
             ARCHIVE="defra-${{ matrix.variant }}_${TAG}_${{ matrix.platform }}.tar.gz"
@@ -202,48 +223,48 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # redb (default)
+          # redb (default; lark included: default runtime backend)
           - variant: redb
             target: x86_64-unknown-linux-gnu
             platform: linux_amd64
             runner: '["self-hosted", "Linux", "X64"]'
-            features: "--features iroh"
+            features: "--no-default-features --features native,wasmtime-runtime,lark,redb,iroh"
           - variant: redb
             target: aarch64-unknown-linux-gnu
             platform: linux_arm64
             runner: '["self-hosted", "Linux", "ARM64"]'
-            features: "--features iroh"
+            features: "--no-default-features --features native,wasmtime-runtime,lark,redb,iroh"
           - variant: redb
             target: x86_64-apple-darwin
             platform: darwin_amd64
             runner: '["self-hosted", "macOS", "ARM64", "studio"]'
-            features: "--features iroh"
+            features: "--no-default-features --features native,wasmtime-runtime,lark,redb,iroh"
           - variant: redb
             target: aarch64-apple-darwin
             platform: darwin_arm64
             runner: '["self-hosted", "macOS", "ARM64", "studio"]'
-            features: "--features iroh"
-          # rocksdb
+            features: "--no-default-features --features native,wasmtime-runtime,lark,redb,iroh"
+          # rocksdb (redb stays: ffi hard-requires it; lark: default runtime backend)
           - variant: rocksdb
             target: x86_64-unknown-linux-gnu
             platform: linux_amd64
             runner: '["self-hosted", "Linux", "X64"]'
-            features: "--features rocksdb,iroh"
+            features: "--no-default-features --features native,wasmtime-runtime,lark,redb,rocksdb,iroh"
           - variant: rocksdb
             target: aarch64-unknown-linux-gnu
             platform: linux_arm64
             runner: '["self-hosted", "Linux", "ARM64"]'
-            features: "--features rocksdb,iroh"
+            features: "--no-default-features --features native,wasmtime-runtime,lark,redb,rocksdb,iroh"
           - variant: rocksdb
             target: x86_64-apple-darwin
             platform: darwin_amd64
             runner: '["self-hosted", "macOS", "ARM64", "studio"]'
-            features: "--features rocksdb,iroh"
+            features: "--no-default-features --features native,wasmtime-runtime,lark,redb,rocksdb,iroh"
           - variant: rocksdb
             target: aarch64-apple-darwin
             platform: darwin_arm64
             runner: '["self-hosted", "macOS", "ARM64", "studio"]'
-            features: "--features rocksdb,iroh"
+            features: "--no-default-features --features native,wasmtime-runtime,lark,redb,rocksdb,iroh"
     steps:
       - uses: actions/checkout@v4
 
@@ -411,12 +432,12 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: defra-rocksdb-linux_amd64
+          name: defra-full-linux_amd64
           path: docker-context/linux/amd64
 
       - uses: actions/download-artifact@v4
         with:
-          name: defra-rocksdb-linux_arm64
+          name: defra-full-linux_arm64
           path: docker-context/linux/arm64
 
       - name: Extract binaries
@@ -446,6 +467,12 @@ jobs:
       needs.docker.result == 'success'
     runs-on: [self-hosted, Linux, X64]
     steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: defra-full-*
+          merge-multiple: true
+
       - uses: actions/download-artifact@v4
         with:
           path: artifacts


### PR DESCRIPTION
All published v0.17.2 artifacts are byte-identical: the release matrix passes \`--features redb\` etc. without \`--no-default-features\`, and cli defaults include every backend — verified by sha256 (defra vs defra-redb identical; both 543MB FFI archives identical).

This makes the variants real:
- CLI matrix: **full** (default features → unsuffixed \`defra_v*\`, feeds Docker via new \`defra-full-linux_*\` artifacts), **rocksdb** (\`--no-default-features --features rocksdb,lark\`), **redb** (\`--no-default-features --features redb,lark\`). Every variant keeps \`lark\` — it is the runtime-default backend for CLI and FFI.
- FFI matrix: redb variant drops rocksdb (\`native,wasmtime-runtime,lark,redb,iroh\`); rocksdb variant is today's content, now explicit. FFI always keeps redb (\`ffi/src/node.rs\` uses \`RedbStore\` unconditionally).
- Linux clang install condition now \`variant != redb\`.

No source changes needed — every backend path was already cfg-gated. All 9 feature combos cargo-checked clean on darwin_arm64.

Release-notes callouts: \`defra-redb_*\`/\`defra-ffi-redb_*\` archives previously contained full builds; \`--store rocksdb\` against the slim redb binary now errors (intended). CI-artifact consumers of \`defra-rocksdb-linux_*\` now get the slim build (full moved to \`defra-full-*\`). CLI matrix grows 8→12 rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)