### PR TITLE
feat(cli)!: make postgres wire support opt-in

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -41,7 +41,7 @@ keyring = { path = "../keyring" }
 orbis = { path = "../orbis" }
 sourcehub = { path = "../sourcehub" }
 defra-version = { path = "../defra-version" }
-pg-compat = { path = "../pg-compat" }
+pg-compat = { path = "../pg-compat", optional = true }
 telemetry = { path = "../telemetry", default-features = false }
 
 # CLI
@@ -113,8 +113,9 @@ version = "0.9"
 optional = true
 
 [features]
-default = ["lark", "rocksdb", "redb"]
+default = ["lark", "rocksdb", "redb", "postgres"]
 lark = ["storage/lark"]
+postgres = ["dep:pg-compat"]
 redb = ["storage/redb"]
 fjall = ["storage/fjall"]
 rocksdb = ["storage/rocksdb"]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -113,7 +113,7 @@ version = "0.9"
 optional = true
 
 [features]
-default = ["lark", "rocksdb", "redb", "postgres"]
+default = ["lark", "rocksdb", "redb"]
 lark = ["storage/lark"]
 postgres = ["dep:pg-compat"]
 redb = ["storage/redb"]

--- a/crates/cli/src/commands/start/mod.rs
+++ b/crates/cli/src/commands/start/mod.rs
@@ -241,6 +241,7 @@ pub struct StartArgs {
     pub p2p_transport: Option<String>,
 
     /// Address for Postgres wire protocol compatibility (e.g., "127.0.0.1:5433")
+    #[cfg(feature = "postgres")]
     #[arg(long)]
     pub pg_address: Option<String>,
 
@@ -549,6 +550,7 @@ impl StartArgs {
         if let Some(depth) = self.query_max_filter_depth {
             config.api.query_max_filter_depth = depth;
         }
+        #[cfg(feature = "postgres")]
         if let Some(ref addr) = self.pg_address {
             config.api.pg_address = addr.clone();
         }

--- a/crates/cli/src/commands/start/node.rs
+++ b/crates/cli/src/commands/start/node.rs
@@ -33,6 +33,17 @@ pub(super) struct P2PTasks {
     pub retry_loop_task: JoinHandle<()>,
 }
 
+/// Servers and background tasks produced by store/server initialization.
+pub(super) struct ServerSetup {
+    pub p2p_handle: Option<p2p::P2PHostHandle>,
+    pub p2p_tasks: Option<P2PTasks>,
+    pub downsample_task: Option<JoinHandle<()>>,
+    pub txn_cleanup_task: Option<JoinHandle<()>>,
+    pub http_server: defra_http::Server,
+    #[cfg(feature = "postgres")]
+    pub pg_server: Option<pg_compat::PgServer>,
+}
+
 /// DefraDB Node
 /// Node manages the DefraDB server lifecycle.
 #[doc(hidden)]
@@ -43,6 +54,7 @@ pub struct Node {
     pub(super) downsample_task: Option<JoinHandle<()>>,
     pub(super) txn_cleanup_task: Option<JoinHandle<()>>,
     pub(super) http_server: Option<defra_http::Server>,
+    #[cfg(feature = "postgres")]
     pub(super) pg_server: Option<pg_compat::PgServer>,
     /// Shutdown signal sender (for tests)
     #[doc(hidden)]
@@ -137,7 +149,6 @@ impl Node {
     /// Build the persistent ACP/Zanzibar stores from a shared store and start
     /// the server. The store may be a bare backend or an [`EncryptedStore`];
     /// both DB and ACP share the same instance so they encrypt uniformly.
-    #[allow(clippy::type_complexity)]
     async fn init_persistent_store_and_server<S>(
         store: Arc<S>,
         config: &Config,
@@ -145,14 +156,7 @@ impl Node {
         user_identity: Option<std::sync::Arc<identity::RawIdentity>>,
         node_identity_did: Option<String>,
         se_key: Option<[u8; 32]>,
-    ) -> Result<(
-        Option<p2p::P2PHostHandle>,
-        Option<P2PTasks>,
-        Option<JoinHandle<()>>,
-        Option<JoinHandle<()>>,
-        defra_http::Server,
-        Option<pg_compat::PgServer>,
-    )>
+    ) -> Result<ServerSetup>
     where
         S: storage::corekv::Store + 'static,
     {
@@ -206,215 +210,213 @@ impl Node {
         }
 
         // Initialize storage, database, and set up P2P and HTTP server
-        let (p2p_handle, p2p_tasks, downsample_task, txn_cleanup_task, http_server, pg_server) =
-            match config.datastore.store {
-                DatastoreType::Memory => {
-                    info!("Using in-memory datastore");
-                    // Use in-memory ACP store for memory datastore
-                    let acp_store: Arc<dyn acp::AcpStore> = Arc::new(acp::MemoryAcpStore::new());
-                    let zanzibar_store: Arc<dyn acp::ZanzibarStore> =
-                        Arc::new(acp::MemoryZanzibarStore::new());
-                    info!("Using in-memory ACP store");
-                    let backend = storage::MemoryStore::new();
-                    if config.datastore.at_rest_encryption {
-                        info!("At-rest encryption enabled (value-only, AES-256-GCM)");
-                        let key = Self::load_or_create_encryption_key(&config)?;
-                        let store =
-                            Arc::new(storage::encrypted_store::EncryptedStore::new(backend, key));
-                        Self::init_store_and_server(
-                            store,
-                            &config,
-                            peer_keypair,
-                            user_identity.clone(),
-                            acp_store,
-                            zanzibar_store,
-                            node_identity_did.clone(),
-                            se_key,
-                        )
-                        .await?
-                    } else {
-                        Self::init_store_and_server(
-                            Arc::new(backend),
-                            &config,
-                            peer_keypair,
-                            user_identity.clone(),
-                            acp_store,
-                            zanzibar_store,
-                            node_identity_did.clone(),
-                            se_key,
-                        )
-                        .await?
-                    }
+        let servers = match config.datastore.store {
+            DatastoreType::Memory => {
+                info!("Using in-memory datastore");
+                // Use in-memory ACP store for memory datastore
+                let acp_store: Arc<dyn acp::AcpStore> = Arc::new(acp::MemoryAcpStore::new());
+                let zanzibar_store: Arc<dyn acp::ZanzibarStore> =
+                    Arc::new(acp::MemoryZanzibarStore::new());
+                info!("Using in-memory ACP store");
+                let backend = storage::MemoryStore::new();
+                if config.datastore.at_rest_encryption {
+                    info!("At-rest encryption enabled (value-only, AES-256-GCM)");
+                    let key = Self::load_or_create_encryption_key(&config)?;
+                    let store =
+                        Arc::new(storage::encrypted_store::EncryptedStore::new(backend, key));
+                    Self::init_store_and_server(
+                        store,
+                        &config,
+                        peer_keypair,
+                        user_identity.clone(),
+                        acp_store,
+                        zanzibar_store,
+                        node_identity_did.clone(),
+                        se_key,
+                    )
+                    .await?
+                } else {
+                    Self::init_store_and_server(
+                        Arc::new(backend),
+                        &config,
+                        peer_keypair,
+                        user_identity.clone(),
+                        acp_store,
+                        zanzibar_store,
+                        node_identity_did.clone(),
+                        se_key,
+                    )
+                    .await?
                 }
-                #[cfg(feature = "redb")]
-                DatastoreType::Redb => {
-                    info!("Using Redb datastore at {}", config.data_path().display());
-                    let opts = RedbStoreOptions::new()
-                        .with_durability(config.datastore.durability)
-                        .with_cache_size(256 * 1024 * 1024);
-                    let backend = storage::RedbStore::open_with_options(config.data_path(), opts)?;
-                    if config.datastore.at_rest_encryption {
-                        info!("At-rest encryption enabled (value-only, AES-256-GCM)");
-                        let key = Self::load_or_create_encryption_key(&config)?;
-                        let store =
-                            Arc::new(storage::encrypted_store::EncryptedStore::new(backend, key));
-                        Self::init_persistent_store_and_server(
-                            store,
-                            &config,
-                            peer_keypair,
-                            user_identity.clone(),
-                            node_identity_did.clone(),
-                            se_key,
-                        )
-                        .await?
-                    } else {
-                        Self::init_persistent_store_and_server(
-                            Arc::new(backend),
-                            &config,
-                            peer_keypair,
-                            user_identity.clone(),
-                            node_identity_did.clone(),
-                            se_key,
-                        )
-                        .await?
-                    }
+            }
+            #[cfg(feature = "redb")]
+            DatastoreType::Redb => {
+                info!("Using Redb datastore at {}", config.data_path().display());
+                let opts = RedbStoreOptions::new()
+                    .with_durability(config.datastore.durability)
+                    .with_cache_size(256 * 1024 * 1024);
+                let backend = storage::RedbStore::open_with_options(config.data_path(), opts)?;
+                if config.datastore.at_rest_encryption {
+                    info!("At-rest encryption enabled (value-only, AES-256-GCM)");
+                    let key = Self::load_or_create_encryption_key(&config)?;
+                    let store =
+                        Arc::new(storage::encrypted_store::EncryptedStore::new(backend, key));
+                    Self::init_persistent_store_and_server(
+                        store,
+                        &config,
+                        peer_keypair,
+                        user_identity.clone(),
+                        node_identity_did.clone(),
+                        se_key,
+                    )
+                    .await?
+                } else {
+                    Self::init_persistent_store_and_server(
+                        Arc::new(backend),
+                        &config,
+                        peer_keypair,
+                        user_identity.clone(),
+                        node_identity_did.clone(),
+                        se_key,
+                    )
+                    .await?
                 }
-                #[cfg(not(feature = "redb"))]
-                DatastoreType::Redb => {
-                    return Err(crate::error::Error::InvalidDatastore(
-                        "redb backend not enabled. Rebuild with --features redb".into(),
-                    ));
+            }
+            #[cfg(not(feature = "redb"))]
+            DatastoreType::Redb => {
+                return Err(crate::error::Error::InvalidDatastore(
+                    "redb backend not enabled. Rebuild with --features redb".into(),
+                ));
+            }
+            #[cfg(feature = "fjall")]
+            DatastoreType::Fjall => {
+                info!("Using Fjall datastore at {}", config.data_path().display());
+                let opts = FjallStoreOptions::new().with_durability(config.datastore.durability);
+                let backend = storage::FjallStore::open_with_options(config.data_path(), opts)?;
+                if config.datastore.at_rest_encryption {
+                    info!("At-rest encryption enabled (value-only, AES-256-GCM)");
+                    let key = Self::load_or_create_encryption_key(&config)?;
+                    let store =
+                        Arc::new(storage::encrypted_store::EncryptedStore::new(backend, key));
+                    Self::init_persistent_store_and_server(
+                        store,
+                        &config,
+                        peer_keypair,
+                        user_identity.clone(),
+                        node_identity_did.clone(),
+                        se_key,
+                    )
+                    .await?
+                } else {
+                    Self::init_persistent_store_and_server(
+                        Arc::new(backend),
+                        &config,
+                        peer_keypair,
+                        user_identity.clone(),
+                        node_identity_did.clone(),
+                        se_key,
+                    )
+                    .await?
                 }
-                #[cfg(feature = "fjall")]
-                DatastoreType::Fjall => {
-                    info!("Using Fjall datastore at {}", config.data_path().display());
-                    let opts =
-                        FjallStoreOptions::new().with_durability(config.datastore.durability);
-                    let backend = storage::FjallStore::open_with_options(config.data_path(), opts)?;
-                    if config.datastore.at_rest_encryption {
-                        info!("At-rest encryption enabled (value-only, AES-256-GCM)");
-                        let key = Self::load_or_create_encryption_key(&config)?;
-                        let store =
-                            Arc::new(storage::encrypted_store::EncryptedStore::new(backend, key));
-                        Self::init_persistent_store_and_server(
-                            store,
-                            &config,
-                            peer_keypair,
-                            user_identity.clone(),
-                            node_identity_did.clone(),
-                            se_key,
-                        )
-                        .await?
-                    } else {
-                        Self::init_persistent_store_and_server(
-                            Arc::new(backend),
-                            &config,
-                            peer_keypair,
-                            user_identity.clone(),
-                            node_identity_did.clone(),
-                            se_key,
-                        )
-                        .await?
-                    }
+            }
+            #[cfg(not(feature = "fjall"))]
+            DatastoreType::Fjall => {
+                return Err(crate::error::Error::InvalidDatastore(
+                    "fjall backend not enabled. Rebuild with --features fjall".into(),
+                ));
+            }
+            #[cfg(feature = "rocksdb")]
+            DatastoreType::RocksDb => {
+                info!(
+                    "Using RocksDB datastore at {}",
+                    config.data_path().display()
+                );
+                let opts =
+                    RocksDbStoreOptions::from_env().with_durability(config.datastore.durability);
+                let backend = storage::RocksDbStore::open_with_options(config.data_path(), opts)?;
+                if config.datastore.at_rest_encryption {
+                    info!("At-rest encryption enabled (value-only, AES-256-GCM)");
+                    let key = Self::load_or_create_encryption_key(&config)?;
+                    let store =
+                        Arc::new(storage::encrypted_store::EncryptedStore::new(backend, key));
+                    Self::init_persistent_store_and_server(
+                        store,
+                        &config,
+                        peer_keypair,
+                        user_identity.clone(),
+                        node_identity_did.clone(),
+                        se_key,
+                    )
+                    .await?
+                } else {
+                    Self::init_persistent_store_and_server(
+                        Arc::new(backend),
+                        &config,
+                        peer_keypair,
+                        user_identity.clone(),
+                        node_identity_did.clone(),
+                        se_key,
+                    )
+                    .await?
                 }
-                #[cfg(not(feature = "fjall"))]
-                DatastoreType::Fjall => {
-                    return Err(crate::error::Error::InvalidDatastore(
-                        "fjall backend not enabled. Rebuild with --features fjall".into(),
-                    ));
+            }
+            #[cfg(not(feature = "rocksdb"))]
+            DatastoreType::RocksDb => {
+                return Err(crate::error::Error::InvalidDatastore(
+                    "rocksdb backend not enabled. Rebuild with --features rocksdb".into(),
+                ));
+            }
+            #[cfg(feature = "lark")]
+            DatastoreType::Lark => {
+                info!("Using Lark datastore at {}", config.data_path().display());
+                let opts =
+                    LarkStoreOptions::from_env().with_durability(config.datastore.durability);
+                let backend = storage::LarkStore::open_with_options(config.data_path(), opts)?;
+                if config.datastore.at_rest_encryption {
+                    info!("At-rest encryption enabled (value-only, AES-256-GCM)");
+                    let key = Self::load_or_create_encryption_key(&config)?;
+                    let store =
+                        Arc::new(storage::encrypted_store::EncryptedStore::new(backend, key));
+                    Self::init_persistent_store_and_server(
+                        store,
+                        &config,
+                        peer_keypair,
+                        user_identity.clone(),
+                        node_identity_did.clone(),
+                        se_key,
+                    )
+                    .await?
+                } else {
+                    Self::init_persistent_store_and_server(
+                        Arc::new(backend),
+                        &config,
+                        peer_keypair,
+                        user_identity.clone(),
+                        node_identity_did.clone(),
+                        se_key,
+                    )
+                    .await?
                 }
-                #[cfg(feature = "rocksdb")]
-                DatastoreType::RocksDb => {
-                    info!(
-                        "Using RocksDB datastore at {}",
-                        config.data_path().display()
-                    );
-                    let opts = RocksDbStoreOptions::from_env()
-                        .with_durability(config.datastore.durability);
-                    let backend =
-                        storage::RocksDbStore::open_with_options(config.data_path(), opts)?;
-                    if config.datastore.at_rest_encryption {
-                        info!("At-rest encryption enabled (value-only, AES-256-GCM)");
-                        let key = Self::load_or_create_encryption_key(&config)?;
-                        let store =
-                            Arc::new(storage::encrypted_store::EncryptedStore::new(backend, key));
-                        Self::init_persistent_store_and_server(
-                            store,
-                            &config,
-                            peer_keypair,
-                            user_identity.clone(),
-                            node_identity_did.clone(),
-                            se_key,
-                        )
-                        .await?
-                    } else {
-                        Self::init_persistent_store_and_server(
-                            Arc::new(backend),
-                            &config,
-                            peer_keypair,
-                            user_identity.clone(),
-                            node_identity_did.clone(),
-                            se_key,
-                        )
-                        .await?
-                    }
-                }
-                #[cfg(not(feature = "rocksdb"))]
-                DatastoreType::RocksDb => {
-                    return Err(crate::error::Error::InvalidDatastore(
-                        "rocksdb backend not enabled. Rebuild with --features rocksdb".into(),
-                    ));
-                }
-                #[cfg(feature = "lark")]
-                DatastoreType::Lark => {
-                    info!("Using Lark datastore at {}", config.data_path().display());
-                    let opts =
-                        LarkStoreOptions::from_env().with_durability(config.datastore.durability);
-                    let backend = storage::LarkStore::open_with_options(config.data_path(), opts)?;
-                    if config.datastore.at_rest_encryption {
-                        info!("At-rest encryption enabled (value-only, AES-256-GCM)");
-                        let key = Self::load_or_create_encryption_key(&config)?;
-                        let store =
-                            Arc::new(storage::encrypted_store::EncryptedStore::new(backend, key));
-                        Self::init_persistent_store_and_server(
-                            store,
-                            &config,
-                            peer_keypair,
-                            user_identity.clone(),
-                            node_identity_did.clone(),
-                            se_key,
-                        )
-                        .await?
-                    } else {
-                        Self::init_persistent_store_and_server(
-                            Arc::new(backend),
-                            &config,
-                            peer_keypair,
-                            user_identity.clone(),
-                            node_identity_did.clone(),
-                            se_key,
-                        )
-                        .await?
-                    }
-                }
-                #[cfg(not(feature = "lark"))]
-                DatastoreType::Lark => {
-                    return Err(crate::error::Error::InvalidDatastore(
-                        "lark backend not enabled. Rebuild with --features lark".into(),
-                    ));
-                }
-            };
+            }
+            #[cfg(not(feature = "lark"))]
+            DatastoreType::Lark => {
+                return Err(crate::error::Error::InvalidDatastore(
+                    "lark backend not enabled. Rebuild with --features lark".into(),
+                ));
+            }
+        };
 
         let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
 
         Ok(Self {
             config,
-            p2p_handle,
-            p2p_tasks,
-            downsample_task,
-            txn_cleanup_task,
-            http_server: Some(http_server),
-            pg_server,
+            p2p_handle: servers.p2p_handle,
+            p2p_tasks: servers.p2p_tasks,
+            downsample_task: servers.downsample_task,
+            txn_cleanup_task: servers.txn_cleanup_task,
+            http_server: Some(servers.http_server),
+            #[cfg(feature = "postgres")]
+            pg_server: servers.pg_server,
             shutdown_tx,
             shutdown_rx,
             user_identity,

--- a/crates/cli/src/commands/start/run.rs
+++ b/crates/cli/src/commands/start/run.rs
@@ -26,6 +26,9 @@ impl Node {
         };
 
         // Start PG wire protocol server
+        #[cfg(not(feature = "postgres"))]
+        let pg_task: Option<JoinHandle<()>> = None;
+        #[cfg(feature = "postgres")]
         let pg_task: Option<JoinHandle<()>> = if let Some(server) = self.pg_server.take() {
             info!(
                 "Starting Postgres wire protocol server on {}",

--- a/crates/cli/src/commands/start/server.rs
+++ b/crates/cli/src/commands/start/server.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use tracing::{info, warn};
 
-use super::node::{Node, P2PTasks};
+use super::node::{Node, ServerSetup};
 use super::server_http::HttpServerArgs;
 use crate::config::Config;
 use crate::error::{Error, Result};
@@ -17,8 +17,8 @@ impl Node {
     /// This function creates the database, loads collections, sets up the query
     /// runner with proper transaction support, and returns the HTTP server.
     ///
-    /// Returns a tuple of (P2PHostHandle, P2PTasks, background tasks, HTTP Server)
-    /// where the background tasks are tracked for graceful shutdown.
+    /// Returns a [`ServerSetup`] holding the servers and background tasks
+    /// tracked for graceful shutdown.
     #[allow(clippy::too_many_arguments)]
     pub(super) async fn init_store_and_server<S>(
         store: Arc<S>,
@@ -29,14 +29,7 @@ impl Node {
         zanzibar_store: Arc<dyn acp::ZanzibarStore>,
         node_identity_did: Option<String>,
         se_key: Option<[u8; 32]>,
-    ) -> Result<(
-        Option<p2p::P2PHostHandle>,
-        Option<P2PTasks>,
-        Option<tokio::task::JoinHandle<()>>,
-        Option<tokio::task::JoinHandle<()>>,
-        defra_http::Server,
-        Option<pg_compat::PgServer>,
-    )>
+    ) -> Result<ServerSetup>
     where
         S: storage::corekv::Store + 'static,
     {
@@ -311,6 +304,7 @@ impl Node {
             None
         };
 
+        #[cfg(feature = "postgres")]
         let zanzibar_store_for_pg = zanzibar_store.clone();
         let http_server = Self::build_http_server(HttpServerArgs {
             database: database.clone(),
@@ -325,6 +319,7 @@ impl Node {
             user_did: user_did.as_ref(),
             node_identity_did,
         })?;
+        #[cfg(feature = "postgres")]
         let pg_server = Self::build_pg_server(
             database,
             config,
@@ -333,13 +328,14 @@ impl Node {
             zanzibar_store_for_pg,
         )?;
 
-        Ok((
-            p2p_setup.host_handle,
-            p2p_setup.p2p_tasks,
+        Ok(ServerSetup {
+            p2p_handle: p2p_setup.host_handle,
+            p2p_tasks: p2p_setup.p2p_tasks,
             downsample_task,
             txn_cleanup_task,
             http_server,
+            #[cfg(feature = "postgres")]
             pg_server,
-        ))
+        })
     }
 }

--- a/crates/cli/src/commands/start/server_http.rs
+++ b/crates/cli/src/commands/start/server_http.rs
@@ -230,6 +230,7 @@ impl Node {
         Ok(server)
     }
 
+    #[cfg(feature = "postgres")]
     pub(super) fn build_pg_server<S>(
         database: Arc<db::DB<S>>,
         config: &Config,

--- a/crates/cli/src/commands/start/server_query.rs
+++ b/crates/cli/src/commands/start/server_query.rs
@@ -12,6 +12,7 @@ pub(super) struct QueryRunnerSetup<S: storage::corekv::Store + 'static> {
     pub(super) runner: Arc<dyn query::executor::QueryExecutor>,
     pub(super) rest_ops: Arc<dyn query::rest::RestOperations>,
     pub(super) registry: Arc<db::DbTransactionRegistry<S>>,
+    #[cfg(feature = "postgres")]
     pub(super) collection_provider: Arc<dyn query::CollectionProvider>,
 }
 
@@ -89,6 +90,7 @@ impl Node {
             runner,
             rest_ops,
             registry,
+            #[cfg(feature = "postgres")]
             collection_provider,
         }
     }

--- a/crates/cli/src/config/sections.rs
+++ b/crates/cli/src/config/sections.rs
@@ -84,6 +84,7 @@ pub struct ApiConfig {
     #[serde(default = "default_query_max_filter_depth")]
     pub query_max_filter_depth: usize,
     /// Postgres wire protocol address (empty = disabled). Default: "" (disabled).
+    #[cfg(feature = "postgres")]
     #[serde(default)]
     pub pg_address: String,
 }
@@ -138,6 +139,7 @@ impl Default for ApiConfig {
             query_max_depth: default_query_max_depth(),
             query_max_width: default_query_max_width(),
             query_max_filter_depth: default_query_max_filter_depth(),
+            #[cfg(feature = "postgres")]
             pg_address: String::new(),
         }
     }

--- a/crates/cli/src/schema_adapter.rs
+++ b/crates/cli/src/schema_adapter.rs
@@ -69,6 +69,7 @@ impl<S: Store + 'static> SchemaAdapter<S> {
     /// `AcpOperations` handle — that variant enables schema-time DRI
     /// validation (#746). This bare constructor exists for tests and
     /// for embedded PG callers that don't have ACP configured.
+    #[cfg(feature = "postgres")]
     pub fn new_pg_arc(database: Arc<db::DB<S>>) -> Arc<dyn pg_compat::SchemaManager> {
         Arc::new(Self::new(database))
     }
@@ -76,6 +77,7 @@ impl<S: Store + 'static> SchemaAdapter<S> {
     /// Create an Arc-wrapped PG schema manager with ACP wired in for
     /// schema-time DRI validation (#746). Use this when the PG server
     /// has access to an `AcpOperations` handle.
+    #[cfg(feature = "postgres")]
     pub fn new_pg_arc_with_acp(
         database: Arc<db::DB<S>>,
         acp: Arc<dyn AcpOperations>,
@@ -147,6 +149,7 @@ impl<S: Store + 'static> SchemaOperations for SchemaAdapter<S> {
     }
 }
 
+#[cfg(feature = "postgres")]
 #[async_trait]
 impl<S: Store + 'static> pg_compat::SchemaManager for SchemaAdapter<S> {
     async fn add_schema(&self, sdl: &str) -> Result<(), String> {

--- a/crates/cli/tests/start_tests.rs
+++ b/crates/cli/tests/start_tests.rs
@@ -56,6 +56,7 @@ fn default_start_args() -> StartArgs {
         query_max_width: None,
         query_max_filter_depth: None,
         p2p_transport: None,
+        #[cfg(feature = "postgres")]
         pg_address: None,
         acp_cache_ttl: None,
         acp_circuit_breaker_threshold: None,
@@ -168,6 +169,7 @@ fn test_apply_to_config_all_flags() {
         query_max_width: Some(64),
         query_max_filter_depth: Some(24),
         p2p_transport: None,
+        #[cfg(feature = "postgres")]
         pg_address: None,
         acp_cache_ttl: None,
         acp_circuit_breaker_threshold: None,


### PR DESCRIPTION
pg-compat (pgwire + sqlparser, ~1.3MiB of .text) is now behind a \`postgres\` cargo feature on cli, **off by default** per maintainer decision — no one uses the pg wire protocol from default builds; enable with \`--features postgres\`.

- Without the feature, \`--pg-address\` and \`api.pg_address\` simply do not exist (absent, not runtime-erroring). An existing config's \`pg_address\` entry is silently ignored — release-notes callout.
- All use sites cfg-gated; the 6-tuple \`init_store_and_server\` return became a \`ServerSetup\` struct (also dropped a \`clippy::type_complexity\` allow).
- cli was the only pg-compat consumer in the workspace.

Verified both ways: \`cargo test -p cli\` (default and \`--no-default-features --features redb\`) pass, clippy \`-D warnings\` clean on both, \`cargo tree -i pg-compat\` absent from the default graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)