### PR TITLE
feat(cli)!: make sourcehub and orbis opt-in

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -38,8 +38,8 @@ events = { path = "../events" }
 lens = { path = "../lens" }
 document = { path = "../document" }
 keyring = { path = "../keyring" }
-orbis = { path = "../orbis" }
-sourcehub = { path = "../sourcehub" }
+orbis = { path = "../orbis", optional = true }
+sourcehub = { path = "../sourcehub", optional = true }
 defra-version = { path = "../defra-version" }
 pg-compat = { path = "../pg-compat" }
 telemetry = { path = "../telemetry", default-features = false }
@@ -113,8 +113,12 @@ version = "0.9"
 optional = true
 
 [features]
-default = ["lark", "rocksdb", "redb"]
+default = ["lark", "rocksdb", "redb", "sourcehub", "orbis"]
 lark = ["storage/lark"]
+# SourceHub/hub.rs on-chain document ACP (`--document-acp-type source-hub|hub-rs`).
+sourcehub = ["dep:sourcehub"]
+# Orbis ring threshold signing (`--signer-type orbis`).
+orbis = ["dep:orbis"]
 redb = ["storage/redb"]
 fjall = ["storage/fjall"]
 rocksdb = ["storage/rocksdb"]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -113,7 +113,7 @@ version = "0.9"
 optional = true
 
 [features]
-default = ["lark", "rocksdb", "redb", "sourcehub", "orbis"]
+default = ["lark", "rocksdb", "redb"]
 lark = ["storage/lark"]
 # SourceHub/hub.rs on-chain document ACP (`--document-acp-type source-hub|hub-rs`).
 sourcehub = ["dep:sourcehub"]

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -79,18 +79,22 @@ pub struct Cli {
     pub no_keyring: Option<bool>,
 
     /// The SourceHub address authorized by the client to make SourceHub transactions
+    #[cfg(feature = "sourcehub")]
     #[arg(long, global = true, env = "DEFRA_SOURCE_HUB_ADDRESS")]
     pub source_hub_address: Option<String>,
 
     /// SourceHub CometBFT RPC address for transaction broadcast
+    #[cfg(feature = "sourcehub")]
     #[arg(long, global = true, env = "DEFRA_SOURCE_HUB_COMET_ADDRESS")]
     pub source_hub_comet_address: Option<String>,
 
     /// SourceHub chain ID (e.g., "sourcehub-test")
+    #[cfg(feature = "sourcehub")]
     #[arg(long, global = true, env = "DEFRA_SOURCE_HUB_CHAIN_ID")]
     pub source_hub_chain_id: Option<String>,
 
     /// hub.rs JSON-RPC endpoint (e.g., "http://localhost:8545")
+    #[cfg(feature = "sourcehub")]
     #[arg(long, global = true, env = "DEFRA_HUB_RS_ADDRESS")]
     pub hub_rs_address: Option<String>,
 
@@ -114,6 +118,16 @@ pub struct Cli {
     pub acp_node_enable: Option<bool>,
 
     /// Document ACP type. Options are none, local, source-hub, or hub-rs
+    #[cfg(feature = "sourcehub")]
+    #[arg(
+        long = "document-acp-type",
+        global = true,
+        env = "DEFRA_ACP_DOCUMENT_TYPE"
+    )]
+    pub acp_document_type: Option<String>,
+
+    /// Document ACP type. Options are none or local
+    #[cfg(not(feature = "sourcehub"))]
     #[arg(
         long = "document-acp-type",
         global = true,

--- a/crates/cli/src/commands/start/mod.rs
+++ b/crates/cli/src/commands/start/mod.rs
@@ -110,18 +110,22 @@ pub struct StartArgs {
     pub durability: Option<String>,
 
     /// Signer type: "local" (default) or "orbis" (Orbis ring threshold signing)
+    #[cfg(feature = "orbis")]
     #[arg(long)]
     pub signer_type: Option<String>,
 
     /// Orbis gRPC endpoint (required when --signer-type=orbis)
+    #[cfg(feature = "orbis")]
     #[arg(long)]
     pub signer_orbis_endpoint: Option<String>,
 
     /// Orbis ring ID from DKG (required when --signer-type=orbis)
+    #[cfg(feature = "orbis")]
     #[arg(long)]
     pub signer_orbis_ring_id: Option<String>,
 
     /// Orbis derivation label for the ring's derived key (e.g. "x-archive")
+    #[cfg(feature = "orbis")]
     #[arg(long)]
     pub signer_orbis_derivation: Option<String>,
 
@@ -295,6 +299,7 @@ impl StartArgs {
         let user_identity = self.parse_user_identity()?;
 
         // Set up Orbis remote signer if configured
+        #[cfg(feature = "orbis")]
         if self.signer_type.as_deref() == Some("orbis") {
             self.setup_orbis_signer(&user_identity).await?;
         }
@@ -308,6 +313,7 @@ impl StartArgs {
     ///
     /// Connects to the Orbis ring, derives the BLS public key, and stores
     /// a SigningConfig with a remote signer under the signer's DID.
+    #[cfg(feature = "orbis")]
     async fn setup_orbis_signer(
         &self,
         user_identity: &Option<std::sync::Arc<identity::RawIdentity>>,

--- a/crates/cli/src/commands/start/server_acp.rs
+++ b/crates/cli/src/commands/start/server_acp.rs
@@ -5,7 +5,9 @@ use std::sync::Arc;
 use tracing::info;
 
 use super::node::Node;
-use crate::config::{AcpDocumentType, Config};
+#[cfg(feature = "sourcehub")]
+use crate::config::AcpDocumentType;
+use crate::config::Config;
 use crate::error::{Error, Result};
 use identity::Did;
 
@@ -15,6 +17,7 @@ pub(super) struct DocumentAcpSetup {
 }
 
 impl Node {
+    #[cfg_attr(not(feature = "sourcehub"), allow(unused_variables))]
     pub(super) async fn setup_document_acp(
         config: &Config,
         identity_key_bytes: Option<&[u8]>,
@@ -23,6 +26,7 @@ impl Node {
         event_bus: Arc<dyn events::Bus>,
         nac_checker: Arc<dyn db::NodeAccessChecker>,
     ) -> Result<DocumentAcpSetup> {
+        #[cfg(feature = "sourcehub")]
         if config.acp.document_type == AcpDocumentType::SourceHub {
             if config.acp.sourcehub_address.is_empty() {
                 return Err(Error::InvalidConfig(
@@ -77,11 +81,14 @@ impl Node {
             );
 
             info!("Document ACP configured (SourceHub)");
-            Ok(DocumentAcpSetup {
+            return Ok(DocumentAcpSetup {
                 document_acp,
                 http_adapter: Some(http_adapter),
-            })
-        } else if config.acp.document_type == AcpDocumentType::HubRs {
+            });
+        }
+
+        #[cfg(feature = "sourcehub")]
+        if config.acp.document_type == AcpDocumentType::HubRs {
             if config.acp.hub_rs_address.is_empty() {
                 return Err(Error::InvalidConfig(
                     "hub_rs_address required when document_type is hub-rs".into(),
@@ -133,21 +140,21 @@ impl Node {
             );
 
             info!("Document ACP configured (hub.rs)");
-            Ok(DocumentAcpSetup {
+            return Ok(DocumentAcpSetup {
                 document_acp,
                 http_adapter: Some(http_adapter),
-            })
-        } else {
-            info!("Document ACP configured (local)");
-            let document_acp = Arc::new(acp::ZanzibarDocumentACP::new(zanzibar_store.clone()));
-            Ok(DocumentAcpSetup {
-                document_acp,
-                http_adapter: Some(crate::acp_adapter::AcpAdapter::new_arc(
-                    zanzibar_store,
-                    nac_checker,
-                )),
-            })
+            });
         }
+
+        info!("Document ACP configured (local)");
+        let document_acp = Arc::new(acp::ZanzibarDocumentACP::new(zanzibar_store.clone()));
+        Ok(DocumentAcpSetup {
+            document_acp,
+            http_adapter: Some(crate::acp_adapter::AcpAdapter::new_arc(
+                zanzibar_store,
+                nac_checker,
+            )),
+        })
     }
 
     pub(super) async fn setup_nac_manager(

--- a/crates/cli/src/commands/start/server_query.rs
+++ b/crates/cli/src/commands/start/server_query.rs
@@ -5,7 +5,9 @@ use std::sync::Arc;
 use tracing::info;
 
 use super::node::Node;
-use crate::config::{AcpDocumentType, Config};
+#[cfg(feature = "sourcehub")]
+use crate::config::AcpDocumentType;
+use crate::config::Config;
 use identity::Did;
 
 pub(super) struct QueryRunnerSetup<S: storage::corekv::Store + 'static> {
@@ -63,9 +65,12 @@ impl Node {
         }
 
         if let Some(did) = user_did {
-            if config.acp.document_type != AcpDocumentType::SourceHub
-                && config.acp.document_type != AcpDocumentType::HubRs
-            {
+            #[cfg(feature = "sourcehub")]
+            let remote_acp = config.acp.document_type == AcpDocumentType::SourceHub
+                || config.acp.document_type == AcpDocumentType::HubRs;
+            #[cfg(not(feature = "sourcehub"))]
+            let remote_acp = false;
+            if !remote_acp {
                 info!("Query runner configured with default identity for ACP");
                 query_runner = query_runner.with_default_identity(did.clone());
             }

--- a/crates/cli/src/config/mod.rs
+++ b/crates/cli/src/config/mod.rs
@@ -201,17 +201,21 @@ impl Config {
         }
 
         // SourceHub
+        #[cfg(feature = "sourcehub")]
         if let Some(ref addr) = cli.source_hub_address {
             self.acp.sourcehub_address = addr.clone();
         }
+        #[cfg(feature = "sourcehub")]
         if let Some(ref addr) = cli.source_hub_comet_address {
             self.acp.sourcehub_comet_address = addr.clone();
         }
+        #[cfg(feature = "sourcehub")]
         if let Some(ref id) = cli.source_hub_chain_id {
             self.acp.sourcehub_chain_id = id.clone();
         }
 
         // hub.rs
+        #[cfg(feature = "sourcehub")]
         if let Some(ref addr) = cli.hub_rs_address {
             self.acp.hub_rs_address = addr.clone();
         }

--- a/crates/cli/src/config/sections.rs
+++ b/crates/cli/src/config/sections.rs
@@ -489,18 +489,22 @@ pub struct AcpConfig {
     pub document_type: AcpDocumentType,
 
     /// SourceHub gRPC/LCD endpoint (e.g., "http://localhost:1317")
+    #[cfg(feature = "sourcehub")]
     #[serde(default)]
     pub sourcehub_address: String,
 
     /// SourceHub CometBFT RPC endpoint (e.g., "http://localhost:26657")
+    #[cfg(feature = "sourcehub")]
     #[serde(default)]
     pub sourcehub_comet_address: String,
 
     /// SourceHub chain ID (e.g., "sourcehub-test")
+    #[cfg(feature = "sourcehub")]
     #[serde(default)]
     pub sourcehub_chain_id: String,
 
     /// hub.rs JSON-RPC endpoint (e.g., "http://localhost:8545")
+    #[cfg(feature = "sourcehub")]
     #[serde(default)]
     pub hub_rs_address: String,
 
@@ -546,9 +550,13 @@ impl Default for AcpConfig {
         Self {
             node_enable: false,
             document_type: AcpDocumentType::None,
+            #[cfg(feature = "sourcehub")]
             sourcehub_address: String::new(),
+            #[cfg(feature = "sourcehub")]
             sourcehub_comet_address: String::new(),
+            #[cfg(feature = "sourcehub")]
             sourcehub_chain_id: String::new(),
+            #[cfg(feature = "sourcehub")]
             hub_rs_address: String::new(),
             circuit_breaker_threshold: default_acp_cb_threshold(),
             circuit_breaker_reset_timeout: default_acp_cb_reset_timeout(),

--- a/crates/cli/src/config/types.rs
+++ b/crates/cli/src/config/types.rs
@@ -195,7 +195,9 @@ pub enum AcpDocumentType {
     #[default]
     None,
     Local,
+    #[cfg(feature = "sourcehub")]
     SourceHub,
+    #[cfg(feature = "sourcehub")]
     HubRs,
 }
 
@@ -204,7 +206,9 @@ impl std::fmt::Display for AcpDocumentType {
         match self {
             AcpDocumentType::None => write!(f, "none"),
             AcpDocumentType::Local => write!(f, "local"),
+            #[cfg(feature = "sourcehub")]
             AcpDocumentType::SourceHub => write!(f, "source-hub"),
+            #[cfg(feature = "sourcehub")]
             AcpDocumentType::HubRs => write!(f, "hub-rs"),
         }
     }
@@ -217,7 +221,9 @@ impl std::str::FromStr for AcpDocumentType {
         match s.to_lowercase().replace('-', "").as_str() {
             "none" | "" => Ok(AcpDocumentType::None),
             "local" => Ok(AcpDocumentType::Local),
+            #[cfg(feature = "sourcehub")]
             "sourcehub" => Ok(AcpDocumentType::SourceHub),
+            #[cfg(feature = "sourcehub")]
             "hubrs" => Ok(AcpDocumentType::HubRs),
             _ => Err(Error::InvalidAcpType(s.to_string())),
         }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -31,6 +31,7 @@ pub(crate) mod p2p_collection_lookup;
 #[allow(dead_code)]
 pub(crate) mod p2p_doc_pusher;
 pub(crate) mod schema_adapter;
+#[cfg(feature = "sourcehub")]
 pub(crate) mod sourcehub_acp_adapter;
 #[cfg(feature = "iroh")]
 #[allow(dead_code)]

--- a/crates/cli/tests/config_tests.rs
+++ b/crates/cli/tests/config_tests.rs
@@ -23,9 +23,13 @@ fn cli_with_defaults() -> Cli {
         keyring_backend: None,
         keyring_path: None,
         no_keyring: None,
+        #[cfg(feature = "sourcehub")]
         source_hub_address: None,
+        #[cfg(feature = "sourcehub")]
         source_hub_comet_address: None,
+        #[cfg(feature = "sourcehub")]
         source_hub_chain_id: None,
+        #[cfg(feature = "sourcehub")]
         hub_rs_address: None,
         secret_file: None,
         no_telemetry: None,

--- a/crates/cli/tests/start_tests.rs
+++ b/crates/cli/tests/start_tests.rs
@@ -24,9 +24,13 @@ fn default_start_args() -> StartArgs {
         identity: None,
         replicator_retry_intervals: None,
         durability: None,
+        #[cfg(feature = "orbis")]
         signer_type: None,
+        #[cfg(feature = "orbis")]
         signer_orbis_endpoint: None,
+        #[cfg(feature = "orbis")]
         signer_orbis_ring_id: None,
+        #[cfg(feature = "orbis")]
         signer_orbis_derivation: None,
         max_body_size: None,
         max_schema_size: None,
@@ -136,9 +140,13 @@ fn test_apply_to_config_all_flags() {
         identity: None, // identity is handled in Node::new, not apply_to_config
         replicator_retry_intervals: Some(vec![10, 20, 30]),
         durability: None,
+        #[cfg(feature = "orbis")]
         signer_type: None,
+        #[cfg(feature = "orbis")]
         signer_orbis_endpoint: None,
+        #[cfg(feature = "orbis")]
         signer_orbis_ring_id: None,
+        #[cfg(feature = "orbis")]
         signer_orbis_derivation: None,
         max_body_size: Some(1024),
         max_schema_size: Some(2048),


### PR DESCRIPTION
Per maintainer decision, the SourceHub on-chain ACP client and Orbis threshold signing are no longer in default builds — the entire cosmrs/tendermint/commonware/acp-light-client subtree (82 dep-tree entries) leaves the default dependency graph. Enable with \`--features sourcehub,orbis\`.

- Gated surfaces compile out cleanly: \`--source-hub-*\`/\`--hub-rs-address\` flags, \`--document-acp-type source-hub|hub-rs\` (help now reads "none or local"), \`--signer-type orbis\` and related flags. Local/none ACP unaffected.
- **\`blst\` stays in all builds deliberately**: BLS block-signature *verification* lives in \`crates/crypto\` as a core wire-behavior dep (nodes must verify BLS-signed blocks from Orbis-enabled peers) — it was never orbis-specific.
- Operator notes: stray \`sourcehub_address\`-style config keys are silently ignored in gated builds (serde tolerates unknown fields); \`DEFRA_SOURCE_HUB_*\` env vars are likewise ignored; \`document_type: sourcehub\` in config and the CLI flag values error at parse time. Running \`--test sourcehub\`/\`--test hubrs\` integration areas now requires \`cargo build -p cli --features sourcehub,orbis\` first.
- Expected size: ~0.5–1.5MiB .text off every build that omits the features, plus a large compile-time win.
- Verified: cli tests pass and clippy clean in both feature sets; \`cargo tree\` shows the stack absent by default, present with \`--features sourcehub,orbis\`. Known trivial merge overlap with #1273 in the \`[features]\` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)