### PR TITLE
Binary size: −37% full / −48% slim — DynStore erasure, real variants, opt-in pg/sourcehub/orbis, slimmed wasmtime/TLS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
         run: cargo install wasm-pack --locked
 
       - name: Build WASM
-        run: wasm-pack build crates/wasm --release --target web --out-dir ../../pkg/wasm
+        run: CARGO_PROFILE_RELEASE_OPT_LEVEL=z wasm-pack build crates/wasm --release --target web --out-dir ../../pkg/wasm
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,7 +195,7 @@ jobs:
         run: cargo install wasm-pack
 
       - name: Build WASM
-        run: wasm-pack build crates/wasm --release --target web --out-dir ../../pkg/wasm
+        run: CARGO_PROFILE_RELEASE_OPT_LEVEL=z wasm-pack build crates/wasm --release --target web --out-dir ../../pkg/wasm
 
       - name: Package
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,48 +16,69 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # rocksdb (default storage backend)
-          - variant: rocksdb
+          # full (all default features: lark + rocksdb + redb)
+          - variant: full
             target: x86_64-unknown-linux-gnu
             platform: linux_amd64
             runner: '["self-hosted", "Linux", "X64"]'
             features: ""
-          - variant: rocksdb
+          - variant: full
             target: aarch64-unknown-linux-gnu
             platform: linux_arm64
             runner: '["self-hosted", "Linux", "ARM64"]'
             features: ""
-          - variant: rocksdb
+          - variant: full
             target: x86_64-apple-darwin
             platform: darwin_amd64
             runner: '["self-hosted", "macOS", "ARM64", "studio"]'
             features: "--features vendored-openssl"
-          - variant: rocksdb
+          - variant: full
             target: aarch64-apple-darwin
             platform: darwin_arm64
             runner: '["self-hosted", "macOS", "ARM64", "studio"]'
             features: ""
-          # redb
-          - variant: redb
+          # rocksdb (lark included: default runtime backend)
+          - variant: rocksdb
             target: x86_64-unknown-linux-gnu
             platform: linux_amd64
             runner: '["self-hosted", "Linux", "X64"]'
-            features: "--features redb"
-          - variant: redb
+            features: "--no-default-features --features rocksdb,lark"
+          - variant: rocksdb
             target: aarch64-unknown-linux-gnu
             platform: linux_arm64
             runner: '["self-hosted", "Linux", "ARM64"]'
-            features: "--features redb"
-          - variant: redb
+            features: "--no-default-features --features rocksdb,lark"
+          - variant: rocksdb
             target: x86_64-apple-darwin
             platform: darwin_amd64
             runner: '["self-hosted", "macOS", "ARM64", "studio"]'
-            features: "--features redb,vendored-openssl"
-          - variant: redb
+            features: "--no-default-features --features rocksdb,lark,vendored-openssl"
+          - variant: rocksdb
             target: aarch64-apple-darwin
             platform: darwin_arm64
             runner: '["self-hosted", "macOS", "ARM64", "studio"]'
-            features: "--features redb"
+            features: "--no-default-features --features rocksdb,lark"
+          # lark (minimal: single default-runtime backend)
+          - variant: lark
+            target: x86_64-unknown-linux-gnu
+            platform: linux_amd64
+            runner: '["self-hosted", "Linux", "X64"]'
+            features: "--no-default-features --features lark"
+          - variant: lark
+            target: aarch64-unknown-linux-gnu
+            platform: linux_arm64
+            runner: '["self-hosted", "Linux", "ARM64"]'
+            features: "--no-default-features --features lark"
+          - variant: lark
+            target: x86_64-apple-darwin
+            platform: darwin_amd64
+            runner: '["self-hosted", "macOS", "ARM64", "studio"]'
+            features: "--no-default-features --features lark,vendored-openssl"
+          - variant: lark
+            target: aarch64-apple-darwin
+            platform: darwin_arm64
+            runner: '["self-hosted", "macOS", "ARM64", "studio"]'
+            features: "--no-default-features --features lark"
     steps:
       - uses: actions/checkout@v4
 
@@ -85,7 +106,7 @@ jobs:
           if ! command -v protoc >/dev/null 2>&1; then
             NEEDS_APT=1
           fi
-          if [ "${{ matrix.variant }}" = "rocksdb" ] && ! command -v clang >/dev/null 2>&1; then
+          if [ "${{ matrix.variant }}" != "lark" ] && ! command -v clang >/dev/null 2>&1; then
             NEEDS_APT=1
           fi
 
@@ -101,7 +122,7 @@ jobs:
 
           bash .github/scripts/apt-update-without-nodesource.sh "${APT_ARGS[@]}"
           sudo apt-get "${APT_ARGS[@]}" install -y libssl-dev pkg-config protobuf-compiler libdbus-1-dev
-          if [ "${{ matrix.variant }}" = "rocksdb" ]; then
+          if [ "${{ matrix.variant }}" != "lark" ]; then
             sudo apt-get "${APT_ARGS[@]}" install -y libclang-dev
           fi
 
@@ -124,7 +145,7 @@ jobs:
         shell: bash
         run: |
           TAG="${GITHUB_REF_NAME}"
-          if [ "${{ matrix.variant }}" = "rocksdb" ]; then
+          if [ "${{ matrix.variant }}" = "full" ]; then
             ARCHIVE="defra_${TAG}_${{ matrix.platform }}.tar.gz"
           else
             ARCHIVE="defra-${{ matrix.variant }}_${TAG}_${{ matrix.platform }}.tar.gz"
@@ -202,48 +223,48 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # redb (default)
+          # redb (default; lark included: default runtime backend)
           - variant: redb
             target: x86_64-unknown-linux-gnu
             platform: linux_amd64
             runner: '["self-hosted", "Linux", "X64"]'
-            features: "--features iroh"
+            features: "--no-default-features --features native,wasmtime-runtime,lark,redb,iroh"
           - variant: redb
             target: aarch64-unknown-linux-gnu
             platform: linux_arm64
             runner: '["self-hosted", "Linux", "ARM64"]'
-            features: "--features iroh"
+            features: "--no-default-features --features native,wasmtime-runtime,lark,redb,iroh"
           - variant: redb
             target: x86_64-apple-darwin
             platform: darwin_amd64
             runner: '["self-hosted", "macOS", "ARM64", "studio"]'
-            features: "--features iroh"
+            features: "--no-default-features --features native,wasmtime-runtime,lark,redb,iroh"
           - variant: redb
             target: aarch64-apple-darwin
             platform: darwin_arm64
             runner: '["self-hosted", "macOS", "ARM64", "studio"]'
-            features: "--features iroh"
-          # rocksdb
+            features: "--no-default-features --features native,wasmtime-runtime,lark,redb,iroh"
+          # rocksdb (redb stays: ffi hard-requires it; lark: default runtime backend)
           - variant: rocksdb
             target: x86_64-unknown-linux-gnu
             platform: linux_amd64
             runner: '["self-hosted", "Linux", "X64"]'
-            features: "--features rocksdb,iroh"
+            features: "--no-default-features --features native,wasmtime-runtime,lark,redb,rocksdb,iroh"
           - variant: rocksdb
             target: aarch64-unknown-linux-gnu
             platform: linux_arm64
             runner: '["self-hosted", "Linux", "ARM64"]'
-            features: "--features rocksdb,iroh"
+            features: "--no-default-features --features native,wasmtime-runtime,lark,redb,rocksdb,iroh"
           - variant: rocksdb
             target: x86_64-apple-darwin
             platform: darwin_amd64
             runner: '["self-hosted", "macOS", "ARM64", "studio"]'
-            features: "--features rocksdb,iroh"
+            features: "--no-default-features --features native,wasmtime-runtime,lark,redb,rocksdb,iroh"
           - variant: rocksdb
             target: aarch64-apple-darwin
             platform: darwin_arm64
             runner: '["self-hosted", "macOS", "ARM64", "studio"]'
-            features: "--features rocksdb,iroh"
+            features: "--no-default-features --features native,wasmtime-runtime,lark,redb,rocksdb,iroh"
     steps:
       - uses: actions/checkout@v4
 
@@ -411,12 +432,12 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: defra-rocksdb-linux_amd64
+          name: defra-full-linux_amd64
           path: docker-context/linux/amd64
 
       - uses: actions/download-artifact@v4
         with:
-          name: defra-rocksdb-linux_arm64
+          name: defra-full-linux_arm64
           path: docker-context/linux/arm64
 
       - name: Extract binaries
@@ -446,6 +467,12 @@ jobs:
       needs.docker.result == 'success'
     runs-on: [self-hosted, Linux, X64]
     steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: defra-full-*
+          merge-multiple: true
+
       - uses: actions/download-artifact@v4
         with:
           path: artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -338,8 +338,18 @@ jobs:
         run: |
           TAG="${GITHUB_REF_NAME}"
           ARCHIVE="defra-ffi-${{ matrix.variant }}_${TAG}_${{ matrix.platform }}.tar.gz"
+          RELEASE_DIR="target/${{ matrix.target }}/release"
+          if [[ "${{ runner.os }}" == "macOS" ]]; then
+            LIB="libdefra_ffi.dylib"
+            cp "${RELEASE_DIR}/libffi.dylib" "${RELEASE_DIR}/${LIB}"
+            install_name_tool -id "@rpath/${LIB}" "${RELEASE_DIR}/${LIB}"
+            codesign --force --sign - "${RELEASE_DIR}/${LIB}"
+          else
+            LIB="libdefra_ffi.so"
+            cp "${RELEASE_DIR}/libffi.so" "${RELEASE_DIR}/${LIB}"
+          fi
           tar czf "${ARCHIVE}" \
-            -C "target/${{ matrix.target }}/release" libffi.a \
+            -C "${RELEASE_DIR}" "${LIB}" \
             -C "${GITHUB_WORKSPACE}" defra.h
           echo "ARCHIVE=${ARCHIVE}" >> "$GITHUB_ENV"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1474,15 +1474,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
-name = "bitmaps"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
-]
-
-[[package]]
 name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2642,15 +2633,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpp_demangle"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3544,15 +3526,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "debugid"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
-dependencies = [
- "uuid",
-]
-
-[[package]]
 name = "defra-core"
 version = "0.5.0"
 dependencies = [
@@ -3913,16 +3886,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "directories-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
 name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3941,17 +3904,6 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -4828,20 +4780,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
-]
-
-[[package]]
-name = "fxprof-processed-profile"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25234f20a3ec0a962a61770cfe39ecf03cb529a6e474ad8cff025ed497eda557"
-dependencies = [
- "bitflags 2.11.0",
- "debugid",
- "rustc-hash",
- "serde",
- "serde_derive",
- "serde_json",
 ]
 
 [[package]]
@@ -5831,20 +5769,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "im-rc"
-version = "15.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1955a75fa080c677d3972822ec4bad316169ab1cfc6c257a942c2265dbe5fe"
-dependencies = [
- "bitmaps",
- "rand_core 0.6.4",
- "rand_xoshiro",
- "sized-chunks",
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "impl-codec"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6316,26 +6240,6 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
-
-[[package]]
-name = "ittapi"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b996fe614c41395cdaedf3cf408a9534851090959d90d54a535f675550b64b1"
-dependencies = [
- "anyhow",
- "ittapi-sys",
- "log",
-]
-
-[[package]]
-name = "ittapi-sys"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5385394064fa2c886205dba02598013ce83d3e92d33dbdc0c52fe0e7bf4fc"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "jmt"
@@ -9955,15 +9859,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xoshiro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "rapidhash"
 version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10979,10 +10874,6 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
-dependencies = [
- "serde",
- "serde_core",
-]
 
 [[package]]
 name = "semver-parser"
@@ -11419,16 +11310,6 @@ name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
-
-[[package]]
-name = "sized-chunks"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
-dependencies = [
- "bitmaps",
- "typenum",
-]
 
 [[package]]
 name = "slab"
@@ -12852,12 +12733,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13181,27 +13056,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe29135b180b72b04c74aa97b2b4a2ef275161eff9a6c7955ea9eaedc7e1d4e"
 
 [[package]]
-name = "wasm-compose"
-version = "0.245.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd23d12cc95c451c1306db5bc63075fbebb612bb70c53b4237b1ce5bc178343"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "im-rc",
- "indexmap 2.13.0",
- "log",
- "petgraph 0.6.5",
- "serde",
- "serde_derive",
- "serde_yaml",
- "smallvec",
- "wasm-encoder 0.245.1",
- "wasmparser 0.245.1",
- "wat",
-]
-
-[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13322,11 +13176,6 @@ dependencies = [
  "bumpalo",
  "cc",
  "cfg-if",
- "encoding_rs",
- "futures",
- "fxprof-processed-profile",
- "gimli 0.33.1",
- "ittapi",
  "libc",
  "log",
  "mach2",
@@ -13335,22 +13184,13 @@ dependencies = [
  "once_cell",
  "postcard",
  "pulley-interpreter",
- "rayon",
  "rustix 1.1.4",
- "semver 1.0.27",
  "serde",
  "serde_derive",
- "serde_json",
  "smallvec",
  "target-lexicon",
- "tempfile",
- "wasm-compose",
- "wasm-encoder 0.245.1",
  "wasmparser 0.245.1",
  "wasmtime-environ",
- "wasmtime-internal-cache",
- "wasmtime-internal-component-macro",
- "wasmtime-internal-component-util",
  "wasmtime-internal-core",
  "wasmtime-internal-cranelift",
  "wasmtime-internal-fiber",
@@ -13358,8 +13198,6 @@ dependencies = [
  "wasmtime-internal-jit-icache-coherence",
  "wasmtime-internal-unwinder",
  "wasmtime-internal-versioned-export-macros",
- "wasmtime-internal-winch",
- "wat",
  "windows-sys 0.61.2",
 ]
 
@@ -13370,7 +13208,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b8b78abf3677d4a0a5db82e5015b4d085ff3a1b8b472cbb8c70d4b769f019ce"
 dependencies = [
  "anyhow",
- "cpp_demangle",
  "cranelift-bforest",
  "cranelift-bitset",
  "cranelift-entity",
@@ -13380,8 +13217,6 @@ dependencies = [
  "log",
  "object 0.38.1",
  "postcard",
- "rustc-demangle",
- "semver 1.0.27",
  "serde",
  "serde_derive",
  "sha2 0.10.9",
@@ -13390,50 +13225,8 @@ dependencies = [
  "wasm-encoder 0.245.1",
  "wasmparser 0.245.1",
  "wasmprinter",
- "wasmtime-internal-component-util",
  "wasmtime-internal-core",
 ]
-
-[[package]]
-name = "wasmtime-internal-cache"
-version = "43.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e4fd4103ba413c0da2e636f73490c6c8e446d708cbde7573703941bc3d6a448"
-dependencies = [
- "base64 0.22.1",
- "directories-next",
- "log",
- "postcard",
- "rustix 1.1.4",
- "serde",
- "serde_derive",
- "sha2 0.10.9",
- "toml 0.9.12+spec-1.1.0",
- "wasmtime-environ",
- "windows-sys 0.61.2",
- "zstd",
-]
-
-[[package]]
-name = "wasmtime-internal-component-macro"
-version = "43.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3d6914f34be2f9d78d8ee9f422e834dfc204e71ccce697205fae95fed87892"
-dependencies = [
- "anyhow",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wasmtime-internal-component-util",
- "wasmtime-internal-wit-bindgen",
- "wit-parser 0.245.1",
-]
-
-[[package]]
-name = "wasmtime-internal-component-util"
-version = "43.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3751b0616b914fdd87fe1bf804694a078f321b000338e6476bc48a4d6e454f21"
 
 [[package]]
 name = "wasmtime-internal-core"
@@ -13441,7 +13234,6 @@ version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22632b187e1b0716f1b9ac57ad29013bed33175fcb19e10bb6896126f82fac67"
 dependencies = [
- "anyhow",
  "hashbrown 0.16.1",
  "libm",
  "serde",
@@ -13496,8 +13288,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d950310d07391d34369f62c48336ebb14eacbd4d6f772bb5f349c24e838e0664"
 dependencies = [
  "cc",
- "object 0.38.1",
- "rustix 1.1.4",
  "wasmtime-internal-versioned-export-macros",
 ]
 
@@ -13535,58 +13325,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "wasmtime-internal-winch"
-version = "43.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8007342bd12ff400293a817973f7ecd6f1d9a8549a53369a9c1af357166f1f1e"
-dependencies = [
- "cranelift-codegen",
- "gimli 0.33.1",
- "log",
- "object 0.38.1",
- "target-lexicon",
- "wasmparser 0.245.1",
- "wasmtime-environ",
- "wasmtime-internal-cranelift",
- "winch-codegen",
-]
-
-[[package]]
-name = "wasmtime-internal-wit-bindgen"
-version = "43.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7900c3e3c1d6e475bc225d73b02d6d5484815f260022e6964dca9558e50dd01a"
-dependencies = [
- "anyhow",
- "bitflags 2.11.0",
- "heck 0.5.0",
- "indexmap 2.13.0",
- "wit-parser 0.245.1",
-]
-
-[[package]]
-name = "wast"
-version = "245.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cf1149285569120b8ce39db8b465e8a2b55c34cbb586bd977e43e2bc7300bf"
-dependencies = [
- "bumpalo",
- "leb128fmt",
- "memchr",
- "unicode-width",
- "wasm-encoder 0.245.1",
-]
-
-[[package]]
-name = "wat"
-version = "1.245.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd48d1679b6858988cb96b154dda0ec5bbb09275b71db46057be37332d5477be"
-dependencies = [
- "wast",
 ]
 
 [[package]]
@@ -13681,25 +13419,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "winch-codegen"
-version = "43.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f45f7172a2628c8317766e427babc0a400f9d10b1c0f0b0617c5ed5b79de6"
-dependencies = [
- "cranelift-assembler-x64",
- "cranelift-codegen",
- "gimli 0.33.1",
- "regalloc2",
- "smallvec",
- "target-lexicon",
- "thiserror 2.0.18",
- "wasmparser 0.245.1",
- "wasmtime-environ",
- "wasmtime-internal-core",
- "wasmtime-internal-cranelift",
-]
 
 [[package]]
 name = "windows"
@@ -14244,7 +13963,7 @@ checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "wit-parser 0.244.0",
+ "wit-parser",
 ]
 
 [[package]]
@@ -14294,7 +14013,7 @@ dependencies = [
  "wasm-encoder 0.244.0",
  "wasm-metadata",
  "wasmparser 0.244.0",
- "wit-parser 0.244.0",
+ "wit-parser",
 ]
 
 [[package]]
@@ -14313,25 +14032,6 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.244.0",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.245.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330698718e82983499419494dd1e3d7811a457a9bf9f69734e8c5f07a2547929"
-dependencies = [
- "anyhow",
- "hashbrown 0.16.1",
- "id-arena",
- "indexmap 2.13.0",
- "log",
- "semver 1.0.27",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.245.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,3 +206,66 @@ inherits = "release"
 strip = false
 debug = 1
 lto = "thin"
+
+[profile.release.package."cranelift-assembler-x64"]
+opt-level = "z"
+[profile.release.package."cranelift-bforest"]
+opt-level = "z"
+[profile.release.package."cranelift-bitset"]
+opt-level = "z"
+[profile.release.package."cranelift-codegen"]
+opt-level = "z"
+[profile.release.package."cranelift-codegen-shared"]
+opt-level = "z"
+[profile.release.package."cranelift-control"]
+opt-level = "z"
+[profile.release.package."cranelift-entity"]
+opt-level = "z"
+[profile.release.package."cranelift-frontend"]
+opt-level = "z"
+[profile.release.package."cranelift-isle"]
+opt-level = "z"
+[profile.release.package."cranelift-native"]
+opt-level = "z"
+[profile.release.package."regalloc2"]
+opt-level = "z"
+[profile.release.package."pulley-interpreter"]
+opt-level = "z"
+[profile.release.package."wasmtime"]
+opt-level = "z"
+[profile.release.package."wasmtime-environ"]
+opt-level = "z"
+[profile.release.package."wasmtime-internal-core"]
+opt-level = "z"
+[profile.release.package."wasmtime-internal-cranelift"]
+opt-level = "z"
+[profile.release.package."wasmtime-internal-fiber"]
+opt-level = "z"
+[profile.release.package."wasmtime-internal-jit-debug"]
+opt-level = "z"
+[profile.release.package."wasmtime-internal-jit-icache-coherence"]
+opt-level = "z"
+[profile.release.package."wasmtime-internal-unwinder"]
+opt-level = "z"
+[profile.release.package."wasmparser"]
+opt-level = "z"
+[profile.release.package."wasm-encoder"]
+opt-level = "z"
+[profile.release.package."clap"]
+opt-level = "z"
+[profile.release.package."clap_builder"]
+opt-level = "z"
+[profile.release.package."clap_lex"]
+opt-level = "z"
+[profile.release.package."serde_yaml"]
+opt-level = "z"
+[profile.release.package."unsafe-libyaml"]
+opt-level = "z"
+[profile.release.package."tracing-subscriber"]
+opt-level = "z"
+[profile.release.package."hickory-proto"]
+opt-level = "z"
+[profile.release.package."hickory-resolver"]
+opt-level = "z"
+[profile.release.package."hickory-net"]
+opt-level = "z"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -207,6 +207,13 @@ strip = false
 debug = 1
 lto = "thin"
 
+# Fast release iteration for CI/dev: measured 1m40s cold vs 6m44s fat LTO
+# (+25% binary size — never ship artifacts from this profile).
+[profile.release-fast]
+inherits = "release"
+lto = "thin"
+codegen-units = 16
+
 [profile.release.package."cranelift-assembler-x64"]
 opt-level = "z"
 [profile.release.package."cranelift-bforest"]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -41,7 +41,7 @@ keyring = { path = "../keyring" }
 orbis = { path = "../orbis" }
 sourcehub = { path = "../sourcehub" }
 defra-version = { path = "../defra-version" }
-pg-compat = { path = "../pg-compat" }
+pg-compat = { path = "../pg-compat", optional = true }
 telemetry = { path = "../telemetry", default-features = false }
 
 # CLI
@@ -115,6 +115,7 @@ optional = true
 [features]
 default = ["lark", "rocksdb", "redb"]
 lark = ["storage/lark"]
+postgres = ["dep:pg-compat"]
 redb = ["storage/redb"]
 fjall = ["storage/fjall"]
 rocksdb = ["storage/rocksdb"]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -38,8 +38,8 @@ events = { path = "../events" }
 lens = { path = "../lens" }
 document = { path = "../document" }
 keyring = { path = "../keyring" }
-orbis = { path = "../orbis" }
-sourcehub = { path = "../sourcehub" }
+orbis = { path = "../orbis", optional = true }
+sourcehub = { path = "../sourcehub", optional = true }
 defra-version = { path = "../defra-version" }
 pg-compat = { path = "../pg-compat", optional = true }
 telemetry = { path = "../telemetry", default-features = false }
@@ -116,6 +116,10 @@ optional = true
 default = ["lark", "rocksdb", "redb"]
 lark = ["storage/lark"]
 postgres = ["dep:pg-compat"]
+# SourceHub/hub.rs on-chain document ACP (`--document-acp-type source-hub|hub-rs`).
+sourcehub = ["dep:sourcehub"]
+# Orbis ring threshold signing (`--signer-type orbis`).
+orbis = ["dep:orbis"]
 redb = ["storage/redb"]
 fjall = ["storage/fjall"]
 rocksdb = ["storage/rocksdb"]

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -79,18 +79,22 @@ pub struct Cli {
     pub no_keyring: Option<bool>,
 
     /// The SourceHub address authorized by the client to make SourceHub transactions
+    #[cfg(feature = "sourcehub")]
     #[arg(long, global = true, env = "DEFRA_SOURCE_HUB_ADDRESS")]
     pub source_hub_address: Option<String>,
 
     /// SourceHub CometBFT RPC address for transaction broadcast
+    #[cfg(feature = "sourcehub")]
     #[arg(long, global = true, env = "DEFRA_SOURCE_HUB_COMET_ADDRESS")]
     pub source_hub_comet_address: Option<String>,
 
     /// SourceHub chain ID (e.g., "sourcehub-test")
+    #[cfg(feature = "sourcehub")]
     #[arg(long, global = true, env = "DEFRA_SOURCE_HUB_CHAIN_ID")]
     pub source_hub_chain_id: Option<String>,
 
     /// hub.rs JSON-RPC endpoint (e.g., "http://localhost:8545")
+    #[cfg(feature = "sourcehub")]
     #[arg(long, global = true, env = "DEFRA_HUB_RS_ADDRESS")]
     pub hub_rs_address: Option<String>,
 
@@ -114,6 +118,16 @@ pub struct Cli {
     pub acp_node_enable: Option<bool>,
 
     /// Document ACP type. Options are none, local, source-hub, or hub-rs
+    #[cfg(feature = "sourcehub")]
+    #[arg(
+        long = "document-acp-type",
+        global = true,
+        env = "DEFRA_ACP_DOCUMENT_TYPE"
+    )]
+    pub acp_document_type: Option<String>,
+
+    /// Document ACP type. Options are none or local
+    #[cfg(not(feature = "sourcehub"))]
     #[arg(
         long = "document-acp-type",
         global = true,

--- a/crates/cli/src/commands/server_dump.rs
+++ b/crates/cli/src/commands/server_dump.rs
@@ -21,10 +21,9 @@ impl ServerDumpArgs {
             DatastoreType::Redb => {
                 let opts = storage::backends::RedbStoreOptions::new()
                     .with_durability(config.datastore.durability);
-                let store = Arc::new(storage::RedbStore::open_with_options(
-                    config.data_path(),
-                    opts,
-                )?);
+                let store = Arc::new(storage::DynStore::new(Arc::new(
+                    storage::RedbStore::open_with_options(config.data_path(), opts)?,
+                )));
                 let database = db::DB::open_from_arc(store)
                     .await
                     .map_err(|e| Error::Server(e.to_string()))?;
@@ -40,10 +39,9 @@ impl ServerDumpArgs {
             DatastoreType::Fjall => {
                 let opts = storage::backends::FjallStoreOptions::new()
                     .with_durability(config.datastore.durability);
-                let store = Arc::new(storage::FjallStore::open_with_options(
-                    config.data_path(),
-                    opts,
-                )?);
+                let store = Arc::new(storage::DynStore::new(Arc::new(
+                    storage::FjallStore::open_with_options(config.data_path(), opts)?,
+                )));
                 let database = db::DB::open_from_arc(store)
                     .await
                     .map_err(|e| Error::Server(e.to_string()))?;
@@ -59,10 +57,9 @@ impl ServerDumpArgs {
             DatastoreType::RocksDb => {
                 let opts = storage::backends::RocksDbStoreOptions::new()
                     .with_durability(config.datastore.durability);
-                let store = Arc::new(storage::RocksDbStore::open_with_options(
-                    config.data_path(),
-                    opts,
-                )?);
+                let store = Arc::new(storage::DynStore::new(Arc::new(
+                    storage::RocksDbStore::open_with_options(config.data_path(), opts)?,
+                )));
                 let database = db::DB::open_from_arc(store)
                     .await
                     .map_err(|e| Error::Server(e.to_string()))?;
@@ -78,10 +75,9 @@ impl ServerDumpArgs {
             DatastoreType::Lark => {
                 let opts = storage::backends::LarkStoreOptions::new()
                     .with_durability(config.datastore.durability);
-                let store = Arc::new(storage::LarkStore::open_with_options(
-                    config.data_path(),
-                    opts,
-                )?);
+                let store = Arc::new(storage::DynStore::new(Arc::new(
+                    storage::LarkStore::open_with_options(config.data_path(), opts)?,
+                )));
                 let database = db::DB::open_from_arc(store)
                     .await
                     .map_err(|e| Error::Server(e.to_string()))?;

--- a/crates/cli/src/commands/start/mod.rs
+++ b/crates/cli/src/commands/start/mod.rs
@@ -241,6 +241,7 @@ pub struct StartArgs {
     pub p2p_transport: Option<String>,
 
     /// Address for Postgres wire protocol compatibility (e.g., "127.0.0.1:5433")
+    #[cfg(feature = "postgres")]
     #[arg(long)]
     pub pg_address: Option<String>,
 
@@ -549,6 +550,7 @@ impl StartArgs {
         if let Some(depth) = self.query_max_filter_depth {
             config.api.query_max_filter_depth = depth;
         }
+        #[cfg(feature = "postgres")]
         if let Some(ref addr) = self.pg_address {
             config.api.pg_address = addr.clone();
         }

--- a/crates/cli/src/commands/start/mod.rs
+++ b/crates/cli/src/commands/start/mod.rs
@@ -110,18 +110,22 @@ pub struct StartArgs {
     pub durability: Option<String>,
 
     /// Signer type: "local" (default) or "orbis" (Orbis ring threshold signing)
+    #[cfg(feature = "orbis")]
     #[arg(long)]
     pub signer_type: Option<String>,
 
     /// Orbis gRPC endpoint (required when --signer-type=orbis)
+    #[cfg(feature = "orbis")]
     #[arg(long)]
     pub signer_orbis_endpoint: Option<String>,
 
     /// Orbis ring ID from DKG (required when --signer-type=orbis)
+    #[cfg(feature = "orbis")]
     #[arg(long)]
     pub signer_orbis_ring_id: Option<String>,
 
     /// Orbis derivation label for the ring's derived key (e.g. "x-archive")
+    #[cfg(feature = "orbis")]
     #[arg(long)]
     pub signer_orbis_derivation: Option<String>,
 
@@ -296,6 +300,7 @@ impl StartArgs {
         let user_identity = self.parse_user_identity()?;
 
         // Set up Orbis remote signer if configured
+        #[cfg(feature = "orbis")]
         if self.signer_type.as_deref() == Some("orbis") {
             self.setup_orbis_signer(&user_identity).await?;
         }
@@ -309,6 +314,7 @@ impl StartArgs {
     ///
     /// Connects to the Orbis ring, derives the BLS public key, and stores
     /// a SigningConfig with a remote signer under the signer's DID.
+    #[cfg(feature = "orbis")]
     async fn setup_orbis_signer(
         &self,
         user_identity: &Option<std::sync::Arc<identity::RawIdentity>>,

--- a/crates/cli/src/commands/start/node.rs
+++ b/crates/cli/src/commands/start/node.rs
@@ -33,6 +33,17 @@ pub(super) struct P2PTasks {
     pub retry_loop_task: JoinHandle<()>,
 }
 
+/// Servers and background tasks produced by store/server initialization.
+pub(super) struct ServerSetup {
+    pub p2p_handle: Option<p2p::P2PHostHandle>,
+    pub p2p_tasks: Option<P2PTasks>,
+    pub downsample_task: Option<JoinHandle<()>>,
+    pub txn_cleanup_task: Option<JoinHandle<()>>,
+    pub http_server: defra_http::Server,
+    #[cfg(feature = "postgres")]
+    pub pg_server: Option<pg_compat::PgServer>,
+}
+
 /// DefraDB Node
 /// Node manages the DefraDB server lifecycle.
 #[doc(hidden)]
@@ -43,6 +54,7 @@ pub struct Node {
     pub(super) downsample_task: Option<JoinHandle<()>>,
     pub(super) txn_cleanup_task: Option<JoinHandle<()>>,
     pub(super) http_server: Option<defra_http::Server>,
+    #[cfg(feature = "postgres")]
     pub(super) pg_server: Option<pg_compat::PgServer>,
     /// Shutdown signal sender (for tests)
     #[doc(hidden)]
@@ -137,7 +149,6 @@ impl Node {
     /// Build the persistent ACP/Zanzibar stores from a shared store and start
     /// the server. The store may be a bare backend or an [`EncryptedStore`];
     /// both DB and ACP share the same instance so they encrypt uniformly.
-    #[allow(clippy::type_complexity)]
     async fn init_persistent_store_and_server<S>(
         store: Arc<S>,
         config: &Config,
@@ -145,14 +156,7 @@ impl Node {
         user_identity: Option<std::sync::Arc<identity::RawIdentity>>,
         node_identity_did: Option<String>,
         se_key: Option<[u8; 32]>,
-    ) -> Result<(
-        Option<p2p::P2PHostHandle>,
-        Option<P2PTasks>,
-        Option<JoinHandle<()>>,
-        Option<JoinHandle<()>>,
-        defra_http::Server,
-        Option<pg_compat::PgServer>,
-    )>
+    ) -> Result<ServerSetup>
     where
         S: storage::corekv::Store + 'static,
     {
@@ -206,215 +210,213 @@ impl Node {
         }
 
         // Initialize storage, database, and set up P2P and HTTP server
-        let (p2p_handle, p2p_tasks, downsample_task, txn_cleanup_task, http_server, pg_server) =
-            match config.datastore.store {
-                DatastoreType::Memory => {
-                    info!("Using in-memory datastore");
-                    // Use in-memory ACP store for memory datastore
-                    let acp_store: Arc<dyn acp::AcpStore> = Arc::new(acp::MemoryAcpStore::new());
-                    let zanzibar_store: Arc<dyn acp::ZanzibarStore> =
-                        Arc::new(acp::MemoryZanzibarStore::new());
-                    info!("Using in-memory ACP store");
-                    let backend = storage::MemoryStore::new();
-                    if config.datastore.at_rest_encryption {
-                        info!("At-rest encryption enabled (value-only, AES-256-GCM)");
-                        let key = Self::load_or_create_encryption_key(&config)?;
-                        let store =
-                            Arc::new(storage::encrypted_store::EncryptedStore::new(backend, key));
-                        Self::init_store_and_server(
-                            store,
-                            &config,
-                            peer_keypair,
-                            user_identity.clone(),
-                            acp_store,
-                            zanzibar_store,
-                            node_identity_did.clone(),
-                            se_key,
-                        )
-                        .await?
-                    } else {
-                        Self::init_store_and_server(
-                            Arc::new(backend),
-                            &config,
-                            peer_keypair,
-                            user_identity.clone(),
-                            acp_store,
-                            zanzibar_store,
-                            node_identity_did.clone(),
-                            se_key,
-                        )
-                        .await?
-                    }
+        let servers = match config.datastore.store {
+            DatastoreType::Memory => {
+                info!("Using in-memory datastore");
+                // Use in-memory ACP store for memory datastore
+                let acp_store: Arc<dyn acp::AcpStore> = Arc::new(acp::MemoryAcpStore::new());
+                let zanzibar_store: Arc<dyn acp::ZanzibarStore> =
+                    Arc::new(acp::MemoryZanzibarStore::new());
+                info!("Using in-memory ACP store");
+                let backend = storage::MemoryStore::new();
+                if config.datastore.at_rest_encryption {
+                    info!("At-rest encryption enabled (value-only, AES-256-GCM)");
+                    let key = Self::load_or_create_encryption_key(&config)?;
+                    let store =
+                        Arc::new(storage::encrypted_store::EncryptedStore::new(backend, key));
+                    Self::init_store_and_server(
+                        store,
+                        &config,
+                        peer_keypair,
+                        user_identity.clone(),
+                        acp_store,
+                        zanzibar_store,
+                        node_identity_did.clone(),
+                        se_key,
+                    )
+                    .await?
+                } else {
+                    Self::init_store_and_server(
+                        Arc::new(backend),
+                        &config,
+                        peer_keypair,
+                        user_identity.clone(),
+                        acp_store,
+                        zanzibar_store,
+                        node_identity_did.clone(),
+                        se_key,
+                    )
+                    .await?
                 }
-                #[cfg(feature = "redb")]
-                DatastoreType::Redb => {
-                    info!("Using Redb datastore at {}", config.data_path().display());
-                    let opts = RedbStoreOptions::new()
-                        .with_durability(config.datastore.durability)
-                        .with_cache_size(256 * 1024 * 1024);
-                    let backend = storage::RedbStore::open_with_options(config.data_path(), opts)?;
-                    if config.datastore.at_rest_encryption {
-                        info!("At-rest encryption enabled (value-only, AES-256-GCM)");
-                        let key = Self::load_or_create_encryption_key(&config)?;
-                        let store =
-                            Arc::new(storage::encrypted_store::EncryptedStore::new(backend, key));
-                        Self::init_persistent_store_and_server(
-                            store,
-                            &config,
-                            peer_keypair,
-                            user_identity.clone(),
-                            node_identity_did.clone(),
-                            se_key,
-                        )
-                        .await?
-                    } else {
-                        Self::init_persistent_store_and_server(
-                            Arc::new(backend),
-                            &config,
-                            peer_keypair,
-                            user_identity.clone(),
-                            node_identity_did.clone(),
-                            se_key,
-                        )
-                        .await?
-                    }
+            }
+            #[cfg(feature = "redb")]
+            DatastoreType::Redb => {
+                info!("Using Redb datastore at {}", config.data_path().display());
+                let opts = RedbStoreOptions::new()
+                    .with_durability(config.datastore.durability)
+                    .with_cache_size(256 * 1024 * 1024);
+                let backend = storage::RedbStore::open_with_options(config.data_path(), opts)?;
+                if config.datastore.at_rest_encryption {
+                    info!("At-rest encryption enabled (value-only, AES-256-GCM)");
+                    let key = Self::load_or_create_encryption_key(&config)?;
+                    let store =
+                        Arc::new(storage::encrypted_store::EncryptedStore::new(backend, key));
+                    Self::init_persistent_store_and_server(
+                        store,
+                        &config,
+                        peer_keypair,
+                        user_identity.clone(),
+                        node_identity_did.clone(),
+                        se_key,
+                    )
+                    .await?
+                } else {
+                    Self::init_persistent_store_and_server(
+                        Arc::new(backend),
+                        &config,
+                        peer_keypair,
+                        user_identity.clone(),
+                        node_identity_did.clone(),
+                        se_key,
+                    )
+                    .await?
                 }
-                #[cfg(not(feature = "redb"))]
-                DatastoreType::Redb => {
-                    return Err(crate::error::Error::InvalidDatastore(
-                        "redb backend not enabled. Rebuild with --features redb".into(),
-                    ));
+            }
+            #[cfg(not(feature = "redb"))]
+            DatastoreType::Redb => {
+                return Err(crate::error::Error::InvalidDatastore(
+                    "redb backend not enabled. Rebuild with --features redb".into(),
+                ));
+            }
+            #[cfg(feature = "fjall")]
+            DatastoreType::Fjall => {
+                info!("Using Fjall datastore at {}", config.data_path().display());
+                let opts = FjallStoreOptions::new().with_durability(config.datastore.durability);
+                let backend = storage::FjallStore::open_with_options(config.data_path(), opts)?;
+                if config.datastore.at_rest_encryption {
+                    info!("At-rest encryption enabled (value-only, AES-256-GCM)");
+                    let key = Self::load_or_create_encryption_key(&config)?;
+                    let store =
+                        Arc::new(storage::encrypted_store::EncryptedStore::new(backend, key));
+                    Self::init_persistent_store_and_server(
+                        store,
+                        &config,
+                        peer_keypair,
+                        user_identity.clone(),
+                        node_identity_did.clone(),
+                        se_key,
+                    )
+                    .await?
+                } else {
+                    Self::init_persistent_store_and_server(
+                        Arc::new(backend),
+                        &config,
+                        peer_keypair,
+                        user_identity.clone(),
+                        node_identity_did.clone(),
+                        se_key,
+                    )
+                    .await?
                 }
-                #[cfg(feature = "fjall")]
-                DatastoreType::Fjall => {
-                    info!("Using Fjall datastore at {}", config.data_path().display());
-                    let opts =
-                        FjallStoreOptions::new().with_durability(config.datastore.durability);
-                    let backend = storage::FjallStore::open_with_options(config.data_path(), opts)?;
-                    if config.datastore.at_rest_encryption {
-                        info!("At-rest encryption enabled (value-only, AES-256-GCM)");
-                        let key = Self::load_or_create_encryption_key(&config)?;
-                        let store =
-                            Arc::new(storage::encrypted_store::EncryptedStore::new(backend, key));
-                        Self::init_persistent_store_and_server(
-                            store,
-                            &config,
-                            peer_keypair,
-                            user_identity.clone(),
-                            node_identity_did.clone(),
-                            se_key,
-                        )
-                        .await?
-                    } else {
-                        Self::init_persistent_store_and_server(
-                            Arc::new(backend),
-                            &config,
-                            peer_keypair,
-                            user_identity.clone(),
-                            node_identity_did.clone(),
-                            se_key,
-                        )
-                        .await?
-                    }
+            }
+            #[cfg(not(feature = "fjall"))]
+            DatastoreType::Fjall => {
+                return Err(crate::error::Error::InvalidDatastore(
+                    "fjall backend not enabled. Rebuild with --features fjall".into(),
+                ));
+            }
+            #[cfg(feature = "rocksdb")]
+            DatastoreType::RocksDb => {
+                info!(
+                    "Using RocksDB datastore at {}",
+                    config.data_path().display()
+                );
+                let opts =
+                    RocksDbStoreOptions::from_env().with_durability(config.datastore.durability);
+                let backend = storage::RocksDbStore::open_with_options(config.data_path(), opts)?;
+                if config.datastore.at_rest_encryption {
+                    info!("At-rest encryption enabled (value-only, AES-256-GCM)");
+                    let key = Self::load_or_create_encryption_key(&config)?;
+                    let store =
+                        Arc::new(storage::encrypted_store::EncryptedStore::new(backend, key));
+                    Self::init_persistent_store_and_server(
+                        store,
+                        &config,
+                        peer_keypair,
+                        user_identity.clone(),
+                        node_identity_did.clone(),
+                        se_key,
+                    )
+                    .await?
+                } else {
+                    Self::init_persistent_store_and_server(
+                        Arc::new(backend),
+                        &config,
+                        peer_keypair,
+                        user_identity.clone(),
+                        node_identity_did.clone(),
+                        se_key,
+                    )
+                    .await?
                 }
-                #[cfg(not(feature = "fjall"))]
-                DatastoreType::Fjall => {
-                    return Err(crate::error::Error::InvalidDatastore(
-                        "fjall backend not enabled. Rebuild with --features fjall".into(),
-                    ));
+            }
+            #[cfg(not(feature = "rocksdb"))]
+            DatastoreType::RocksDb => {
+                return Err(crate::error::Error::InvalidDatastore(
+                    "rocksdb backend not enabled. Rebuild with --features rocksdb".into(),
+                ));
+            }
+            #[cfg(feature = "lark")]
+            DatastoreType::Lark => {
+                info!("Using Lark datastore at {}", config.data_path().display());
+                let opts =
+                    LarkStoreOptions::from_env().with_durability(config.datastore.durability);
+                let backend = storage::LarkStore::open_with_options(config.data_path(), opts)?;
+                if config.datastore.at_rest_encryption {
+                    info!("At-rest encryption enabled (value-only, AES-256-GCM)");
+                    let key = Self::load_or_create_encryption_key(&config)?;
+                    let store =
+                        Arc::new(storage::encrypted_store::EncryptedStore::new(backend, key));
+                    Self::init_persistent_store_and_server(
+                        store,
+                        &config,
+                        peer_keypair,
+                        user_identity.clone(),
+                        node_identity_did.clone(),
+                        se_key,
+                    )
+                    .await?
+                } else {
+                    Self::init_persistent_store_and_server(
+                        Arc::new(backend),
+                        &config,
+                        peer_keypair,
+                        user_identity.clone(),
+                        node_identity_did.clone(),
+                        se_key,
+                    )
+                    .await?
                 }
-                #[cfg(feature = "rocksdb")]
-                DatastoreType::RocksDb => {
-                    info!(
-                        "Using RocksDB datastore at {}",
-                        config.data_path().display()
-                    );
-                    let opts = RocksDbStoreOptions::from_env()
-                        .with_durability(config.datastore.durability);
-                    let backend =
-                        storage::RocksDbStore::open_with_options(config.data_path(), opts)?;
-                    if config.datastore.at_rest_encryption {
-                        info!("At-rest encryption enabled (value-only, AES-256-GCM)");
-                        let key = Self::load_or_create_encryption_key(&config)?;
-                        let store =
-                            Arc::new(storage::encrypted_store::EncryptedStore::new(backend, key));
-                        Self::init_persistent_store_and_server(
-                            store,
-                            &config,
-                            peer_keypair,
-                            user_identity.clone(),
-                            node_identity_did.clone(),
-                            se_key,
-                        )
-                        .await?
-                    } else {
-                        Self::init_persistent_store_and_server(
-                            Arc::new(backend),
-                            &config,
-                            peer_keypair,
-                            user_identity.clone(),
-                            node_identity_did.clone(),
-                            se_key,
-                        )
-                        .await?
-                    }
-                }
-                #[cfg(not(feature = "rocksdb"))]
-                DatastoreType::RocksDb => {
-                    return Err(crate::error::Error::InvalidDatastore(
-                        "rocksdb backend not enabled. Rebuild with --features rocksdb".into(),
-                    ));
-                }
-                #[cfg(feature = "lark")]
-                DatastoreType::Lark => {
-                    info!("Using Lark datastore at {}", config.data_path().display());
-                    let opts =
-                        LarkStoreOptions::from_env().with_durability(config.datastore.durability);
-                    let backend = storage::LarkStore::open_with_options(config.data_path(), opts)?;
-                    if config.datastore.at_rest_encryption {
-                        info!("At-rest encryption enabled (value-only, AES-256-GCM)");
-                        let key = Self::load_or_create_encryption_key(&config)?;
-                        let store =
-                            Arc::new(storage::encrypted_store::EncryptedStore::new(backend, key));
-                        Self::init_persistent_store_and_server(
-                            store,
-                            &config,
-                            peer_keypair,
-                            user_identity.clone(),
-                            node_identity_did.clone(),
-                            se_key,
-                        )
-                        .await?
-                    } else {
-                        Self::init_persistent_store_and_server(
-                            Arc::new(backend),
-                            &config,
-                            peer_keypair,
-                            user_identity.clone(),
-                            node_identity_did.clone(),
-                            se_key,
-                        )
-                        .await?
-                    }
-                }
-                #[cfg(not(feature = "lark"))]
-                DatastoreType::Lark => {
-                    return Err(crate::error::Error::InvalidDatastore(
-                        "lark backend not enabled. Rebuild with --features lark".into(),
-                    ));
-                }
-            };
+            }
+            #[cfg(not(feature = "lark"))]
+            DatastoreType::Lark => {
+                return Err(crate::error::Error::InvalidDatastore(
+                    "lark backend not enabled. Rebuild with --features lark".into(),
+                ));
+            }
+        };
 
         let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
 
         Ok(Self {
             config,
-            p2p_handle,
-            p2p_tasks,
-            downsample_task,
-            txn_cleanup_task,
-            http_server: Some(http_server),
-            pg_server,
+            p2p_handle: servers.p2p_handle,
+            p2p_tasks: servers.p2p_tasks,
+            downsample_task: servers.downsample_task,
+            txn_cleanup_task: servers.txn_cleanup_task,
+            http_server: Some(servers.http_server),
+            #[cfg(feature = "postgres")]
+            pg_server: servers.pg_server,
             shutdown_tx,
             shutdown_rx,
             user_identity,

--- a/crates/cli/src/commands/start/node.rs
+++ b/crates/cli/src/commands/start/node.rs
@@ -146,20 +146,35 @@ impl Node {
         Ok(Some(key))
     }
 
+    /// Wrap a concrete backend in a type-erased [`storage::DynStore`],
+    /// applying at-rest encryption when configured. The erasure keeps the
+    /// whole node stack at a single `S = DynStore` instantiation.
+    fn wrap_store<S>(config: &Config, backend: S) -> Result<storage::DynStore>
+    where
+        S: storage::corekv::Store + 'static,
+    {
+        if config.datastore.at_rest_encryption {
+            info!("At-rest encryption enabled (value-only, AES-256-GCM)");
+            let key = Self::load_or_create_encryption_key(config)?;
+            Ok(storage::DynStore::new(Arc::new(
+                storage::encrypted_store::EncryptedStore::new(backend, key),
+            )))
+        } else {
+            Ok(storage::DynStore::new(Arc::new(backend)))
+        }
+    }
+
     /// Build the persistent ACP/Zanzibar stores from a shared store and start
-    /// the server. The store may be a bare backend or an [`EncryptedStore`];
+    /// the server. The store may wrap a bare backend or an [`EncryptedStore`];
     /// both DB and ACP share the same instance so they encrypt uniformly.
-    async fn init_persistent_store_and_server<S>(
-        store: Arc<S>,
+    async fn init_persistent_store_and_server(
+        store: Arc<storage::DynStore>,
         config: &Config,
         peer_keypair: Option<p2p::Keypair>,
         user_identity: Option<std::sync::Arc<identity::RawIdentity>>,
         node_identity_did: Option<String>,
         se_key: Option<[u8; 32]>,
-    ) -> Result<ServerSetup>
-    where
-        S: storage::corekv::Store + 'static,
-    {
+    ) -> Result<ServerSetup> {
         info!("Using unified ACP store (namespace isolated in main database)");
         let acp_store: Arc<dyn acp::AcpStore> =
             Arc::new(acp::PersistentAcpStore::from_store(store.clone()));
@@ -219,35 +234,18 @@ impl Node {
                     Arc::new(acp::MemoryZanzibarStore::new());
                 info!("Using in-memory ACP store");
                 let backend = storage::MemoryStore::new();
-                if config.datastore.at_rest_encryption {
-                    info!("At-rest encryption enabled (value-only, AES-256-GCM)");
-                    let key = Self::load_or_create_encryption_key(&config)?;
-                    let store =
-                        Arc::new(storage::encrypted_store::EncryptedStore::new(backend, key));
-                    Self::init_store_and_server(
-                        store,
-                        &config,
-                        peer_keypair,
-                        user_identity.clone(),
-                        acp_store,
-                        zanzibar_store,
-                        node_identity_did.clone(),
-                        se_key,
-                    )
-                    .await?
-                } else {
-                    Self::init_store_and_server(
-                        Arc::new(backend),
-                        &config,
-                        peer_keypair,
-                        user_identity.clone(),
-                        acp_store,
-                        zanzibar_store,
-                        node_identity_did.clone(),
-                        se_key,
-                    )
-                    .await?
-                }
+                let store = Self::wrap_store(&config, backend)?;
+                Self::init_store_and_server(
+                    Arc::new(store),
+                    &config,
+                    peer_keypair,
+                    user_identity.clone(),
+                    acp_store,
+                    zanzibar_store,
+                    node_identity_did.clone(),
+                    se_key,
+                )
+                .await?
             }
             #[cfg(feature = "redb")]
             DatastoreType::Redb => {
@@ -256,31 +254,16 @@ impl Node {
                     .with_durability(config.datastore.durability)
                     .with_cache_size(256 * 1024 * 1024);
                 let backend = storage::RedbStore::open_with_options(config.data_path(), opts)?;
-                if config.datastore.at_rest_encryption {
-                    info!("At-rest encryption enabled (value-only, AES-256-GCM)");
-                    let key = Self::load_or_create_encryption_key(&config)?;
-                    let store =
-                        Arc::new(storage::encrypted_store::EncryptedStore::new(backend, key));
-                    Self::init_persistent_store_and_server(
-                        store,
-                        &config,
-                        peer_keypair,
-                        user_identity.clone(),
-                        node_identity_did.clone(),
-                        se_key,
-                    )
-                    .await?
-                } else {
-                    Self::init_persistent_store_and_server(
-                        Arc::new(backend),
-                        &config,
-                        peer_keypair,
-                        user_identity.clone(),
-                        node_identity_did.clone(),
-                        se_key,
-                    )
-                    .await?
-                }
+                let store = Self::wrap_store(&config, backend)?;
+                Self::init_persistent_store_and_server(
+                    Arc::new(store),
+                    &config,
+                    peer_keypair,
+                    user_identity.clone(),
+                    node_identity_did.clone(),
+                    se_key,
+                )
+                .await?
             }
             #[cfg(not(feature = "redb"))]
             DatastoreType::Redb => {
@@ -293,31 +276,16 @@ impl Node {
                 info!("Using Fjall datastore at {}", config.data_path().display());
                 let opts = FjallStoreOptions::new().with_durability(config.datastore.durability);
                 let backend = storage::FjallStore::open_with_options(config.data_path(), opts)?;
-                if config.datastore.at_rest_encryption {
-                    info!("At-rest encryption enabled (value-only, AES-256-GCM)");
-                    let key = Self::load_or_create_encryption_key(&config)?;
-                    let store =
-                        Arc::new(storage::encrypted_store::EncryptedStore::new(backend, key));
-                    Self::init_persistent_store_and_server(
-                        store,
-                        &config,
-                        peer_keypair,
-                        user_identity.clone(),
-                        node_identity_did.clone(),
-                        se_key,
-                    )
-                    .await?
-                } else {
-                    Self::init_persistent_store_and_server(
-                        Arc::new(backend),
-                        &config,
-                        peer_keypair,
-                        user_identity.clone(),
-                        node_identity_did.clone(),
-                        se_key,
-                    )
-                    .await?
-                }
+                let store = Self::wrap_store(&config, backend)?;
+                Self::init_persistent_store_and_server(
+                    Arc::new(store),
+                    &config,
+                    peer_keypair,
+                    user_identity.clone(),
+                    node_identity_did.clone(),
+                    se_key,
+                )
+                .await?
             }
             #[cfg(not(feature = "fjall"))]
             DatastoreType::Fjall => {
@@ -334,31 +302,16 @@ impl Node {
                 let opts =
                     RocksDbStoreOptions::from_env().with_durability(config.datastore.durability);
                 let backend = storage::RocksDbStore::open_with_options(config.data_path(), opts)?;
-                if config.datastore.at_rest_encryption {
-                    info!("At-rest encryption enabled (value-only, AES-256-GCM)");
-                    let key = Self::load_or_create_encryption_key(&config)?;
-                    let store =
-                        Arc::new(storage::encrypted_store::EncryptedStore::new(backend, key));
-                    Self::init_persistent_store_and_server(
-                        store,
-                        &config,
-                        peer_keypair,
-                        user_identity.clone(),
-                        node_identity_did.clone(),
-                        se_key,
-                    )
-                    .await?
-                } else {
-                    Self::init_persistent_store_and_server(
-                        Arc::new(backend),
-                        &config,
-                        peer_keypair,
-                        user_identity.clone(),
-                        node_identity_did.clone(),
-                        se_key,
-                    )
-                    .await?
-                }
+                let store = Self::wrap_store(&config, backend)?;
+                Self::init_persistent_store_and_server(
+                    Arc::new(store),
+                    &config,
+                    peer_keypair,
+                    user_identity.clone(),
+                    node_identity_did.clone(),
+                    se_key,
+                )
+                .await?
             }
             #[cfg(not(feature = "rocksdb"))]
             DatastoreType::RocksDb => {
@@ -372,31 +325,16 @@ impl Node {
                 let opts =
                     LarkStoreOptions::from_env().with_durability(config.datastore.durability);
                 let backend = storage::LarkStore::open_with_options(config.data_path(), opts)?;
-                if config.datastore.at_rest_encryption {
-                    info!("At-rest encryption enabled (value-only, AES-256-GCM)");
-                    let key = Self::load_or_create_encryption_key(&config)?;
-                    let store =
-                        Arc::new(storage::encrypted_store::EncryptedStore::new(backend, key));
-                    Self::init_persistent_store_and_server(
-                        store,
-                        &config,
-                        peer_keypair,
-                        user_identity.clone(),
-                        node_identity_did.clone(),
-                        se_key,
-                    )
-                    .await?
-                } else {
-                    Self::init_persistent_store_and_server(
-                        Arc::new(backend),
-                        &config,
-                        peer_keypair,
-                        user_identity.clone(),
-                        node_identity_did.clone(),
-                        se_key,
-                    )
-                    .await?
-                }
+                let store = Self::wrap_store(&config, backend)?;
+                Self::init_persistent_store_and_server(
+                    Arc::new(store),
+                    &config,
+                    peer_keypair,
+                    user_identity.clone(),
+                    node_identity_did.clone(),
+                    se_key,
+                )
+                .await?
             }
             #[cfg(not(feature = "lark"))]
             DatastoreType::Lark => {

--- a/crates/cli/src/commands/start/p2p.rs
+++ b/crates/cli/src/commands/start/p2p.rs
@@ -88,9 +88,9 @@ impl Node {
     ///
     /// Returns the handle, events receiver, and host task handle so that the caller
     /// can connect events to the sync coordinator and track the host task for shutdown.
-    pub(super) async fn start_p2p<S: p2p::BitswapStore>(
+    pub(super) async fn start_p2p(
         config: &Config,
-        bitswap_store: S,
+        bitswap_store: p2p::BitswapStoreAdapter<blockstore::DefraBlockstore<storage::DynStore>>,
         keypair: Option<p2p::Keypair>,
         enable_pubsub: bool,
         classifier: std::sync::Arc<dyn p2p::bitswap::BlockClassifier>,

--- a/crates/cli/src/commands/start/run.rs
+++ b/crates/cli/src/commands/start/run.rs
@@ -26,6 +26,9 @@ impl Node {
         };
 
         // Start PG wire protocol server
+        #[cfg(not(feature = "postgres"))]
+        let pg_task: Option<JoinHandle<()>> = None;
+        #[cfg(feature = "postgres")]
         let pg_task: Option<JoinHandle<()>> = if let Some(server) = self.pg_server.take() {
             info!(
                 "Starting Postgres wire protocol server on {}",

--- a/crates/cli/src/commands/start/server.rs
+++ b/crates/cli/src/commands/start/server.rs
@@ -20,8 +20,8 @@ impl Node {
     /// Returns a [`ServerSetup`] holding the servers and background tasks
     /// tracked for graceful shutdown.
     #[allow(clippy::too_many_arguments)]
-    pub(super) async fn init_store_and_server<S>(
-        store: Arc<S>,
+    pub(super) async fn init_store_and_server(
+        store: Arc<storage::DynStore>,
         config: &Config,
         peer_keypair: Option<p2p::Keypair>,
         user_identity: Option<std::sync::Arc<identity::RawIdentity>>,
@@ -29,10 +29,7 @@ impl Node {
         zanzibar_store: Arc<dyn acp::ZanzibarStore>,
         node_identity_did: Option<String>,
         se_key: Option<[u8; 32]>,
-    ) -> Result<ServerSetup>
-    where
-        S: storage::corekv::Store + 'static,
-    {
+    ) -> Result<ServerSetup> {
         let user_did = match &user_identity {
             Some(identity) => Some(identity.did().map_err(|e| {
                 Error::InvalidIdentity(format!(

--- a/crates/cli/src/commands/start/server.rs
+++ b/crates/cli/src/commands/start/server.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use tracing::{info, warn};
 
-use super::node::{Node, P2PTasks};
+use super::node::{Node, ServerSetup};
 use super::server_http::HttpServerArgs;
 use crate::config::Config;
 use crate::error::{Error, Result};
@@ -17,8 +17,8 @@ impl Node {
     /// This function creates the database, loads collections, sets up the query
     /// runner with proper transaction support, and returns the HTTP server.
     ///
-    /// Returns a tuple of (P2PHostHandle, P2PTasks, background tasks, HTTP Server)
-    /// where the background tasks are tracked for graceful shutdown.
+    /// Returns a [`ServerSetup`] holding the servers and background tasks
+    /// tracked for graceful shutdown.
     #[allow(clippy::too_many_arguments)]
     pub(super) async fn init_store_and_server<S>(
         store: Arc<S>,
@@ -29,14 +29,7 @@ impl Node {
         zanzibar_store: Arc<dyn acp::ZanzibarStore>,
         node_identity_did: Option<String>,
         se_key: Option<[u8; 32]>,
-    ) -> Result<(
-        Option<p2p::P2PHostHandle>,
-        Option<P2PTasks>,
-        Option<tokio::task::JoinHandle<()>>,
-        Option<tokio::task::JoinHandle<()>>,
-        defra_http::Server,
-        Option<pg_compat::PgServer>,
-    )>
+    ) -> Result<ServerSetup>
     where
         S: storage::corekv::Store + 'static,
     {
@@ -311,6 +304,7 @@ impl Node {
             None
         };
 
+        #[cfg(feature = "postgres")]
         let zanzibar_store_for_pg = zanzibar_store.clone();
         let http_server = Self::build_http_server(HttpServerArgs {
             database: database.clone(),
@@ -325,6 +319,7 @@ impl Node {
             user_did: user_did.as_ref(),
             node_identity_did,
         })?;
+        #[cfg(feature = "postgres")]
         let pg_server = Self::build_pg_server(
             database,
             config,
@@ -333,13 +328,14 @@ impl Node {
             zanzibar_store_for_pg,
         )?;
 
-        Ok((
-            p2p_setup.host_handle,
-            p2p_setup.p2p_tasks,
+        Ok(ServerSetup {
+            p2p_handle: p2p_setup.host_handle,
+            p2p_tasks: p2p_setup.p2p_tasks,
             downsample_task,
             txn_cleanup_task,
             http_server,
+            #[cfg(feature = "postgres")]
             pg_server,
-        ))
+        })
     }
 }

--- a/crates/cli/src/commands/start/server_acp.rs
+++ b/crates/cli/src/commands/start/server_acp.rs
@@ -5,7 +5,9 @@ use std::sync::Arc;
 use tracing::info;
 
 use super::node::Node;
-use crate::config::{AcpDocumentType, Config};
+#[cfg(feature = "sourcehub")]
+use crate::config::AcpDocumentType;
+use crate::config::Config;
 use crate::error::{Error, Result};
 use identity::Did;
 
@@ -15,6 +17,7 @@ pub(super) struct DocumentAcpSetup {
 }
 
 impl Node {
+    #[cfg_attr(not(feature = "sourcehub"), allow(unused_variables))]
     pub(super) async fn setup_document_acp(
         config: &Config,
         identity_key_bytes: Option<&[u8]>,
@@ -23,6 +26,7 @@ impl Node {
         event_bus: Arc<dyn events::Bus>,
         nac_checker: Arc<dyn db::NodeAccessChecker>,
     ) -> Result<DocumentAcpSetup> {
+        #[cfg(feature = "sourcehub")]
         if config.acp.document_type == AcpDocumentType::SourceHub {
             if config.acp.sourcehub_address.is_empty() {
                 return Err(Error::InvalidConfig(
@@ -77,11 +81,14 @@ impl Node {
             );
 
             info!("Document ACP configured (SourceHub)");
-            Ok(DocumentAcpSetup {
+            return Ok(DocumentAcpSetup {
                 document_acp,
                 http_adapter: Some(http_adapter),
-            })
-        } else if config.acp.document_type == AcpDocumentType::HubRs {
+            });
+        }
+
+        #[cfg(feature = "sourcehub")]
+        if config.acp.document_type == AcpDocumentType::HubRs {
             if config.acp.hub_rs_address.is_empty() {
                 return Err(Error::InvalidConfig(
                     "hub_rs_address required when document_type is hub-rs".into(),
@@ -133,21 +140,21 @@ impl Node {
             );
 
             info!("Document ACP configured (hub.rs)");
-            Ok(DocumentAcpSetup {
+            return Ok(DocumentAcpSetup {
                 document_acp,
                 http_adapter: Some(http_adapter),
-            })
-        } else {
-            info!("Document ACP configured (local)");
-            let document_acp = Arc::new(acp::ZanzibarDocumentACP::new(zanzibar_store.clone()));
-            Ok(DocumentAcpSetup {
-                document_acp,
-                http_adapter: Some(crate::acp_adapter::AcpAdapter::new_arc(
-                    zanzibar_store,
-                    nac_checker,
-                )),
-            })
+            });
         }
+
+        info!("Document ACP configured (local)");
+        let document_acp = Arc::new(acp::ZanzibarDocumentACP::new(zanzibar_store.clone()));
+        Ok(DocumentAcpSetup {
+            document_acp,
+            http_adapter: Some(crate::acp_adapter::AcpAdapter::new_arc(
+                zanzibar_store,
+                nac_checker,
+            )),
+        })
     }
 
     pub(super) async fn setup_nac_manager(

--- a/crates/cli/src/commands/start/server_http.rs
+++ b/crates/cli/src/commands/start/server_http.rs
@@ -12,11 +12,11 @@ use crate::config::{AcpDocumentType, Config, TransportType};
 use crate::error::{Error, Result};
 use identity::Did;
 
-pub(super) struct HttpServerArgs<'a, S: storage::corekv::Store + 'static> {
-    pub(super) database: Arc<db::DB<S>>,
+pub(super) struct HttpServerArgs<'a> {
+    pub(super) database: Arc<db::DB<storage::DynStore>>,
     pub(super) config: &'a Config,
     pub(super) event_bus: Arc<dyn events::Bus>,
-    pub(super) query_setup: &'a QueryRunnerSetup<S>,
+    pub(super) query_setup: &'a QueryRunnerSetup,
     pub(super) p2p_adapter: Option<Arc<dyn defra_http::router::P2POperations>>,
     pub(super) manage_requester: Option<Arc<dyn defra_http::router::ManageRequester>>,
     pub(super) nac_adapter: Option<Arc<crate::nac_adapter::NacAdapter>>,
@@ -27,10 +27,7 @@ pub(super) struct HttpServerArgs<'a, S: storage::corekv::Store + 'static> {
 }
 
 impl Node {
-    pub(super) fn build_http_server<S>(args: HttpServerArgs<'_, S>) -> Result<defra_http::Server>
-    where
-        S: storage::corekv::Store + 'static,
-    {
+    pub(super) fn build_http_server(args: HttpServerArgs<'_>) -> Result<defra_http::Server> {
         let HttpServerArgs {
             database,
             config,
@@ -231,16 +228,13 @@ impl Node {
     }
 
     #[cfg(feature = "postgres")]
-    pub(super) fn build_pg_server<S>(
-        database: Arc<db::DB<S>>,
+    pub(super) fn build_pg_server(
+        database: Arc<db::DB<storage::DynStore>>,
         config: &Config,
-        query_setup: &QueryRunnerSetup<S>,
+        query_setup: &QueryRunnerSetup,
         acp_setup: &DocumentAcpSetup,
         zanzibar_store: Arc<dyn acp::ZanzibarStore>,
-    ) -> Result<Option<pg_compat::PgServer>>
-    where
-        S: storage::corekv::Store + 'static,
-    {
+    ) -> Result<Option<pg_compat::PgServer>> {
         if config.api.pg_address.is_empty() {
             return Ok(None);
         }

--- a/crates/cli/src/commands/start/server_http.rs
+++ b/crates/cli/src/commands/start/server_http.rs
@@ -230,6 +230,7 @@ impl Node {
         Ok(server)
     }
 
+    #[cfg(feature = "postgres")]
     pub(super) fn build_pg_server<S>(
         database: Arc<db::DB<S>>,
         config: &Config,

--- a/crates/cli/src/commands/start/server_p2p/iroh.rs
+++ b/crates/cli/src/commands/start/server_p2p/iroh.rs
@@ -10,17 +10,14 @@ use crate::config::Config;
 use crate::error::{Error, Result};
 
 impl Node {
-    pub(super) async fn setup_iroh_p2p<S>(
-        store: Arc<S>,
-        database: Arc<db::DB<S>>,
+    pub(super) async fn setup_iroh_p2p(
+        store: Arc<storage::DynStore>,
+        database: Arc<db::DB<storage::DynStore>>,
         event_bus: Arc<dyn events::Bus>,
         config: &Config,
         peer_keypair: Option<p2p::Keypair>,
         se_key: Option<[u8; 32]>,
-    ) -> Result<P2PSetup>
-    where
-        S: storage::corekv::Store + 'static,
-    {
+    ) -> Result<P2PSetup> {
         info!("Initializing P2P network (iroh)");
 
         let sync_blockstore = Arc::new(blockstore::DefraBlockstore::new(store.clone(), true));

--- a/crates/cli/src/commands/start/server_p2p/libp2p.rs
+++ b/crates/cli/src/commands/start/server_p2p/libp2p.rs
@@ -9,17 +9,14 @@ use crate::config::Config;
 use crate::error::{Error, Result};
 
 impl Node {
-    pub(super) async fn setup_libp2p_p2p<S>(
-        store: Arc<S>,
-        database: Arc<db::DB<S>>,
+    pub(super) async fn setup_libp2p_p2p(
+        store: Arc<storage::DynStore>,
+        database: Arc<db::DB<storage::DynStore>>,
         event_bus: Arc<dyn events::Bus>,
         config: &Config,
         peer_keypair: Option<p2p::Keypair>,
         se_key: Option<[u8; 32]>,
-    ) -> Result<P2PSetup>
-    where
-        S: storage::corekv::Store + 'static,
-    {
+    ) -> Result<P2PSetup> {
         info!("Initializing P2P network (libp2p)");
 
         let blockstore = Arc::new(blockstore::DefraBlockstore::new(store.clone(), true));

--- a/crates/cli/src/commands/start/server_p2p/mod.rs
+++ b/crates/cli/src/commands/start/server_p2p/mod.rs
@@ -18,8 +18,8 @@ type WireKms = Option<Box<dyn FnOnce(Arc<dyn kms::KmsService>) + Send>>;
 /// stalled connection cannot strand the peer's persisted retry ledger after
 /// the target restarts (the connectivity gate below would otherwise skip it
 /// forever, while nothing else redials it).
-async fn redial_replicator<S: storage::corekv::Store>(
-    peerstore: &storage::stores::Peerstore<S>,
+async fn redial_replicator(
+    peerstore: &storage::stores::Peerstore<storage::DynStore>,
     handle: &p2p::P2PHostHandle,
     peer_id_str: &str,
     peer_id: libp2p::PeerId,
@@ -43,8 +43,8 @@ async fn redial_replicator<S: storage::corekv::Store>(
     }
 }
 
-async fn set_persisted_replicator_status<S: storage::corekv::Store>(
-    peerstore: &storage::stores::Peerstore<S>,
+async fn set_persisted_replicator_status(
+    peerstore: &storage::stores::Peerstore<storage::DynStore>,
     peer_id: &str,
     status: p2p::ReplicatorStatus,
 ) -> Result<bool> {
@@ -120,17 +120,14 @@ pub(super) struct P2PSetup {
 }
 
 impl Node {
-    pub(super) async fn setup_p2p<S>(
-        store: Arc<S>,
-        database: Arc<db::DB<S>>,
+    pub(super) async fn setup_p2p(
+        store: Arc<storage::DynStore>,
+        database: Arc<db::DB<storage::DynStore>>,
         event_bus: Arc<dyn events::Bus>,
         config: &Config,
         peer_keypair: Option<p2p::Keypair>,
         se_key: Option<[u8; 32]>,
-    ) -> Result<P2PSetup>
-    where
-        S: storage::corekv::Store + 'static,
-    {
+    ) -> Result<P2PSetup> {
         if config.net.p2p_disabled {
             return Ok(Self::p2p_disabled(database));
         }
@@ -160,10 +157,7 @@ impl Node {
         Self::setup_libp2p_p2p(store, database, event_bus, config, peer_keypair, se_key).await
     }
 
-    fn p2p_disabled<S>(database: Arc<db::DB<S>>) -> P2PSetup
-    where
-        S: storage::corekv::Store + 'static,
-    {
+    fn p2p_disabled(database: Arc<db::DB<storage::DynStore>>) -> P2PSetup {
         P2PSetup {
             host_handle: None,
             p2p_tasks: None,

--- a/crates/cli/src/commands/start/server_query.rs
+++ b/crates/cli/src/commands/start/server_query.rs
@@ -5,7 +5,9 @@ use std::sync::Arc;
 use tracing::info;
 
 use super::node::Node;
-use crate::config::{AcpDocumentType, Config};
+#[cfg(feature = "sourcehub")]
+use crate::config::AcpDocumentType;
+use crate::config::Config;
 use identity::Did;
 
 pub(super) struct QueryRunnerSetup<S: storage::corekv::Store + 'static> {
@@ -64,9 +66,12 @@ impl Node {
         }
 
         if let Some(did) = user_did {
-            if config.acp.document_type != AcpDocumentType::SourceHub
-                && config.acp.document_type != AcpDocumentType::HubRs
-            {
+            #[cfg(feature = "sourcehub")]
+            let remote_acp = config.acp.document_type == AcpDocumentType::SourceHub
+                || config.acp.document_type == AcpDocumentType::HubRs;
+            #[cfg(not(feature = "sourcehub"))]
+            let remote_acp = false;
+            if !remote_acp {
                 info!("Query runner configured with default identity for ACP");
                 query_runner = query_runner.with_default_identity(did.clone());
             }

--- a/crates/cli/src/commands/start/server_query.rs
+++ b/crates/cli/src/commands/start/server_query.rs
@@ -12,6 +12,7 @@ pub(super) struct QueryRunnerSetup<S: storage::corekv::Store + 'static> {
     pub(super) runner: Arc<dyn query::executor::QueryExecutor>,
     pub(super) rest_ops: Arc<dyn query::rest::RestOperations>,
     pub(super) registry: Arc<db::DbTransactionRegistry<S>>,
+    #[cfg(feature = "postgres")]
     pub(super) collection_provider: Arc<dyn query::CollectionProvider>,
 }
 
@@ -89,6 +90,7 @@ impl Node {
             runner,
             rest_ops,
             registry,
+            #[cfg(feature = "postgres")]
             collection_provider,
         }
     }

--- a/crates/cli/src/commands/start/server_query.rs
+++ b/crates/cli/src/commands/start/server_query.rs
@@ -10,18 +10,18 @@ use crate::config::AcpDocumentType;
 use crate::config::Config;
 use identity::Did;
 
-pub(super) struct QueryRunnerSetup<S: storage::corekv::Store + 'static> {
+pub(super) struct QueryRunnerSetup {
     pub(super) runner: Arc<dyn query::executor::QueryExecutor>,
     pub(super) rest_ops: Arc<dyn query::rest::RestOperations>,
-    pub(super) registry: Arc<db::DbTransactionRegistry<S>>,
+    pub(super) registry: Arc<db::DbTransactionRegistry<storage::DynStore>>,
     #[cfg(feature = "postgres")]
     pub(super) collection_provider: Arc<dyn query::CollectionProvider>,
 }
 
 impl Node {
     #[allow(clippy::too_many_arguments)]
-    pub(super) fn setup_query_runner<S>(
-        database: Arc<db::DB<S>>,
+    pub(super) fn setup_query_runner(
+        database: Arc<db::DB<storage::DynStore>>,
         config: &Config,
         user_did: Option<&Did>,
         document_acp: Arc<dyn acp::DocumentACP>,
@@ -29,10 +29,7 @@ impl Node {
         mutator: Arc<dyn query::mutator::DocMutator>,
         txn_broadcaster: Option<Arc<dyn db::event_emission::TxnBroadcaster>>,
         se_transport: Option<Arc<dyn query::SeQueryTransport>>,
-    ) -> QueryRunnerSetup<S>
-    where
-        S: storage::corekv::Store + 'static,
-    {
+    ) -> QueryRunnerSetup {
         let fetcher = db::LensedAutoCommitFetcher::new(database.clone());
         let registry = Arc::new(match txn_broadcaster {
             Some(b) => db::DbTransactionRegistry::with_broadcaster(database.clone(), b),

--- a/crates/cli/src/config/mod.rs
+++ b/crates/cli/src/config/mod.rs
@@ -201,17 +201,21 @@ impl Config {
         }
 
         // SourceHub
+        #[cfg(feature = "sourcehub")]
         if let Some(ref addr) = cli.source_hub_address {
             self.acp.sourcehub_address = addr.clone();
         }
+        #[cfg(feature = "sourcehub")]
         if let Some(ref addr) = cli.source_hub_comet_address {
             self.acp.sourcehub_comet_address = addr.clone();
         }
+        #[cfg(feature = "sourcehub")]
         if let Some(ref id) = cli.source_hub_chain_id {
             self.acp.sourcehub_chain_id = id.clone();
         }
 
         // hub.rs
+        #[cfg(feature = "sourcehub")]
         if let Some(ref addr) = cli.hub_rs_address {
             self.acp.hub_rs_address = addr.clone();
         }

--- a/crates/cli/src/config/sections.rs
+++ b/crates/cli/src/config/sections.rs
@@ -491,18 +491,22 @@ pub struct AcpConfig {
     pub document_type: AcpDocumentType,
 
     /// SourceHub gRPC/LCD endpoint (e.g., "http://localhost:1317")
+    #[cfg(feature = "sourcehub")]
     #[serde(default)]
     pub sourcehub_address: String,
 
     /// SourceHub CometBFT RPC endpoint (e.g., "http://localhost:26657")
+    #[cfg(feature = "sourcehub")]
     #[serde(default)]
     pub sourcehub_comet_address: String,
 
     /// SourceHub chain ID (e.g., "sourcehub-test")
+    #[cfg(feature = "sourcehub")]
     #[serde(default)]
     pub sourcehub_chain_id: String,
 
     /// hub.rs JSON-RPC endpoint (e.g., "http://localhost:8545")
+    #[cfg(feature = "sourcehub")]
     #[serde(default)]
     pub hub_rs_address: String,
 
@@ -548,9 +552,13 @@ impl Default for AcpConfig {
         Self {
             node_enable: false,
             document_type: AcpDocumentType::None,
+            #[cfg(feature = "sourcehub")]
             sourcehub_address: String::new(),
+            #[cfg(feature = "sourcehub")]
             sourcehub_comet_address: String::new(),
+            #[cfg(feature = "sourcehub")]
             sourcehub_chain_id: String::new(),
+            #[cfg(feature = "sourcehub")]
             hub_rs_address: String::new(),
             circuit_breaker_threshold: default_acp_cb_threshold(),
             circuit_breaker_reset_timeout: default_acp_cb_reset_timeout(),

--- a/crates/cli/src/config/sections.rs
+++ b/crates/cli/src/config/sections.rs
@@ -84,6 +84,7 @@ pub struct ApiConfig {
     #[serde(default = "default_query_max_filter_depth")]
     pub query_max_filter_depth: usize,
     /// Postgres wire protocol address (empty = disabled). Default: "" (disabled).
+    #[cfg(feature = "postgres")]
     #[serde(default)]
     pub pg_address: String,
 }
@@ -138,6 +139,7 @@ impl Default for ApiConfig {
             query_max_depth: default_query_max_depth(),
             query_max_width: default_query_max_width(),
             query_max_filter_depth: default_query_max_filter_depth(),
+            #[cfg(feature = "postgres")]
             pg_address: String::new(),
         }
     }

--- a/crates/cli/src/config/types.rs
+++ b/crates/cli/src/config/types.rs
@@ -195,7 +195,9 @@ pub enum AcpDocumentType {
     #[default]
     None,
     Local,
+    #[cfg(feature = "sourcehub")]
     SourceHub,
+    #[cfg(feature = "sourcehub")]
     HubRs,
 }
 
@@ -204,7 +206,9 @@ impl std::fmt::Display for AcpDocumentType {
         match self {
             AcpDocumentType::None => write!(f, "none"),
             AcpDocumentType::Local => write!(f, "local"),
+            #[cfg(feature = "sourcehub")]
             AcpDocumentType::SourceHub => write!(f, "source-hub"),
+            #[cfg(feature = "sourcehub")]
             AcpDocumentType::HubRs => write!(f, "hub-rs"),
         }
     }
@@ -217,7 +221,9 @@ impl std::str::FromStr for AcpDocumentType {
         match s.to_lowercase().replace('-', "").as_str() {
             "none" | "" => Ok(AcpDocumentType::None),
             "local" => Ok(AcpDocumentType::Local),
+            #[cfg(feature = "sourcehub")]
             "sourcehub" => Ok(AcpDocumentType::SourceHub),
+            #[cfg(feature = "sourcehub")]
             "hubrs" => Ok(AcpDocumentType::HubRs),
             _ => Err(Error::InvalidAcpType(s.to_string())),
         }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -31,6 +31,7 @@ pub(crate) mod p2p_collection_lookup;
 #[allow(dead_code)]
 pub(crate) mod p2p_doc_pusher;
 pub(crate) mod schema_adapter;
+#[cfg(feature = "sourcehub")]
 pub(crate) mod sourcehub_acp_adapter;
 #[cfg(feature = "iroh")]
 #[allow(dead_code)]

--- a/crates/cli/src/schema_adapter.rs
+++ b/crates/cli/src/schema_adapter.rs
@@ -69,6 +69,7 @@ impl<S: Store + 'static> SchemaAdapter<S> {
     /// `AcpOperations` handle — that variant enables schema-time DRI
     /// validation (#746). This bare constructor exists for tests and
     /// for embedded PG callers that don't have ACP configured.
+    #[cfg(feature = "postgres")]
     pub fn new_pg_arc(database: Arc<db::DB<S>>) -> Arc<dyn pg_compat::SchemaManager> {
         Arc::new(Self::new(database))
     }
@@ -76,6 +77,7 @@ impl<S: Store + 'static> SchemaAdapter<S> {
     /// Create an Arc-wrapped PG schema manager with ACP wired in for
     /// schema-time DRI validation (#746). Use this when the PG server
     /// has access to an `AcpOperations` handle.
+    #[cfg(feature = "postgres")]
     pub fn new_pg_arc_with_acp(
         database: Arc<db::DB<S>>,
         acp: Arc<dyn AcpOperations>,
@@ -147,6 +149,7 @@ impl<S: Store + 'static> SchemaOperations for SchemaAdapter<S> {
     }
 }
 
+#[cfg(feature = "postgres")]
 #[async_trait]
 impl<S: Store + 'static> pg_compat::SchemaManager for SchemaAdapter<S> {
     async fn add_schema(&self, sdl: &str) -> Result<(), String> {

--- a/crates/cli/tests/config_tests.rs
+++ b/crates/cli/tests/config_tests.rs
@@ -23,9 +23,13 @@ fn cli_with_defaults() -> Cli {
         keyring_backend: None,
         keyring_path: None,
         no_keyring: None,
+        #[cfg(feature = "sourcehub")]
         source_hub_address: None,
+        #[cfg(feature = "sourcehub")]
         source_hub_comet_address: None,
+        #[cfg(feature = "sourcehub")]
         source_hub_chain_id: None,
+        #[cfg(feature = "sourcehub")]
         hub_rs_address: None,
         secret_file: None,
         no_telemetry: None,

--- a/crates/cli/tests/start_tests.rs
+++ b/crates/cli/tests/start_tests.rs
@@ -24,9 +24,13 @@ fn default_start_args() -> StartArgs {
         identity: None,
         replicator_retry_intervals: None,
         durability: None,
+        #[cfg(feature = "orbis")]
         signer_type: None,
+        #[cfg(feature = "orbis")]
         signer_orbis_endpoint: None,
+        #[cfg(feature = "orbis")]
         signer_orbis_ring_id: None,
+        #[cfg(feature = "orbis")]
         signer_orbis_derivation: None,
         max_body_size: None,
         max_schema_size: None,
@@ -137,9 +141,13 @@ fn test_apply_to_config_all_flags() {
         identity: None, // identity is handled in Node::new, not apply_to_config
         replicator_retry_intervals: Some(vec![10, 20, 30]),
         durability: None,
+        #[cfg(feature = "orbis")]
         signer_type: None,
+        #[cfg(feature = "orbis")]
         signer_orbis_endpoint: None,
+        #[cfg(feature = "orbis")]
         signer_orbis_ring_id: None,
+        #[cfg(feature = "orbis")]
         signer_orbis_derivation: None,
         max_body_size: Some(1024),
         max_schema_size: Some(2048),

--- a/crates/cli/tests/start_tests.rs
+++ b/crates/cli/tests/start_tests.rs
@@ -56,6 +56,7 @@ fn default_start_args() -> StartArgs {
         query_max_width: None,
         query_max_filter_depth: None,
         p2p_transport: None,
+        #[cfg(feature = "postgres")]
         pg_address: None,
         acp_cache_ttl: None,
         acp_circuit_breaker_threshold: None,
@@ -168,6 +169,7 @@ fn test_apply_to_config_all_flags() {
         query_max_width: Some(64),
         query_max_filter_depth: Some(24),
         p2p_transport: None,
+        #[cfg(feature = "postgres")]
         pg_address: None,
         acp_cache_ttl: None,
         acp_circuit_breaker_threshold: None,

--- a/crates/lens/Cargo.toml
+++ b/crates/lens/Cargo.toml
@@ -37,7 +37,11 @@ hex.workspace = true
 # Wasmtime runtime dependencies (optional for wasm32)
 tokio = { workspace = true, optional = true }
 parking_lot = { workspace = true, optional = true }
-wasmtime = { version = "43.0.1", optional = true }
+wasmtime = { version = "43.0.1", optional = true, default-features = false, features = [
+    "runtime",
+    "cranelift",
+    "std",
+] }
 
 [lints]
 workspace = true

--- a/crates/sourcehub/Cargo.toml
+++ b/crates/sourcehub/Cargo.toml
@@ -13,7 +13,7 @@ description = "SourceHub ACP client for DefraDB"
 reqwest = { version = "0.12", features = ["json"] }
 
 # Cosmos SDK transaction building and signing
-cosmrs = { version = "0.22", features = ["rpc"] }
+cosmrs = "0.22"
 
 # Serialization
 serde.workspace = true

--- a/crates/storage/src/dyn_store.rs
+++ b/crates/storage/src/dyn_store.rs
@@ -1,0 +1,38 @@
+//! Type-erased [`Store`] wrapper.
+//!
+//! Erasing the concrete backend at construction time collapses the per-backend
+//! monomorphization fan-out (DB, blockstore, P2P sync stack) into a single
+//! `S = DynStore` copy-set. Hot paths already dispatch through `Box<dyn Txn>`,
+//! so the erasure costs one vtable hop on `new_txn`/`close` only.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::corekv::{private, Result, Store, Txn};
+
+/// A [`Store`] that erases the concrete backend behind `Arc<dyn Store>`.
+#[derive(Clone)]
+pub struct DynStore {
+    inner: Arc<dyn Store>,
+}
+
+impl DynStore {
+    pub fn new(inner: Arc<dyn Store>) -> Self {
+        Self { inner }
+    }
+}
+
+impl private::Sealed for DynStore {}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl Store for DynStore {
+    async fn new_txn(&self, readonly: bool) -> Result<Box<dyn Txn>> {
+        self.inner.new_txn(readonly).await
+    }
+
+    async fn close(&self) -> Result<()> {
+        self.inner.close().await
+    }
+}

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -97,6 +97,7 @@
 /// - Architecture guides
 pub mod backends;
 pub mod corekv;
+pub mod dyn_store;
 pub mod encoding;
 pub mod encrypted_store;
 pub mod field_value;
@@ -139,3 +140,4 @@ pub use backends::OpfsEnv;
 pub use corekv::{
     Error, IterOptions, Iterator, KvPair, Reader, ReaderWriter, Result, Store, Txn, Writer,
 };
+pub use dyn_store::DynStore;

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -75,7 +75,7 @@ default = []
 debug = []
 
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = ["-O3", "--enable-mutable-globals", "--enable-bulk-memory", "--enable-nontrapping-float-to-int"]
+wasm-opt = ["-Oz", "--enable-mutable-globals", "--enable-bulk-memory", "--enable-nontrapping-float-to-int"]
 
 [lints]
 workspace = true


### PR DESCRIPTION
Consolidated binary-size pass (subsumes closed #1270–#1274 plus DynStore stage 1). All numbers measured on identical hardware/toolchain (darwin_arm64, release profile, fat LTO):

| Build | Bytes | vs v0.17.2 |
|---|---|---|
| v0.17.2 released \`defra\` | 61,805,904 (58.9MiB) | — |
| Feature gates only (no DynStore) | 56,156,016 (53.6MiB) | −9.1% |
| **Full default (this branch)** | **38,897,248 (37.1MiB)** | **−37.1%** |
| **\`defra-lark\` slim (this branch)** | **31,983,600 (30.5MiB)** | **−48.3%** |

**What's in here:**
1. **DynStore erasure (−17.3MB on the full build alone)** — new \`storage::DynStore\` (\`Arc<dyn Store>\`) erases the backend at cli construction; the init chain is de-genericized so exactly one \`S=DynStore\` instantiation of the DB/blockstore/merge/P2P stack exists instead of 8 (4 backends × encrypted/plain). Hot paths were already \`Box<dyn Txn>\`/boxed-future dispatched — one extra vtable hop at \`new_txn\`/\`close\` only. No changes to db/db-merge/p2p/query/http.
2. **release.yml builds real variants** — every v0.17.2 artifact was byte-identical (sha256-verified); slim CLI variant is now lark-only.
3. **Opt-in features, default-off**: \`postgres\` (pgwire+sqlparser), \`sourcehub\` (cosmrs/tendermint/commonware subtree), \`orbis\` (threshold signing). \`blst\` stays: BLS block *verification* in crates/crypto is core wire behavior.
4. **wasmtime slimmed** to \`runtime,cranelift,std\` (WAT parser, winch, component-model, cache, profiling gone — lens functionality unchanged).
5. **Legacy TLS stack gone** — sourcehub never used cosmrs's \`rpc\` client; hyper 0.14/h2 0.3/rustls 0.21/reqwest 0.11 left the graph.

**Validation:** 150 integration tests green on this exact branch — basic 24, query 40 (lens migrations), **p2p 73** (multi-node replication through the erased store), encryption 7, backup 6; cli tests + clippy \`-D warnings\` across default/slim/full-featured (\`iroh,fjall,sourcehub,orbis,postgres\`) sets; wasm32 storage check clean; release binaries smoke-tested.

**Release-notes callouts:** \`--features postgres|sourcehub,orbis\` to re-enable pg wire / on-chain ACP / orbis signing (stray config keys are ignored, \`document_type: sourcehub\` and CLI flags error); slim/CI artifact contents change; \`sourcehub\`/\`hubrs\` test areas need \`cargo build -p cli --features sourcehub,orbis\`.

Follow-ups tracked separately: stage-2 query de-genericization (~0.5MiB), defra-node/ffi DynStore adoption (same win for embedded artifacts), stage-3 \`DB<S>\` de-genericization (compile-time hygiene), build-std experiment (data incoming).

🤖 Generated with [Claude Code](https://claude.com/claude-code)