### PR TITLE
fix(release): ship FFI as cdylib instead of 385MB static archive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -338,8 +338,18 @@ jobs:
         run: |
           TAG="${GITHUB_REF_NAME}"
           ARCHIVE="defra-ffi-${{ matrix.variant }}_${TAG}_${{ matrix.platform }}.tar.gz"
+          RELEASE_DIR="target/${{ matrix.target }}/release"
+          if [[ "${{ runner.os }}" == "macOS" ]]; then
+            LIB="libdefra_ffi.dylib"
+            cp "${RELEASE_DIR}/libffi.dylib" "${RELEASE_DIR}/${LIB}"
+            install_name_tool -id "@rpath/${LIB}" "${RELEASE_DIR}/${LIB}"
+            codesign --force --sign - "${RELEASE_DIR}/${LIB}"
+          else
+            LIB="libdefra_ffi.so"
+            cp "${RELEASE_DIR}/libffi.so" "${RELEASE_DIR}/${LIB}"
+          fi
           tar czf "${ARCHIVE}" \
-            -C "target/${{ matrix.target }}/release" libffi.a \
+            -C "${RELEASE_DIR}" "${LIB}" \
             -C "${GITHUB_WORKSPACE}" defra.h
           echo "ARCHIVE=${ARCHIVE}" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
Stacked on #1275 (base = \`size/integration\`); retarget to main after it merges.

The released \`defra-ffi\` archives were ~543MB (v0.17.2) because release.yml packaged \`libffi.a\` — a pre-LTO rlib bitcode bundle. The crate already builds a cdylib; this ships it: **34.1MiB vs 384.8MiB same-build .a — 11× smaller** (stripping the .a recovers only 2%).

No consumer regression: the Go rustffi client links dynamically (\`-ldefra_ffi\` + rpath), \`ffi-test\` copies the dylib/so, and iOS static needs are served by the separate xcframework job (staticlib stays in crate-type for that). macOS install_name rewritten to \`@rpath/libdefra_ffi.dylib\`; smoke-tested via a C binary calling \`defra_version()\`.

Needs one release dry-run to verify the Linux \`.so\` rows (not buildable locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)