### PR TITLE
fix(cli): correct release contracts and encrypted dumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,11 @@ jobs:
 
       - run: cargo clippy --all -- -D warnings
 
+      # Release builds use explicit feature contracts rather than Cargo defaults.
+      - run: cargo clippy -p cli --no-default-features --features release-full --all-targets -- -D warnings
+      - run: cargo clippy -p cli --no-default-features --features rocksdb,lark --all-targets -- -D warnings
+      - run: cargo clippy -p cli --no-default-features --features lark --all-targets -- -D warnings
+
       # OTel feature paths are opt-in (mirror Go's `//go:build telemetry`),
       # so the default clippy pass doesn't exercise them. These checks keep
       # the feature-gated code from rotting silently. Issue #977.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,27 +16,27 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # full (all default features: lark + rocksdb + redb)
+          # full (all supported release integrations)
           - variant: full
             target: x86_64-unknown-linux-gnu
             platform: linux_amd64
             runner: '["self-hosted", "Linux", "X64"]'
-            features: ""
+            features: "--no-default-features --features release-full"
           - variant: full
             target: aarch64-unknown-linux-gnu
             platform: linux_arm64
             runner: '["self-hosted", "Linux", "ARM64"]'
-            features: ""
+            features: "--no-default-features --features release-full"
           - variant: full
             target: x86_64-apple-darwin
             platform: darwin_amd64
             runner: '["self-hosted", "macOS", "ARM64", "studio"]'
-            features: "--features vendored-openssl"
+            features: "--no-default-features --features release-full,vendored-openssl"
           - variant: full
             target: aarch64-apple-darwin
             platform: darwin_arm64
             runner: '["self-hosted", "macOS", "ARM64", "studio"]'
-            features: ""
+            features: "--no-default-features --features release-full"
           # rocksdb (lark included: default runtime backend)
           - variant: rocksdb
             target: x86_64-unknown-linux-gnu
@@ -486,7 +486,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: artifacts
-          pattern: defra-redb-*
+          pattern: defra-lark-*
           merge-multiple: true
 
       - uses: actions/download-artifact@v4

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -114,6 +114,7 @@ optional = true
 
 [features]
 default = ["lark", "rocksdb", "redb"]
+release-full = ["lark", "rocksdb", "redb", "postgres", "sourcehub", "orbis"]
 lark = ["storage/lark"]
 postgres = ["dep:pg-compat"]
 # SourceHub/hub.rs on-chain document ACP (`--document-acp-type source-hub|hub-rs`).

--- a/crates/cli/src/commands/server_dump.rs
+++ b/crates/cli/src/commands/server_dump.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use clap::Args;
 
+use crate::commands::start::Node;
 use crate::config::{Config, DatastoreType};
 use crate::error::{Error, Result};
 
@@ -21,9 +22,8 @@ impl ServerDumpArgs {
             DatastoreType::Redb => {
                 let opts = storage::backends::RedbStoreOptions::new()
                     .with_durability(config.datastore.durability);
-                let store = Arc::new(storage::DynStore::new(Arc::new(
-                    storage::RedbStore::open_with_options(config.data_path(), opts)?,
-                )));
+                let backend = storage::RedbStore::open_with_options(config.data_path(), opts)?;
+                let store = Arc::new(Node::wrap_store(config, backend)?);
                 let database = db::DB::open_from_arc(store)
                     .await
                     .map_err(|e| Error::Server(e.to_string()))?;
@@ -39,9 +39,8 @@ impl ServerDumpArgs {
             DatastoreType::Fjall => {
                 let opts = storage::backends::FjallStoreOptions::new()
                     .with_durability(config.datastore.durability);
-                let store = Arc::new(storage::DynStore::new(Arc::new(
-                    storage::FjallStore::open_with_options(config.data_path(), opts)?,
-                )));
+                let backend = storage::FjallStore::open_with_options(config.data_path(), opts)?;
+                let store = Arc::new(Node::wrap_store(config, backend)?);
                 let database = db::DB::open_from_arc(store)
                     .await
                     .map_err(|e| Error::Server(e.to_string()))?;
@@ -57,9 +56,8 @@ impl ServerDumpArgs {
             DatastoreType::RocksDb => {
                 let opts = storage::backends::RocksDbStoreOptions::new()
                     .with_durability(config.datastore.durability);
-                let store = Arc::new(storage::DynStore::new(Arc::new(
-                    storage::RocksDbStore::open_with_options(config.data_path(), opts)?,
-                )));
+                let backend = storage::RocksDbStore::open_with_options(config.data_path(), opts)?;
+                let store = Arc::new(Node::wrap_store(config, backend)?);
                 let database = db::DB::open_from_arc(store)
                     .await
                     .map_err(|e| Error::Server(e.to_string()))?;
@@ -75,9 +73,8 @@ impl ServerDumpArgs {
             DatastoreType::Lark => {
                 let opts = storage::backends::LarkStoreOptions::new()
                     .with_durability(config.datastore.durability);
-                let store = Arc::new(storage::DynStore::new(Arc::new(
-                    storage::LarkStore::open_with_options(config.data_path(), opts)?,
-                )));
+                let backend = storage::LarkStore::open_with_options(config.data_path(), opts)?;
+                let store = Arc::new(Node::wrap_store(config, backend)?);
                 let database = db::DB::open_from_arc(store)
                     .await
                     .map_err(|e| Error::Server(e.to_string()))?;

--- a/crates/cli/src/commands/start/node.rs
+++ b/crates/cli/src/commands/start/node.rs
@@ -149,7 +149,7 @@ impl Node {
     /// Wrap a concrete backend in a type-erased [`storage::DynStore`],
     /// applying at-rest encryption when configured. The erasure keeps the
     /// whole node stack at a single `S = DynStore` instantiation.
-    fn wrap_store<S>(config: &Config, backend: S) -> Result<storage::DynStore>
+    pub(crate) fn wrap_store<S>(config: &Config, backend: S) -> Result<storage::DynStore>
     where
         S: storage::corekv::Store + 'static,
     {

--- a/crates/cli/tests/server_dump_tests.rs
+++ b/crates/cli/tests/server_dump_tests.rs
@@ -1,0 +1,63 @@
+#![cfg(feature = "lark")]
+
+use std::process::Command;
+use std::sync::Arc;
+
+use db::database::DB;
+use keyring::{FileKeyring, Keyring, ENCRYPTION_KEY, KEYRING_SECRET_ENV};
+use storage::encrypted_store::EncryptedStore;
+
+#[tokio::test]
+async fn server_dump_reads_encrypted_lark_store() {
+    let root = tempfile::tempdir().unwrap();
+    let secret = "server-dump-test-secret";
+    let encryption_key = [42; 32];
+
+    let mut config = cli::config::Config {
+        rootdir: root.path().to_path_buf(),
+        ..Default::default()
+    };
+    config.datastore.at_rest_encryption = true;
+
+    let keyring = FileKeyring::open(config.keyring_path(), secret.as_bytes()).unwrap();
+    keyring.set(ENCRYPTION_KEY, &encryption_key).unwrap();
+
+    std::fs::write(
+        root.path().join("config.yaml"),
+        serde_yaml::to_string(&config).unwrap(),
+    )
+    .unwrap();
+
+    let expected = {
+        let backend = storage::LarkStore::open(config.data_path()).unwrap();
+        let store = Arc::new(EncryptedStore::new(backend, encryption_key));
+        let database = DB::open_from_arc(store).await.unwrap();
+        let collections = query::parse_sdl("type Users { name: String }").unwrap();
+        database
+            .create_collections_atomic(collections)
+            .await
+            .unwrap();
+        database.print_dump().await.unwrap()
+    };
+
+    let output = Command::new(env!("CARGO_BIN_EXE_defra"))
+        .args(["--rootdir"])
+        .arg(root.path())
+        .arg("server-dump")
+        .env(KEYRING_SECRET_ENV, secret)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "server-dump failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8(output.stdout)
+            .unwrap()
+            .lines()
+            .collect::<Vec<_>>(),
+        expected
+    );
+}


### PR DESCRIPTION
Targets #1275.

## Problem

The release matrix produced a Lark-only artifact but the release job still requested the retired Redb artifact, so the Lark binary would not be published. The unqualified full binary and Docker image also relied on the new lean defaults, silently omitting PostgreSQL, SourceHub, and Orbis support.

Those explicit release feature sets were not compiled by CI. Separately, `server-dump` opened persistent backends without the configured at-rest encryption wrapper and therefore inspected encrypted values rather than the plaintext view used by a running node.

## What changed

- Add a `release-full` CLI feature covering Lark, RocksDB, Redb, PostgreSQL, SourceHub, and Orbis.
- Build every full native artifact with that explicit contract while keeping the Lark-only and Lark-plus-RocksDB variants lean.
- Publish the produced `defra-lark-*` artifacts instead of requesting nonexistent `defra-redb-*` artifacts.
- Compile all three shipped CLI feature sets in CI.
- Reuse the node encryption-aware store wrapper in `server-dump` for every persistent backend.
- Add a regression that writes a real encrypted Lark database and verifies the offline dump matches its decrypted view.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p cli --no-default-features --features lark --all-targets -- -D warnings`
- [x] `cargo clippy -p cli --no-default-features --features rocksdb,lark --all-targets -- -D warnings`
- [x] `cargo clippy -p cli --no-default-features --features release-full --all-targets -- -D warnings`
- [x] `cargo test -p cli --no-default-features --features lark --test server_dump_tests`
- [x] `cargo test -p cli --no-default-features --features release-full`
- [x] Workflow YAML syntax check
- [x] `git diff --check`