### PR TITLE
perf(db): reserve document short IDs outside mutation transactions

### DIFF
--- a/crates/db-merge/src/head_provider.rs
+++ b/crates/db-merge/src/head_provider.rs
@@ -441,9 +441,7 @@ mod tests {
             .unwrap();
         {
             let systemstore = txn.systemstore().unwrap();
-            let short_id = db::doc_id_map::next_doc_short_id(&systemstore)
-                .await
-                .unwrap();
+            let short_id = db.next_doc_short_id().await.unwrap();
             db::doc_id_map::set_doc_id_mapping(&systemstore, 1, short_id, &doc_id)
                 .await
                 .unwrap();

--- a/crates/db-merge/src/merge_handler/composite.rs
+++ b/crates/db-merge/src/merge_handler/composite.rs
@@ -418,12 +418,14 @@ impl<S: Store, B: blockstore::Blockstore> DbMergeHandler<S, B> {
                     return Err(MergeError::Database(e));
                 }
             };
-            match db::doc_id_map::resolve_or_allocate_doc_short_id(
-                &systemstore,
-                collection.resolved_root_id(),
-                doc_id_str,
-            )
-            .await
+            match self
+                .db
+                .resolve_or_allocate_doc_short_id(
+                    &systemstore,
+                    collection.resolved_root_id(),
+                    doc_id_str,
+                )
+                .await
             {
                 Ok(short_id) => short_id,
                 Err(e) => {
@@ -814,13 +816,14 @@ impl<S: Store, B: blockstore::Blockstore> DbMergeHandler<S, B> {
                     payload.schema_version_id
                 ))
             })?;
-            db::doc_id_map::resolve_or_allocate_doc_short_id(
-                systemstore,
-                collection.resolved_root_id(),
-                doc_id_str,
-            )
-            .await
-            .map_err(MergeError::Database)?
+            self.db
+                .resolve_or_allocate_doc_short_id(
+                    systemstore,
+                    collection.resolved_root_id(),
+                    doc_id_str,
+                )
+                .await
+                .map_err(MergeError::Database)?
         };
         let context = CompositeMergeContext::new(
             cid,

--- a/crates/db-merge/src/merge_handler/tests.rs
+++ b/crates/db-merge/src/merge_handler/tests.rs
@@ -24,7 +24,9 @@ async fn register_test_block_owner(
     let txn = handler.db.new_txn(false).await.unwrap();
     {
         let systemstore = txn.systemstore().unwrap();
-        db::doc_id_map::resolve_or_allocate_doc_short_id(&systemstore, collection_short_id, doc_id)
+        handler
+            .db
+            .resolve_or_allocate_doc_short_id(&systemstore, collection_short_id, doc_id)
             .await
             .unwrap();
         db::doc_id_map::set_block_doc_id_mapping(&systemstore, &cid.to_string(), doc_id)
@@ -48,9 +50,7 @@ async fn create_doc_locally(
         let headstore = txn.headstore().unwrap();
         let raw_blockstore = txn.blockstore().unwrap();
         let systemstore = txn.systemstore().unwrap();
-        let short_id = db::doc_id_map::next_doc_short_id(&systemstore)
-            .await
-            .unwrap();
+        let short_id = handler.db.next_doc_short_id().await.unwrap();
         let identity = db_blocks::DocStorageIdentity::new(collection.resolved_root_id(), short_id);
         let result = db_blocks::write_document_blocks(
             &raw_blockstore,

--- a/crates/db/src/auto_commit_mutator/batch.rs
+++ b/crates/db/src/auto_commit_mutator/batch.rs
@@ -201,7 +201,9 @@ impl<S: Store + 'static> DocMutator for BatchMutator<S> {
         let enc_config = get_encryption_config();
         let sign_config = get_signing_config();
 
-        let doc_short_id = crate::doc_id_map::next_doc_short_id(&systemstore)
+        let doc_short_id = self
+            .db
+            .next_doc_short_id()
             .await
             .map_err(|e| query::error::QueryError::execution(e.to_string()))?;
         let identity = DocStorageIdentity::new(short_id, doc_short_id);

--- a/crates/db/src/auto_commit_mutator/create.rs
+++ b/crates/db/src/auto_commit_mutator/create.rs
@@ -77,7 +77,9 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                 .await
                 .map_err(|e| query::error::QueryError::execution(e.to_string()))?;
 
-            let doc_short_id = crate::doc_id_map::next_doc_short_id(&systemstore)
+            let doc_short_id = self
+                .db
+                .next_doc_short_id()
                 .await
                 .map_err(|e| query::error::QueryError::execution(e.to_string()))?;
             let identity = DocStorageIdentity::new(short_id, doc_short_id);

--- a/crates/db/src/auto_commit_mutator/create_many.rs
+++ b/crates/db/src/auto_commit_mutator/create_many.rs
@@ -71,19 +71,15 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
             query::error::QueryError::execution(format!("failed to create txn: {}", e))
         })?;
 
-        let identities: Vec<DocStorageIdentity> = {
-            let systemstore = txn.systemstore().map_err(|e| {
-                query::error::QueryError::execution(format!("failed to get systemstore: {}", e))
-            })?;
-            let mut identities = Vec::with_capacity(prepared_docs.len());
-            for _ in &prepared_docs {
-                let doc_short_id = crate::doc_id_map::next_doc_short_id(&systemstore)
-                    .await
-                    .map_err(|e| query::error::QueryError::execution(e.to_string()))?;
-                identities.push(DocStorageIdentity::new(short_id, doc_short_id));
-            }
-            identities
-        };
+        let mut identities = Vec::with_capacity(prepared_docs.len());
+        for _ in &prepared_docs {
+            let doc_short_id = self
+                .db
+                .next_doc_short_id()
+                .await
+                .map_err(|e| query::error::QueryError::execution(e.to_string()))?;
+            identities.push(DocStorageIdentity::new(short_id, doc_short_id));
+        }
 
         // Compute blocks (parallel on native, sequential on WASM). A failure
         // aborts the batch: without blocks there is no derived DocID.

--- a/crates/db/src/database.rs
+++ b/crates/db/src/database.rs
@@ -213,6 +213,8 @@ pub struct DB<S: Store> {
     /// local writes and P2P merges that touch the same document never interleave
     /// their CRDT read-modify-write (#1021 counter convergence).
     doc_write_queue: Arc<crate::doc_write_queue::DocWriteQueue>,
+    /// Process-local document short-ID range allocator.
+    doc_short_id_allocator: crate::doc_id_map::DocShortIdAllocator<S>,
     /// Process-local claims for collection-wide actions.
     ///
     /// Persisted action statuses are observable lifecycle state, not locks: a
@@ -237,8 +239,10 @@ impl<S: Store> DB<S> {
     /// to load existing collections from the store.
     pub fn with_options(store: S, options: DbOptions) -> Result<Self> {
         let lens_store: Arc<dyn TransformStore> = Self::create_lens_store()?;
+        let store = Arc::new(store);
         Ok(Self {
-            store: Arc::new(store),
+            doc_short_id_allocator: crate::doc_id_map::DocShortIdAllocator::new(store.clone()),
+            store,
             options,
             txn_id_counter: AtomicU64::new(0),
             migration_generation: AtomicU64::new(0),
@@ -293,6 +297,7 @@ impl<S: Store> DB<S> {
     pub fn from_arc_with_options(store: Arc<S>, options: DbOptions) -> Result<Self> {
         let lens_store: Arc<dyn TransformStore> = Self::create_lens_store()?;
         Ok(Self {
+            doc_short_id_allocator: crate::doc_id_map::DocShortIdAllocator::new(store.clone()),
             store,
             options,
             txn_id_counter: AtomicU64::new(0),
@@ -347,6 +352,30 @@ impl<S: Store> DB<S> {
     /// document are mutually serialized (#1021).
     pub fn doc_write_queue(&self) -> Arc<crate::doc_write_queue::DocWriteQueue> {
         self.doc_write_queue.clone()
+    }
+
+    /// Allocate a globally unique document short ID.
+    pub async fn next_doc_short_id(&self) -> Result<u64> {
+        self.doc_short_id_allocator.next().await
+    }
+
+    /// Resolve a document short ID or allocate and stage a new mapping.
+    pub async fn resolve_or_allocate_doc_short_id(
+        &self,
+        systemstore: &datastore::NamespaceView,
+        collection_short_id: u32,
+        doc_id: &str,
+    ) -> Result<u64> {
+        if let Some(short_id) =
+            crate::doc_id_map::get_doc_short_id(systemstore, collection_short_id, doc_id).await?
+        {
+            return Ok(short_id);
+        }
+
+        let short_id = self.next_doc_short_id().await?;
+        crate::doc_id_map::set_doc_id_mapping(systemstore, collection_short_id, short_id, doc_id)
+            .await?;
+        Ok(short_id)
     }
 
     /// Return the generation of the committed migration graph.

--- a/crates/db/src/doc_id_map.rs
+++ b/crates/db/src/doc_id_map.rs
@@ -5,22 +5,115 @@
 //! holds the bidirectional mapping between short IDs and the public
 //! genesis-CID-derived DocIDs, plus a block-CID -> DocID ownership index.
 
+use async_lock::Mutex;
 use datastore::NamespaceView;
-use storage::corekv::Key;
+use std::sync::Arc;
+use storage::corekv::{Key, Store};
 use storage::keys::doc_id_index::{
     BlockCIDToDocIDKey, DocIDToDocRefKey, DocRef, DocShortIDSequenceKey, DocShortIDToDocIDAliasKey,
     DocShortIDToDocIDKey,
 };
+use storage::stores::Systemstore;
 
 use crate::error::{Error, Result};
 
-/// Allocate the next document short ID from the systemstore sequence.
-pub async fn next_doc_short_id(systemstore: &NamespaceView) -> Result<u64> {
-    let key = DocShortIDSequenceKey::new().bytes();
-    let current: u64 = match systemstore.get(&key).await.map_err(Error::Storage)? {
+const DOC_SHORT_ID_RESERVATION_SIZE: u64 = 1024;
+const MAX_RESERVATION_CONFLICT_RETRIES: u32 = 16;
+
+#[derive(Default)]
+struct ReservedRange {
+    next: u64,
+    remaining: u64,
+}
+
+/// Allocates document short IDs from persisted ranges.
+///
+/// The sequence stores the end of the latest reserved range. A crash can leave
+/// gaps, but every returned ID remains unique across restarts and DB instances.
+pub(crate) struct DocShortIdAllocator<S: Store> {
+    systemstore: Systemstore<S>,
+    range: Mutex<ReservedRange>,
+    reservation_size: u64,
+}
+
+impl<S: Store> DocShortIdAllocator<S> {
+    pub(crate) fn new(store: Arc<S>) -> Self {
+        Self::with_reservation_size(store, DOC_SHORT_ID_RESERVATION_SIZE)
+    }
+
+    fn with_reservation_size(store: Arc<S>, reservation_size: u64) -> Self {
+        assert!(reservation_size > 0, "reservation size must be non-zero");
+        Self {
+            systemstore: Systemstore::new(store),
+            range: Mutex::new(ReservedRange::default()),
+            reservation_size,
+        }
+    }
+
+    pub(crate) async fn next(&self) -> Result<u64> {
+        let mut range = self.range.lock().await;
+        if range.remaining == 0 {
+            range.next = self.reserve_range().await?;
+            range.remaining = self.reservation_size;
+        }
+
+        let id = range.next;
+        range.remaining -= 1;
+        if range.remaining > 0 {
+            range.next = id
+                .checked_add(1)
+                .ok_or_else(|| Error::Other("document short-ID sequence exhausted".into()))?;
+        }
+        Ok(id)
+    }
+
+    async fn reserve_range(&self) -> Result<u64> {
+        let key = DocShortIDSequenceKey::new().bytes();
+        let mut conflicts = 0;
+        loop {
+            let mut txn = self
+                .systemstore
+                .new_txn(false)
+                .await
+                .map_err(Error::Storage)?;
+            let current = decode_sequence(txn.get(&key).await.map_err(Error::Storage)?);
+            let start = current
+                .checked_add(1)
+                .ok_or_else(|| Error::Other("document short-ID sequence exhausted".into()))?;
+            let end = current
+                .checked_add(self.reservation_size)
+                .ok_or_else(|| Error::Other("document short-ID sequence exhausted".into()))?;
+            txn.set(&key, &end.to_be_bytes())
+                .await
+                .map_err(Error::Storage)?;
+
+            match txn.commit().await {
+                Ok(()) => return Ok(start),
+                Err(error)
+                    if error.is_txn_conflict() && conflicts < MAX_RESERVATION_CONFLICT_RETRIES =>
+                {
+                    conflicts += 1;
+                }
+                Err(error) => return Err(Error::Storage(error)),
+            }
+        }
+    }
+}
+
+fn decode_sequence(value: Option<Vec<u8>>) -> u64 {
+    match value {
         Some(bytes) if bytes.len() == 8 => u64::from_be_bytes(bytes.as_slice().try_into().unwrap()),
         _ => 0,
-    };
+    }
+}
+
+/// Allocate the next document short ID within a migration transaction.
+///
+/// Runtime writes must use [`crate::DB::next_doc_short_id`] so the global
+/// sequence is not part of the caller's conflict set.
+pub async fn next_doc_short_id(systemstore: &NamespaceView) -> Result<u64> {
+    let key = DocShortIDSequenceKey::new().bytes();
+    let current = decode_sequence(systemstore.get(&key).await.map_err(Error::Storage)?);
     let next = current + 1;
     systemstore
         .set(&key, &next.to_be_bytes())
@@ -39,10 +132,7 @@ pub async fn ensure_doc_short_id_sequence_at_least(
     minimum: u64,
 ) -> Result<()> {
     let key = DocShortIDSequenceKey::new().bytes();
-    let current: u64 = match systemstore.get(&key).await.map_err(Error::Storage)? {
-        Some(bytes) if bytes.len() == 8 => u64::from_be_bytes(bytes.as_slice().try_into().unwrap()),
-        _ => 0,
-    };
+    let current = decode_sequence(systemstore.get(&key).await.map_err(Error::Storage)?);
     if current < minimum {
         systemstore
             .set(&key, &minimum.to_be_bytes())
@@ -159,22 +249,6 @@ pub async fn get_doc_short_id(
         }
         _ => Ok(None),
     }
-}
-
-/// Resolve a short ID for a DocID, allocating and persisting a new mapping
-/// if none exists (merge/ingest path, mirrors Go's
-/// `resolveOrAllocateDocShortID`).
-pub async fn resolve_or_allocate_doc_short_id(
-    systemstore: &NamespaceView,
-    collection_short_id: u32,
-    doc_id: &str,
-) -> Result<u64> {
-    if let Some(short_id) = get_doc_short_id(systemstore, collection_short_id, doc_id).await? {
-        return Ok(short_id);
-    }
-    let short_id = next_doc_short_id(systemstore).await?;
-    set_doc_id_mapping(systemstore, collection_short_id, short_id, doc_id).await?;
-    Ok(short_id)
 }
 
 /// Register an additional public DocID for an existing document (backup
@@ -368,6 +442,7 @@ pub async fn delete_doc_id_mappings(systemstore: &NamespaceView, doc_short_id: u
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::DB;
     use datastore::SharedTxn;
     use storage::backends::MemoryStore;
     use storage::corekv::Store;
@@ -377,6 +452,16 @@ mod tests {
         let store = MemoryStore::new();
         let txn = store.new_txn(false).await.unwrap();
         NamespaceView::new(SharedTxn::new(txn), Namespace::Systemstore)
+    }
+
+    async fn persisted_sequence(store: Arc<MemoryStore>) -> u64 {
+        let systemstore = Systemstore::new(store);
+        let txn = systemstore.new_txn(true).await.unwrap();
+        decode_sequence(
+            txn.get(&DocShortIDSequenceKey::new().bytes())
+                .await
+                .unwrap(),
+        )
     }
 
     #[tokio::test]
@@ -420,12 +505,65 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resolve_or_allocate_is_idempotent() {
-        let store = systemstore().await;
-        let a = resolve_or_allocate_doc_short_id(&store, 3, "bae-y")
+    async fn allocator_reserves_ranges_across_instances_and_restarts() {
+        let store = Arc::new(MemoryStore::new());
+        let allocator_a = DocShortIdAllocator::with_reservation_size(store.clone(), 4);
+        let allocator_b = DocShortIdAllocator::with_reservation_size(store.clone(), 4);
+
+        let (a, b) = tokio::join!(allocator_a.next(), allocator_b.next());
+        let mut first_ids = vec![a.unwrap(), b.unwrap()];
+        first_ids.sort_unstable();
+        assert_eq!(first_ids, vec![1, 5]);
+        assert_eq!(persisted_sequence(store.clone()).await, 8);
+
+        drop((allocator_a, allocator_b));
+        let restarted = DocShortIdAllocator::with_reservation_size(store, 4);
+        assert_eq!(restarted.next().await.unwrap(), 9);
+    }
+
+    #[tokio::test]
+    async fn allocations_do_not_conflict_unrelated_caller_transactions() {
+        let store = Arc::new(MemoryStore::new());
+        let db = DB::from_arc(store).unwrap();
+        let txn_a = db.new_txn(false).await.unwrap();
+        let txn_b = db.new_txn(false).await.unwrap();
+
+        let a = db.next_doc_short_id().await.unwrap();
+        let b = db.next_doc_short_id().await.unwrap();
+        set_doc_id_mapping(&txn_a.systemstore().unwrap(), 1, a, "bae-a")
             .await
             .unwrap();
-        let b = resolve_or_allocate_doc_short_id(&store, 3, "bae-y")
+        set_doc_id_mapping(&txn_b.systemstore().unwrap(), 2, b, "bae-b")
+            .await
+            .unwrap();
+
+        txn_a.commit().await.unwrap();
+        txn_b.commit().await.unwrap();
+
+        let txn = db.new_txn(true).await.unwrap();
+        let systemstore = txn.systemstore().unwrap();
+        assert_eq!(
+            get_doc_short_id(&systemstore, 1, "bae-a").await.unwrap(),
+            Some(a)
+        );
+        assert_eq!(
+            get_doc_short_id(&systemstore, 2, "bae-b").await.unwrap(),
+            Some(b)
+        );
+    }
+
+    #[tokio::test]
+    async fn database_resolve_or_allocate_is_idempotent() {
+        let store = Arc::new(MemoryStore::new());
+        let db = DB::from_arc(store).unwrap();
+        let txn = db.new_txn(false).await.unwrap();
+        let systemstore = txn.systemstore().unwrap();
+        let a = db
+            .resolve_or_allocate_doc_short_id(&systemstore, 3, "bae-y")
+            .await
+            .unwrap();
+        let b = db
+            .resolve_or_allocate_doc_short_id(&systemstore, 3, "bae-y")
             .await
             .unwrap();
         assert_eq!(a, b);

--- a/crates/db/src/doc_id_map.rs
+++ b/crates/db/src/doc_id_map.rs
@@ -522,6 +522,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn allocator_keeps_ids_unique_across_many_database_instances() {
+        const DATABASES: usize = 8;
+        const IDS_PER_DATABASE: usize = 128;
+
+        let store = Arc::new(MemoryStore::new());
+        let mut tasks = Vec::with_capacity(DATABASES);
+        for _ in 0..DATABASES {
+            let db = DB::from_arc(store.clone()).unwrap();
+            tasks.push(tokio::spawn(async move {
+                let mut ids = Vec::with_capacity(IDS_PER_DATABASE);
+                for _ in 0..IDS_PER_DATABASE {
+                    ids.push(db.next_doc_short_id().await.unwrap());
+                }
+                ids
+            }));
+        }
+
+        let mut ids = Vec::with_capacity(DATABASES * IDS_PER_DATABASE);
+        for task in tasks {
+            ids.extend(task.await.unwrap());
+        }
+        ids.sort_unstable();
+        ids.dedup();
+
+        assert_eq!(ids.len(), DATABASES * IDS_PER_DATABASE);
+        assert_eq!(persisted_sequence(store).await, 8192);
+    }
+
+    #[tokio::test]
     async fn allocations_do_not_conflict_unrelated_caller_transactions() {
         let store = Arc::new(MemoryStore::new());
         let db = DB::from_arc(store).unwrap();

--- a/crates/db/src/doc_mutator.rs
+++ b/crates/db/src/doc_mutator.rs
@@ -197,7 +197,9 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
             .await
             .map_err(|e| query::error::QueryError::execution(e.to_string()))?;
 
-        let doc_short_id = crate::doc_id_map::next_doc_short_id(&systemstore)
+        let doc_short_id = self
+            .db
+            .next_doc_short_id()
             .await
             .map_err(|e| query::error::QueryError::execution(e.to_string()))?;
         let identity = DocStorageIdentity::new(collection.resolved_root_id(), doc_short_id);


### PR DESCRIPTION
Closes #1264.

## Problem

Every document create and previously unknown merged document read and updated the same global `/seq/doc` key inside its mutation transaction. Under the shared conflict tracker, unrelated creates therefore conflicted across collections and workloads, forcing individual writes or entire batches to retry.

## What changed

- Add a database-owned allocator that reserves 1,024 document short IDs in a dedicated conflict-retried systemstore transaction and serves the reserved IDs from memory.
- Route auto-commit, batched, explicit-transaction, and P2P merge allocation through the shared allocator so mutation transactions no longer touch the global sequence key.
- Retain the transactional sequence helper only for startup migration work and preserve the existing persisted high-water format for compatibility.
- Allow crashes or restarts to skip unused reserved IDs while preserving uniqueness across database instances and restarts.
- Add regressions for multi-instance reservations, restart behavior, idempotent resolution, and concurrent unrelated caller transactions.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test -p db -p db-merge`
- [x] `git diff --check`
