### PR TITLE
perf(index): shard full-text corpus statistics

### DIFF
--- a/crates/storage/src/index/fulltext.rs
+++ b/crates/storage/src/index/fulltext.rs
@@ -5,7 +5,8 @@
 //!
 //! Key layout:
 //!   Posting:  /[col_id]/[idx_id]/[term]/[doc_short_id] -> [term_freq, field_len]
-//!   Stats:    /[col_id]/[idx_id]/_stats                 -> [total_docs, total_field_len]
+//!   Legacy stats: /[col_id]/[idx_id]/_stats             -> [total_docs, total_field_len]
+//!   Stats shard:  /[col_id]/[idx_id]/0xff/s/[shard]     -> [doc_delta, field_len_delta]
 
 use async_trait::async_trait;
 use bm25::{DefaultTokenizer, Language, Tokenizer};
@@ -17,6 +18,10 @@ use super::validate_doc_short_id;
 use super::CollectionIndex;
 use crate::corekv::{IterOptions, MaybeSend, Reader, Result, Writer};
 use crate::keys::doc_id_index::{decode_doc_short_id, encode_doc_short_id};
+
+const METADATA_PREFIX: u8 = 0xff;
+const STATS_SHARD_TAG: u8 = b's';
+const STATS_SHARD_HASH: u64 = 0x9e37_79b9_7f4a_7c15;
 
 /// Map a language string to the bm25 crate's Language enum.
 pub fn parse_language(lang: &str) -> Language {
@@ -103,6 +108,23 @@ impl FullTextIndex {
         key
     }
 
+    fn metadata_prefix(&self, tag: u8) -> Vec<u8> {
+        let mut key = self.index_prefix();
+        // Terms are UTF-8 strings, so 0xff reserves a disjoint metadata namespace.
+        key.extend_from_slice(&[METADATA_PREFIX, tag, b'/']);
+        key
+    }
+
+    fn stats_shard_prefix(&self) -> Vec<u8> {
+        self.metadata_prefix(STATS_SHARD_TAG)
+    }
+
+    fn stats_shard_key(&self, doc_short_id: u64) -> Vec<u8> {
+        let mut key = self.stats_shard_prefix();
+        key.push((doc_short_id.wrapping_mul(STATS_SHARD_HASH) >> (u64::BITS - u8::BITS)) as u8);
+        key
+    }
+
     /// Tokenize text and return term frequencies.
     fn tokenize_with_freqs(&self, text: &str) -> HashMap<String, u32> {
         let tokens = self.tokenizer.tokenize(text);
@@ -113,29 +135,76 @@ impl FullTextIndex {
         freqs
     }
 
-    async fn read_stats<R: Reader + MaybeSend>(&self, txn: &R) -> Result<(u64, u64)> {
-        let key = self.stats_key();
-        match txn.get(&key).await? {
+    fn decode_stats(value: Option<Vec<u8>>) -> (u64, u64) {
+        match value {
             Some(bytes) if bytes.len() == 16 => {
                 let total_docs = u64::from_be_bytes(bytes[0..8].try_into().unwrap());
                 let total_field_len = u64::from_be_bytes(bytes[8..16].try_into().unwrap());
-                Ok((total_docs, total_field_len))
+                (total_docs, total_field_len)
             }
-            _ => Ok((0, 0)),
+            _ => (0, 0),
         }
     }
 
-    async fn write_stats<T: Writer + MaybeSend>(
+    fn decode_stats_delta(value: Option<Vec<u8>>) -> (i128, i128) {
+        match value {
+            Some(bytes) if bytes.len() == 32 => {
+                let docs = i128::from_be_bytes(bytes[0..16].try_into().unwrap());
+                let field_len = i128::from_be_bytes(bytes[16..32].try_into().unwrap());
+                (docs, field_len)
+            }
+            _ => (0, 0),
+        }
+    }
+
+    async fn apply_stats_delta<T: Reader + Writer + MaybeSend>(
         &self,
         txn: &mut T,
-        total_docs: u64,
-        total_field_len: u64,
+        doc_short_id: u64,
+        docs_delta: i128,
+        field_len_delta: i128,
     ) -> Result<()> {
-        let key = self.stats_key();
-        let mut value = Vec::with_capacity(16);
-        value.extend_from_slice(&total_docs.to_be_bytes());
-        value.extend_from_slice(&total_field_len.to_be_bytes());
+        let key = self.stats_shard_key(doc_short_id);
+        let (docs, field_len) = Self::decode_stats_delta(txn.get(&key).await?);
+        let docs = docs
+            .checked_add(docs_delta)
+            .ok_or_else(|| crate::corekv::Error::Other("full-text stats overflow".to_string()))?;
+        let field_len = field_len
+            .checked_add(field_len_delta)
+            .ok_or_else(|| crate::corekv::Error::Other("full-text stats overflow".to_string()))?;
+        let mut value = Vec::with_capacity(32);
+        value.extend_from_slice(&docs.to_be_bytes());
+        value.extend_from_slice(&field_len.to_be_bytes());
         txn.set(&key, &value).await
+    }
+
+    async fn read_stats<R: Reader + MaybeSend>(&self, txn: &R) -> Result<(u64, u64)> {
+        let (legacy_docs, legacy_field_len) = Self::decode_stats(txn.get(&self.stats_key()).await?);
+        let mut total_docs = i128::from(legacy_docs);
+        let mut total_field_len = i128::from(legacy_field_len);
+        let prefix = self.stats_shard_prefix();
+        let mut iter = txn
+            .iterator(IterOptions::new().with_prefix(prefix.clone()))
+            .await?;
+        while let Some(kv) = iter.next().await? {
+            if kv.key.len() != prefix.len() + 1 {
+                continue;
+            }
+            let (shard_docs, shard_field_len) = Self::decode_stats_delta(Some(kv.value));
+            total_docs = total_docs.checked_add(shard_docs).ok_or_else(|| {
+                crate::corekv::Error::Other("full-text stats overflow".to_string())
+            })?;
+            total_field_len = total_field_len
+                .checked_add(shard_field_len)
+                .ok_or_else(|| {
+                    crate::corekv::Error::Other("full-text stats overflow".to_string())
+                })?;
+        }
+        let total_docs = u64::try_from(total_docs.max(0))
+            .map_err(|_| crate::corekv::Error::Other("full-text stats overflow".to_string()))?;
+        let total_field_len = u64::try_from(total_field_len.max(0))
+            .map_err(|_| crate::corekv::Error::Other("full-text stats overflow".to_string()))?;
+        Ok((total_docs, total_field_len))
     }
 
     fn extract_text(values: &[NormalValue]) -> &str {
@@ -322,9 +391,8 @@ impl CollectionIndex for FullTextIndex {
         if text.is_empty() {
             return Ok(());
         }
-        let (total_docs, total_field_len) = self.read_stats(txn).await?;
         let field_len = self.write_postings(txn, doc_short_id, text).await?;
-        self.write_stats(txn, total_docs + 1, total_field_len + field_len)
+        self.apply_stats_delta(txn, doc_short_id, 1, i128::from(field_len))
             .await
     }
 
@@ -338,21 +406,28 @@ impl CollectionIndex for FullTextIndex {
         validate_doc_short_id(doc_short_id, &self.desc.name)?;
         let old_text = Self::extract_text(old_values);
         let new_text = Self::extract_text(new_values);
-        let (mut total_docs, mut total_field_len) = self.read_stats(txn).await?;
-
-        if !old_text.is_empty() {
-            let old_field_len = self.remove_postings(txn, doc_short_id, old_text).await?;
-            total_docs = total_docs.saturating_sub(1);
-            total_field_len = total_field_len.saturating_sub(old_field_len);
+        if old_text == new_text {
+            return Ok(());
         }
 
-        if !new_text.is_empty() {
-            let new_field_len = self.write_postings(txn, doc_short_id, new_text).await?;
-            total_docs += 1;
-            total_field_len += new_field_len;
+        let old_field_len = if old_text.is_empty() {
+            0
+        } else {
+            self.remove_postings(txn, doc_short_id, old_text).await?
+        };
+        let new_field_len = if new_text.is_empty() {
+            0
+        } else {
+            self.write_postings(txn, doc_short_id, new_text).await?
+        };
+        let docs_delta =
+            i128::from(u8::from(!new_text.is_empty())) - i128::from(u8::from(!old_text.is_empty()));
+        let field_len_delta = i128::from(new_field_len) - i128::from(old_field_len);
+        if docs_delta != 0 || field_len_delta != 0 {
+            self.apply_stats_delta(txn, doc_short_id, docs_delta, field_len_delta)
+                .await?;
         }
-
-        self.write_stats(txn, total_docs, total_field_len).await
+        Ok(())
     }
 
     async fn delete<T: Reader + Writer + MaybeSend>(
@@ -366,14 +441,9 @@ impl CollectionIndex for FullTextIndex {
         if text.is_empty() {
             return Ok(());
         }
-        let (total_docs, total_field_len) = self.read_stats(txn).await?;
         let field_len = self.remove_postings(txn, doc_short_id, text).await?;
-        self.write_stats(
-            txn,
-            total_docs.saturating_sub(1),
-            total_field_len.saturating_sub(field_len),
-        )
-        .await
+        self.apply_stats_delta(txn, doc_short_id, -1, -i128::from(field_len))
+            .await
     }
 
     async fn remove_all<T: Reader + Writer + MaybeSend>(&self, txn: &mut T) -> Result<()> {

--- a/crates/storage/src/index/tests.rs
+++ b/crates/storage/src/index/tests.rs
@@ -3,7 +3,7 @@ use crate::backends::MemoryStore;
 use crate::corekv::{IterOptions, Store};
 use crate::keys::IndexDataStoreKey;
 use document::NormalValue;
-use schema::IndexedFieldDescription;
+use schema::{FullTextIndexDescription, IndexedFieldDescription};
 
 fn test_index_description(unique: bool) -> schema::IndexDescription {
     schema::IndexDescription {
@@ -35,6 +35,36 @@ fn composite_index_description(unique: bool) -> schema::IndexDescription {
             },
         ],
     }
+}
+
+fn fulltext_index_description() -> schema::IndexDescription {
+    schema::IndexDescription {
+        id: 3,
+        name: "__fulltext__:text".to_string(),
+        unique: false,
+        auto_generated: false,
+        fields: vec![IndexedFieldDescription {
+            name: "text".to_string(),
+            descending: false,
+        }],
+    }
+}
+
+fn test_fulltext_index() -> FullTextIndex {
+    FullTextIndex::new(
+        1,
+        fulltext_index_description(),
+        FullTextIndexDescription::new("text"),
+    )
+}
+
+fn legacy_fulltext_stats_key() -> Vec<u8> {
+    let mut key = Vec::new();
+    key.extend_from_slice(&1u32.to_be_bytes());
+    key.push(b'/');
+    key.extend_from_slice(&3u32.to_be_bytes());
+    key.extend_from_slice(b"/_stats");
+    key
 }
 
 /// Helper to count entries with a prefix
@@ -450,4 +480,149 @@ async fn test_composite_index_sort_order() {
         keys[0] < keys[1] && keys[1] < keys[2],
         "composite index should maintain correct sort order"
     );
+}
+
+#[tokio::test]
+async fn concurrent_fulltext_saves_use_independent_stats_shards() {
+    let store = MemoryStore::new();
+    let index = test_fulltext_index();
+    let mut first = store.new_txn(false).await.unwrap();
+    let mut second = store.new_txn(false).await.unwrap();
+
+    index
+        .save(&mut first, 1, &[NormalValue::String("one two".to_string())])
+        .await
+        .unwrap();
+    index
+        .save(
+            &mut second,
+            2,
+            &[NormalValue::String("three four five".to_string())],
+        )
+        .await
+        .unwrap();
+
+    first.commit().await.unwrap();
+    second.commit().await.unwrap();
+
+    let txn = store.new_txn(true).await.unwrap();
+    assert_eq!(index.stats(&txn).await.unwrap(), (2, 2.5));
+}
+
+#[tokio::test]
+async fn fulltext_stats_preserve_legacy_base_and_apply_deltas() {
+    let store = MemoryStore::new();
+    let index = test_fulltext_index();
+    let legacy_key = legacy_fulltext_stats_key();
+    let mut legacy_value = Vec::new();
+    legacy_value.extend_from_slice(&2u64.to_be_bytes());
+    legacy_value.extend_from_slice(&4u64.to_be_bytes());
+
+    let mut seed = store.new_txn(false).await.unwrap();
+    seed.set(&legacy_key, &legacy_value).await.unwrap();
+    seed.commit().await.unwrap();
+
+    let mut create = store.new_txn(false).await.unwrap();
+    index
+        .save(
+            &mut create,
+            10,
+            &[NormalValue::String("new sharded document".to_string())],
+        )
+        .await
+        .unwrap();
+    create.commit().await.unwrap();
+
+    let read = store.new_txn(true).await.unwrap();
+    assert_eq!(index.stats(&read).await.unwrap(), (3, 7.0 / 3.0));
+
+    let mut update = store.new_txn(false).await.unwrap();
+    index
+        .update(
+            &mut update,
+            99,
+            &[NormalValue::String("old document".to_string())],
+            &[NormalValue::String("updated legacy document".to_string())],
+        )
+        .await
+        .unwrap();
+    update.commit().await.unwrap();
+
+    let read = store.new_txn(true).await.unwrap();
+    assert_eq!(index.stats(&read).await.unwrap(), (3, 8.0 / 3.0));
+
+    let legacy_value = read.get(&legacy_key).await.unwrap().unwrap();
+    assert_eq!(
+        u64::from_be_bytes(legacy_value[0..8].try_into().unwrap()),
+        2
+    );
+    assert_eq!(
+        u64::from_be_bytes(legacy_value[8..16].try_into().unwrap()),
+        4
+    );
+
+    let mut delete = store.new_txn(false).await.unwrap();
+    index
+        .delete(
+            &mut delete,
+            99,
+            &[NormalValue::String("updated legacy document".to_string())],
+        )
+        .await
+        .unwrap();
+    delete.commit().await.unwrap();
+
+    let read = store.new_txn(true).await.unwrap();
+    assert_eq!(index.stats(&read).await.unwrap(), (2, 2.5));
+}
+
+#[tokio::test]
+async fn fulltext_scoring_tracks_updates_and_deletes_with_sharded_stats() {
+    let store = MemoryStore::new();
+    let index = test_fulltext_index();
+    let mut create = store.new_txn(false).await.unwrap();
+    index
+        .save(
+            &mut create,
+            1,
+            &[NormalValue::String("rust database".to_string())],
+        )
+        .await
+        .unwrap();
+    index
+        .save(
+            &mut create,
+            2,
+            &[NormalValue::String("rust storage engine".to_string())],
+        )
+        .await
+        .unwrap();
+    create.commit().await.unwrap();
+
+    let read = store.new_txn(true).await.unwrap();
+    assert_eq!(index.search_scored(&read, "rust").await.unwrap().len(), 2);
+
+    let mut mutate = store.new_txn(false).await.unwrap();
+    index
+        .update(
+            &mut mutate,
+            1,
+            &[NormalValue::String("rust database".to_string())],
+            &[NormalValue::String("graph database".to_string())],
+        )
+        .await
+        .unwrap();
+    index
+        .delete(
+            &mut mutate,
+            2,
+            &[NormalValue::String("rust storage engine".to_string())],
+        )
+        .await
+        .unwrap();
+    mutate.commit().await.unwrap();
+
+    let read = store.new_txn(true).await.unwrap();
+    assert!(index.search_scored(&read, "rust").await.unwrap().is_empty());
+    assert_eq!(index.stats(&read).await.unwrap(), (1, 2.0));
 }


### PR DESCRIPTION
Closes #1265.

## Problem

Every full-text document create read and rewrote the same collection-wide `_stats` key inside its mutation transaction. Concurrent writes to otherwise unrelated documents therefore conflicted after their posting and document work had already been performed, serializing writes to collections with full-text indexes.

## What changed

- Replace the single writable corpus statistics record with 256 deterministic shards selected from the document short ID.
- Store signed document-count and field-length deltas so creates, updates, and deletes remain exact without rewriting collection-wide state.
- Preserve the existing `_stats` value as an immutable compatibility base and combine it with shard deltas when calculating BM25 statistics.
- Reserve a binary metadata namespace that cannot collide with UTF-8 posting terms and keep storage bounded to at most 256 shard records per full-text index.
- Add regressions for concurrent creates, legacy statistics compatibility, and scoring after updates and deletes.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test -p storage -p db-index -p db`
- [x] `cargo test -p storage index::tests`
- [x] `git diff --check`
