### PR TITLE
feat(sourcehub): invalidate cached access from CometBFT events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11422,15 +11422,18 @@ dependencies = [
  "crypto",
  "defra-core",
  "events",
+ "futures",
  "hex",
  "identity",
  "k256",
+ "prost 0.14.3",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite 0.26.2",
  "tracing",
  "zanzibar",
 ]
@@ -12210,8 +12213,12 @@ checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
+ "rustls 0.23.37",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls 0.26.4",
  "tungstenite 0.26.2",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -12627,6 +12634,8 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.2",
+ "rustls 0.23.37",
+ "rustls-pki-types",
  "sha1 0.10.6",
  "thiserror 2.0.18",
  "utf-8",
@@ -13363,6 +13372,15 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
+]
 
 [[package]]
 name = "webpki-roots"

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -88,6 +88,16 @@ pub struct Cli {
     #[arg(long, global = true, env = "DEFRA_SOURCE_HUB_COMET_ADDRESS")]
     pub source_hub_comet_address: Option<String>,
 
+    /// SourceHub CometBFT WebSocket endpoint for ACP cache invalidation
+    #[cfg(feature = "sourcehub")]
+    #[arg(
+        long,
+        visible_alias = "sourcehub-events-ws",
+        global = true,
+        env = "DEFRA_SOURCE_HUB_EVENTS_WS"
+    )]
+    pub source_hub_events_ws: Option<String>,
+
     /// SourceHub chain ID (e.g., "sourcehub-test")
     #[cfg(feature = "sourcehub")]
     #[arg(long, global = true, env = "DEFRA_SOURCE_HUB_CHAIN_ID")]
@@ -178,5 +188,29 @@ impl Cli {
             Command::Sdl(args) => args.execute(),
             Command::ServerDump(args) => args.execute(&config).await,
         }
+    }
+}
+
+#[cfg(all(test, feature = "sourcehub"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sourcehub_events_endpoint_flows_into_config() {
+        let cli = Cli::try_parse_from([
+            "defra",
+            "--sourcehub-events-ws",
+            "ws://127.0.0.1:26657/websocket",
+            "version",
+        ])
+        .unwrap();
+        let mut config = Config::default();
+
+        config.apply_cli_flags(&cli).unwrap();
+
+        assert_eq!(
+            config.acp.sourcehub_events_ws,
+            "ws://127.0.0.1:26657/websocket"
+        );
     }
 }

--- a/crates/cli/src/commands/start/server_acp.rs
+++ b/crates/cli/src/commands/start/server_acp.rs
@@ -70,10 +70,17 @@ impl Node {
                 .map_err(|e| Error::InvalidConfig(format!("SourceHub provider: {}", e)))?,
             );
 
-            let document_acp = Arc::new(sourcehub::SourceHubDocumentACP::new(
-                provider,
-                tuning.cache_ttl,
-            ));
+            let document_acp = sourcehub::SourceHubDocumentACP::new(provider, tuning.cache_ttl);
+            let document_acp = if config.acp.sourcehub_events_ws.is_empty() {
+                document_acp
+            } else {
+                document_acp
+                    .with_cosmos_event_invalidation(config.acp.sourcehub_events_ws.clone())
+                    .map_err(|e| {
+                        Error::InvalidConfig(format!("SourceHub event subscriber: {}", e))
+                    })?
+            };
+            let document_acp = Arc::new(document_acp);
             let http_adapter = crate::sourcehub_acp_adapter::SourceHubAcpAdapter::new_arc(
                 document_acp.clone(),
                 zanzibar_store,

--- a/crates/cli/src/config/mod.rs
+++ b/crates/cli/src/config/mod.rs
@@ -210,6 +210,10 @@ impl Config {
             self.acp.sourcehub_comet_address = addr.clone();
         }
         #[cfg(feature = "sourcehub")]
+        if let Some(ref addr) = cli.source_hub_events_ws {
+            self.acp.sourcehub_events_ws = addr.clone();
+        }
+        #[cfg(feature = "sourcehub")]
         if let Some(ref id) = cli.source_hub_chain_id {
             self.acp.sourcehub_chain_id = id.clone();
         }

--- a/crates/cli/src/config/sections.rs
+++ b/crates/cli/src/config/sections.rs
@@ -500,6 +500,11 @@ pub struct AcpConfig {
     #[serde(default)]
     pub sourcehub_comet_address: String,
 
+    /// SourceHub CometBFT WebSocket endpoint for ACP cache invalidation.
+    #[cfg(feature = "sourcehub")]
+    #[serde(default)]
+    pub sourcehub_events_ws: String,
+
     /// SourceHub chain ID (e.g., "sourcehub-test")
     #[cfg(feature = "sourcehub")]
     #[serde(default)]
@@ -556,6 +561,8 @@ impl Default for AcpConfig {
             sourcehub_address: String::new(),
             #[cfg(feature = "sourcehub")]
             sourcehub_comet_address: String::new(),
+            #[cfg(feature = "sourcehub")]
+            sourcehub_events_ws: String::new(),
             #[cfg(feature = "sourcehub")]
             sourcehub_chain_id: String::new(),
             #[cfg(feature = "sourcehub")]

--- a/crates/cli/tests/config_tests.rs
+++ b/crates/cli/tests/config_tests.rs
@@ -28,6 +28,8 @@ fn cli_with_defaults() -> Cli {
         #[cfg(feature = "sourcehub")]
         source_hub_comet_address: None,
         #[cfg(feature = "sourcehub")]
+        source_hub_events_ws: None,
+        #[cfg(feature = "sourcehub")]
         source_hub_chain_id: None,
         #[cfg(feature = "sourcehub")]
         hub_rs_address: None,

--- a/crates/sourcehub/Cargo.toml
+++ b/crates/sourcehub/Cargo.toml
@@ -58,5 +58,10 @@ bs58.workspace = true
 # ACP light client (proof-validated cache)
 acp-light-client = { git = "ssh://git@github.com/sourcenetwork/backbone.git", rev = "086ddadc98bc55183920aa0fe6bc4d3719e0e5e7" }
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+futures.workspace = true
+prost.workspace = true
+tokio-tungstenite = { version = "0.26.2", features = ["rustls-tls-webpki-roots"] }
+
 [lints]
 workspace = true

--- a/crates/sourcehub/src/access_cache.rs
+++ b/crates/sourcehub/src/access_cache.rs
@@ -2,6 +2,15 @@ use std::collections::HashMap;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
+#[derive(PartialEq, Eq, Hash)]
+struct CacheKey {
+    actor_did: String,
+    policy_id: String,
+    resource: String,
+    doc_id: String,
+    permission: String,
+}
+
 struct CachedDecision {
     allowed: bool,
     cached_at: Instant,
@@ -15,7 +24,7 @@ struct CachedDecision {
 /// all entries for the affected document.
 pub(crate) struct AccessCache {
     ttl: Duration,
-    entries: Mutex<HashMap<String, CachedDecision>>,
+    entries: Mutex<HashMap<CacheKey, CachedDecision>>,
 }
 
 fn cache_key(
@@ -24,15 +33,14 @@ fn cache_key(
     resource: &str,
     doc_id: &str,
     permission: &str,
-) -> String {
-    format!(
-        "{}|{}|{}|{}|{}",
-        actor_did, policy_id, resource, doc_id, permission
-    )
-}
-
-fn object_prefix(policy_id: &str, resource: &str, doc_id: &str) -> String {
-    format!("|{}|{}|{}|", policy_id, resource, doc_id)
+) -> CacheKey {
+    CacheKey {
+        actor_did: actor_did.to_string(),
+        policy_id: policy_id.to_string(),
+        resource: resource.to_string(),
+        doc_id: doc_id.to_string(),
+        permission: permission.to_string(),
+    }
 }
 
 impl AccessCache {
@@ -88,10 +96,35 @@ impl AccessCache {
     /// unregistration. Invalidates all actors and permissions for the
     /// document to avoid subtle races where permission changes affect
     /// multiple actors through indirect relations.
-    pub(crate) fn invalidate_object(&self, policy_id: &str, resource: &str, doc_id: &str) {
-        let prefix = object_prefix(policy_id, resource, doc_id);
+    pub(crate) fn invalidate_object(&self, policy_id: &str, resource: &str, doc_id: &str) -> usize {
         if let Ok(mut entries) = self.entries.lock() {
-            entries.retain(|key, _| !key.contains(&prefix));
+            let previous_len = entries.len();
+            entries.retain(|key, _| {
+                key.policy_id != policy_id || key.resource != resource || key.doc_id != doc_id
+            });
+            previous_len - entries.len()
+        } else {
+            0
+        }
+    }
+
+    pub(crate) fn invalidate_policy(&self, policy_id: &str) -> usize {
+        if let Ok(mut entries) = self.entries.lock() {
+            let previous_len = entries.len();
+            entries.retain(|key, _| key.policy_id != policy_id);
+            previous_len - entries.len()
+        } else {
+            0
+        }
+    }
+
+    pub(crate) fn clear(&self) -> usize {
+        if let Ok(mut entries) = self.entries.lock() {
+            let previous_len = entries.len();
+            entries.clear();
+            previous_len
+        } else {
+            0
         }
     }
 }
@@ -172,6 +205,54 @@ mod tests {
         assert_eq!(
             cache.get("did:key:alice", "p1", "users", "doc2", "read"),
             Some(true)
+        );
+    }
+
+    #[test]
+    fn invalidate_object_uses_exact_key_components() {
+        let cache = AccessCache::new(Duration::from_secs(300));
+        cache.set("did:key:alice", "p1", "users", "doc1", "read", true);
+        cache.set("did:key:alice", "p1", "users|doc1", "other", "read", true);
+
+        cache.invalidate_object("p1", "users", "doc1");
+
+        assert_eq!(
+            cache.get("did:key:alice", "p1", "users|doc1", "other", "read"),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn invalidate_policy_preserves_other_policies() {
+        let cache = AccessCache::new(Duration::from_secs(300));
+        cache.set("did:key:alice", "p1", "users", "doc1", "read", true);
+        cache.set("did:key:alice", "p2", "users", "doc1", "read", true);
+
+        assert_eq!(cache.invalidate_policy("p1"), 1);
+        assert_eq!(
+            cache.get("did:key:alice", "p1", "users", "doc1", "read"),
+            None
+        );
+        assert_eq!(
+            cache.get("did:key:alice", "p2", "users", "doc1", "read"),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn clear_removes_every_entry() {
+        let cache = AccessCache::new(Duration::from_secs(300));
+        cache.set("did:key:alice", "p1", "users", "doc1", "read", true);
+        cache.set("did:key:bob", "p2", "books", "doc2", "update", true);
+
+        assert_eq!(cache.clear(), 2);
+        assert_eq!(
+            cache.get("did:key:alice", "p1", "users", "doc1", "read"),
+            None
+        );
+        assert_eq!(
+            cache.get("did:key:bob", "p2", "books", "doc2", "update"),
+            None
         );
     }
 }

--- a/crates/sourcehub/src/access_cache.rs
+++ b/crates/sourcehub/src/access_cache.rs
@@ -21,7 +21,7 @@ struct CachedDecision {
 /// Caches the result of `verify_access` calls keyed by
 /// `(actor, policy, resource, doc_id, permission)`. Entries expire
 /// after a configurable TTL. Relationship mutations eagerly invalidate
-/// all entries for the affected document.
+/// all entries for their policy so indirect grants cannot remain cached.
 pub(crate) struct AccessCache {
     ttl: Duration,
     entries: Mutex<HashMap<CacheKey, CachedDecision>>,
@@ -92,10 +92,8 @@ impl AccessCache {
 
     /// Invalidate ALL cached decisions for a specific document.
     ///
-    /// Called on relationship mutations (grant/revoke) and document
-    /// unregistration. Invalidates all actors and permissions for the
-    /// document to avoid subtle races where permission changes affect
-    /// multiple actors through indirect relations.
+    /// Called on document registration and archival mutations. Invalidates all
+    /// actors and permissions for the affected document.
     pub(crate) fn invalidate_object(&self, policy_id: &str, resource: &str, doc_id: &str) -> usize {
         if let Ok(mut entries) = self.entries.lock() {
             let previous_len = entries.len();

--- a/crates/sourcehub/src/cosmos/dac.rs
+++ b/crates/sourcehub/src/cosmos/dac.rs
@@ -23,14 +23,18 @@ use crate::provider::{AcpLightClientStatus, ProviderError, SourceHubProvider, Su
 /// DefraDB's mutation path.
 pub struct SourceHubDocumentACP {
     provider: Arc<dyn SourceHubProvider>,
-    access_cache: Option<AccessCache>,
+    access_cache: Option<Arc<AccessCache>>,
+    #[cfg(not(target_arch = "wasm32"))]
+    event_subscriber: Option<super::event_subscriber::CosmosEventSubscriber>,
 }
 
 impl SourceHubDocumentACP {
     pub fn new(provider: Arc<dyn SourceHubProvider>, cache_ttl: Duration) -> Self {
         Self {
             provider,
-            access_cache: Some(AccessCache::new(cache_ttl)),
+            access_cache: Some(Arc::new(AccessCache::new(cache_ttl))),
+            #[cfg(not(target_arch = "wasm32"))]
+            event_subscriber: None,
         }
     }
 
@@ -38,7 +42,26 @@ impl SourceHubDocumentACP {
         Self {
             provider,
             access_cache: None,
+            #[cfg(not(target_arch = "wasm32"))]
+            event_subscriber: None,
         }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn with_cosmos_event_invalidation(
+        mut self,
+        websocket_url: impl Into<String>,
+    ) -> std::result::Result<Self, ProviderError> {
+        let cache = self.access_cache.as_ref().ok_or_else(|| {
+            ProviderError::Config(
+                "Cosmos event invalidation requires the access cache to be enabled".into(),
+            )
+        })?;
+        self.event_subscriber = Some(super::event_subscriber::CosmosEventSubscriber::start(
+            websocket_url.into(),
+            Arc::clone(cache),
+        )?);
+        Ok(self)
     }
 
     fn invalidate_cached_access(&self, policy_id: &str, resource_name: &str, doc_id: &str) {

--- a/crates/sourcehub/src/cosmos/event_decoder.rs
+++ b/crates/sourcehub/src/cosmos/event_decoder.rs
@@ -1,0 +1,420 @@
+use base64::Engine as _;
+use prost::Message;
+
+const BEARER_POLICY_COMMAND: &str = "sourcehub.acp.MsgBearerPolicyCmd";
+const CHECK_ACCESS: &str = "sourcehub.acp.MsgCheckAccess";
+const CREATE_POLICY: &str = "sourcehub.acp.MsgCreatePolicy";
+const DIRECT_POLICY_COMMAND: &str = "sourcehub.acp.MsgDirectPolicyCmd";
+const EDIT_POLICY: &str = "sourcehub.acp.MsgEditPolicy";
+const SIGNED_POLICY_COMMAND: &str = "sourcehub.acp.MsgSignedPolicyCmd";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum CacheInvalidation {
+    Object {
+        policy_id: String,
+        resource: String,
+        object_id: String,
+    },
+    Policy(String),
+    All,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(super) enum EventDecodeError {
+    #[error("invalid CometBFT event JSON: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("CometBFT subscription failed: {0}")]
+    Subscription(String),
+    #[error("transaction event is missing its transaction bytes")]
+    MissingTransaction,
+    #[error("invalid transaction base64: {0}")]
+    Base64(#[from] base64::DecodeError),
+    #[error("invalid Cosmos transaction: {0}")]
+    Transaction(#[source] prost::DecodeError),
+    #[error("invalid {message_type}: {source}")]
+    AcpMessage {
+        message_type: String,
+        #[source]
+        source: prost::DecodeError,
+    },
+}
+
+pub(super) fn decode_event(message: &str) -> Result<Vec<CacheInvalidation>, EventDecodeError> {
+    let event: serde_json::Value = serde_json::from_str(message)?;
+    if let Some(error) = event.get("error") {
+        return Err(EventDecodeError::Subscription(error.to_string()));
+    }
+
+    let Some(data) = event.pointer("/result/data") else {
+        return Ok(Vec::new());
+    };
+    if data.get("type").and_then(|value| value.as_str()) != Some("tendermint/event/Tx") {
+        return Ok(Vec::new());
+    }
+
+    let tx_result = data
+        .pointer("/value/TxResult")
+        .or_else(|| data.pointer("/value/tx_result"))
+        .ok_or(EventDecodeError::MissingTransaction)?;
+    if !transaction_succeeded(tx_result.pointer("/result/code")) {
+        return Ok(Vec::new());
+    }
+
+    let encoded_tx = tx_result
+        .get("tx")
+        .and_then(|value| value.as_str())
+        .ok_or(EventDecodeError::MissingTransaction)?;
+    let tx_bytes = base64::engine::general_purpose::STANDARD.decode(encoded_tx)?;
+    decode_transaction(&tx_bytes)
+}
+
+fn transaction_succeeded(code: Option<&serde_json::Value>) -> bool {
+    match code {
+        None => true,
+        Some(serde_json::Value::Number(value)) => value.as_u64() == Some(0),
+        Some(serde_json::Value::String(value)) => value == "0",
+        Some(_) => false,
+    }
+}
+
+fn decode_transaction(tx_bytes: &[u8]) -> Result<Vec<CacheInvalidation>, EventDecodeError> {
+    let raw = RawTransaction::decode(tx_bytes).map_err(EventDecodeError::Transaction)?;
+    let body = TransactionBody::decode(raw.body_bytes.as_slice())
+        .map_err(EventDecodeError::Transaction)?;
+    let mut invalidations = Vec::new();
+
+    for message in body.messages {
+        let message_type = message.type_url.trim_start_matches('/');
+        let invalidation = match message_type {
+            BEARER_POLICY_COMMAND => {
+                let command =
+                    BearerPolicyCommand::decode(message.value.as_slice()).map_err(|source| {
+                        EventDecodeError::AcpMessage {
+                            message_type: message.type_url.clone(),
+                            source,
+                        }
+                    })?;
+                command_invalidation(command.policy_id, command.command)
+            }
+            DIRECT_POLICY_COMMAND => {
+                let command =
+                    DirectPolicyCommand::decode(message.value.as_slice()).map_err(|source| {
+                        EventDecodeError::AcpMessage {
+                            message_type: message.type_url.clone(),
+                            source,
+                        }
+                    })?;
+                command_invalidation(command.policy_id, command.command)
+            }
+            EDIT_POLICY => {
+                let edit =
+                    EditPolicyCommand::decode(message.value.as_slice()).map_err(|source| {
+                        EventDecodeError::AcpMessage {
+                            message_type: message.type_url.clone(),
+                            source,
+                        }
+                    })?;
+                if edit.policy_id.is_empty() {
+                    CacheInvalidation::All
+                } else {
+                    CacheInvalidation::Policy(edit.policy_id)
+                }
+            }
+            SIGNED_POLICY_COMMAND => CacheInvalidation::All,
+            CREATE_POLICY | CHECK_ACCESS => continue,
+            message_type if message_type.starts_with("sourcehub.acp.") => CacheInvalidation::All,
+            _ => continue,
+        };
+
+        if invalidation == CacheInvalidation::All {
+            return Ok(vec![CacheInvalidation::All]);
+        }
+        if !invalidations.contains(&invalidation) {
+            invalidations.push(invalidation);
+        }
+    }
+
+    Ok(invalidations)
+}
+
+fn command_invalidation(policy_id: String, command: Option<PolicyCommand>) -> CacheInvalidation {
+    if policy_id.is_empty() {
+        return CacheInvalidation::All;
+    }
+
+    let Some(object) = command.and_then(PolicyCommand::object) else {
+        return CacheInvalidation::Policy(policy_id);
+    };
+    if object.resource.is_empty() || object.id.is_empty() {
+        CacheInvalidation::Policy(policy_id)
+    } else {
+        CacheInvalidation::Object {
+            policy_id,
+            resource: object.resource,
+            object_id: object.id,
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct RawTransaction {
+    #[prost(bytes = "vec", tag = "1")]
+    body_bytes: Vec<u8>,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct TransactionBody {
+    #[prost(message, repeated, tag = "1")]
+    messages: Vec<ProtoAny>,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct ProtoAny {
+    #[prost(string, tag = "1")]
+    type_url: String,
+    #[prost(bytes = "vec", tag = "2")]
+    value: Vec<u8>,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct BearerPolicyCommand {
+    #[prost(string, tag = "3")]
+    policy_id: String,
+    #[prost(message, optional, tag = "4")]
+    command: Option<PolicyCommand>,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct DirectPolicyCommand {
+    #[prost(string, tag = "2")]
+    policy_id: String,
+    #[prost(message, optional, tag = "3")]
+    command: Option<PolicyCommand>,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct EditPolicyCommand {
+    #[prost(string, tag = "2")]
+    policy_id: String,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct PolicyCommand {
+    #[prost(message, optional, tag = "1")]
+    set_relationship: Option<RelationshipCommand>,
+    #[prost(message, optional, tag = "2")]
+    delete_relationship: Option<RelationshipCommand>,
+    #[prost(message, optional, tag = "3")]
+    register_object: Option<ObjectCommand>,
+    #[prost(message, optional, tag = "4")]
+    archive_object: Option<ObjectCommand>,
+    #[prost(message, optional, tag = "8")]
+    unarchive_object: Option<ObjectCommand>,
+}
+
+impl PolicyCommand {
+    fn object(self) -> Option<ObjectRef> {
+        self.set_relationship
+            .or(self.delete_relationship)
+            .and_then(|command| command.relationship)
+            .and_then(|relationship| relationship.object)
+            .or_else(|| self.register_object.and_then(|command| command.object))
+            .or_else(|| self.archive_object.and_then(|command| command.object))
+            .or_else(|| self.unarchive_object.and_then(|command| command.object))
+    }
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct RelationshipCommand {
+    #[prost(message, optional, tag = "1")]
+    relationship: Option<Relationship>,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct Relationship {
+    #[prost(message, optional, tag = "1")]
+    object: Option<ObjectRef>,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct ObjectCommand {
+    #[prost(message, optional, tag = "1")]
+    object: Option<ObjectRef>,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct ObjectRef {
+    #[prost(string, tag = "1")]
+    resource: String,
+    #[prost(string, tag = "2")]
+    id: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn transaction_event(messages: Vec<ProtoAny>, code: u64) -> String {
+        let body = TransactionBody { messages }.encode_to_vec();
+        let tx = RawTransaction { body_bytes: body }.encode_to_vec();
+        serde_json::json!({
+            "result": {
+                "data": {
+                    "type": "tendermint/event/Tx",
+                    "value": {
+                        "TxResult": {
+                            "tx": base64::engine::general_purpose::STANDARD.encode(tx),
+                            "result": { "code": code }
+                        }
+                    }
+                }
+            }
+        })
+        .to_string()
+    }
+
+    fn object(resource: &str, id: &str) -> ObjectRef {
+        ObjectRef {
+            resource: resource.into(),
+            id: id.into(),
+        }
+    }
+
+    #[test]
+    fn decodes_bearer_relationship_object() {
+        let command = BearerPolicyCommand {
+            policy_id: "policy-1".into(),
+            command: Some(PolicyCommand {
+                set_relationship: Some(RelationshipCommand {
+                    relationship: Some(Relationship {
+                        object: Some(object("users", "doc-1")),
+                    }),
+                }),
+                ..Default::default()
+            }),
+        };
+        let event = transaction_event(
+            vec![ProtoAny {
+                type_url: format!("/{BEARER_POLICY_COMMAND}"),
+                value: command.encode_to_vec(),
+            }],
+            0,
+        );
+
+        assert_eq!(
+            decode_event(&event).unwrap(),
+            vec![CacheInvalidation::Object {
+                policy_id: "policy-1".into(),
+                resource: "users".into(),
+                object_id: "doc-1".into(),
+            }]
+        );
+    }
+
+    #[test]
+    fn decodes_direct_archive_object() {
+        let command = DirectPolicyCommand {
+            policy_id: "policy-2".into(),
+            command: Some(PolicyCommand {
+                archive_object: Some(ObjectCommand {
+                    object: Some(object("books", "doc-2")),
+                }),
+                ..Default::default()
+            }),
+        };
+        let event = transaction_event(
+            vec![ProtoAny {
+                type_url: format!("/{DIRECT_POLICY_COMMAND}"),
+                value: command.encode_to_vec(),
+            }],
+            0,
+        );
+
+        assert_eq!(
+            decode_event(&event).unwrap(),
+            vec![CacheInvalidation::Object {
+                policy_id: "policy-2".into(),
+                resource: "books".into(),
+                object_id: "doc-2".into(),
+            }]
+        );
+    }
+
+    #[test]
+    fn edit_policy_invalidates_the_whole_policy() {
+        let edit = EditPolicyCommand {
+            policy_id: "policy-1".into(),
+        };
+        let event = transaction_event(
+            vec![ProtoAny {
+                type_url: format!("/{EDIT_POLICY}"),
+                value: edit.encode_to_vec(),
+            }],
+            0,
+        );
+
+        assert_eq!(
+            decode_event(&event).unwrap(),
+            vec![CacheInvalidation::Policy("policy-1".into())]
+        );
+    }
+
+    #[test]
+    fn opaque_signed_command_fails_safe() {
+        let event = transaction_event(
+            vec![ProtoAny {
+                type_url: format!("/{SIGNED_POLICY_COMMAND}"),
+                value: Vec::new(),
+            }],
+            0,
+        );
+
+        assert_eq!(decode_event(&event).unwrap(), vec![CacheInvalidation::All]);
+    }
+
+    #[test]
+    fn unknown_acp_message_fails_safe() {
+        let event = transaction_event(
+            vec![ProtoAny {
+                type_url: "/sourcehub.acp.MsgFuturePolicyMutation".into(),
+                value: Vec::new(),
+            }],
+            0,
+        );
+
+        assert_eq!(decode_event(&event).unwrap(), vec![CacheInvalidation::All]);
+    }
+
+    #[test]
+    fn create_policy_does_not_invalidate() {
+        let event = transaction_event(
+            vec![ProtoAny {
+                type_url: format!("/{CREATE_POLICY}"),
+                value: Vec::new(),
+            }],
+            0,
+        );
+
+        assert!(decode_event(&event).unwrap().is_empty());
+    }
+
+    #[test]
+    fn failed_transactions_do_not_invalidate() {
+        let event = transaction_event(
+            vec![ProtoAny {
+                type_url: format!("/{SIGNED_POLICY_COMMAND}"),
+                value: Vec::new(),
+            }],
+            7,
+        );
+
+        assert!(decode_event(&event).unwrap().is_empty());
+    }
+
+    #[test]
+    fn subscription_ack_is_ignored() {
+        assert!(decode_event(r#"{"jsonrpc":"2.0","id":1,"result":{}}"#)
+            .unwrap()
+            .is_empty());
+    }
+}

--- a/crates/sourcehub/src/cosmos/event_decoder.rs
+++ b/crates/sourcehub/src/cosmos/event_decoder.rs
@@ -142,7 +142,13 @@ fn command_invalidation(policy_id: String, command: Option<PolicyCommand>) -> Ca
         return CacheInvalidation::All;
     }
 
-    let Some(object) = command.and_then(PolicyCommand::object) else {
+    let Some(command) = command else {
+        return CacheInvalidation::Policy(policy_id);
+    };
+    if command.set_relationship.is_some() || command.delete_relationship.is_some() {
+        return CacheInvalidation::Policy(policy_id);
+    }
+    let Some(object) = command.object() else {
         return CacheInvalidation::Policy(policy_id);
     };
     if object.resource.is_empty() || object.id.is_empty() {
@@ -214,11 +220,8 @@ struct PolicyCommand {
 
 impl PolicyCommand {
     fn object(self) -> Option<ObjectRef> {
-        self.set_relationship
-            .or(self.delete_relationship)
-            .and_then(|command| command.relationship)
-            .and_then(|relationship| relationship.object)
-            .or_else(|| self.register_object.and_then(|command| command.object))
+        self.register_object
+            .and_then(|command| command.object)
             .or_else(|| self.archive_object.and_then(|command| command.object))
             .or_else(|| self.unarchive_object.and_then(|command| command.object))
     }
@@ -281,7 +284,7 @@ mod tests {
     }
 
     #[test]
-    fn decodes_bearer_relationship_object() {
+    fn relationship_mutation_invalidates_the_whole_policy() {
         let command = BearerPolicyCommand {
             policy_id: "policy-1".into(),
             command: Some(PolicyCommand {
@@ -303,11 +306,7 @@ mod tests {
 
         assert_eq!(
             decode_event(&event).unwrap(),
-            vec![CacheInvalidation::Object {
-                policy_id: "policy-1".into(),
-                resource: "users".into(),
-                object_id: "doc-1".into(),
-            }]
+            vec![CacheInvalidation::Policy("policy-1".into())]
         );
     }
 

--- a/crates/sourcehub/src/cosmos/event_subscriber.rs
+++ b/crates/sourcehub/src/cosmos/event_subscriber.rs
@@ -1,0 +1,252 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::{SinkExt, StreamExt};
+use tokio::task::AbortHandle;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::Message;
+
+use crate::access_cache::AccessCache;
+use crate::provider::ProviderError;
+
+use super::event_decoder::{decode_event, CacheInvalidation, EventDecodeError};
+
+const SUBSCRIPTION_QUERY: &str = "tm.event='Tx' AND message.module='acp'";
+const INITIAL_RECONNECT_DELAY: Duration = Duration::from_secs(1);
+const MAX_RECONNECT_DELAY: Duration = Duration::from_secs(30);
+
+pub(super) struct CosmosEventSubscriber {
+    abort_handle: AbortHandle,
+}
+
+impl CosmosEventSubscriber {
+    pub(super) fn start(
+        websocket_url: String,
+        cache: Arc<AccessCache>,
+    ) -> Result<Self, ProviderError> {
+        websocket_url
+            .as_str()
+            .into_client_request()
+            .map_err(|error| {
+                ProviderError::Config(format!("invalid SourceHub events WebSocket URL: {error}"))
+            })?;
+        let runtime = tokio::runtime::Handle::try_current().map_err(|error| {
+            ProviderError::Config(format!(
+                "SourceHub event invalidation requires a Tokio runtime: {error}"
+            ))
+        })?;
+        let task = runtime.spawn(run(websocket_url, cache));
+        Ok(Self {
+            abort_handle: task.abort_handle(),
+        })
+    }
+}
+
+impl Drop for CosmosEventSubscriber {
+    fn drop(&mut self) {
+        self.abort_handle.abort();
+    }
+}
+
+async fn run(websocket_url: String, cache: Arc<AccessCache>) {
+    let mut reconnect_delay = INITIAL_RECONNECT_DELAY;
+    loop {
+        match tokio_tungstenite::connect_async(&websocket_url).await {
+            Ok((mut socket, _)) => {
+                reconnect_delay = INITIAL_RECONNECT_DELAY;
+                let subscription = serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "subscribe",
+                    "params": { "query": SUBSCRIPTION_QUERY }
+                });
+                if let Err(error) = socket
+                    .send(Message::Text(subscription.to_string().into()))
+                    .await
+                {
+                    tracing::warn!(%error, "failed to subscribe to SourceHub ACP events");
+                } else {
+                    tracing::info!(url = %websocket_url, "subscribed to SourceHub ACP events");
+                    if let Err(error) = consume(&mut socket, &cache).await {
+                        tracing::warn!(%error, "SourceHub ACP event stream disconnected");
+                    }
+                }
+            }
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    retry_in_seconds = reconnect_delay.as_secs(),
+                    "failed to connect to SourceHub ACP event stream"
+                );
+            }
+        }
+
+        tokio::time::sleep(reconnect_delay).await;
+        reconnect_delay = reconnect_delay.saturating_mul(2).min(MAX_RECONNECT_DELAY);
+    }
+}
+
+async fn consume<S>(
+    socket: &mut tokio_tungstenite::WebSocketStream<S>,
+    cache: &AccessCache,
+) -> Result<(), tokio_tungstenite::tungstenite::Error>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    while let Some(message) = socket.next().await {
+        match message? {
+            Message::Text(text) => {
+                if !process_event(&text, cache) {
+                    return Ok(());
+                }
+            }
+            Message::Binary(bytes) => match std::str::from_utf8(&bytes) {
+                Ok(text) => {
+                    if !process_event(text, cache) {
+                        return Ok(());
+                    }
+                }
+                Err(error) => {
+                    let invalidated_entries = cache.clear();
+                    tracing::warn!(
+                        %error,
+                        invalidated_entries,
+                        "invalid SourceHub ACP event payload; cleared access cache"
+                    );
+                }
+            },
+            Message::Ping(payload) => socket.send(Message::Pong(payload)).await?,
+            Message::Close(_) => return Ok(()),
+            Message::Pong(_) | Message::Frame(_) => {}
+        }
+    }
+    Ok(())
+}
+
+fn process_event(message: &str, cache: &AccessCache) -> bool {
+    let invalidations = match decode_event(message) {
+        Ok(invalidations) => invalidations,
+        Err(error) => {
+            let invalidated_entries = cache.clear();
+            tracing::warn!(
+                %error,
+                invalidated_entries,
+                "could not decode SourceHub ACP event; cleared access cache"
+            );
+            return !matches!(error, EventDecodeError::Subscription(_));
+        }
+    };
+
+    for invalidation in invalidations {
+        let invalidated_entries = match &invalidation {
+            CacheInvalidation::Object {
+                policy_id,
+                resource,
+                object_id,
+            } => cache.invalidate_object(policy_id, resource, object_id),
+            CacheInvalidation::Policy(policy_id) => cache.invalidate_policy(policy_id),
+            CacheInvalidation::All => cache.clear(),
+        };
+        tracing::debug!(
+            ?invalidation,
+            invalidated_entries,
+            "invalidated cached SourceHub access decisions"
+        );
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::net::TcpListener;
+    use tokio::time::timeout;
+    use tokio_tungstenite::accept_async;
+
+    #[test]
+    fn malformed_event_clears_cached_grants() {
+        let cache = AccessCache::new(Duration::from_secs(300));
+        cache.set("did:key:alice", "p1", "users", "doc1", "read", true);
+
+        assert!(process_event("not-json", &cache));
+
+        assert_eq!(
+            cache.get("did:key:alice", "p1", "users", "doc1", "read"),
+            None
+        );
+    }
+
+    #[test]
+    fn subscription_error_clears_cache_and_requests_reconnect() {
+        let cache = AccessCache::new(Duration::from_secs(300));
+        cache.set("did:key:alice", "p1", "users", "doc1", "read", true);
+
+        assert!(!process_event(
+            r#"{"jsonrpc":"2.0","id":1,"error":{"code":-32603}}"#,
+            &cache
+        ));
+        assert_eq!(
+            cache.get("did:key:alice", "p1", "users", "doc1", "read"),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn subscriber_rejects_invalid_urls_before_spawning() {
+        let cache = Arc::new(AccessCache::new(Duration::from_secs(300)));
+        let result = CosmosEventSubscriber::start("not a websocket URL".into(), cache);
+
+        assert!(matches!(result, Err(ProviderError::Config(_))));
+    }
+
+    #[tokio::test]
+    async fn subscriber_processes_events_and_stops_on_drop() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let websocket_url = format!("ws://{}/websocket", listener.local_addr().unwrap());
+        let cache = Arc::new(AccessCache::new(Duration::from_secs(300)));
+        cache.set("did:key:alice", "p1", "users", "doc1", "read", true);
+
+        let subscriber = CosmosEventSubscriber::start(websocket_url, Arc::clone(&cache)).unwrap();
+        let (stream, _) = timeout(Duration::from_secs(1), listener.accept())
+            .await
+            .unwrap()
+            .unwrap();
+        let mut socket = accept_async(stream).await.unwrap();
+
+        let request = timeout(Duration::from_secs(1), socket.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap()
+            .into_text()
+            .unwrap();
+        let request: serde_json::Value = serde_json::from_str(&request).unwrap();
+        assert_eq!(request["method"], "subscribe");
+        assert_eq!(request["params"]["query"], SUBSCRIPTION_QUERY);
+
+        socket.send(Message::Text("not-json".into())).await.unwrap();
+        timeout(Duration::from_secs(1), async {
+            loop {
+                if cache
+                    .get("did:key:alice", "p1", "users", "doc1", "read")
+                    .is_none()
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+
+        let abort_handle = subscriber.abort_handle.clone();
+        drop(subscriber);
+        timeout(Duration::from_secs(1), async {
+            while !abort_handle.is_finished() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+    }
+}

--- a/crates/sourcehub/src/cosmos/event_subscriber.rs
+++ b/crates/sourcehub/src/cosmos/event_subscriber.rs
@@ -67,6 +67,11 @@ async fn run(websocket_url: String, cache: Arc<AccessCache>) {
                     tracing::warn!(%error, "failed to subscribe to SourceHub ACP events");
                 } else {
                     tracing::info!(url = %websocket_url, "subscribed to SourceHub ACP events");
+                    let invalidated_entries = cache.clear();
+                    tracing::info!(
+                        invalidated_entries,
+                        "cleared access cache after subscribing; events during the gap are not replayed"
+                    );
                     if let Err(error) = consume(&mut socket, &cache).await {
                         tracing::warn!(%error, "SourceHub ACP event stream disconnected");
                     }
@@ -223,6 +228,19 @@ mod tests {
         let request: serde_json::Value = serde_json::from_str(&request).unwrap();
         assert_eq!(request["method"], "subscribe");
         assert_eq!(request["params"]["query"], SUBSCRIPTION_QUERY);
+
+        timeout(Duration::from_secs(1), async {
+            while cache
+                .get("did:key:alice", "p1", "users", "doc1", "read")
+                .is_some()
+            {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+
+        cache.set("did:key:alice", "p1", "users", "doc1", "read", true);
 
         socket.send(Message::Text("not-json".into())).await.unwrap();
         timeout(Duration::from_secs(1), async {

--- a/crates/sourcehub/src/cosmos/mod.rs
+++ b/crates/sourcehub/src/cosmos/mod.rs
@@ -1,6 +1,10 @@
 mod client;
 mod cosmos_provider;
 mod dac;
+#[cfg(not(target_arch = "wasm32"))]
+mod event_decoder;
+#[cfg(not(target_arch = "wasm32"))]
+mod event_subscriber;
 mod tx;
 
 pub use cosmos_provider::CosmosProvider;


### PR DESCRIPTION
Closes #520.

## Problem

SourceHub ACP access decisions remain cached until their TTL expires. Relationship changes submitted by another client bypass the local mutation path, so revoked permissions can remain effective during that staleness window.

## What changed

- Add an optional `--sourcehub-events-ws` / `DEFRA_SOURCE_HUB_EVENTS_WS` endpoint while preserving TTL-only behavior when unset.
- Subscribe to successful ACP transaction events over the CometBFT WebSocket and decode their transaction payloads.
- Invalidate exact object entries for relationship and object commands, whole-policy entries for policy edits, and the full cache for opaque or unknown ACP mutations.
- Clear cached decisions on malformed event payloads and reconnect with bounded exponential backoff after connection or subscription failures.
- Replace delimiter-based cache keys with typed components so invalidation matches policy, resource, and document identifiers exactly.
- Stop the background subscriber with its owning ACP instance and cover decoding, fail-safe handling, subscription requests, invalidation, and cancellation.

## Validation

- [x] `cargo test -p sourcehub`
- [x] `cargo test -p cli --no-default-features --features sourcehub,lark --all-targets`
- [x] `cargo clippy -p sourcehub --all-targets -- -D warnings`
- [x] `cargo clippy -p cli --no-default-features --features sourcehub,lark --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`