### PR TITLE
fix(kms): bind key release to authenticated peer identities

### DIFF
--- a/crates/cli/src/commands/start/server.rs
+++ b/crates/cli/src/commands/start/server.rs
@@ -217,8 +217,8 @@ impl Node {
                 policy.set_node_acp(Arc::new(db::DbNodeAcpRead::new(adapter.nac_manager())));
             }
 
-            // Node identity for the wire `identity` fallback on gossip-initiated
-            // fetches. Anonymous nodes use a stable placeholder DID.
+            // Node identity used for cross-peer DEK requests. Anonymous nodes
+            // use a stable placeholder DID.
             let node_did = database.node_did().unwrap_or_else(|| {
                 identity::Did::new("did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK")
                     .expect("static anonymous DID parses")

--- a/crates/cli/src/commands/start/server_p2p/iroh.rs
+++ b/crates/cli/src/commands/start/server_p2p/iroh.rs
@@ -104,9 +104,10 @@ impl Node {
         // raw gossip on the encryption topic is routed to it (mirrors
         // crates/embedded/src/node_p2p.rs::setup_iroh).
         let local_peer_id = transport.local_peer_id().to_string();
-        let kms_transport = p2p::kms::PubsubKeyTransport::new(transport.clone())
-            .await
-            .map_err(|e| Error::Server(format!("failed to create KMS transport: {e}")))?;
+        let kms_transport =
+            p2p::kms::PubsubKeyTransport::new(transport.clone(), Arc::new(p2p::AnonymousResolver))
+                .await
+                .map_err(|e| Error::Server(format!("failed to create KMS transport: {e}")))?;
         coordinator.install_kms_transport(kms_transport.clone());
 
         match db_merge::load_persisted_collections(&coordinator).await {

--- a/crates/cli/src/commands/start/server_p2p/libp2p.rs
+++ b/crates/cli/src/commands/start/server_p2p/libp2p.rs
@@ -99,10 +99,12 @@ impl Node {
         // Build the KMS pubsub transport and install it on the coordinator so
         // raw gossip on the encryption topic is routed to it (mirrors
         // crates/embedded/src/node_p2p.rs::setup_libp2p).
-        let kms_transport =
-            p2p::kms::PubsubKeyTransport::new(p2p::Libp2pTransport::new(handle.clone()))
-                .await
-                .map_err(|e| Error::Server(format!("failed to create KMS transport: {e}")))?;
+        let kms_transport = p2p::kms::PubsubKeyTransport::new(
+            p2p::Libp2pTransport::new(handle.clone()),
+            Arc::new(p2p::HandlePeerIdentityResolver::new(handle.clone())),
+        )
+        .await
+        .map_err(|e| Error::Server(format!("failed to create KMS transport: {e}")))?;
         coordinator.install_kms_transport(kms_transport.clone());
         let local_peer_id = {
             use p2p::transport::P2PTransport;

--- a/crates/db-merge/src/merge_handler/encryption.rs
+++ b/crates/db-merge/src/merge_handler/encryption.rs
@@ -70,11 +70,16 @@ impl<S: Store, B: blockstore::Blockstore> DbMergeHandler<S, B> {
         let Some(collection_id) = metadata.collection_id else {
             return kms::RequestContext::anonymous();
         };
-        let Some(authorizer) = metadata.explicit_replay_authorizer_for(collection_id) else {
+        let Some(authorization) = metadata.explicit_replay_authorization_for(collection_id) else {
             return kms::RequestContext::anonymous();
         };
-        match identity::Did::new(authorizer) {
-            Ok(did) => kms::RequestContext::with_user(did),
+        match identity::Did::new(&authorization.authorizer_did) {
+            Ok(did) => match &authorization.capability {
+                Some(capability) => {
+                    kms::RequestContext::with_explicit_replay(did, capability.clone())
+                }
+                None => kms::RequestContext::with_user(did),
+            },
             Err(_) => kms::RequestContext::anonymous(),
         }
     }

--- a/crates/db-merge/src/merge_handler/tests.rs
+++ b/crates/db-merge/src/merge_handler/tests.rs
@@ -378,6 +378,7 @@ async fn validate_explicit_replay_authorization_checks_collection_and_creator() 
         collection_id: "v1".to_string(),
         authorizer_did: did.clone(),
         expires_at: u64::MAX,
+        capability: None,
     };
 
     handler

--- a/crates/defra-core/src/merge.rs
+++ b/crates/defra-core/src/merge.rs
@@ -16,6 +16,7 @@ pub struct ExplicitReplayAuthorization {
     pub collection_id: String,
     pub authorizer_did: String,
     pub expires_at: u64,
+    pub capability: Option<String>,
 }
 
 /// Owned block data for batch processing.
@@ -286,14 +287,21 @@ impl<'a> BlockMetadata<'a> {
         self.verified_creator.as_deref().or(self.creator)
     }
 
-    pub fn explicit_replay_authorizer_for(&self, collection_id: &str) -> Option<&str> {
+    pub fn explicit_replay_authorization_for(
+        &self,
+        collection_id: &str,
+    ) -> Option<&ExplicitReplayAuthorization> {
         self.explicit_replay_authorization
             .as_ref()
             .filter(|authorization| authorization.collection_id == collection_id)
-            .and_then(|authorization| {
-                (self.effective_creator() == Some(authorization.authorizer_did.as_str()))
-                    .then_some(authorization.authorizer_did.as_str())
+            .filter(|authorization| {
+                self.effective_creator() == Some(authorization.authorizer_did.as_str())
             })
+    }
+
+    pub fn explicit_replay_authorizer_for(&self, collection_id: &str) -> Option<&str> {
+        self.explicit_replay_authorization_for(collection_id)
+            .map(|authorization| authorization.authorizer_did.as_str())
     }
 
     pub fn allows_explicit_replay_for(&self, collection_id: &str) -> bool {
@@ -486,6 +494,7 @@ mod tests {
                 collection_id: "col1".to_string(),
                 authorizer_did: "did:key:OWNER".to_string(),
                 expires_at: 1,
+                capability: None,
             }));
 
         assert_eq!(
@@ -505,6 +514,7 @@ mod tests {
             collection_id: "col1".to_string(),
             authorizer_did: "did:key:OWNER".to_string(),
             expires_at: 1,
+            capability: None,
         }));
 
         assert_eq!(
@@ -523,6 +533,7 @@ mod tests {
                 collection_id: "col1".to_string(),
                 authorizer_did: "did:key:OWNER".to_string(),
                 expires_at: 1,
+                capability: None,
             }));
 
         assert_eq!(meta.explicit_replay_authorizer_for("col1"), None);

--- a/crates/embedded/src/node.rs
+++ b/crates/embedded/src/node.rs
@@ -590,8 +590,8 @@ where
         let policy = Arc::new(kms::NacDacPolicy::new(document_acp.clone(), doc_lookup));
         policy.set_node_acp(Arc::new(db::DbNodeAcpRead::new(nac_manager.clone())));
 
-        // Node identity for the wire `identity` fallback on gossip-initiated
-        // fetches. Anonymous nodes use a stable placeholder DID.
+        // Node identity used for cross-peer DEK requests. Anonymous nodes use
+        // a stable placeholder DID.
         let node_did = database.node_did().unwrap_or_else(|| {
             identity::Did::new("did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK")
                 .expect("static anonymous DID parses")

--- a/crates/embedded/src/node_p2p.rs
+++ b/crates/embedded/src/node_p2p.rs
@@ -185,9 +185,12 @@ where
         use p2p::transport::P2PTransport;
         kms_libp2p_transport.local_peer_id().to_string()
     };
-    let kms_transport = p2p::kms::PubsubKeyTransport::new(kms_libp2p_transport)
-        .await
-        .map_err(|e| anyhow!("failed to create KMS transport: {e}"))?;
+    let kms_transport = p2p::kms::PubsubKeyTransport::new(
+        kms_libp2p_transport,
+        Arc::new(p2p::HandlePeerIdentityResolver::new(handle.clone())),
+    )
+    .await
+    .map_err(|e| anyhow!("failed to create KMS transport: {e}"))?;
     coordinator.install_kms_transport(kms_transport.clone());
     let merge_handler_inner_for_kms = replication.merge_handler_inner.clone();
 
@@ -478,9 +481,10 @@ where
         use p2p::transport::P2PTransport;
         transport.local_peer_id().to_string()
     };
-    let kms_transport = p2p::kms::PubsubKeyTransport::new(transport.clone())
-        .await
-        .map_err(|e| anyhow!("failed to create KMS transport: {e}"))?;
+    let kms_transport =
+        p2p::kms::PubsubKeyTransport::new(transport.clone(), Arc::new(p2p::AnonymousResolver))
+            .await
+            .map_err(|e| anyhow!("failed to create KMS transport: {e}"))?;
     coordinator.install_kms_transport(kms_transport.clone());
     let merge_handler_inner_for_kms = replication.merge_handler_inner.clone();
 

--- a/crates/kms/src/context.rs
+++ b/crates/kms/src/context.rs
@@ -11,6 +11,7 @@ use identity::Did;
 #[derive(Debug, Clone, Default)]
 pub struct RequestContext {
     user_identity: Option<Did>,
+    explicit_replay_capability: Option<String>,
 }
 
 impl RequestContext {
@@ -24,12 +25,25 @@ impl RequestContext {
     pub fn with_user(did: Did) -> Self {
         Self {
             user_identity: Some(did),
+            explicit_replay_capability: None,
+        }
+    }
+
+    /// Construct a request authorized by a verified explicit-replay capability.
+    pub fn with_explicit_replay(did: Did, capability: String) -> Self {
+        Self {
+            user_identity: Some(did),
+            explicit_replay_capability: Some(capability),
         }
     }
 
     /// Return the verified user DID, if one is attached. `None` ⇒ anonymous.
     pub fn user_identity(&self) -> Option<&Did> {
         self.user_identity.as_ref()
+    }
+
+    pub fn explicit_replay_capability(&self) -> Option<&str> {
+        self.explicit_replay_capability.as_deref()
     }
 }
 
@@ -47,5 +61,14 @@ mod tests {
         let did: identity::Did = "did:key:zalice".parse().unwrap();
         let ctx = RequestContext::with_user(did.clone());
         assert_eq!(ctx.user_identity(), Some(&did));
+        assert!(ctx.explicit_replay_capability().is_none());
+    }
+
+    #[test]
+    fn explicit_replay_carries_did_and_capability() {
+        let did: identity::Did = "did:key:zalice".parse().unwrap();
+        let ctx = RequestContext::with_explicit_replay(did.clone(), "signed-proof".into());
+        assert_eq!(ctx.user_identity(), Some(&did));
+        assert_eq!(ctx.explicit_replay_capability(), Some("signed-proof"));
     }
 }

--- a/crates/kms/src/context.rs
+++ b/crates/kms/src/context.rs
@@ -15,7 +15,7 @@ pub struct RequestContext {
 
 impl RequestContext {
     /// Construct an anonymous request context (no user identity attached).
-    /// The KMS will fall back to node identity at the wire boundary.
+    /// Cross-peer requests are always made as the node identity.
     pub fn anonymous() -> Self {
         Self::default()
     }

--- a/crates/kms/src/defra_kms.rs
+++ b/crates/kms/src/defra_kms.rs
@@ -41,8 +41,7 @@ pub struct DefraKms {
     transports: Vec<Arc<dyn KeyTransport>>,
     policy: Arc<dyn AccessPolicy>,
     doc_resolver: Arc<dyn BlockDocIDResolver>,
-    /// Fallback identity used when `RequestContext::user_identity` is None
-    /// (gossip-triggered syncs with no caller).
+    /// Node identity sent on cross-peer requests and authenticated by peers.
     node_identity: Did,
     /// This node's transport-level peer id, bound into the ECIES AAD of
     /// served replies (Go's `makeAssociatedData`). Empty until the node
@@ -70,10 +69,6 @@ impl DefraKms {
             local_peer_id: RwLock::new(String::new()),
             test_ephemeral: RwLock::new(None),
         }
-    }
-
-    fn principal<'a>(&'a self, ctx: &'a RequestContext) -> &'a Did {
-        ctx.user_identity().unwrap_or(&self.node_identity)
     }
 
     fn local_peer_id(&self) -> String {
@@ -242,10 +237,10 @@ impl KmsService for DefraKms {
                     let _ = tx.send(Err(Error::KeyUnavailable)).await;
                 }
             } else {
-                // Wire path: fall back to node identity for gossip-triggered
-                // syncs where ctx has no user identity (mirrors Go's
-                // behavior in internal/kms/pubsub.go per PR #4778).
-                let wire_actor = self.principal(ctx).clone();
+                // Cross-peer DEK access is authorized as the requesting node.
+                // Go responders still consume this legacy wire field, while
+                // Rust responders bind it to the authenticated transport peer.
+                let wire_actor = self.node_identity.clone();
                 let eph = self.ephemeral();
                 let pub_bytes = x25519_dalek::PublicKey::from(&eph).as_bytes().to_vec();
                 let req = FetchEncryptionKeyRequest {
@@ -440,18 +435,25 @@ impl KmsService for DefraKms {
 
     async fn serve_request(
         &self,
-        _from: PeerIdentity,
+        from: PeerIdentity,
         req: FetchEncryptionKeyRequest,
     ) -> Result<FetchEncryptionKeyReply> {
-        let actor: Option<Did> = std::str::from_utf8(&req.identity)
+        let claimed_actor: Option<Did> = std::str::from_utf8(&req.identity)
             .ok()
             .and_then(|s| s.parse().ok());
-        if actor.is_none() && !req.identity.is_empty() {
+        if claimed_actor.is_none() && !req.identity.is_empty() {
             tracing::warn!(
                 identity_bytes_len = req.identity.len(),
-                "KMS request identity field is non-empty but failed DID parse; treating as anonymous"
+                "KMS request identity field is non-empty but failed DID parse"
             );
         }
+        if claimed_actor.as_ref() != from.authenticated_did.as_ref() {
+            tracing::warn!(
+                peer_id = %from.peer_id,
+                "KMS request identity does not match authenticated peer identity"
+            );
+        }
+        let actor = from.authenticated_did;
 
         let mut out_links: Vec<Vec<u8>> = Vec::new();
         let mut out_blocks: Vec<Vec<u8>> = Vec::new();

--- a/crates/kms/src/defra_kms.rs
+++ b/crates/kms/src/defra_kms.rs
@@ -127,6 +127,7 @@ impl DefraKms {
         &self,
         actor: Option<&Did>,
         cid: &EncryptionCid,
+        delegated_actor: Option<(&Did, &str)>,
     ) -> Result<LocalRelease> {
         let doc_ids = self.doc_resolver.doc_ids_for_block(cid).await?;
         if doc_ids.is_empty() {
@@ -143,6 +144,16 @@ impl DefraKms {
             ) {
                 return Ok(LocalRelease::Allow);
             }
+            if let Some((delegate, collection_id)) = delegated_actor {
+                if matches!(
+                    self.policy
+                        .check_delegated_release(delegate, &scope, collection_id)
+                        .await?,
+                    PolicyDecision::Allow
+                ) {
+                    return Ok(LocalRelease::Allow);
+                }
+            }
         }
         Ok(LocalRelease::Deny)
     }
@@ -150,9 +161,15 @@ impl DefraKms {
     /// Serve-side release decision: the owner node has recorded ownership,
     /// so unknown ownership is treated as a denial (never leak a key we
     /// cannot attribute).
-    async fn may_serve(&self, actor: Option<&Did>, cid: &EncryptionCid) -> Result<bool> {
+    async fn may_serve(
+        &self,
+        actor: Option<&Did>,
+        cid: &EncryptionCid,
+        delegated_actor: Option<(&Did, &str)>,
+    ) -> Result<bool> {
         Ok(matches!(
-            self.local_release_decision(actor, cid).await?,
+            self.local_release_decision(actor, cid, delegated_actor)
+                .await?,
             LocalRelease::Allow
         ))
     }
@@ -205,7 +222,7 @@ impl KmsService for DefraKms {
                         }
                     };
                     match self
-                        .local_release_decision(user_actor.as_ref(), &cid)
+                        .local_release_decision(user_actor.as_ref(), &cid, None)
                         .await?
                     {
                         LocalRelease::Allow => {
@@ -247,6 +264,7 @@ impl KmsService for DefraKms {
                     identity: wire_actor.to_string().into_bytes(),
                     links: remote.iter().map(|c| c.to_bytes()).collect(),
                     ephemeral_public_key: pub_bytes,
+                    explicit_replay_capability: ctx.explicit_replay_capability().map(str::to_owned),
                 };
                 let payload =
                     serde_cbor::to_vec(&req).map_err(|e| Error::WireEncode(e.to_string()))?;
@@ -454,6 +472,16 @@ impl KmsService for DefraKms {
             );
         }
         let actor = from.authenticated_did;
+        let delegated_actor =
+            from.explicit_replay_authorization
+                .as_ref()
+                .and_then(|authorization| {
+                    authorization
+                        .authorizer_did
+                        .parse::<Did>()
+                        .ok()
+                        .map(|did| (did, authorization.collection_id.as_str()))
+                });
 
         let mut out_links: Vec<Vec<u8>> = Vec::new();
         let mut out_blocks: Vec<Vec<u8>> = Vec::new();
@@ -472,7 +500,16 @@ impl KmsService for DefraKms {
             let Some(stored) = self.store.get(&cid).await? else {
                 continue;
             };
-            if self.may_serve(actor.as_ref(), &cid).await? {
+            if self
+                .may_serve(
+                    actor.as_ref(),
+                    &cid,
+                    delegated_actor
+                        .as_ref()
+                        .map(|(did, collection_id)| (did, *collection_id)),
+                )
+                .await?
+            {
                 tracing::debug!(cid = %cid, "KMS serve_request: DEK release GRANTED");
             } else {
                 tracing::warn!(cid = %cid, "KMS serve_request: DEK release DENIED");

--- a/crates/kms/src/defra_kms_tests.rs
+++ b/crates/kms/src/defra_kms_tests.rs
@@ -79,6 +79,45 @@ impl crate::policy::AccessPolicy for AllowActor {
     }
 }
 
+struct AllowDelegatedActor {
+    actor: identity::Did,
+    collection_id: String,
+}
+
+#[async_trait::async_trait]
+impl crate::policy::AccessPolicy for AllowDelegatedActor {
+    async fn check_release(
+        &self,
+        _: Option<&identity::Did>,
+        _: &KeyScope,
+    ) -> crate::Result<crate::PolicyDecision> {
+        Ok(crate::PolicyDecision::Deny)
+    }
+
+    async fn check_delegated_release(
+        &self,
+        actor: &identity::Did,
+        _: &KeyScope,
+        collection_id: &str,
+    ) -> crate::Result<crate::PolicyDecision> {
+        Ok(
+            if actor == &self.actor && collection_id == self.collection_id {
+                crate::PolicyDecision::Allow
+            } else {
+                crate::PolicyDecision::Deny
+            },
+        )
+    }
+
+    async fn check_node_release(
+        &self,
+        _: Option<&identity::Did>,
+        _: &KeyScope,
+    ) -> crate::Result<crate::PolicyDecision> {
+        Ok(crate::PolicyDecision::Deny)
+    }
+}
+
 fn node_did() -> identity::Did {
     "did:key:znode".parse().unwrap()
 }
@@ -178,10 +217,12 @@ async fn serve_request_returns_ecies_wrapped_block_bytes() {
         identity: b"did:key:zalice".to_vec(),
         links: vec![cid.to_bytes()],
         ephemeral_public_key: req_pub.clone(),
+        explicit_replay_capability: None,
     };
     let from = crate::service::PeerIdentity {
         peer_id: "peer-1".into(),
         authenticated_did: Some("did:key:zalice".parse().unwrap()),
+        explicit_replay_authorization: None,
     };
     let reply = kms.serve_request(from, req).await.unwrap();
     assert_eq!(reply.links.len(), 1);
@@ -235,6 +276,7 @@ async fn serve_request_authorizes_authenticated_peer_not_claimed_identity() {
         ephemeral_public_key: x25519_dalek::PublicKey::from(&requester)
             .as_bytes()
             .to_vec(),
+        explicit_replay_capability: None,
     };
 
     let denied = kms
@@ -242,6 +284,7 @@ async fn serve_request_authorizes_authenticated_peer_not_claimed_identity() {
             crate::service::PeerIdentity {
                 peer_id: "attacker-peer".into(),
                 authenticated_did: Some("did:key:zattacker".parse().unwrap()),
+                explicit_replay_authorization: None,
             },
             request.clone(),
         )
@@ -255,6 +298,7 @@ async fn serve_request_authorizes_authenticated_peer_not_claimed_identity() {
             crate::service::PeerIdentity {
                 peer_id: "allowed-peer".into(),
                 authenticated_did: Some(allowed_did),
+                explicit_replay_authorization: None,
             },
             request,
         )
@@ -262,6 +306,73 @@ async fn serve_request_authorizes_authenticated_peer_not_claimed_identity() {
         .unwrap();
     assert_eq!(allowed.links, vec![cid.to_bytes()]);
     assert_eq!(allowed.blocks.len(), 1);
+}
+
+#[tokio::test]
+async fn serve_request_accepts_collection_bound_replay_delegation() {
+    let store: Arc<dyn crate::KeyStore> = Arc::new(MemoryKeyStore::new());
+    let generator = DefraKms::new(
+        store.clone(),
+        vec![],
+        Arc::new(AllowAll),
+        any_doc_resolver(),
+        node_did(),
+    );
+    let (cid, _) = generator
+        .generate_key(
+            &RequestContext::anonymous(),
+            KeyScope::Document {
+                doc_id: "d1".into(),
+                field: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let authorizer: identity::Did = "did:key:zauthorizer".parse().unwrap();
+    let kms = DefraKms::new(
+        store,
+        vec![],
+        Arc::new(AllowDelegatedActor {
+            actor: authorizer.clone(),
+            collection_id: "collection-a".into(),
+        }),
+        any_doc_resolver(),
+        node_did(),
+    );
+    let requester = crypto::generate_x25519().unwrap();
+    let request = crate::wire::FetchEncryptionKeyRequest {
+        identity: b"did:key:zrequester-node".to_vec(),
+        links: vec![cid.to_bytes()],
+        ephemeral_public_key: x25519_dalek::PublicKey::from(&requester)
+            .as_bytes()
+            .to_vec(),
+        explicit_replay_capability: Some("signed-capability".into()),
+    };
+    let peer = |collection_id: &str| crate::service::PeerIdentity {
+        peer_id: "target-peer".into(),
+        authenticated_did: Some("did:key:zrequester-node".parse().unwrap()),
+        explicit_replay_authorization: Some(defra_core::merge::ExplicitReplayAuthorization {
+            source_peer_id: "source-peer".into(),
+            target_peer_id: "target-peer".into(),
+            collection_id: collection_id.into(),
+            authorizer_did: authorizer.to_string(),
+            expires_at: u64::MAX,
+            capability: Some("signed-capability".into()),
+        }),
+    };
+
+    let denied = kms
+        .serve_request(peer("collection-b"), request.clone())
+        .await
+        .unwrap();
+    assert!(denied.links.is_empty());
+
+    let allowed = kms
+        .serve_request(peer("collection-a"), request)
+        .await
+        .unwrap();
+    assert_eq!(allowed.links, vec![cid.to_bytes()]);
 }
 
 #[tokio::test]
@@ -280,10 +391,12 @@ async fn serve_request_skips_unknown_cids() {
         ephemeral_public_key: x25519_dalek::PublicKey::from(&requester)
             .as_bytes()
             .to_vec(),
+        explicit_replay_capability: None,
     };
     let from = crate::service::PeerIdentity {
         peer_id: "peer-1".into(),
         authenticated_did: Some("did:key:zalice".parse().unwrap()),
+        explicit_replay_authorization: None,
     };
     let reply = kms.serve_request(from, req).await.unwrap();
     assert!(reply.links.is_empty());
@@ -398,12 +511,14 @@ async fn get_keys_fans_out_when_local_miss() {
         ephemeral_public_key: x25519_dalek::PublicKey::from(&requester)
             .as_bytes()
             .to_vec(),
+        explicit_replay_capability: None,
     };
     let reply = peer_kms
         .serve_request(
             crate::service::PeerIdentity {
                 peer_id: "peer".into(),
                 authenticated_did: Some("did:key:znode".parse().unwrap()),
+                explicit_replay_authorization: None,
             },
             req,
         )
@@ -463,12 +578,14 @@ async fn get_keys_ignores_failed_transport_when_another_resolves_key() {
         ephemeral_public_key: x25519_dalek::PublicKey::from(&requester)
             .as_bytes()
             .to_vec(),
+        explicit_replay_capability: None,
     };
     let reply = peer_kms
         .serve_request(
             crate::service::PeerIdentity {
                 peer_id: "peer".into(),
                 authenticated_did: Some("did:key:znode".parse().unwrap()),
+                explicit_replay_authorization: None,
             },
             req,
         )

--- a/crates/kms/src/defra_kms_tests.rs
+++ b/crates/kms/src/defra_kms_tests.rs
@@ -55,6 +55,30 @@ impl crate::policy::AccessPolicy for DenyAll {
     }
 }
 
+struct AllowActor(identity::Did);
+#[async_trait::async_trait]
+impl crate::policy::AccessPolicy for AllowActor {
+    async fn check_release(
+        &self,
+        actor: Option<&identity::Did>,
+        _: &KeyScope,
+    ) -> crate::Result<crate::PolicyDecision> {
+        Ok(if actor == Some(&self.0) {
+            crate::PolicyDecision::Allow
+        } else {
+            crate::PolicyDecision::Deny
+        })
+    }
+
+    async fn check_node_release(
+        &self,
+        actor: Option<&identity::Did>,
+        scope: &KeyScope,
+    ) -> crate::Result<crate::PolicyDecision> {
+        self.check_release(actor, scope).await
+    }
+}
+
 fn node_did() -> identity::Did {
     "did:key:znode".parse().unwrap()
 }
@@ -157,6 +181,7 @@ async fn serve_request_returns_ecies_wrapped_block_bytes() {
     };
     let from = crate::service::PeerIdentity {
         peer_id: "peer-1".into(),
+        authenticated_did: Some("did:key:zalice".parse().unwrap()),
     };
     let reply = kms.serve_request(from, req).await.unwrap();
     assert_eq!(reply.links.len(), 1);
@@ -172,6 +197,71 @@ async fn serve_request_returns_ecies_wrapped_block_bytes() {
     let block = defra_core::Encryption::from_dag_cbor(&unwrapped).unwrap();
 
     assert_eq!(block.key.len(), 32);
+}
+
+#[tokio::test]
+async fn serve_request_authorizes_authenticated_peer_not_claimed_identity() {
+    let store: Arc<dyn crate::KeyStore> = Arc::new(MemoryKeyStore::new());
+    let generator = DefraKms::new(
+        store.clone(),
+        vec![],
+        Arc::new(AllowAll),
+        any_doc_resolver(),
+        node_did(),
+    );
+    let (cid, _) = generator
+        .generate_key(
+            &RequestContext::anonymous(),
+            KeyScope::Document {
+                doc_id: "d1".into(),
+                field: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let allowed_did: identity::Did = "did:key:zallowed".parse().unwrap();
+    let kms = DefraKms::new(
+        store,
+        vec![],
+        Arc::new(AllowActor(allowed_did.clone())),
+        any_doc_resolver(),
+        node_did(),
+    );
+    let requester = crypto::generate_x25519().unwrap();
+    let request = crate::wire::FetchEncryptionKeyRequest {
+        identity: allowed_did.to_string().into_bytes(),
+        links: vec![cid.to_bytes()],
+        ephemeral_public_key: x25519_dalek::PublicKey::from(&requester)
+            .as_bytes()
+            .to_vec(),
+    };
+
+    let denied = kms
+        .serve_request(
+            crate::service::PeerIdentity {
+                peer_id: "attacker-peer".into(),
+                authenticated_did: Some("did:key:zattacker".parse().unwrap()),
+            },
+            request.clone(),
+        )
+        .await
+        .unwrap();
+    assert!(denied.links.is_empty());
+    assert!(denied.blocks.is_empty());
+
+    let allowed = kms
+        .serve_request(
+            crate::service::PeerIdentity {
+                peer_id: "allowed-peer".into(),
+                authenticated_did: Some(allowed_did),
+            },
+            request,
+        )
+        .await
+        .unwrap();
+    assert_eq!(allowed.links, vec![cid.to_bytes()]);
+    assert_eq!(allowed.blocks.len(), 1);
 }
 
 #[tokio::test]
@@ -193,6 +283,7 @@ async fn serve_request_skips_unknown_cids() {
     };
     let from = crate::service::PeerIdentity {
         peer_id: "peer-1".into(),
+        authenticated_did: Some("did:key:zalice".parse().unwrap()),
     };
     let reply = kms.serve_request(from, req).await.unwrap();
     assert!(reply.links.is_empty());
@@ -216,6 +307,63 @@ impl KeyTransport for FakeTransport {
         Ok(rx)
     }
     fn install_handler(&self, _: Arc<dyn IncomingHandler>) {}
+}
+
+struct RecordingTransport {
+    payload: tokio::sync::Mutex<Option<Vec<u8>>>,
+}
+
+#[async_trait::async_trait]
+impl KeyTransport for RecordingTransport {
+    fn name(&self) -> &'static str {
+        "recording"
+    }
+
+    async fn send_request(
+        &self,
+        request: EncodedFetchRequest,
+    ) -> crate::Result<TransportReplyStream> {
+        *self.payload.lock().await = Some(request.payload);
+        let (_tx, rx) = tokio::sync::mpsc::channel(1);
+        Ok(rx)
+    }
+
+    fn install_handler(&self, _: Arc<dyn IncomingHandler>) {}
+}
+
+#[tokio::test]
+async fn get_keys_identifies_the_requesting_node_on_the_wire() {
+    let transport = Arc::new(RecordingTransport {
+        payload: tokio::sync::Mutex::new(None),
+    });
+    let node = node_did();
+    let kms = DefraKms::new(
+        Arc::new(MemoryKeyStore::new()),
+        vec![transport.clone()],
+        Arc::new(AllowAll),
+        any_doc_resolver(),
+        node.clone(),
+    );
+    let cid: crate::EncryptionCid = "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi"
+        .parse()
+        .unwrap();
+    let user: identity::Did = "did:key:zuser".parse().unwrap();
+
+    let results = kms
+        .get_keys(&RequestContext::with_user(user.clone()), &[cid])
+        .await
+        .unwrap();
+    drop(results);
+
+    let payload = transport
+        .payload
+        .lock()
+        .await
+        .clone()
+        .expect("transport must receive a request");
+    let request: crate::FetchEncryptionKeyRequest = serde_cbor::from_slice(&payload).unwrap();
+    assert_eq!(request.identity, node.to_string().into_bytes());
+    assert_ne!(request.identity, user.to_string().into_bytes());
 }
 
 #[tokio::test]
@@ -255,6 +403,7 @@ async fn get_keys_fans_out_when_local_miss() {
         .serve_request(
             crate::service::PeerIdentity {
                 peer_id: "peer".into(),
+                authenticated_did: Some("did:key:znode".parse().unwrap()),
             },
             req,
         )
@@ -319,6 +468,7 @@ async fn get_keys_ignores_failed_transport_when_another_resolves_key() {
         .serve_request(
             crate::service::PeerIdentity {
                 peer_id: "peer".into(),
+                authenticated_did: Some("did:key:znode".parse().unwrap()),
             },
             req,
         )

--- a/crates/kms/src/nac_dac_policy.rs
+++ b/crates/kms/src/nac_dac_policy.rs
@@ -52,6 +52,46 @@ impl NacDacPolicy {
     pub fn set_node_acp(&self, nac: Arc<dyn NodeAcpRead>) {
         let _ = self.node_acp.set(nac);
     }
+
+    async fn check_document_release(
+        &self,
+        actor: Option<&Did>,
+        doc_id: &str,
+        required_collection_id: Option<&str>,
+    ) -> Result<PolicyDecision> {
+        let Some(info) = self.doc_lookup.collection_for_doc(doc_id).await? else {
+            return Ok(if required_collection_id.is_some() {
+                PolicyDecision::Deny
+            } else {
+                PolicyDecision::Allow
+            });
+        };
+        if required_collection_id.is_some_and(|id| id != info.collection_id) {
+            return Ok(PolicyDecision::Deny);
+        }
+
+        let actor_id: acp::Identity = actor.into();
+        let checker = acp::read_access::DirectChecker {
+            acp: self.doc_acp.as_ref(),
+            identity: &actor_id,
+            node_did: None,
+        };
+        let allowed = acp::read_access::check_doc_read_access(
+            &checker,
+            &info.policy_id,
+            &info.resource_name,
+            &info.collection_id,
+            info.is_branchable,
+            doc_id,
+        )
+        .await
+        .map_err(classify_acp_error)?;
+        Ok(if allowed {
+            PolicyDecision::Allow
+        } else {
+            PolicyDecision::Deny
+        })
+    }
 }
 
 /// Map an `acp::Error` to either `AccessDenied` (the backend actively
@@ -85,33 +125,24 @@ impl AccessPolicy for NacDacPolicy {
                 // no per-document access gate, so the DEK is freely releasable —
                 // matching the legacy decrypt path, which reads the key from the
                 // Encryption block with no policy check at all.
-                let Some(info) = self.doc_lookup.collection_for_doc(doc_id).await? else {
-                    return Ok(PolicyDecision::Allow);
-                };
-
-                let actor_id: acp::Identity = actor.into();
-                let checker = acp::read_access::DirectChecker {
-                    acp: self.doc_acp.as_ref(),
-                    identity: &actor_id,
-                    node_did: None,
-                };
-                let allowed = acp::read_access::check_doc_read_access(
-                    &checker,
-                    &info.policy_id,
-                    &info.resource_name,
-                    &info.collection_id,
-                    info.is_branchable,
-                    doc_id,
-                )
-                .await
-                .map_err(classify_acp_error)?;
-                Ok(if allowed {
-                    PolicyDecision::Allow
-                } else {
-                    PolicyDecision::Deny
-                })
+                self.check_document_release(actor, doc_id, None).await
             }
             KeyScope::Collection { .. } => self.check_node_release(actor, scope).await,
+        }
+    }
+
+    async fn check_delegated_release(
+        &self,
+        actor: &Did,
+        scope: &KeyScope,
+        collection_id: &str,
+    ) -> Result<PolicyDecision> {
+        match scope {
+            KeyScope::Document { doc_id, .. } => {
+                self.check_document_release(Some(actor), doc_id, Some(collection_id))
+                    .await
+            }
+            KeyScope::Collection { .. } => Ok(PolicyDecision::Deny),
         }
     }
 

--- a/crates/kms/src/nac_dac_policy.rs
+++ b/crates/kms/src/nac_dac_policy.rs
@@ -4,8 +4,7 @@
 //!   - Collection lookup runs internally (node-level; no actor check at
 //!     this step, mirroring how the serving peer resolves which policy
 //!     to apply).
-//!   - DAC permission check runs as the **actor** (the caller from the
-//!     wire `identity` field).
+//!   - DAC permission check runs as the transport-authenticated peer DID.
 //!
 //! Collection-scoped DEK release:
 //!   - NAC `read-document` check on the actor.
@@ -25,7 +24,7 @@ use crate::types::{KeyScope, PolicyDecision};
 
 /// Default `AccessPolicy` impl for `DefraKms`. Combines DAC for
 /// document-scoped keys with NAC for collection-scoped keys, both gated
-/// on the actor (the caller DID from the wire request).
+/// on the transport-authenticated peer DID.
 pub struct NacDacPolicy {
     doc_acp: Arc<dyn acp::DocumentACP>,
     doc_lookup: Arc<dyn DocCollectionLookup>,

--- a/crates/kms/src/nac_dac_policy_tests.rs
+++ b/crates/kms/src/nac_dac_policy_tests.rs
@@ -174,6 +174,31 @@ async fn doc_scope_allow_when_user_has_dac_grant() {
 }
 
 #[tokio::test]
+async fn delegated_release_is_bound_to_the_document_collection() {
+    let policy = NacDacPolicy::new(Arc::new(FakeDac { allow: true }), Arc::new(FakeLookup));
+    let scope = KeyScope::Document {
+        doc_id: "d1".into(),
+        field: None,
+    };
+    let actor = did("did:key:zalice");
+
+    assert_eq!(
+        policy
+            .check_delegated_release(&actor, &scope, "col-1")
+            .await
+            .unwrap(),
+        PolicyDecision::Allow
+    );
+    assert_eq!(
+        policy
+            .check_delegated_release(&actor, &scope, "other-collection")
+            .await
+            .unwrap(),
+        PolicyDecision::Deny
+    );
+}
+
+#[tokio::test]
 async fn doc_scope_deny_when_user_lacks_grant() {
     let policy = NacDacPolicy::new(Arc::new(FakeDac { allow: false }), Arc::new(FakeLookup));
     policy.set_node_acp(Arc::new(FakeNac { allow: true }));

--- a/crates/kms/src/policy.rs
+++ b/crates/kms/src/policy.rs
@@ -20,6 +20,18 @@ pub trait AccessPolicy: MaybeSendSync {
     /// `Deny` to refuse.
     async fn check_release(&self, actor: Option<&Did>, scope: &KeyScope) -> Result<PolicyDecision>;
 
+    /// Check a delegated document release and require the document to belong
+    /// to the collection named by the delegation. Implementations that cannot
+    /// prove the binding deny by default.
+    async fn check_delegated_release(
+        &self,
+        _actor: &Did,
+        _scope: &KeyScope,
+        _collection_id: &str,
+    ) -> Result<PolicyDecision> {
+        Ok(PolicyDecision::Deny)
+    }
+
     /// Node-level authorization check for collection-scoped keys.
     /// Called when the scope is `KeyScope::Collection`.
     async fn check_node_release(

--- a/crates/kms/src/service.rs
+++ b/crates/kms/src/service.rs
@@ -9,13 +9,14 @@ use crate::results::KeyResults;
 use crate::types::{EncryptionCid, KeyScope};
 use crate::wire::{FetchEncryptionKeyReply, FetchEncryptionKeyRequest};
 
-/// Identity of an incoming peer at the transport boundary. Used by
-/// `KmsService::serve_request` for tracing and audit (NOT for authorization —
-/// the wire `identity` field on the request carries the authorization principal).
+/// Identity of an incoming peer established at the transport boundary.
 #[derive(Debug, Clone)]
 pub struct PeerIdentity {
     /// Transport-level peer id (libp2p `PeerId` stringified, or iroh node id).
     pub peer_id: String,
+    /// DID authenticated by the transport's peer-identity protocol. `None`
+    /// means the transport could not establish an authorization principal.
+    pub authenticated_did: Option<identity::Did>,
 }
 
 /// Top-level KMS surface. One concrete implementation (`DefraKms`) lives

--- a/crates/kms/src/service.rs
+++ b/crates/kms/src/service.rs
@@ -17,6 +17,8 @@ pub struct PeerIdentity {
     /// DID authenticated by the transport's peer-identity protocol. `None`
     /// means the transport could not establish an authorization principal.
     pub authenticated_did: Option<identity::Did>,
+    /// Replay delegation verified by the transport against this peer.
+    pub explicit_replay_authorization: Option<defra_core::merge::ExplicitReplayAuthorization>,
 }
 
 /// Top-level KMS surface. One concrete implementation (`DefraKms`) lives

--- a/crates/kms/src/transport.rs
+++ b/crates/kms/src/transport.rs
@@ -16,7 +16,8 @@ use crate::wire::{FetchEncryptionKeyReply, FetchEncryptionKeyRequest};
 
 /// A CBOR-encoded `FetchEncryptionKeyRequest` ready to publish on a
 /// `KeyTransport`. KMS wire is bare CBOR (matching Go's
-/// `internal/kms/pubsub.go`) — there is no signature envelope here.
+/// `internal/kms/pubsub.go`); peer identity is authenticated separately by
+/// the transport.
 ///
 /// `request_id` is local-only for tracing/correlation; NOT on the wire.
 #[derive(Debug, Clone)]

--- a/crates/kms/src/wire.rs
+++ b/crates/kms/src/wire.rs
@@ -8,6 +8,8 @@
 //! bare CBOR on gossipsub topic "encryption" and matches replies by
 //! cryptographic compatibility (the requester's ephemeral pubkey is
 //! wrapped into each ECIES reply block).
+//! Rust may add an optional signed replay capability; older Go and Rust
+//! decoders ignore that unknown map field.
 
 use serde::{Deserialize, Serialize};
 
@@ -72,6 +74,14 @@ pub struct FetchEncryptionKeyRequest {
     /// responder to ECIES-wrap each reply block.
     #[serde(rename = "EphemeralPublicKey", with = "serde_bytes")]
     pub ephemeral_public_key: Vec<u8>,
+
+    /// Signed explicit-replay capability used only for owner-authorized replay.
+    #[serde(
+        rename = "ExplicitReplayCapability",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub explicit_replay_capability: Option<String>,
 }
 
 /// KMS fetch reply.
@@ -104,6 +114,7 @@ mod tests {
             identity: vec![0xaa; 32],
             links: vec![vec![0x01; 36], vec![0x02; 36]],
             ephemeral_public_key: vec![0xee; 32],
+            explicit_replay_capability: Some("signed-proof".into()),
         };
         let bytes = serde_cbor::to_vec(&req).unwrap();
         let parsed: FetchEncryptionKeyRequest = serde_cbor::from_slice(&bytes).unwrap();
@@ -128,6 +139,7 @@ mod tests {
             identity: vec![1],
             links: vec![vec![2]],
             ephemeral_public_key: vec![3],
+            explicit_replay_capability: None,
         };
         let bytes = serde_cbor::to_vec(&req).unwrap();
         let val: serde_cbor::Value = serde_cbor::from_slice(&bytes).unwrap();
@@ -145,6 +157,7 @@ mod tests {
         assert!(keys.contains(&"Identity".to_string()));
         assert!(keys.contains(&"Links".to_string()));
         assert!(keys.contains(&"EphemeralPublicKey".to_string()));
+        assert!(!keys.contains(&"ExplicitReplayCapability".to_string()));
     }
 
     #[test]
@@ -155,6 +168,7 @@ mod tests {
             identity: vec![],
             links: vec![vec![0x01, 0x02]],
             ephemeral_public_key: vec![],
+            explicit_replay_capability: None,
         };
         let bytes = serde_cbor::to_vec(&req).unwrap();
         // Find the Links field's value in the encoded bytes. We just check that

--- a/crates/kms/src/wire.rs
+++ b/crates/kms/src/wire.rs
@@ -59,8 +59,8 @@ mod vec_of_bytes {
 /// KMS fetch request published on the `"encryption"` gossipsub topic.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FetchEncryptionKeyRequest {
-    /// DID of the requesting principal (user identity if attached to the
-    /// request context, else node identity). NOT the requesting peer's libp2p key.
+    /// DID of the requesting node. Retained for Go wire compatibility; Rust
+    /// responders authorize against the transport-authenticated peer DID.
     #[serde(rename = "Identity", with = "serde_bytes")]
     pub identity: Vec<u8>,
 

--- a/crates/p2p/src/explicit_replay.rs
+++ b/crates/p2p/src/explicit_replay.rs
@@ -118,12 +118,7 @@ fn decode_envelope(capability: &str) -> Result<ExplicitReplayCapabilityEnvelope>
         .map_err(|error| Error::ExplicitReplayCapability(format!("invalid payload: {error}")))
 }
 
-fn validate_claims(
-    claims: &ExplicitReplayCapabilityClaims,
-    transport_sender_peer_id: &str,
-    target_peer_id: &str,
-    collection_id: &str,
-) -> Result<()> {
+fn validate_common_claims(claims: &ExplicitReplayCapabilityClaims) -> Result<()> {
     if claims.version != CAPABILITY_VERSION {
         return Err(Error::ExplicitReplayCapability(format!(
             "unsupported version {}",
@@ -138,25 +133,10 @@ fn validate_claims(
         )));
     }
 
-    if claims.source_peer_id != transport_sender_peer_id {
-        return Err(Error::ExplicitReplayCapability(format!(
-            "source {} did not match transport sender {}",
-            claims.source_peer_id, transport_sender_peer_id
-        )));
-    }
-
-    if claims.target_peer_id != target_peer_id {
-        return Err(Error::ExplicitReplayCapability(format!(
-            "target {} did not match local peer {}",
-            claims.target_peer_id, target_peer_id
-        )));
-    }
-
-    if claims.collection_id != collection_id {
-        return Err(Error::ExplicitReplayCapability(format!(
-            "collection {} did not match request collection {}",
-            claims.collection_id, collection_id
-        )));
+    if claims.collection_id.is_empty() {
+        return Err(Error::ExplicitReplayCapability(
+            "collection was empty".to_string(),
+        ));
     }
 
     if claims.authorizer_did.is_empty() {
@@ -178,6 +158,46 @@ fn validate_claims(
             "expires_at {} exceeds max ttl of {} seconds",
             claims.expires_at,
             MAX_CAPABILITY_TTL.as_secs()
+        )));
+    }
+
+    Ok(())
+}
+
+fn validate_peer_binding(
+    claims: &ExplicitReplayCapabilityClaims,
+    source_peer_id: &str,
+    target_peer_id: &str,
+) -> Result<()> {
+    if claims.source_peer_id != source_peer_id {
+        return Err(Error::ExplicitReplayCapability(format!(
+            "source {} did not match expected peer {}",
+            claims.source_peer_id, source_peer_id
+        )));
+    }
+
+    if claims.target_peer_id != target_peer_id {
+        return Err(Error::ExplicitReplayCapability(format!(
+            "target {} did not match expected peer {}",
+            claims.target_peer_id, target_peer_id
+        )));
+    }
+
+    Ok(())
+}
+
+fn validate_claims(
+    claims: &ExplicitReplayCapabilityClaims,
+    transport_sender_peer_id: &str,
+    target_peer_id: &str,
+    collection_id: &str,
+) -> Result<()> {
+    validate_common_claims(claims)?;
+    validate_peer_binding(claims, transport_sender_peer_id, target_peer_id)?;
+    if claims.collection_id != collection_id {
+        return Err(Error::ExplicitReplayCapability(format!(
+            "collection {} did not match request collection {}",
+            claims.collection_id, collection_id
         )));
     }
 
@@ -273,6 +293,34 @@ pub fn verify_capability_with_revocations(
         collection_id,
     )?;
 
+    verify_envelope(&envelope, revocations)?;
+
+    Ok(authorization_from_envelope(envelope, capability))
+}
+
+/// Verify a capability presented by its target peer when requesting replay keys
+/// from the source peer that originally sent the encrypted blocks.
+pub fn verify_capability_for_key_request(
+    capability: &str,
+    source_peer_id: &str,
+    transport_requester_peer_id: &str,
+) -> Result<ExplicitReplayAuthorization> {
+    let envelope = decode_envelope(capability)?;
+    validate_common_claims(&envelope.claims)?;
+    validate_peer_binding(
+        &envelope.claims,
+        source_peer_id,
+        transport_requester_peer_id,
+    )?;
+    verify_envelope(&envelope, &PROCESS_REVOCATIONS)?;
+
+    Ok(authorization_from_envelope(envelope, capability))
+}
+
+fn verify_envelope(
+    envelope: &ExplicitReplayCapabilityEnvelope,
+    revocations: &ExplicitReplayRevocationRegistry,
+) -> Result<()> {
     let public_key = decode_authorizer_public_key(&envelope.claims.authorizer_did)?;
     let claims_bytes = encode_claims(&envelope.claims)?;
     if !public_key
@@ -286,19 +334,27 @@ pub fn verify_capability_with_revocations(
         ));
     }
 
-    if revocations.is_envelope_revoked(&envelope)? {
+    if revocations.is_envelope_revoked(envelope)? {
         return Err(Error::ExplicitReplayCapability(
             "capability has been revoked".to_string(),
         ));
     }
 
-    Ok(ExplicitReplayAuthorization {
+    Ok(())
+}
+
+fn authorization_from_envelope(
+    envelope: ExplicitReplayCapabilityEnvelope,
+    capability: &str,
+) -> ExplicitReplayAuthorization {
+    ExplicitReplayAuthorization {
         source_peer_id: envelope.claims.source_peer_id,
         target_peer_id: envelope.claims.target_peer_id,
         collection_id: envelope.claims.collection_id,
         authorizer_did: envelope.claims.authorizer_did,
         expires_at: envelope.claims.expires_at,
-    })
+        capability: Some(capability.to_string()),
+    }
 }
 
 pub fn revoke_capability(capability: &str) -> Result<bool> {
@@ -351,6 +407,33 @@ mod tests {
         assert_eq!(
             authorization.authorizer_did,
             authorizer.did().unwrap().to_string()
+        );
+        assert_eq!(
+            authorization.capability.as_deref(),
+            Some(capability.as_str())
+        );
+    }
+
+    #[test]
+    fn verify_capability_for_key_request_reverses_source_and_target() {
+        let authorizer = authorizer();
+        let capability = generate_capability(
+            &authorizer,
+            "source-peer",
+            "target-peer",
+            "collection-a",
+            Duration::from_secs(60),
+        )
+        .unwrap();
+
+        let authorization =
+            verify_capability_for_key_request(&capability, "source-peer", "target-peer").unwrap();
+        assert_eq!(authorization.collection_id, "collection-a");
+        assert!(
+            verify_capability_for_key_request(&capability, "other-source", "target-peer").is_err()
+        );
+        assert!(
+            verify_capability_for_key_request(&capability, "source-peer", "other-target").is_err()
         );
     }
 

--- a/crates/p2p/src/kms/pubsub_transport.rs
+++ b/crates/p2p/src/kms/pubsub_transport.rs
@@ -32,9 +32,10 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 use tracing::{debug, warn};
 
+use crate::peer_identity::PeerIdentityResolver;
 use crate::pubsub_rpc::{response_topic, Correlator, InternalResponse, PublishOptions};
 use crate::topics::{DefraTopic, ENCRYPTION_TOPIC};
-use crate::transport::P2PTransport;
+use crate::transport::{P2PTransport, PeerId};
 
 /// Upper bound on how long `send_request` waits for at least one peer to be
 /// known as an encryption-topic subscriber before publishing. gossipsub
@@ -69,6 +70,7 @@ const REPUBLISH_INTERVAL: Duration = Duration::from_secs(1);
 /// by publishing an envelope on the caller's `_response` sub-topic.
 pub struct PubsubKeyTransport<T: P2PTransport> {
     transport: T,
+    identity_resolver: Arc<dyn PeerIdentityResolver>,
     handler: RwLock<Option<Arc<dyn IncomingHandler>>>,
     correlator: Correlator,
     /// This node's libp2p peer id (gossip source string form).
@@ -81,7 +83,10 @@ pub struct PubsubKeyTransport<T: P2PTransport> {
 impl<T: P2PTransport> PubsubKeyTransport<T> {
     /// Construct, subscribe to ENCRYPTION_TOPIC and the local `_response`
     /// sub-topic, and register both for raw routing.
-    pub async fn new(transport: T) -> KmsResult<Arc<Self>> {
+    pub async fn new(
+        transport: T,
+        identity_resolver: Arc<dyn PeerIdentityResolver>,
+    ) -> KmsResult<Arc<Self>> {
         let local_peer_id = transport.local_peer_id().to_string();
         let self_response_topic = match local_peer_id.parse::<libp2p::PeerId>() {
             Ok(pid) => response_topic(ENCRYPTION_TOPIC, &pid),
@@ -112,6 +117,7 @@ impl<T: P2PTransport> PubsubKeyTransport<T> {
 
         Ok(Arc::new(Self {
             transport,
+            identity_resolver,
             handler: RwLock::new(None),
             correlator: Correlator::new(),
             local_peer_id,
@@ -195,10 +201,15 @@ impl<T: P2PTransport> PubsubKeyTransport<T> {
             }
         };
         let request_id = crate::pubsub_rpc::derive_request_id(&payload);
+        let authenticated_did = self
+            .identity_resolver
+            .resolve(&PeerId::new(from.clone()))
+            .await;
         let (reply_bytes, err) = match handler
             .handle(
                 kms::PeerIdentity {
                     peer_id: from.clone(),
+                    authenticated_did,
                 },
                 req,
             )
@@ -662,7 +673,9 @@ mod tests {
         let transport = RacyTransport::new(3);
         let publish_attempts = transport.publish_attempts.clone();
         let published = transport.published.clone();
-        let kt = PubsubKeyTransport::new(transport).await.unwrap();
+        let kt = PubsubKeyTransport::new(transport, Arc::new(crate::AnonymousResolver))
+            .await
+            .unwrap();
 
         let req = EncodedFetchRequest {
             payload: b"fetch".to_vec(),
@@ -690,7 +703,9 @@ mod tests {
     #[tokio::test]
     async fn response_envelope_routes_to_waiting_request() {
         let transport = RacyTransport::new(1);
-        let kt = PubsubKeyTransport::new(transport).await.unwrap();
+        let kt = PubsubKeyTransport::new(transport, Arc::new(crate::AnonymousResolver))
+            .await
+            .unwrap();
 
         let payload = b"the-request-bytes".to_vec();
         let req = EncodedFetchRequest {
@@ -738,7 +753,9 @@ mod tests {
     #[tokio::test]
     async fn empty_reply_does_not_hide_later_key_reply() {
         let transport = RacyTransport::new(1);
-        let kt = PubsubKeyTransport::new(transport).await.unwrap();
+        let kt = PubsubKeyTransport::new(transport, Arc::new(crate::AnonymousResolver))
+            .await
+            .unwrap();
 
         let payload = b"multi-peer-key-request".to_vec();
         let req = EncodedFetchRequest {
@@ -797,7 +814,9 @@ mod tests {
     #[tokio::test]
     async fn partial_replies_are_collected_until_all_requested_links_arrive() {
         let transport = RacyTransport::new(1);
-        let kt = PubsubKeyTransport::new(transport).await.unwrap();
+        let kt = PubsubKeyTransport::new(transport, Arc::new(crate::AnonymousResolver))
+            .await
+            .unwrap();
 
         let first_link = vec![1, 2, 3];
         let second_link = vec![4, 5, 6];
@@ -862,7 +881,9 @@ mod tests {
     #[tokio::test]
     async fn claimed_complete_reply_does_not_hide_later_verified_candidate() {
         let transport = RacyTransport::new(1);
-        let kt = PubsubKeyTransport::new(transport).await.unwrap();
+        let kt = PubsubKeyTransport::new(transport, Arc::new(crate::AnonymousResolver))
+            .await
+            .unwrap();
 
         let requested_link = vec![1, 2, 3];
         let request = FetchEncryptionKeyRequest {
@@ -923,7 +944,9 @@ mod tests {
     async fn request_republishes_until_reply_arrives() {
         let transport = RacyTransport::new(0);
         let published = transport.published.clone();
-        let kt = PubsubKeyTransport::new(transport).await.unwrap();
+        let kt = PubsubKeyTransport::new(transport, Arc::new(crate::AnonymousResolver))
+            .await
+            .unwrap();
 
         let payload = b"retry-me".to_vec();
         let req = EncodedFetchRequest {
@@ -981,7 +1004,9 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn request_with_no_reply_reports_unavailable() {
         let transport = RacyTransport::new(0);
-        let kt = PubsubKeyTransport::new(transport).await.unwrap();
+        let kt = PubsubKeyTransport::new(transport, Arc::new(crate::AnonymousResolver))
+            .await
+            .unwrap();
 
         let req = EncodedFetchRequest {
             payload: b"never-answered".to_vec(),
@@ -1002,14 +1027,25 @@ mod tests {
     /// internalResponse envelope on the caller's `_response` sub-topic.
     #[tokio::test]
     async fn inbound_request_publishes_reply_on_caller_response_topic() {
-        struct EchoHandler;
+        struct FixedIdentityResolver(identity::Did);
+        #[async_trait]
+        impl PeerIdentityResolver for FixedIdentityResolver {
+            async fn resolve(&self, _peer_id: &PeerId) -> Option<identity::Did> {
+                Some(self.0.clone())
+            }
+        }
+
+        struct EchoHandler {
+            seen: Arc<Mutex<Option<kms::PeerIdentity>>>,
+        }
         #[async_trait]
         impl IncomingHandler for EchoHandler {
             async fn handle(
                 &self,
-                _from: kms::PeerIdentity,
+                from: kms::PeerIdentity,
                 _req: FetchEncryptionKeyRequest,
             ) -> KmsResult<FetchEncryptionKeyReply> {
+                *self.seen.lock() = Some(from);
                 Ok(FetchEncryptionKeyReply {
                     links: vec![vec![9]],
                     blocks: vec![vec![8]],
@@ -1023,8 +1059,15 @@ mod tests {
         // wait_for_subscriber).
         let transport = RacyTransport::new(0);
         let published = transport.published.clone();
-        let kt = PubsubKeyTransport::new(transport).await.unwrap();
-        kt.install_handler(Arc::new(EchoHandler));
+        let resolved_did: identity::Did = "did:key:zalice".parse().unwrap();
+        let seen = Arc::new(Mutex::new(None));
+        let kt = PubsubKeyTransport::new(
+            transport,
+            Arc::new(FixedIdentityResolver(resolved_did.clone())),
+        )
+        .await
+        .unwrap();
+        kt.install_handler(Arc::new(EchoHandler { seen: seen.clone() }));
 
         let caller = a_libp2p_peer();
         let req = FetchEncryptionKeyRequest {
@@ -1047,5 +1090,8 @@ mod tests {
         let reply: FetchEncryptionKeyReply =
             serde_cbor::from_slice(&env.data).expect("decode reply");
         assert_eq!(reply.blocks, vec![vec![8]]);
+        let from = seen.lock().clone().expect("handler must see peer identity");
+        assert_eq!(from.peer_id, caller.to_string());
+        assert_eq!(from.authenticated_did, Some(resolved_did));
     }
 }

--- a/crates/p2p/src/kms/pubsub_transport.rs
+++ b/crates/p2p/src/kms/pubsub_transport.rs
@@ -205,11 +205,32 @@ impl<T: P2PTransport> PubsubKeyTransport<T> {
             .identity_resolver
             .resolve(&PeerId::new(from.clone()))
             .await;
+        let explicit_replay_authorization =
+            req.explicit_replay_capability
+                .as_deref()
+                .and_then(|capability| {
+                    match crate::verify_explicit_replay_capability_for_key_request(
+                        capability,
+                        &self.local_peer_id,
+                        &from,
+                    ) {
+                        Ok(authorization) => Some(authorization),
+                        Err(error) => {
+                            warn!(
+                                peer_id = %from,
+                                error = %error,
+                                "KMS request carried an invalid explicit-replay capability"
+                            );
+                            None
+                        }
+                    }
+                });
         let (reply_bytes, err) = match handler
             .handle(
                 kms::PeerIdentity {
                     peer_id: from.clone(),
                     authenticated_did,
+                    explicit_replay_authorization,
                 },
                 req,
             )
@@ -824,6 +845,7 @@ mod tests {
             identity: b"did:key:zrequester".to_vec(),
             links: vec![first_link.clone(), second_link.clone()],
             ephemeral_public_key: vec![9; 32],
+            explicit_replay_capability: None,
         };
         let payload = serde_cbor::to_vec(&request).unwrap();
         let req = EncodedFetchRequest {
@@ -890,6 +912,7 @@ mod tests {
             identity: b"did:key:zrequester".to_vec(),
             links: vec![requested_link.clone()],
             ephemeral_public_key: vec![9; 32],
+            explicit_replay_capability: None,
         };
         let payload = serde_cbor::to_vec(&request).unwrap();
         let mut rx = kt
@@ -1059,6 +1082,18 @@ mod tests {
         // wait_for_subscriber).
         let transport = RacyTransport::new(0);
         let published = transport.published.clone();
+        let source_peer_id = transport.local_peer_id().to_string();
+        let caller = a_libp2p_peer();
+        let authorizer =
+            identity::RawIdentity::from_private_key(crypto::generate_ed25519().unwrap()).unwrap();
+        let capability = crate::generate_explicit_replay_capability(
+            &authorizer,
+            &source_peer_id,
+            &caller.to_string(),
+            "collection-a",
+            Duration::from_secs(60),
+        )
+        .unwrap();
         let resolved_did: identity::Did = "did:key:zalice".parse().unwrap();
         let seen = Arc::new(Mutex::new(None));
         let kt = PubsubKeyTransport::new(
@@ -1069,11 +1104,11 @@ mod tests {
         .unwrap();
         kt.install_handler(Arc::new(EchoHandler { seen: seen.clone() }));
 
-        let caller = a_libp2p_peer();
         let req = FetchEncryptionKeyRequest {
             identity: b"did:key:zalice".to_vec(),
             links: vec![vec![1]],
             ephemeral_public_key: vec![2; 32],
+            explicit_replay_capability: Some(capability),
         };
         let req_bytes = serde_cbor::to_vec(&req).unwrap();
 
@@ -1093,5 +1128,11 @@ mod tests {
         let from = seen.lock().clone().expect("handler must see peer identity");
         assert_eq!(from.peer_id, caller.to_string());
         assert_eq!(from.authenticated_did, Some(resolved_did));
+        let authorization = from
+            .explicit_replay_authorization
+            .expect("handler must receive verified replay authorization");
+        assert_eq!(authorization.source_peer_id, source_peer_id);
+        assert_eq!(authorization.target_peer_id, caller.to_string());
+        assert_eq!(authorization.collection_id, "collection-a");
     }
 }

--- a/crates/p2p/src/lib.rs
+++ b/crates/p2p/src/lib.rs
@@ -98,6 +98,7 @@ pub use explicit_replay::{
     is_capability_revoked as is_explicit_replay_capability_revoked,
     revoke_capability as revoke_explicit_replay_capability,
     verify_capability as verify_explicit_replay_capability,
+    verify_capability_for_key_request as verify_explicit_replay_capability_for_key_request,
     verify_capability_with_revocations as verify_explicit_replay_capability_with_revocations,
     ExplicitReplayAuthorization, ExplicitReplayCapabilityClaims, ExplicitReplayRevocationRegistry,
     DEFAULT_CAPABILITY_TTL as DEFAULT_EXPLICIT_REPLAY_CAPABILITY_TTL,

--- a/crates/p2p/src/sync/manager/process/pushlog.rs
+++ b/crates/p2p/src/sync/manager/process/pushlog.rs
@@ -827,6 +827,7 @@ mod tests {
             collection_id: "collection1".to_string(),
             authorizer_did: "creator1".to_string(),
             expires_at: u64::MAX,
+            capability: None,
         };
 
         manager

--- a/crates/p2p/src/sync/pending_store.rs
+++ b/crates/p2p/src/sync/pending_store.rs
@@ -28,11 +28,9 @@ use storage::stores::Systemstore;
 use crate::error::{Error, Result};
 use crate::ExplicitReplayAuthorization;
 
-/// Verified explicit-replay claims carried by a persisted registration.
-///
-/// The capability signature was verified at admission time; persisting the
-/// claim summary lets a restored registration merge with the same
-/// authorization semantics it was admitted with.
+/// Verified explicit-replay authorization carried by a persisted registration.
+/// The original proof is retained so a restored replay can authenticate a
+/// reverse KMS request without trusting the request's claimed DID.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PersistedReplayAuthorization {
     pub source_peer_id: String,
@@ -40,6 +38,8 @@ pub struct PersistedReplayAuthorization {
     pub collection_id: String,
     pub authorizer_did: String,
     pub expires_at: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capability: Option<String>,
 }
 
 impl From<&ExplicitReplayAuthorization> for PersistedReplayAuthorization {
@@ -50,6 +50,7 @@ impl From<&ExplicitReplayAuthorization> for PersistedReplayAuthorization {
             collection_id: auth.collection_id.clone(),
             authorizer_did: auth.authorizer_did.clone(),
             expires_at: auth.expires_at,
+            capability: auth.capability.clone(),
         }
     }
 }
@@ -62,6 +63,7 @@ impl From<PersistedReplayAuthorization> for ExplicitReplayAuthorization {
             collection_id: auth.collection_id,
             authorizer_did: auth.authorizer_did,
             expires_at: auth.expires_at,
+            capability: auth.capability,
         }
     }
 }
@@ -330,6 +332,7 @@ mod tests {
                 collection_id: "collection".to_string(),
                 authorizer_did: "did:key:z123".to_string(),
                 expires_at: 42,
+                capability: Some("signed-capability".to_string()),
             }),
         }
     }

--- a/crates/p2p/src/sync/replication/tests.rs
+++ b/crates/p2p/src/sync/replication/tests.rs
@@ -1862,6 +1862,7 @@ async fn test_batch_validates_explicit_replay_before_merge() {
             collection_id: "col1".to_string(),
             authorizer_did: "did:key:authorizer".to_string(),
             expires_at: u64::MAX,
+            capability: None,
         }),
     }];
 


### PR DESCRIPTION
Targets #523.

## Problem

KMS pubsub requests carried a caller-controlled `Identity` field. The serving node used that field directly for DAC/NAC authorization, while the authenticated gossip source was retained only as metadata. A connected peer could therefore claim another DID and have an authorized DEK wrapped to its own ephemeral key.

Rust also sent a request-context user DID on cross-peer fetches, even though encrypted replication gates key access by the requesting node.

## What changed

- Resolve each inbound libp2p request through the existing signed peer-identity protocol and pass the authenticated DID across the KMS transport boundary.
- Authorize DEK release against the authenticated peer DID instead of the request payload, while retaining the payload field for Go wire compatibility and logging mismatches.
- Send the node DID on every outbound cross-peer fetch so Rust-to-Go requests preserve the node-level access gate.
- Keep transports without authenticated identity resolution anonymous, causing protected key release to fail closed.
- Add regressions for claimed-DID spoofing, outbound node identity, and resolver propagation into the KMS handler.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p kms`
- [x] `cargo test -p p2p kms::pubsub_transport`
- [x] `cargo check -p cli -p embedded`
- [x] `cargo clippy -p kms -p p2p -p cli -p embedded --all-targets -- -D warnings`
- [x] `git diff --check`
