### PR TITLE
fix(db): preserve stale update conflict type

### DIFF
--- a/crates/db/src/auto_commit_mutator/update.rs
+++ b/crates/db/src/auto_commit_mutator/update.rs
@@ -116,7 +116,7 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                 || expected.is_deleted() != current_doc.is_deleted()
                 || !values_unchanged
             {
-                return Err(query::error::QueryError::execution(
+                return Err(query::error::QueryError::transaction_conflict(
                     "transaction conflict. Please retry",
                 ));
             }
@@ -482,10 +482,11 @@ mod tests {
             )
             .await
             .expect_err("stale conditional update must conflict");
-        assert!(
-            error.to_string().contains("transaction conflict"),
-            "unexpected error: {error}"
-        );
+        assert!(matches!(
+            error,
+            query::error::QueryError::TransactionConflict(ref message)
+                if message == "transaction conflict. Please retry"
+        ));
 
         let final_doc = mutator
             .get_for_update("Patch", &created.doc_id)


### PR DESCRIPTION
Targets #699.

## Problem

Stale conditional updates detected a transaction conflict before commit but returned it as a generic query execution error. Although the message told clients to retry, the lost error type prevented the query boundary from emitting the stable `TXN_CONFLICT` code used by other transaction conflicts.

## What changed

- Return the existing typed `TransactionConflict` error for stale conditional updates.
- Strengthen the regression to verify the exact error variant and public message.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p db`
- [x] `cargo test -p query transaction_conflict_response_has_stable_graphql_code`
- [x] `cargo clippy -p db -p query --all-targets -- -D warnings`
- [x] `git diff --check`