### PR TITLE
chore(embedded): make SourceHub support opt-in

### DIFF
--- a/crates/embedded/Cargo.toml
+++ b/crates/embedded/Cargo.toml
@@ -26,7 +26,7 @@ p2p = { path = "../p2p", features = ["libp2p-transport"] }
 query = { path = "../query" }
 replication-filter = { path = "../replication-filter" }
 schema = { path = "../schema" }
-sourcehub = { path = "../sourcehub" }
+sourcehub = { path = "../sourcehub", optional = true }
 storage = { path = "../storage" }
 
 anyhow.workspace = true
@@ -54,6 +54,8 @@ wasmtime-runtime = [
 ]
 lark = ["storage/lark"]
 redb = ["db/redb", "storage/redb"]
+# SourceHub on-chain document ACP.
+sourcehub = ["dep:sourcehub"]
 iroh = ["p2p/iroh-transport", "defra-p2p-adapter/iroh"]
 
 [dev-dependencies]

--- a/crates/embedded/src/lib.rs
+++ b/crates/embedded/src/lib.rs
@@ -89,10 +89,12 @@ pub enum SigningKey {
 pub enum DocumentAcpConfig {
     #[default]
     Local,
+    #[cfg(feature = "sourcehub")]
     SourceHub(SourceHubConfig),
 }
 
 /// SourceHub document ACP configuration.
+#[cfg(feature = "sourcehub")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SourceHubConfig {
     pub grpc_address: String,

--- a/crates/embedded/src/node.rs
+++ b/crates/embedded/src/node.rs
@@ -181,13 +181,10 @@ impl<S: storage::corekv::Store + 'static> EmbeddedNode<S> {
     ///    gracefully and aborts the replication/merge background tasks.
     ///    Addresses the `Endpoint dropped without calling Endpoint::close`
     ///    iroh warning downstream embedders have been hitting.
-    /// 2. **Database** — close-guards future transactions (new `begin_txn`
+    /// 2. **Background tasks** — aborts and awaits node-owned tasks.
+    /// 3. **Database** — close-guards future transactions (new `begin_txn`
     ///    calls will return `Error::DatabaseClosed`) and closes the
     ///    underlying store.
-    ///
-    /// The background downsample task is aborted by the `Drop` impl on
-    /// `BackgroundTasks` when the node itself is dropped, so no explicit
-    /// step is needed here.
     ///
     /// This method is **idempotent** — the first caller performs the
     /// work, concurrent callers wait for that teardown to finish and
@@ -220,7 +217,10 @@ impl<S: storage::corekv::Store + 'static> EmbeddedNode<S> {
             p2p.shutdown().await;
         }
 
-        // 2. Database — sets the is_closed flag and closes the store.
+        // 2. Background tasks — await cancellation so they release store handles.
+        self.background_tasks.shutdown().await;
+
+        // 3. Database — sets the is_closed flag and closes the store.
         //    Log but don't propagate errors: shutdown should complete
         //    even if the store close returns an I/O error, so embedders
         //    can't be blocked from exiting by a closing store.

--- a/crates/embedded/src/node.rs
+++ b/crates/embedded/src/node.rs
@@ -7,9 +7,11 @@ use crate::node_identity::create_node_identity;
 use crate::node_tasks::BackgroundTasks;
 #[cfg(feature = "iroh")]
 use crate::IrohConfig;
+#[cfg(feature = "sourcehub")]
+use crate::{DocumentAcpConfig, SourceHubConfig};
 use crate::{
-    DocumentAcpConfig, EmbeddedNodeConfig, EmbeddedStore, Libp2pConfig, ManagedP2PSystem,
-    Persistence, SigningConfig, SigningKey, SourceHubConfig, TransportConfig,
+    EmbeddedNodeConfig, EmbeddedStore, Libp2pConfig, ManagedP2PSystem, Persistence, SigningConfig,
+    SigningKey, TransportConfig,
 };
 use anyhow::{anyhow, Context, Result};
 use p2p::sync::SyncConfig;
@@ -52,6 +54,7 @@ pub struct EmbeddedNode<S: storage::corekv::Store> {
     pub local_zanzibar_store: Option<Arc<dyn acp::ZanzibarStore>>,
     pub event_bus: Arc<dyn events::Bus>,
     pub node_identity_did: Option<String>,
+    #[cfg(feature = "sourcehub")]
     pub sourcehub_acp: Option<Arc<sourcehub::SourceHubDocumentACP>>,
     pub query_limits: query::QueryLimits,
     pub p2p: Option<Arc<ManagedP2PSystem>>,
@@ -298,6 +301,7 @@ impl NodeBuilder {
         self
     }
 
+    #[cfg(feature = "sourcehub")]
     pub fn with_sourcehub(mut self, config: SourceHubConfig) -> Self {
         self.config.document_acp = DocumentAcpConfig::SourceHub(config);
         self
@@ -550,8 +554,12 @@ where
         ),
     };
 
-    let (document_acp, local_zanzibar_store, sourcehub_acp) =
+    let acp_setup =
         create_document_acp(store.clone(), config.persistence, &config.document_acp).await?;
+    let document_acp = acp_setup.document_acp;
+    let local_zanzibar_store = acp_setup.local_zanzibar_store;
+    #[cfg(feature = "sourcehub")]
+    let sourcehub_acp = acp_setup.sourcehub_acp;
     let nac_manager = create_nac_manager(store.clone(), config.persistence).await?;
 
     // Wire the NAC manager into the DB so DB-layer `check_node_access` calls go
@@ -561,9 +569,12 @@ where
 
     if let Some(ref mut setup) = p2p_setup {
         setup.merge_handler.set_document_acp(document_acp.clone());
+        #[cfg(feature = "sourcehub")]
         setup
             .merge_handler
             .set_strict_replicated_doc_access(sourcehub_acp.is_some());
+        #[cfg(not(feature = "sourcehub"))]
+        setup.merge_handler.set_strict_replicated_doc_access(false);
         if let Some(wire_document_acp) = setup.wire_document_acp.take() {
             wire_document_acp(document_acp.clone());
         }
@@ -710,6 +721,7 @@ where
         local_zanzibar_store,
         event_bus,
         node_identity_did,
+        #[cfg(feature = "sourcehub")]
         sourcehub_acp,
         query_limits: config.query_limits,
         p2p: p2p_setup.map(|setup| setup.system),

--- a/crates/embedded/src/node_acp.rs
+++ b/crates/embedded/src/node_acp.rs
@@ -4,19 +4,23 @@ use anyhow::{anyhow, Result};
 
 use crate::Persistence;
 
+pub(crate) struct DocumentAcpSetup {
+    pub document_acp: Arc<dyn acp::DocumentACP>,
+    pub local_zanzibar_store: Option<Arc<dyn acp::ZanzibarStore>>,
+    #[cfg(feature = "sourcehub")]
+    pub sourcehub_acp: Option<Arc<sourcehub::SourceHubDocumentACP>>,
+}
+
 pub(crate) async fn create_document_acp<S>(
     store: Arc<S>,
     persistence: Persistence,
     config: &crate::DocumentAcpConfig,
-) -> Result<(
-    Arc<dyn acp::DocumentACP>,
-    Option<Arc<dyn acp::ZanzibarStore>>,
-    Option<Arc<sourcehub::SourceHubDocumentACP>>,
-)>
+) -> Result<DocumentAcpSetup>
 where
     S: storage::corekv::Store + 'static,
 {
     match config {
+        #[cfg(feature = "sourcehub")]
         crate::DocumentAcpConfig::SourceHub(sourcehub_config) => {
             let tuning = sourcehub::AcpTuning::default();
             let provider = Arc::new(
@@ -33,20 +37,36 @@ where
                 provider,
                 tuning.cache_ttl,
             ));
-            Ok((sh_acp.clone(), None, Some(sh_acp)))
+            Ok(DocumentAcpSetup {
+                document_acp: sh_acp.clone(),
+                local_zanzibar_store: None,
+                sourcehub_acp: Some(sh_acp),
+            })
         }
         crate::DocumentAcpConfig::Local => match persistence {
             Persistence::Persistent => {
                 let zanzibar_store = Arc::new(acp::PersistentZanzibarStore::from_store(store));
                 let document_acp = Arc::new(acp::ZanzibarDocumentACP::new(zanzibar_store.clone()));
-                Ok((document_acp, Some(zanzibar_store), None))
+                Ok(local_document_acp_setup(document_acp, zanzibar_store))
             }
             Persistence::Memory => {
                 let zanzibar_store = Arc::new(acp::MemoryZanzibarStore::new());
                 let document_acp = Arc::new(acp::ZanzibarDocumentACP::new(zanzibar_store.clone()));
-                Ok((document_acp, Some(zanzibar_store), None))
+                Ok(local_document_acp_setup(document_acp, zanzibar_store))
             }
         },
+    }
+}
+
+fn local_document_acp_setup(
+    document_acp: Arc<dyn acp::DocumentACP>,
+    zanzibar_store: Arc<dyn acp::ZanzibarStore>,
+) -> DocumentAcpSetup {
+    DocumentAcpSetup {
+        document_acp,
+        local_zanzibar_store: Some(zanzibar_store),
+        #[cfg(feature = "sourcehub")]
+        sourcehub_acp: None,
     }
 }
 
@@ -90,13 +110,16 @@ mod tests {
     #[tokio::test]
     async fn local_document_acp_enforces_stored_custom_policy() {
         let store = Arc::new(storage::MemoryStore::new());
-        let (document_acp, local_store, sourcehub_acp) =
-            create_document_acp(store, Persistence::Memory, &DocumentAcpConfig::Local)
-                .await
-                .unwrap();
+        let acp_setup = create_document_acp(store, Persistence::Memory, &DocumentAcpConfig::Local)
+            .await
+            .unwrap();
 
-        assert!(sourcehub_acp.is_none());
-        let local_store = local_store.expect("local ACP should expose a Zanzibar store");
+        #[cfg(feature = "sourcehub")]
+        assert!(acp_setup.sourcehub_acp.is_none());
+        let document_acp = acp_setup.document_acp;
+        let local_store = acp_setup
+            .local_zanzibar_store
+            .expect("local ACP should expose a Zanzibar store");
 
         let parsed = acp::policy_yaml::parse_policy_yaml(
             r#"

--- a/crates/ffi/Cargo.toml
+++ b/crates/ffi/Cargo.toml
@@ -77,7 +77,7 @@ sourcehub = { path = "../sourcehub" }
 lens = { path = "../lens", default-features = false }
 p2p = { path = "../p2p", features = ["libp2p-transport"] }
 blockstore = { path = "../blockstore" }
-embedded = { path = "../embedded", default-features = false }
+embedded = { path = "../embedded", default-features = false, features = ["sourcehub"] }
 
 # IPLD
 cid.workspace = true


### PR DESCRIPTION
Targets #1288.

## Problem

The `embedded` crate depended on SourceHub unconditionally, so consumers using only local document ACP still compiled the entire SourceHub dependency tree. This also prevented downstream embedders from excluding advisories in unreachable SourceHub dependencies.

SourceHub-enabled validation also exposed that embedded shutdown did not await its node-owned background task before closing the database, allowing that task to retain the final persistent-store handle briefly after shutdown returned.

## What changed

- Make the embedded `sourcehub` dependency optional and expose it through an opt-in `sourcehub` feature, matching the CLI feature policy.
- Gate the SourceHub ACP configuration, builder API, retained ACP handle, and construction path behind that feature.
- Keep local ACP behavior unchanged when SourceHub support is disabled.
- Await embedded background-task cancellation before closing the database so shutdown reliably releases persistent-store locks.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p embedded`
- [x] `cargo test -p embedded --features sourcehub`
- [x] `cargo clippy -p embedded --all-targets -- -D warnings`
- [x] `cargo clippy -p embedded --features sourcehub --all-targets -- -D warnings`
- [x] `cargo clippy -p embedded --no-default-features --lib -- -D warnings`
- [x] `cargo tree -p embedded --features sourcehub -i sourcehub`
- [x] `git diff --check`
