### PR TITLE
chore(ci): update Go compatibility baseline

### DIFF
--- a/crates/defra-version/src/lib.rs
+++ b/crates/defra-version/src/lib.rs
@@ -1,11 +1,11 @@
 use serde::Serialize;
 
 /// Go upstream commit we last synced with.
-pub const GO_COMPAT_COMMIT: &str = "3de01484";
+pub const GO_COMPAT_COMMIT: &str = "13c46ec9";
 /// Go upstream branch.
-pub const GO_COMPAT_BRANCH: &str = "release/1.0.0";
-/// Go release tag; CI downloads this release binary for go-compat runs.
-pub const GO_COMPAT_TAG: &str = "v1.0.0";
+pub const GO_COMPAT_BRANCH: &str = "develop";
+/// Go release tag; empty when CI should build the pinned commit from source.
+pub const GO_COMPAT_TAG: &str = "";
 
 /// Go compatibility metadata.
 #[derive(Debug, Clone, Serialize)]


### PR DESCRIPTION
Closes #1302.

## Problem

The Go compatibility workflow was still pinned to the v1.0.0 release commit and downloaded release artifact, despite the newer Go `develop` baseline having already been validated during #1261. This left the blocking compatibility checks behind the upstream behavior they are intended to track.

## What changed

- Pin Go compatibility to `develop` commit `13c46ec9`.
- Clear the release tag so CI builds and tests the exact pinned source revision instead of downloading the v1.0.0 binary.
- Keep the existing integration skips unchanged because the new baseline introduces no failures in the blocking compatibility matrix.

Residual non-blocking FFI parity work remains tracked by #1258 and #1200.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test -p defra-version`
- [x] Go fixture generators for message and pubsub RPC constants
- [x] Go-compat integration matrix (179 passed, 28 ignored)
- [x] Go-compat conformance parity (14 passed)
- [x] `git diff --check`
