### PR TITLE
fix(defra-version): re-run build script when git HEAD moves

### DIFF
--- a/crates/defra-version/build.rs
+++ b/crates/defra-version/build.rs
@@ -1,22 +1,48 @@
+use std::path::Path;
 use std::process::Command;
 
-fn main() {
-    // Auto-detect git commit hash
-    let commit = Command::new("git")
-        .args(["rev-parse", "HEAD"])
+fn git(args: &[&str]) -> Option<String> {
+    Command::new("git")
+        .args(args)
         .output()
         .ok()
         .filter(|o| o.status.success())
         .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
-        .unwrap_or_else(|| "unknown".to_string());
+}
 
-    // Auto-detect commit date
-    let date = Command::new("git")
-        .args(["show", "-s", "--date=short", "--format=%cd", "HEAD"])
-        .output()
-        .ok()
-        .filter(|o| o.status.success())
-        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+/// Emitting a path that does not exist would leave the build script permanently dirty,
+/// rebuilding every dependent crate on every build.
+fn rerun_if_exists(path: &str) {
+    if Path::new(path).exists() {
+        println!("cargo:rerun-if-changed={path}");
+    }
+}
+
+fn main() {
+    // Without these the build script is cached and the constants below drift from the commit
+    // actually built. `--git-path` is what resolves each file in a linked worktree, where HEAD
+    // lives in the per-worktree git dir but refs live in the common one.
+    //
+    // refs/heads is watched as a directory: a ref that is packed at build time has no loose
+    // file to watch, and a later commit writes it back out without touching packed-refs or the
+    // contents of HEAD. It is shared, so a commit in a sibling worktree also rebuilds this one;
+    // that is the price of staying correct across packed refs and branch switches.
+    //
+    // The reftable backend keeps refs outside refs/heads entirely, leaving HEAD a fixed stub.
+    for entry in ["HEAD", "refs/heads", "packed-refs", "reftable"] {
+        if let Some(path) = git(&["rev-parse", "--git-path", entry]) {
+            rerun_if_exists(&path);
+        }
+    }
+
+    // --git-path resolves reftable to the per-worktree stack, but a linked worktree writes its
+    // branch refs to the common one, and only reflogs happen to touch the former.
+    if let Some(dir) = git(&["rev-parse", "--git-common-dir"]) {
+        rerun_if_exists(&format!("{dir}/reftable"));
+    }
+
+    let commit = git(&["rev-parse", "HEAD"]).unwrap_or_else(|| "unknown".to_string());
+    let date = git(&["show", "-s", "--date=short", "--format=%cd", "HEAD"])
         .unwrap_or_else(|| "unknown".to_string());
 
     println!("cargo:rustc-env=GIT_COMMIT={commit}");


### PR DESCRIPTION
Closes #1297.

## Problem

`crates/defra-version/build.rs` emitted no `cargo:rerun-if-changed`, so cargo cached the build script
and never re-ran it when git HEAD moved. `GIT_COMMIT` and `BUILD_DATE` kept whatever values were
current at the last incidental rebuild, and `defra --version` silently drifted from the commit the
binary was actually built from. Reproduced in a linked worktree: the script emitted `30fb6525` while
HEAD had already moved to `6f116222`. The script now watches `HEAD`, `refs/heads`, `packed-refs` and
both reftable stacks, resolving each path with `git rev-parse --git-path` and emitting only if it
exists.

## What changed

- `--git-path` instead of assembling `.git/...`: in a linked worktree `.git` is a file, HEAD lives in
  the per-worktree git dir and refs in the common one, so `.git/HEAD` watches nothing and fails silently.
- `refs/heads` watched as a directory, not one ref file: a packed ref has no loose file, and a later
  commit rewrites it without touching `packed-refs` or `HEAD`. Also subsumes detached HEAD.
- Both reftable stacks: under reftable, `HEAD` is a fixed stub and `refs/heads` never moves. A linked
  worktree writes branch refs to the common stack, which `--git-path` does not resolve to.
- Each path emitted only if it exists: a missing watched path makes cargo re-run the script on every
  build, rebuilding every dependent crate.
- Fixes `BUILD_DATE` as well as `GIT_COMMIT`. The issue names only the hash; the date went stale identically.
- Audit of other build-time constants found nothing: `defra-node/build.rs` already emits three
  directives, `orbis/build.rs` bakes no git state, `db-blocks/src/build.rs` is a module, not a build script.

## Validation

- [x] `cargo fmt --all --check`, `cargo clippy -p defra-version --all-targets -- -D warnings`,
      `cargo test -p defra-version` (6), `git diff --check`, all exit 0 at `a8f80e6e`
- [x] Acceptance script (written pre-fix, RED first) in a plain clone, a linked worktree, and a
      `--ref-format=reftable` clone including `core.logAllRefUpdates=false`
- [x] Branch switch invalidates; `BUILD_DATE` tracks a backdated commit rather than wall-clock
- [x] No-op rebuild does **not** re-run the script; `git archive` tarball builds and emits `unknown`
- [ ] Integration suites not run: this changes build-script cache invalidation, not database behavior.
      Full-workspace `clippy --all --all-targets` last clean at `10d6bc27`; the delta since is confined
      to `build.rs`. **CI should confirm the full-workspace lint.**
