### PR TITLE
fix(crypto): derive block encryption from the DAG instead of a process-global store

### DIFF
--- a/crates/datastore/src/multistore.rs
+++ b/crates/datastore/src/multistore.rs
@@ -118,6 +118,17 @@ impl NamespaceView {
         Self { txn, namespace }
     }
 
+    /// View a different namespace of the same transaction.
+    ///
+    /// Lets a caller holding one view reach a sibling namespace without
+    /// threading the transaction (or a second view) through its signature.
+    pub fn sibling(&self, namespace: Namespace) -> Self {
+        Self {
+            txn: self.txn.clone(),
+            namespace,
+        }
+    }
+
     /// Get a value.
     pub async fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
         self.txn.get(self.namespace, key).await

--- a/crates/db-blocks/src/write.rs
+++ b/crates/db-blocks/src/write.rs
@@ -1,5 +1,88 @@
 use super::*;
 
+/// The `Encryption` link a new block should carry forward, read off the
+/// previous block, when the write brings no config of its own.
+///
+/// Mirrors the fallback half of Go's `determineBlockEncryption`
+/// (internal/core/block/store.go): the DAG, not any process-local state, is
+/// what records that a document is encrypted, and the existing link is reused
+/// so no new encryption block is written.
+///
+/// A head whose block cannot be read is an error rather than a miss: guessing
+/// "not encrypted" is exactly the silent downgrade this derivation exists to
+/// prevent. Matches Go, which returns `ErrCouldNotFindBlock` here.
+///
+/// Heads with no encryption are skipped rather than ending the search, but an
+/// empty `heads` yields `None` — so a field first written by an update inherits
+/// nothing and is stored in plaintext. That is Go's behaviour too (its head set
+/// is per-field, `store.go:82-86`); see
+/// `field_added_by_update_is_written_plaintext_matching_go`.
+async fn inherited_encryption_cid(
+    blockstore: &NamespaceView,
+    heads: &[Cid],
+) -> Result<Option<Cid>, String> {
+    for head in heads {
+        let block_bytes = blockstore
+            .get(&head.to_bytes())
+            .await
+            .map_err(|e| format!("Failed to read previous block {}: {}", head, e))?
+            .ok_or_else(|| format!("Previous block {} not found", head))?;
+        let prev = Block::from_dag_cbor(&block_bytes)
+            .map_err(|e| format!("Failed to decode previous block {}: {}", head, e))?;
+
+        if prev.encryption.is_some() {
+            return Ok(prev.encryption);
+        }
+    }
+
+    Ok(None)
+}
+
+/// The inherited encryption link together with the key it points at, for the
+/// field deltas that actually need to encrypt with it.
+///
+/// Reusing one key across a field's whole history is safe only because every
+/// delta is sealed with a fresh random nonce (see `encrypt_delta`). Do not make
+/// that nonce deterministic or counter-based without revisiting this.
+async fn inherited_encryption(
+    blockstore: &NamespaceView,
+    heads: &[Cid],
+) -> Result<Option<([u8; 32], Cid)>, String> {
+    let Some(enc_cid) = inherited_encryption_cid(blockstore, heads).await? else {
+        return Ok(None);
+    };
+
+    // Encstore first, then blockstore: blocks arriving over P2P land in the
+    // encstore while locally-written ones go to the blockstore. Mirrors the
+    // merge decrypt path (`db-merge/src/merge_handler/encryption.rs`) and
+    // `versioned_fetcher`.
+    let enc_key = enc_cid.to_bytes();
+    let enc_bytes = match blockstore
+        .sibling(storage::namespace::Namespace::Encstore)
+        .get(&enc_key)
+        .await
+        .map_err(|e| format!("Failed to read encryption block {}: {}", enc_cid, e))?
+    {
+        Some(bytes) => bytes,
+        None => blockstore
+            .get(&enc_key)
+            .await
+            .map_err(|e| format!("Failed to read encryption block {}: {}", enc_cid, e))?
+            .ok_or_else(|| format!("Encryption block {} not found", enc_cid))?,
+    };
+    let enc_block = Encryption::from_dag_cbor(&enc_bytes)
+        .map_err(|e| format!("Failed to decode encryption block {}: {}", enc_cid, e))?;
+    let key: [u8; 32] = enc_block.key.as_slice().try_into().map_err(|_| {
+        format!(
+            "Encryption block {} has a {}-byte key, expected 32",
+            enc_cid,
+            enc_block.key.len()
+        )
+    })?;
+
+    Ok(Some((key, enc_cid)))
+}
+
 /// Write document blocks to blockstore and heads to headstore.
 ///
 /// This function creates CRDT blocks for a document and writes:
@@ -86,73 +169,78 @@ pub async fn write_document_blocks(
 
             let value_bytes = encode_value_as_cbor(cbor_value)?;
 
-            let (value_bytes, encryption_cid) = if let Some(enc) = encryption_config {
-                if enc.should_encrypt_field(field_name) {
-                    let key_field_name = if enc.should_encrypt_individual_field(field_name) {
-                        Some(field_name.as_str())
-                    } else {
-                        None
-                    };
-
-                    if let Some(kms_svc) = kms {
-                        // KMS path: the KMS generates + persists the Encryption
-                        // block (in its KeyStore) and returns the CID + plain key
-                        // for us to encrypt the field delta with. The scope is
-                        // keyed by the node-local DocRef: the public DocID is
-                        // not yet known on the create path.
-                        let scope = kms::KeyScope::Document {
-                            doc_id: hex::encode(&doc_ref_bytes),
-                            field: key_field_name.map(str::to_owned),
-                        };
-                        let ctx = kms::RequestContext::anonymous();
-                        let (enc_cid, key) = kms_svc
-                            .generate_key(&ctx, scope)
-                            .await
-                            .map_err(|e| format!("kms generate_key: {e}"))?;
-                        let encrypted = encrypt_delta(&value_bytes, &key)?;
-                        tracing::debug!(
-                            field = %field_name,
-                            ciphertext_len = encrypted.len(),
-                            "Encrypted field delta via KMS"
-                        );
-                        (encrypted, Some(enc_cid))
-                    } else {
-                        // Legacy path (unchanged): inline key generation + direct block store.
-                        let key = defra_core::encryption::generate_encryption_key_for(
-                            &doc_ref_bytes,
-                            key_field_name,
-                        );
-                        let encrypted = encrypt_delta(&value_bytes, &key)?;
-
-                        tracing::debug!(
-                            field = %field_name,
-                            ciphertext_len = encrypted.len(),
-                            "Encrypted field delta"
-                        );
-
-                        let enc_block = Encryption { key: key.to_vec() };
-                        let enc_bytes = enc_block
-                            .to_dag_cbor()
-                            .map_err(|e| format!("Failed to encode encryption block: {}", e))?;
-                        let enc_cid = generate_cid_from_bytes(&enc_bytes)
-                            .map_err(|e| format!("Failed to generate encryption CID: {}", e))?;
-                        blockstore
-                            .set(&enc_cid.to_bytes(), &enc_bytes)
-                            .await
-                            .map_err(|e| format!("Failed to store encryption block: {}", e))?;
-
-                        (encrypted, Some(enc_cid))
-                    }
+            let explicit = encryption_config.filter(|enc| enc.should_encrypt_field(field_name));
+            let (value_bytes, encryption_cid) = if let Some(enc) = explicit {
+                let key_field_name = if enc.should_encrypt_individual_field(field_name) {
+                    Some(field_name.as_str())
                 } else {
-                    (value_bytes, None)
+                    None
+                };
+
+                if let Some(kms_svc) = kms {
+                    // KMS path: the KMS generates + persists the Encryption
+                    // block (in its KeyStore) and returns the CID + plain key
+                    // for us to encrypt the field delta with. The scope is
+                    // keyed by the node-local DocRef: the public DocID is
+                    // not yet known on the create path.
+                    let scope = kms::KeyScope::Document {
+                        doc_id: hex::encode(&doc_ref_bytes),
+                        field: key_field_name.map(str::to_owned),
+                    };
+                    let ctx = kms::RequestContext::anonymous();
+                    let (enc_cid, key) = kms_svc
+                        .generate_key(&ctx, scope)
+                        .await
+                        .map_err(|e| format!("kms generate_key: {e}"))?;
+                    let encrypted = encrypt_delta(&value_bytes, &key)?;
+                    tracing::debug!(
+                        field = %field_name,
+                        ciphertext_len = encrypted.len(),
+                        "Encrypted field delta via KMS"
+                    );
+                    encryption_cids.push(enc_cid);
+                    (encrypted, Some(enc_cid))
+                } else {
+                    // Legacy path (unchanged): inline key generation + direct block store.
+                    let key = defra_core::encryption::generate_encryption_key_for(
+                        &doc_ref_bytes,
+                        key_field_name,
+                    );
+                    let encrypted = encrypt_delta(&value_bytes, &key)?;
+
+                    tracing::debug!(
+                        field = %field_name,
+                        ciphertext_len = encrypted.len(),
+                        "Encrypted field delta"
+                    );
+
+                    let enc_block = Encryption { key: key.to_vec() };
+                    let enc_bytes = enc_block
+                        .to_dag_cbor()
+                        .map_err(|e| format!("Failed to encode encryption block: {}", e))?;
+                    let enc_cid = generate_cid_from_bytes(&enc_bytes)
+                        .map_err(|e| format!("Failed to generate encryption CID: {}", e))?;
+                    blockstore
+                        .set(&enc_cid.to_bytes(), &enc_bytes)
+                        .await
+                        .map_err(|e| format!("Failed to store encryption block: {}", e))?;
+
+                    encryption_cids.push(enc_cid);
+                    (encrypted, Some(enc_cid))
                 }
+            } else if let Some((key, enc_cid)) = inherited_encryption(blockstore, &heads).await? {
+                let encrypted = encrypt_delta(&value_bytes, &key)?;
+
+                tracing::debug!(
+                    field = %field_name,
+                    ciphertext_len = encrypted.len(),
+                    "Encrypted field delta with the previous block's key"
+                );
+
+                (encrypted, Some(enc_cid))
             } else {
                 (value_bytes, None)
             };
-
-            if let Some(enc_cid) = encryption_cid {
-                encryption_cids.push(enc_cid);
-            }
 
             let is_counter = doc
                 .fields()
@@ -282,30 +370,25 @@ pub async fn write_document_blocks(
         status: 1,
     };
 
-    let composite_encryption_cid = if let Some(enc) = encryption_config {
-        if enc.encrypt_doc {
-            let key = defra_core::encryption::generate_encryption_key_for(&doc_ref_bytes, None);
-            let enc_block = Encryption { key: key.to_vec() };
-            let enc_bytes = enc_block
-                .to_dag_cbor()
-                .map_err(|e| format!("Failed to encode composite encryption block: {}", e))?;
-            let enc_cid = generate_cid_from_bytes(&enc_bytes)
-                .map_err(|e| format!("Failed to generate composite encryption CID: {}", e))?;
-            blockstore
-                .set(&enc_cid.to_bytes(), &enc_bytes)
-                .await
-                .map_err(|e| format!("Failed to store composite encryption block: {}", e))?;
-            Some(enc_cid)
-        } else {
-            None
-        }
-    } else {
-        None
-    };
-
-    if let Some(enc_cid) = composite_encryption_cid {
+    let composite_encryption_cid = if encryption_config.is_some_and(|enc| enc.encrypt_doc) {
+        let key = defra_core::encryption::generate_encryption_key_for(&doc_ref_bytes, None);
+        let enc_block = Encryption { key: key.to_vec() };
+        let enc_bytes = enc_block
+            .to_dag_cbor()
+            .map_err(|e| format!("Failed to encode composite encryption block: {}", e))?;
+        let enc_cid = generate_cid_from_bytes(&enc_bytes)
+            .map_err(|e| format!("Failed to generate composite encryption CID: {}", e))?;
+        blockstore
+            .set(&enc_cid.to_bytes(), &enc_bytes)
+            .await
+            .map_err(|e| format!("Failed to store composite encryption block: {}", e))?;
         encryption_cids.push(enc_cid);
-    }
+        Some(enc_cid)
+    } else {
+        // The composite payload is never encrypted with the key, only linked,
+        // so the CID alone is enough here.
+        inherited_encryption_cid(blockstore, &composite_heads).await?
+    };
 
     let mut composite_block = Block::new_with_options(
         CrdtDelta::Composite(composite_payload),
@@ -408,10 +491,14 @@ pub async fn write_delete_block(
         status: 2,
     };
 
-    let mut composite_block = Block::new(
+    let composite_encryption_cid = inherited_encryption_cid(blockstore, &composite_heads).await?;
+
+    let mut composite_block = Block::new_with_options(
         CrdtDelta::Composite(composite_payload),
         composite_heads,
         vec![],
+        composite_encryption_cid,
+        None,
     );
 
     if let Some(signer) = signing_config {
@@ -582,3 +669,7 @@ mod kms_write_tests {
         );
     }
 }
+
+#[cfg(test)]
+#[path = "write_encryption_tests.rs"]
+mod encryption_derivation_tests;

--- a/crates/db-blocks/src/write.rs
+++ b/crates/db-blocks/src/write.rs
@@ -12,11 +12,10 @@ use super::*;
 /// "not encrypted" is exactly the silent downgrade this derivation exists to
 /// prevent. Matches Go, which returns `ErrCouldNotFindBlock` here.
 ///
-/// Heads with no encryption are skipped rather than ending the search, but an
-/// empty `heads` yields `None` — so a field first written by an update inherits
-/// nothing and is stored in plaintext. That is Go's behaviour too (its head set
-/// is per-field, `store.go:82-86`); see
-/// `field_added_by_update_is_written_plaintext_matching_go`.
+/// Heads with no encryption are skipped rather than ending the search, and an
+/// empty `heads` yields `None`. A field with nothing of its own to inherit is
+/// not thereby in the clear: `write_document_blocks` falls back to the
+/// document-level policy the composite head records before writing plaintext.
 async fn inherited_encryption_cid(
     blockstore: &NamespaceView,
     heads: &[Cid],
@@ -38,6 +37,29 @@ async fn inherited_encryption_cid(
     Ok(None)
 }
 
+/// Last resort for an `Encryption` block neither block namespace holds: ask the
+/// configured KMS, which may keep it in a `KeyStore` of its own.
+///
+/// `DefraKms` serves what it holds locally before any peer fan-out
+/// (`kms/src/defra_kms.rs`), so this stays a local read in the common case.
+async fn kms_resolved_key(
+    kms: Option<&std::sync::Arc<dyn kms::KmsService>>,
+    enc_cid: Cid,
+) -> Result<Option<([u8; 32], Cid)>, String> {
+    let kms_svc = kms.ok_or_else(|| format!("Encryption block {} not found", enc_cid))?;
+    let key = kms_svc
+        .get_keys(&kms::RequestContext::anonymous(), &[enc_cid])
+        .await
+        .map_err(|e| format!("kms get_keys for {}: {}", enc_cid, e))?
+        .wait_all()
+        .await
+        .map_err(|e| format!("kms get_keys for {}: {}", enc_cid, e))?
+        .remove(&enc_cid)
+        .ok_or_else(|| format!("Encryption block {} not found", enc_cid))?;
+
+    Ok(Some((key, enc_cid)))
+}
+
 /// The inherited encryption link together with the key it points at, for the
 /// field deltas that actually need to encrypt with it.
 ///
@@ -47,6 +69,7 @@ async fn inherited_encryption_cid(
 async fn inherited_encryption(
     blockstore: &NamespaceView,
     heads: &[Cid],
+    kms: Option<&std::sync::Arc<dyn kms::KmsService>>,
 ) -> Result<Option<([u8; 32], Cid)>, String> {
     let Some(enc_cid) = inherited_encryption_cid(blockstore, heads).await? else {
         return Ok(None);
@@ -64,11 +87,18 @@ async fn inherited_encryption(
         .map_err(|e| format!("Failed to read encryption block {}: {}", enc_cid, e))?
     {
         Some(bytes) => bytes,
-        None => blockstore
+        None => match blockstore
             .get(&enc_key)
             .await
             .map_err(|e| format!("Failed to read encryption block {}: {}", enc_cid, e))?
-            .ok_or_else(|| format!("Encryption block {} not found", enc_cid))?,
+        {
+            Some(bytes) => bytes,
+            // A `KmsService` only promises that `generate_key` persisted the
+            // block in its own `KeyStore`; nothing requires that store to be
+            // either of these namespaces. Ask it for the key rather than
+            // assuming the aliasing today's wiring happens to give us.
+            None => return kms_resolved_key(kms, enc_cid).await,
+        },
     };
     let enc_block = Encryption::from_dag_cbor(&enc_bytes)
         .map_err(|e| format!("Failed to decode encryption block {}: {}", enc_cid, e))?;
@@ -81,6 +111,66 @@ async fn inherited_encryption(
     })?;
 
     Ok(Some((key, enc_cid)))
+}
+
+/// Mint a fresh key for a field, seal its delta with it, and persist the
+/// `Encryption` block the new block will link to.
+///
+/// Shared by the explicit-config path and the document-policy path so both
+/// route through the KMS whenever one is configured.
+async fn encrypt_with_new_key(
+    blockstore: &NamespaceView,
+    kms: Option<&std::sync::Arc<dyn kms::KmsService>>,
+    doc_ref_bytes: &[u8],
+    field_name: &str,
+    key_field_name: Option<&str>,
+    value_bytes: &[u8],
+) -> Result<(Vec<u8>, Cid), String> {
+    if let Some(kms_svc) = kms {
+        // KMS path: the KMS generates + persists the Encryption block (in its
+        // KeyStore) and returns the CID + plain key for us to encrypt the field
+        // delta with. The scope is keyed by the node-local DocRef: the public
+        // DocID is not yet known on the create path.
+        let scope = kms::KeyScope::Document {
+            doc_id: hex::encode(doc_ref_bytes),
+            field: key_field_name.map(str::to_owned),
+        };
+        let ctx = kms::RequestContext::anonymous();
+        let (enc_cid, key) = kms_svc
+            .generate_key(&ctx, scope)
+            .await
+            .map_err(|e| format!("kms generate_key: {e}"))?;
+        let encrypted = encrypt_delta(value_bytes, &key)?;
+        tracing::debug!(
+            field = %field_name,
+            ciphertext_len = encrypted.len(),
+            "Encrypted field delta via KMS"
+        );
+        return Ok((encrypted, enc_cid));
+    }
+
+    // Legacy path: inline key generation + direct block store.
+    let key = defra_core::encryption::generate_encryption_key_for(doc_ref_bytes, key_field_name);
+    let encrypted = encrypt_delta(value_bytes, &key)?;
+
+    tracing::debug!(
+        field = %field_name,
+        ciphertext_len = encrypted.len(),
+        "Encrypted field delta"
+    );
+
+    let enc_block = Encryption { key: key.to_vec() };
+    let enc_bytes = enc_block
+        .to_dag_cbor()
+        .map_err(|e| format!("Failed to encode encryption block: {}", e))?;
+    let enc_cid = generate_cid_from_bytes(&enc_bytes)
+        .map_err(|e| format!("Failed to generate encryption CID: {}", e))?;
+    blockstore
+        .set(&enc_cid.to_bytes(), &enc_bytes)
+        .await
+        .map_err(|e| format!("Failed to store encryption block: {}", e))?;
+
+    Ok((encrypted, enc_cid))
 }
 
 /// Write document blocks to blockstore and heads to headstore.
@@ -139,6 +229,29 @@ pub async fn write_document_blocks(
             + 1
     };
 
+    let (composite_head_entries, composite_heads) = if is_create {
+        (Vec::new(), Vec::new())
+    } else {
+        let entries = snapshot
+            .as_ref()
+            .ok_or_else(|| "snapshot required for updates".to_string())?
+            .field_heads("C");
+        let heads: Vec<Cid> = entries.iter().map(|h| h.cid).collect();
+        (entries, heads)
+    };
+
+    // The composite block's encryption link is set only for whole-document
+    // encryption, so its presence is what records that policy in the DAG. Read
+    // once, before the field loop, and reused for the composite block below.
+    // Skipped when this write sets the policy itself, since every field then
+    // takes the explicit path anyway.
+    let explicit_doc_encryption = encryption_config.is_some_and(|enc| enc.encrypt_doc);
+    let inherited_doc_encryption_cid = if explicit_doc_encryption {
+        None
+    } else {
+        inherited_encryption_cid(blockstore, &composite_heads).await?
+    };
+
     for (field_name, field_value) in doc.values() {
         if field_name == "_docID" {
             continue;
@@ -177,58 +290,20 @@ pub async fn write_document_blocks(
                     None
                 };
 
-                if let Some(kms_svc) = kms {
-                    // KMS path: the KMS generates + persists the Encryption
-                    // block (in its KeyStore) and returns the CID + plain key
-                    // for us to encrypt the field delta with. The scope is
-                    // keyed by the node-local DocRef: the public DocID is
-                    // not yet known on the create path.
-                    let scope = kms::KeyScope::Document {
-                        doc_id: hex::encode(&doc_ref_bytes),
-                        field: key_field_name.map(str::to_owned),
-                    };
-                    let ctx = kms::RequestContext::anonymous();
-                    let (enc_cid, key) = kms_svc
-                        .generate_key(&ctx, scope)
-                        .await
-                        .map_err(|e| format!("kms generate_key: {e}"))?;
-                    let encrypted = encrypt_delta(&value_bytes, &key)?;
-                    tracing::debug!(
-                        field = %field_name,
-                        ciphertext_len = encrypted.len(),
-                        "Encrypted field delta via KMS"
-                    );
-                    encryption_cids.push(enc_cid);
-                    (encrypted, Some(enc_cid))
-                } else {
-                    // Legacy path (unchanged): inline key generation + direct block store.
-                    let key = defra_core::encryption::generate_encryption_key_for(
-                        &doc_ref_bytes,
-                        key_field_name,
-                    );
-                    let encrypted = encrypt_delta(&value_bytes, &key)?;
-
-                    tracing::debug!(
-                        field = %field_name,
-                        ciphertext_len = encrypted.len(),
-                        "Encrypted field delta"
-                    );
-
-                    let enc_block = Encryption { key: key.to_vec() };
-                    let enc_bytes = enc_block
-                        .to_dag_cbor()
-                        .map_err(|e| format!("Failed to encode encryption block: {}", e))?;
-                    let enc_cid = generate_cid_from_bytes(&enc_bytes)
-                        .map_err(|e| format!("Failed to generate encryption CID: {}", e))?;
-                    blockstore
-                        .set(&enc_cid.to_bytes(), &enc_bytes)
-                        .await
-                        .map_err(|e| format!("Failed to store encryption block: {}", e))?;
-
-                    encryption_cids.push(enc_cid);
-                    (encrypted, Some(enc_cid))
-                }
-            } else if let Some((key, enc_cid)) = inherited_encryption(blockstore, &heads).await? {
+                let (encrypted, enc_cid) = encrypt_with_new_key(
+                    blockstore,
+                    kms,
+                    &doc_ref_bytes,
+                    field_name,
+                    key_field_name,
+                    &value_bytes,
+                )
+                .await?;
+                encryption_cids.push(enc_cid);
+                (encrypted, Some(enc_cid))
+            } else if let Some((key, enc_cid)) =
+                inherited_encryption(blockstore, &heads, kms).await?
+            {
                 let encrypted = encrypt_delta(&value_bytes, &key)?;
 
                 tracing::debug!(
@@ -237,6 +312,21 @@ pub async fn write_document_blocks(
                     "Encrypted field delta with the previous block's key"
                 );
 
+                (encrypted, Some(enc_cid))
+            } else if inherited_doc_encryption_cid.is_some() {
+                // The document is encrypted as a whole but this field has no
+                // history of its own to inherit from, so mint it a key under
+                // the document-level policy rather than dropping to plaintext.
+                let (encrypted, enc_cid) = encrypt_with_new_key(
+                    blockstore,
+                    kms,
+                    &doc_ref_bytes,
+                    field_name,
+                    None,
+                    &value_bytes,
+                )
+                .await?;
+                encryption_cids.push(enc_cid);
                 (encrypted, Some(enc_cid))
             } else {
                 (value_bytes, None)
@@ -353,24 +443,13 @@ pub async fn write_document_blocks(
         }
     }
 
-    let (composite_head_entries, composite_heads) = if is_create {
-        (Vec::new(), Vec::new())
-    } else {
-        let entries = snapshot
-            .as_ref()
-            .ok_or_else(|| "snapshot required for updates".to_string())?
-            .field_heads("C");
-        let heads: Vec<Cid> = entries.iter().map(|h| h.cid).collect();
-        (entries, heads)
-    };
-
     let composite_payload = CompositeDeltaPayload {
         schema_version_id: schema_version_id.to_string(),
         priority,
         status: 1,
     };
 
-    let composite_encryption_cid = if encryption_config.is_some_and(|enc| enc.encrypt_doc) {
+    let composite_encryption_cid = if explicit_doc_encryption {
         let key = defra_core::encryption::generate_encryption_key_for(&doc_ref_bytes, None);
         let enc_block = Encryption { key: key.to_vec() };
         let enc_bytes = enc_block
@@ -387,7 +466,7 @@ pub async fn write_document_blocks(
     } else {
         // The composite payload is never encrypted with the key, only linked,
         // so the CID alone is enough here.
-        inherited_encryption_cid(blockstore, &composite_heads).await?
+        inherited_doc_encryption_cid
     };
 
     let mut composite_block = Block::new_with_options(
@@ -560,116 +639,9 @@ pub async fn write_delete_block(
 }
 
 #[cfg(test)]
-mod kms_write_tests {
-    use super::*;
-    use async_trait::async_trait;
-    use datastore::{NamespaceView, SharedTxn};
-    use defra_core::encryption::EncryptionConfig;
-    use std::sync::Arc;
-    use storage::backends::MemoryStore;
-    use storage::corekv::Store;
-    use storage::namespace::Namespace;
-
-    /// Stub KMS that mirrors the real `MemoryKeyStore::generate` block shape so
-    /// the returned CID matches what the legacy path would produce for the same
-    /// scope. The key is fixed to make the assertion deterministic.
-    struct StubKms;
-
-    #[async_trait]
-    impl kms::KmsService for StubKms {
-        async fn get_keys(
-            &self,
-            _: &kms::RequestContext,
-            _: &[kms::EncryptionCid],
-        ) -> kms::Result<kms::KeyResults> {
-            let (r, tx) = kms::KeyResults::new(1);
-            drop(tx);
-            Ok(r)
-        }
-
-        async fn generate_key(
-            &self,
-            _: &kms::RequestContext,
-            scope: kms::KeyScope,
-        ) -> kms::Result<(kms::EncryptionCid, [u8; 32])> {
-            let (doc_id_bytes, field_name) = match scope {
-                kms::KeyScope::Document { doc_id, field } => (doc_id.into_bytes(), field),
-                kms::KeyScope::Collection { collection_id } => (Vec::new(), Some(collection_id)),
-            };
-            let _ = (doc_id_bytes, field_name);
-            let block = defra_core::Encryption { key: vec![5u8; 32] };
-            let bytes = block.to_dag_cbor().unwrap();
-            let cid = defra_core::block::generate_cid_from_bytes(&bytes).unwrap();
-            Ok((cid, [5u8; 32]))
-        }
-
-        async fn serve_request(
-            &self,
-            _: kms::PeerIdentity,
-            _: kms::FetchEncryptionKeyRequest,
-        ) -> kms::Result<kms::FetchEncryptionKeyReply> {
-            Err(kms::Error::Unsupported("stub"))
-        }
-    }
-
-    /// Recompute the CID the stub KMS would return, so the test asserts
-    /// against the KMS-derived CID rather than a hardcoded value.
-    fn expected_field_cid() -> Cid {
-        let block = defra_core::Encryption { key: vec![5u8; 32] };
-        let bytes = block.to_dag_cbor().unwrap();
-        generate_cid_from_bytes(&bytes).unwrap()
-    }
-
-    #[tokio::test]
-    async fn kms_write_path_links_field_block_to_kms_encryption_cid() {
-        let store = MemoryStore::new();
-        let txn = store.new_txn(false).await.unwrap();
-        let shared = SharedTxn::new(txn);
-        let blockstore = NamespaceView::new(shared.clone(), Namespace::Blockstore);
-        let headstore = NamespaceView::new(shared.clone(), Namespace::Headstore);
-
-        let mut doc = Document::new();
-        doc.set("secret", NormalValue::String("classified".to_string()));
-
-        let enc = EncryptionConfig {
-            encrypt_doc: false,
-            encrypt_fields: vec!["secret".to_string()],
-        };
-
-        let kms: Arc<dyn kms::KmsService> = Arc::new(StubKms);
-
-        let result = write_document_blocks(
-            &blockstore,
-            &headstore,
-            &doc,
-            "schema-v1",
-            DocStorageIdentity::new(1, 1),
-            None,
-            Some(&enc),
-            None,
-            Some(&kms),
-        )
-        .await
-        .expect("KMS write path should succeed");
-
-        assert_eq!(result.field_cids.len(), 1);
-        let field_cid = result.field_cids[0];
-        let field_bytes = blockstore
-            .get(&field_cid.to_bytes())
-            .await
-            .unwrap()
-            .expect("field block stored");
-        let field_block = Block::from_dag_cbor(&field_bytes).unwrap();
-
-        let expected = expected_field_cid();
-        assert_eq!(
-            field_block.encryption,
-            Some(expected),
-            "field block must link to the KMS-generated encryption CID"
-        );
-    }
-}
-
-#[cfg(test)]
 #[path = "write_encryption_tests.rs"]
 mod encryption_derivation_tests;
+
+#[cfg(test)]
+#[path = "write_kms_tests.rs"]
+mod kms_write_tests;

--- a/crates/db-blocks/src/write_encryption_tests.rs
+++ b/crates/db-blocks/src/write_encryption_tests.rs
@@ -1,0 +1,534 @@
+//! Encryption-derivation behaviour for `write_document_blocks`.
+//!
+//! Split out of `write.rs` to keep that file within the repo's size guidance.
+
+use super::*;
+use datastore::{NamespaceView, SharedTxn};
+use defra_core::encryption::EncryptionConfig;
+use std::collections::HashSet;
+use storage::backends::MemoryStore;
+use storage::corekv::Store;
+use storage::namespace::Namespace;
+
+async fn stores() -> (NamespaceView, NamespaceView) {
+    let store = MemoryStore::new();
+    let txn = store.new_txn(false).await.unwrap();
+    let shared = SharedTxn::new(txn);
+    (
+        NamespaceView::new(shared.clone(), Namespace::Blockstore),
+        NamespaceView::new(shared, Namespace::Headstore),
+    )
+}
+
+async fn field_block(blockstore: &NamespaceView, cid: &Cid) -> Block {
+    let bytes = blockstore
+        .get(&cid.to_bytes())
+        .await
+        .unwrap()
+        .expect("block stored");
+    Block::from_dag_cbor(&bytes).unwrap()
+}
+
+/// An update that carries no encryption config must still be encrypted when
+/// the field's previous block was encrypted, by inheriting that block's
+/// encryption link. Mirrors Go's `determineBlockEncryption`
+/// (internal/core/block/store.go) and its
+/// `TestDocEncryption_UponUpdateOnLWWCRDT_ShouldEncryptCommitDelta`.
+#[tokio::test]
+async fn update_without_config_inherits_encryption_from_previous_block() {
+    let (blockstore, headstore) = stores().await;
+    let identity = DocStorageIdentity::new(1, 1);
+
+    let mut doc = Document::new();
+    doc.set("secret", NormalValue::String("classified".to_string()));
+
+    let enc = EncryptionConfig {
+        encrypt_doc: false,
+        encrypt_fields: vec!["secret".to_string()],
+    };
+
+    let created = write_document_blocks(
+        &blockstore,
+        &headstore,
+        &doc,
+        "schema-v1",
+        identity,
+        None,
+        Some(&enc),
+        None,
+        None,
+    )
+    .await
+    .expect("create should succeed");
+
+    let created_enc_cid = field_block(&blockstore, &created.field_cids[0])
+        .await
+        .encryption
+        .expect("created field block must be encrypted");
+
+    doc.set_id(document::DocID::from_string(&created.doc_id).unwrap());
+    doc.set(
+        "secret",
+        NormalValue::String("still classified".to_string()),
+    );
+    let modified: HashSet<String> = ["secret".to_string()].into_iter().collect();
+
+    let updated = write_document_blocks(
+        &blockstore,
+        &headstore,
+        &doc,
+        "schema-v1",
+        identity,
+        Some(&modified),
+        None,
+        None,
+        None,
+    )
+    .await
+    .expect("update should succeed");
+
+    assert_eq!(
+        field_block(&blockstore, &updated.field_cids[0])
+            .await
+            .encryption,
+        Some(created_enc_cid),
+        "update must inherit the previous block's encryption link, not write plaintext"
+    );
+}
+
+/// The composite block carries its own encryption link for whole-document
+/// encryption, and must inherit it on update for the same reason.
+#[tokio::test]
+async fn update_without_config_inherits_composite_encryption() {
+    let (blockstore, headstore) = stores().await;
+    let identity = DocStorageIdentity::new(2, 2);
+
+    let mut doc = Document::new();
+    doc.set("name", NormalValue::String("Alice".to_string()));
+
+    let enc = EncryptionConfig {
+        encrypt_doc: true,
+        encrypt_fields: vec![],
+    };
+
+    let created = write_document_blocks(
+        &blockstore,
+        &headstore,
+        &doc,
+        "schema-v1",
+        identity,
+        None,
+        Some(&enc),
+        None,
+        None,
+    )
+    .await
+    .expect("create should succeed");
+
+    let created_enc_cid = field_block(&blockstore, &created.cid)
+        .await
+        .encryption
+        .expect("created composite block must be encrypted");
+
+    doc.set_id(document::DocID::from_string(&created.doc_id).unwrap());
+    doc.set("name", NormalValue::String("Alicia".to_string()));
+    let modified: HashSet<String> = ["name".to_string()].into_iter().collect();
+
+    let updated = write_document_blocks(
+        &blockstore,
+        &headstore,
+        &doc,
+        "schema-v1",
+        identity,
+        Some(&modified),
+        None,
+        None,
+        None,
+    )
+    .await
+    .expect("update should succeed");
+
+    assert_eq!(
+        field_block(&blockstore, &updated.cid).await.encryption,
+        Some(created_enc_cid),
+        "composite block must inherit the previous composite block's encryption link"
+    );
+}
+
+/// Inheriting reuses the existing `Encryption` block rather than writing a
+/// new one, matching Go's `determineBlockEncryption`, which returns the
+/// previous link untouched.
+#[tokio::test]
+async fn inherited_encryption_writes_no_new_encryption_block() {
+    let (blockstore, headstore) = stores().await;
+    let identity = DocStorageIdentity::new(4, 4);
+
+    let mut doc = Document::new();
+    doc.set("secret", NormalValue::String("classified".to_string()));
+
+    let enc = EncryptionConfig {
+        encrypt_doc: false,
+        encrypt_fields: vec!["secret".to_string()],
+    };
+
+    let created = write_document_blocks(
+        &blockstore,
+        &headstore,
+        &doc,
+        "schema-v1",
+        identity,
+        None,
+        Some(&enc),
+        None,
+        None,
+    )
+    .await
+    .expect("create should succeed");
+    assert_eq!(
+        created.encryption_cids.len(),
+        1,
+        "create must mint one encryption block"
+    );
+
+    doc.set_id(document::DocID::from_string(&created.doc_id).unwrap());
+    doc.set(
+        "secret",
+        NormalValue::String("still classified".to_string()),
+    );
+    let modified: HashSet<String> = ["secret".to_string()].into_iter().collect();
+
+    let updated = write_document_blocks(
+        &blockstore,
+        &headstore,
+        &doc,
+        "schema-v1",
+        identity,
+        Some(&modified),
+        None,
+        None,
+        None,
+    )
+    .await
+    .expect("update should succeed");
+
+    assert!(
+        updated.encryption_cids.is_empty(),
+        "inheriting must not mint a new encryption block"
+    );
+}
+
+/// An explicit config on the update takes precedence over what the heads
+/// say, and rotates the key.
+#[tokio::test]
+async fn explicit_config_on_update_overrides_inheritance() {
+    let (blockstore, headstore) = stores().await;
+    let identity = DocStorageIdentity::new(5, 5);
+
+    let mut doc = Document::new();
+    doc.set("secret", NormalValue::String("classified".to_string()));
+
+    let enc = EncryptionConfig {
+        encrypt_doc: false,
+        encrypt_fields: vec!["secret".to_string()],
+    };
+
+    let created = write_document_blocks(
+        &blockstore,
+        &headstore,
+        &doc,
+        "schema-v1",
+        identity,
+        None,
+        Some(&enc),
+        None,
+        None,
+    )
+    .await
+    .expect("create should succeed");
+    let created_enc_cid = field_block(&blockstore, &created.field_cids[0])
+        .await
+        .encryption
+        .expect("created field block must be encrypted");
+
+    doc.set_id(document::DocID::from_string(&created.doc_id).unwrap());
+    doc.set(
+        "secret",
+        NormalValue::String("still classified".to_string()),
+    );
+    let modified: HashSet<String> = ["secret".to_string()].into_iter().collect();
+
+    let updated = write_document_blocks(
+        &blockstore,
+        &headstore,
+        &doc,
+        "schema-v1",
+        identity,
+        Some(&modified),
+        Some(&enc),
+        None,
+        None,
+    )
+    .await
+    .expect("update should succeed");
+
+    let updated_enc_cid = field_block(&blockstore, &updated.field_cids[0])
+        .await
+        .encryption
+        .expect("explicitly configured update must be encrypted");
+    assert_ne!(
+        updated_enc_cid, created_enc_cid,
+        "an explicit config must mint a fresh key rather than inherit"
+    );
+    assert_eq!(
+        updated.encryption_cids.len(),
+        1,
+        "the explicit path must record the encryption block it wrote"
+    );
+}
+
+/// Inheritance is per field: a field that was never encrypted does not
+/// become encrypted because a sibling field was.
+#[tokio::test]
+async fn inheritance_is_per_field() {
+    let (blockstore, headstore) = stores().await;
+    let identity = DocStorageIdentity::new(6, 6);
+
+    let mut doc = Document::new();
+    doc.set("secret", NormalValue::String("classified".to_string()));
+    doc.set("public", NormalValue::String("open".to_string()));
+
+    let enc = EncryptionConfig {
+        encrypt_doc: false,
+        encrypt_fields: vec!["secret".to_string()],
+    };
+
+    let created = write_document_blocks(
+        &blockstore,
+        &headstore,
+        &doc,
+        "schema-v1",
+        identity,
+        None,
+        Some(&enc),
+        None,
+        None,
+    )
+    .await
+    .expect("create should succeed");
+
+    doc.set_id(document::DocID::from_string(&created.doc_id).unwrap());
+    doc.set(
+        "secret",
+        NormalValue::String("still classified".to_string()),
+    );
+    doc.set("public", NormalValue::String("still open".to_string()));
+    let modified: HashSet<String> = ["secret".to_string(), "public".to_string()]
+        .into_iter()
+        .collect();
+
+    let updated = write_document_blocks(
+        &blockstore,
+        &headstore,
+        &doc,
+        "schema-v1",
+        identity,
+        Some(&modified),
+        None,
+        None,
+        None,
+    )
+    .await
+    .expect("update should succeed");
+
+    let mut encrypted = 0;
+    for cid in &updated.field_cids {
+        if field_block(&blockstore, cid).await.encryption.is_some() {
+            encrypted += 1;
+        }
+    }
+    assert_eq!(
+        (updated.field_cids.len(), encrypted),
+        (2, 1),
+        "exactly the previously-encrypted field should inherit encryption"
+    );
+}
+
+/// KNOWN GAP, deliberately matching Go: a field first written by an update
+/// has no heads of its own, so there is nothing to inherit from and the
+/// delta is written in plaintext — even on a document created with
+/// `encrypt_doc: true`.
+///
+/// Go behaves identically. `addDelta` builds its head set from the field's
+/// own prefix (`internal/core/block/store.go:82-86`,
+/// `NewHeadSet(txn.Headstore(), crdtData.HeadstorePrefix())`), so
+/// `determineBlockEncryption` sees no heads and attaches no encryption.
+///
+/// This is a characterization test, not an endorsement: it pins the
+/// behaviour so a future change cannot alter it silently. To be disclosed
+/// upstream to the Go team.
+#[tokio::test]
+async fn field_added_by_update_is_written_plaintext_matching_go() {
+    let (blockstore, headstore) = stores().await;
+    let identity = DocStorageIdentity::new(7, 7);
+
+    let mut doc = Document::new();
+    doc.set("name", NormalValue::String("Alice".to_string()));
+
+    let enc = EncryptionConfig {
+        encrypt_doc: true,
+        encrypt_fields: vec![],
+    };
+
+    let created = write_document_blocks(
+        &blockstore,
+        &headstore,
+        &doc,
+        "schema-v1",
+        identity,
+        None,
+        Some(&enc),
+        None,
+        None,
+    )
+    .await
+    .expect("create should succeed");
+
+    doc.set_id(document::DocID::from_string(&created.doc_id).unwrap());
+    doc.set("bio", NormalValue::String("ssn 123-45-6789".to_string()));
+    let modified: HashSet<String> = ["bio".to_string()].into_iter().collect();
+
+    let updated = write_document_blocks(
+        &blockstore,
+        &headstore,
+        &doc,
+        "schema-v1",
+        identity,
+        Some(&modified),
+        None,
+        None,
+        None,
+    )
+    .await
+    .expect("update should succeed");
+
+    assert_eq!(updated.field_cids.len(), 1, "only `bio` should get a block");
+    assert_eq!(
+        field_block(&blockstore, &updated.field_cids[0])
+            .await
+            .encryption,
+        None,
+        "matches Go: a field with no prior head has nothing to inherit. \
+         Changing this is a deliberate divergence, not a bug fix."
+    );
+}
+
+/// Derivation must not invent encryption: a document created in the clear
+/// stays in the clear.
+#[tokio::test]
+async fn update_of_unencrypted_document_stays_plaintext() {
+    let (blockstore, headstore) = stores().await;
+    let identity = DocStorageIdentity::new(3, 3);
+
+    let mut doc = Document::new();
+    doc.set("name", NormalValue::String("Bob".to_string()));
+
+    let created = write_document_blocks(
+        &blockstore,
+        &headstore,
+        &doc,
+        "schema-v1",
+        identity,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await
+    .expect("create should succeed");
+
+    doc.set_id(document::DocID::from_string(&created.doc_id).unwrap());
+    doc.set("name", NormalValue::String("Bobby".to_string()));
+    let modified: HashSet<String> = ["name".to_string()].into_iter().collect();
+
+    let updated = write_document_blocks(
+        &blockstore,
+        &headstore,
+        &doc,
+        "schema-v1",
+        identity,
+        Some(&modified),
+        None,
+        None,
+        None,
+    )
+    .await
+    .expect("update should succeed");
+
+    assert_eq!(
+        field_block(&blockstore, &updated.field_cids[0])
+            .await
+            .encryption,
+        None,
+        "an unencrypted document must not become encrypted by derivation"
+    );
+    assert_eq!(
+        field_block(&blockstore, &updated.cid).await.encryption,
+        None
+    );
+}
+
+/// Deleting an encrypted document must leave a tombstone carrying the same
+/// `Encryption` link as the composite it supersedes. Go's delete path runs
+/// through the same `addDelta` as every other write
+/// (`internal/db/document_delete.go:181-195`), so `determineBlockEncryption`
+/// inherits from the composite heads. The composite payload itself is never
+/// ciphertext (`store.go:213-215`); only the link is attached.
+#[tokio::test]
+async fn delete_block_inherits_composite_encryption() {
+    let (blockstore, headstore) = stores().await;
+    let identity = DocStorageIdentity::new(8, 8);
+
+    let mut doc = Document::new();
+    doc.set("name", NormalValue::String("Alice".to_string()));
+
+    let enc = EncryptionConfig {
+        encrypt_doc: true,
+        encrypt_fields: vec![],
+    };
+
+    let created = write_document_blocks(
+        &blockstore,
+        &headstore,
+        &doc,
+        "schema-v1",
+        identity,
+        None,
+        Some(&enc),
+        None,
+        None,
+    )
+    .await
+    .expect("create should succeed");
+
+    let created_enc_cid = field_block(&blockstore, &created.cid)
+        .await
+        .encryption
+        .expect("created composite must carry an encryption link");
+
+    let deleted = write_delete_block(
+        &blockstore,
+        &headstore,
+        &created.doc_id,
+        8,
+        "schema-v1",
+        None,
+    )
+    .await
+    .expect("delete should succeed");
+
+    assert_eq!(
+        field_block(&blockstore, &deleted.cid).await.encryption,
+        Some(created_enc_cid),
+        "delete tombstone must inherit the composite's encryption link"
+    );
+}

--- a/crates/db-blocks/src/write_encryption_tests.rs
+++ b/crates/db-blocks/src/write_encryption_tests.rs
@@ -20,6 +20,13 @@ async fn stores() -> (NamespaceView, NamespaceView) {
     )
 }
 
+fn delta_data(block: &Block) -> Vec<u8> {
+    match &block.delta {
+        CrdtDelta::Lww(payload) => payload.data.clone(),
+        other => panic!("expected an LWW delta, got {:?}", other),
+    }
+}
+
 async fn field_block(blockstore: &NamespaceView, cid: &Cid) -> Block {
     let bytes = blockstore
         .get(&cid.to_bytes())
@@ -353,21 +360,19 @@ async fn inheritance_is_per_field() {
     );
 }
 
-/// KNOWN GAP, deliberately matching Go: a field first written by an update
-/// has no heads of its own, so there is nothing to inherit from and the
-/// delta is written in plaintext — even on a document created with
-/// `encrypt_doc: true`.
+/// A field first written by an update has no heads of its own, so field-level
+/// inheritance finds nothing. On a document encrypted as a whole it must still
+/// be encrypted, under the document-level policy the composite head records.
 ///
-/// Go behaves identically. `addDelta` builds its head set from the field's
-/// own prefix (`internal/core/block/store.go:82-86`,
+/// **Deliberate divergence from Go.** Go's `addDelta` builds its head set from
+/// the field's own prefix (`internal/core/block/store.go:82-86`,
 /// `NewHeadSet(txn.Headstore(), crdtData.HeadstorePrefix())`), so
-/// `determineBlockEncryption` sees no heads and attaches no encryption.
-///
-/// This is a characterization test, not an endorsement: it pins the
-/// behaviour so a future change cannot alter it silently. To be disclosed
-/// upstream to the Go team.
+/// `determineBlockEncryption` sees no heads and writes the new field in
+/// plaintext. Matching that would regress our own pre-#1292 behaviour, which
+/// encrypted this field, and would reopen the silent-plaintext hazard this
+/// derivation exists to close.
 #[tokio::test]
-async fn field_added_by_update_is_written_plaintext_matching_go() {
+async fn field_added_by_update_inherits_document_encryption() {
     let (blockstore, headstore) = stores().await;
     let identity = DocStorageIdentity::new(7, 7);
 
@@ -412,13 +417,16 @@ async fn field_added_by_update_is_written_plaintext_matching_go() {
     .expect("update should succeed");
 
     assert_eq!(updated.field_cids.len(), 1, "only `bio` should get a block");
-    assert_eq!(
-        field_block(&blockstore, &updated.field_cids[0])
-            .await
-            .encryption,
-        None,
-        "matches Go: a field with no prior head has nothing to inherit. \
-         Changing this is a deliberate divergence, not a bug fix."
+    let bio = field_block(&blockstore, &updated.field_cids[0]).await;
+    assert!(
+        bio.encryption.is_some(),
+        "a field introduced on an `encrypt_doc` document must be encrypted \
+         under the document-level policy, not written in plaintext"
+    );
+    assert_ne!(
+        delta_data(&bio),
+        encode_value_as_cbor(&NormalValue::String("ssn 123-45-6789".to_string())).unwrap(),
+        "the delta must hold ciphertext, not the plaintext value"
     );
 }
 
@@ -530,5 +538,190 @@ async fn delete_block_inherits_composite_encryption() {
         field_block(&blockstore, &deleted.cid).await.encryption,
         Some(created_enc_cid),
         "delete tombstone must inherit the composite's encryption link"
+    );
+}
+
+/// The document-level fallback must key off whole-document encryption only.
+/// A document with `encrypt_fields` leaves its composite unencrypted, so a
+/// field that was never in that list stays in the clear when introduced later.
+#[tokio::test]
+async fn field_added_to_field_encrypted_document_stays_plaintext() {
+    let (blockstore, headstore) = stores().await;
+    let identity = DocStorageIdentity::new(9, 9);
+
+    let mut doc = Document::new();
+    doc.set("secret", NormalValue::String("classified".to_string()));
+
+    let enc = EncryptionConfig {
+        encrypt_doc: false,
+        encrypt_fields: vec!["secret".to_string()],
+    };
+
+    let created = write_document_blocks(
+        &blockstore,
+        &headstore,
+        &doc,
+        "schema-v1",
+        identity,
+        None,
+        Some(&enc),
+        None,
+        None,
+    )
+    .await
+    .expect("create should succeed");
+
+    doc.set_id(document::DocID::from_string(&created.doc_id).unwrap());
+    doc.set("bio", NormalValue::String("public".to_string()));
+    let modified: HashSet<String> = ["bio".to_string()].into_iter().collect();
+
+    let updated = write_document_blocks(
+        &blockstore,
+        &headstore,
+        &doc,
+        "schema-v1",
+        identity,
+        Some(&modified),
+        None,
+        None,
+        None,
+    )
+    .await
+    .expect("update should succeed");
+
+    assert_eq!(
+        field_block(&blockstore, &updated.field_cids[0])
+            .await
+            .encryption,
+        None,
+        "`bio` was never in `encrypt_fields`, so nothing should encrypt it"
+    );
+}
+
+/// Derivation must not invent encryption for a field either: a document
+/// created in the clear stays in the clear when a field is added to it.
+#[tokio::test]
+async fn field_added_to_unencrypted_document_stays_plaintext() {
+    let (blockstore, headstore) = stores().await;
+    let identity = DocStorageIdentity::new(10, 10);
+
+    let mut doc = Document::new();
+    doc.set("name", NormalValue::String("Alice".to_string()));
+
+    let created = write_document_blocks(
+        &blockstore,
+        &headstore,
+        &doc,
+        "schema-v1",
+        identity,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await
+    .expect("create should succeed");
+
+    doc.set_id(document::DocID::from_string(&created.doc_id).unwrap());
+    doc.set("bio", NormalValue::String("public".to_string()));
+    let modified: HashSet<String> = ["bio".to_string()].into_iter().collect();
+
+    let updated = write_document_blocks(
+        &blockstore,
+        &headstore,
+        &doc,
+        "schema-v1",
+        identity,
+        Some(&modified),
+        None,
+        None,
+        None,
+    )
+    .await
+    .expect("update should succeed");
+
+    assert_eq!(
+        field_block(&blockstore, &updated.field_cids[0])
+            .await
+            .encryption,
+        None,
+        "an unencrypted document must not acquire encryption from a new field"
+    );
+}
+
+/// The fallback is not gated on the field being brand new. A field whose
+/// history predates the document being encrypted has heads, but none of them
+/// carry an encryption link, so field-level inheritance finds nothing — the
+/// document-level policy must still cover it.
+#[tokio::test]
+async fn document_policy_covers_field_whose_history_predates_encryption() {
+    let (blockstore, headstore) = stores().await;
+    let identity = DocStorageIdentity::new(11, 11);
+
+    let mut doc = Document::new();
+    doc.set("name", NormalValue::String("Alice".to_string()));
+    doc.set("bio", NormalValue::String("public".to_string()));
+
+    let created = write_document_blocks(
+        &blockstore,
+        &headstore,
+        &doc,
+        "schema-v1",
+        identity,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await
+    .expect("create should succeed");
+
+    doc.set_id(document::DocID::from_string(&created.doc_id).unwrap());
+
+    // Turn on whole-document encryption while touching only `bio`.
+    doc.set("bio", NormalValue::String("still public".to_string()));
+    let enc = EncryptionConfig {
+        encrypt_doc: true,
+        encrypt_fields: vec![],
+    };
+    write_document_blocks(
+        &blockstore,
+        &headstore,
+        &doc,
+        "schema-v1",
+        identity,
+        Some(&["bio".to_string()].into_iter().collect()),
+        Some(&enc),
+        None,
+        None,
+    )
+    .await
+    .expect("encrypting update should succeed");
+
+    // `name` still has only its unencrypted create block as a head.
+    doc.set("name", NormalValue::String("Bob".to_string()));
+    let updated = write_document_blocks(
+        &blockstore,
+        &headstore,
+        &doc,
+        "schema-v1",
+        identity,
+        Some(&["name".to_string()].into_iter().collect()),
+        None,
+        None,
+        None,
+    )
+    .await
+    .expect("update should succeed");
+
+    let name = field_block(&blockstore, &updated.field_cids[0]).await;
+    assert!(
+        name.encryption.is_some(),
+        "the document is encrypted as a whole, so `name` must be too"
+    );
+    assert_ne!(
+        delta_data(&name),
+        encode_value_as_cbor(&NormalValue::String("Bob".to_string())).unwrap(),
+        "the delta must hold ciphertext, not the plaintext value"
     );
 }

--- a/crates/db-blocks/src/write_kms_tests.rs
+++ b/crates/db-blocks/src/write_kms_tests.rs
@@ -1,0 +1,258 @@
+//! KMS interaction on the write path: key generation and inherited-key
+//! resolution when a `KmsService` is configured.
+//!
+//! Split out of `write.rs` to keep that file within the repo's size guidance.
+
+use super::*;
+use async_trait::async_trait;
+use datastore::{NamespaceView, SharedTxn};
+use defra_core::encryption::EncryptionConfig;
+use std::sync::Arc;
+use storage::backends::MemoryStore;
+use storage::corekv::Store;
+use storage::namespace::Namespace;
+
+/// Stub KMS that mirrors the real `MemoryKeyStore::generate` block shape so
+/// the returned CID matches what the legacy path would produce for the same
+/// scope. The key is fixed to make the assertion deterministic.
+///
+/// Like `MemoryKeyStore`, it keeps the `Encryption` block to itself rather
+/// than writing it into the encstore or blockstore — the write path must
+/// come back through `get_keys` to resolve it.
+struct StubKms;
+
+#[async_trait]
+impl kms::KmsService for StubKms {
+    async fn get_keys(
+        &self,
+        _: &kms::RequestContext,
+        cids: &[kms::EncryptionCid],
+    ) -> kms::Result<kms::KeyResults> {
+        let (r, tx) = kms::KeyResults::new(cids.len());
+        for cid in cids {
+            if *cid == expected_field_cid() {
+                let _ = tx.send(Ok((*cid, [5u8; 32]))).await;
+            }
+        }
+        drop(tx);
+        Ok(r)
+    }
+
+    async fn generate_key(
+        &self,
+        _: &kms::RequestContext,
+        scope: kms::KeyScope,
+    ) -> kms::Result<(kms::EncryptionCid, [u8; 32])> {
+        let (doc_id_bytes, field_name) = match scope {
+            kms::KeyScope::Document { doc_id, field } => (doc_id.into_bytes(), field),
+            kms::KeyScope::Collection { collection_id } => (Vec::new(), Some(collection_id)),
+        };
+        let _ = (doc_id_bytes, field_name);
+        let block = defra_core::Encryption { key: vec![5u8; 32] };
+        let bytes = block.to_dag_cbor().unwrap();
+        let cid = defra_core::block::generate_cid_from_bytes(&bytes).unwrap();
+        Ok((cid, [5u8; 32]))
+    }
+
+    async fn serve_request(
+        &self,
+        _: kms::PeerIdentity,
+        _: kms::FetchEncryptionKeyRequest,
+    ) -> kms::Result<kms::FetchEncryptionKeyReply> {
+        Err(kms::Error::Unsupported("stub"))
+    }
+}
+
+/// Recompute the CID the stub KMS would return, so the test asserts
+/// against the KMS-derived CID rather than a hardcoded value.
+fn expected_field_cid() -> Cid {
+    let block = defra_core::Encryption { key: vec![5u8; 32] };
+    let bytes = block.to_dag_cbor().unwrap();
+    generate_cid_from_bytes(&bytes).unwrap()
+}
+
+#[tokio::test]
+async fn kms_write_path_links_field_block_to_kms_encryption_cid() {
+    let store = MemoryStore::new();
+    let txn = store.new_txn(false).await.unwrap();
+    let shared = SharedTxn::new(txn);
+    let blockstore = NamespaceView::new(shared.clone(), Namespace::Blockstore);
+    let headstore = NamespaceView::new(shared.clone(), Namespace::Headstore);
+
+    let mut doc = Document::new();
+    doc.set("secret", NormalValue::String("classified".to_string()));
+
+    let enc = EncryptionConfig {
+        encrypt_doc: false,
+        encrypt_fields: vec!["secret".to_string()],
+    };
+
+    let kms: Arc<dyn kms::KmsService> = Arc::new(StubKms);
+
+    let result = write_document_blocks(
+        &blockstore,
+        &headstore,
+        &doc,
+        "schema-v1",
+        DocStorageIdentity::new(1, 1),
+        None,
+        Some(&enc),
+        None,
+        Some(&kms),
+    )
+    .await
+    .expect("KMS write path should succeed");
+
+    assert_eq!(result.field_cids.len(), 1);
+    let field_cid = result.field_cids[0];
+    let field_bytes = blockstore
+        .get(&field_cid.to_bytes())
+        .await
+        .unwrap()
+        .expect("field block stored");
+    let field_block = Block::from_dag_cbor(&field_bytes).unwrap();
+
+    let expected = expected_field_cid();
+    assert_eq!(
+        field_block.encryption,
+        Some(expected),
+        "field block must link to the KMS-generated encryption CID"
+    );
+}
+
+/// Inheritance must resolve the previous block's key through the KMS when
+/// one is configured. A `KeyStore` is only promised local persistence, not
+/// persistence into the encstore or blockstore, so reading those alone
+/// fails an update that carries no config of its own.
+#[tokio::test]
+async fn inheritance_resolves_the_key_through_the_kms() {
+    let store = MemoryStore::new();
+    let txn = store.new_txn(false).await.unwrap();
+    let shared = SharedTxn::new(txn);
+    let blockstore = NamespaceView::new(shared.clone(), Namespace::Blockstore);
+    let headstore = NamespaceView::new(shared.clone(), Namespace::Headstore);
+    let identity = DocStorageIdentity::new(1, 1);
+
+    let mut doc = Document::new();
+    doc.set("secret", NormalValue::String("classified".to_string()));
+
+    let enc = EncryptionConfig {
+        encrypt_doc: false,
+        encrypt_fields: vec!["secret".to_string()],
+    };
+
+    let kms: Arc<dyn kms::KmsService> = Arc::new(StubKms);
+
+    let created = write_document_blocks(
+        &blockstore,
+        &headstore,
+        &doc,
+        "schema-v1",
+        identity,
+        None,
+        Some(&enc),
+        None,
+        Some(&kms),
+    )
+    .await
+    .expect("KMS create should succeed");
+
+    doc.set_id(document::DocID::from_string(&created.doc_id).unwrap());
+    doc.set(
+        "secret",
+        NormalValue::String("still classified".to_string()),
+    );
+    let modified: std::collections::HashSet<String> = ["secret".to_string()].into_iter().collect();
+
+    let updated = write_document_blocks(
+        &blockstore,
+        &headstore,
+        &doc,
+        "schema-v1",
+        identity,
+        Some(&modified),
+        None,
+        None,
+        Some(&kms),
+    )
+    .await
+    .expect("update must resolve the inherited key through the KMS");
+
+    let field_bytes = blockstore
+        .get(&updated.field_cids[0].to_bytes())
+        .await
+        .unwrap()
+        .expect("field block stored");
+    assert_eq!(
+        Block::from_dag_cbor(&field_bytes).unwrap().encryption,
+        Some(expected_field_cid()),
+        "update must inherit the KMS-generated encryption link"
+    );
+}
+
+/// The document-level policy fallback must mint through the KMS as well. A
+/// field introduced by an update on an `encrypt_doc` document has no head to
+/// inherit from, so it takes the generate path — and on a KMS-configured node
+/// that key belongs in the KMS, not in an inline block.
+#[tokio::test]
+async fn document_policy_fallback_mints_through_the_kms() {
+    let store = MemoryStore::new();
+    let txn = store.new_txn(false).await.unwrap();
+    let shared = SharedTxn::new(txn);
+    let blockstore = NamespaceView::new(shared.clone(), Namespace::Blockstore);
+    let headstore = NamespaceView::new(shared.clone(), Namespace::Headstore);
+    let identity = DocStorageIdentity::new(2, 2);
+
+    let mut doc = Document::new();
+    doc.set("name", NormalValue::String("Alice".to_string()));
+
+    let enc = EncryptionConfig {
+        encrypt_doc: true,
+        encrypt_fields: vec![],
+    };
+
+    let kms: Arc<dyn kms::KmsService> = Arc::new(StubKms);
+
+    let created = write_document_blocks(
+        &blockstore,
+        &headstore,
+        &doc,
+        "schema-v1",
+        identity,
+        None,
+        Some(&enc),
+        None,
+        Some(&kms),
+    )
+    .await
+    .expect("KMS create should succeed");
+
+    doc.set_id(document::DocID::from_string(&created.doc_id).unwrap());
+    doc.set("bio", NormalValue::String("ssn 123-45-6789".to_string()));
+    let modified: std::collections::HashSet<String> = ["bio".to_string()].into_iter().collect();
+
+    let updated = write_document_blocks(
+        &blockstore,
+        &headstore,
+        &doc,
+        "schema-v1",
+        identity,
+        Some(&modified),
+        None,
+        None,
+        Some(&kms),
+    )
+    .await
+    .expect("update should succeed");
+
+    let bio_bytes = blockstore
+        .get(&updated.field_cids[0].to_bytes())
+        .await
+        .unwrap()
+        .expect("field block stored");
+    assert_eq!(
+        Block::from_dag_cbor(&bio_bytes).unwrap().encryption,
+        Some(expected_field_cid()),
+        "the new field's key must come from the KMS, not from an inline block"
+    );
+}

--- a/crates/db/src/auto_commit_mutator/batch.rs
+++ b/crates/db/src/auto_commit_mutator/batch.rs
@@ -21,7 +21,7 @@ use crate::database::DB;
 use crate::event_emission::register_update_event_callback;
 use crate::txn::DbTxn;
 use db_blocks::DocStorageIdentity;
-use defra_core::encryption::{get_doc_encryption, get_encryption_config, store_doc_encryption};
+use defra_core::encryption::get_encryption_config;
 use defra_core::signing::get_signing_config;
 
 pub struct BatchMutator<S: Store> {
@@ -251,10 +251,6 @@ impl<S: Store + 'static> DocMutator for BatchMutator<S> {
             .await?;
             doc.set_id(doc_id.clone());
 
-            if let Some(ref config) = enc_config {
-                store_doc_encryption(&doc_id.to_string(), config.clone());
-            }
-
             write_local_create(&datastore, &collection, &doc, doc_short_id, &index_manager).await?;
 
             let mut col_block_data: Option<(Cid, Vec<u8>)> = None;
@@ -375,8 +371,7 @@ impl<S: Store + 'static> DocMutator for BatchMutator<S> {
 
         let short_id = collection.resolved_root_id();
         let schema_version_id = collection.version_id();
-        let enc_config =
-            get_encryption_config().or_else(|| get_doc_encryption(&canonical_doc_id.to_string()));
+        let enc_config = get_encryption_config();
         let sign_config = get_signing_config();
 
         let (doc_cid, doc_block, col_block_data) = {

--- a/crates/db/src/auto_commit_mutator/create.rs
+++ b/crates/db/src/auto_commit_mutator/create.rs
@@ -134,11 +134,6 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
             .await?;
             doc.set_id(doc_id.clone());
 
-            // Store encryption config per-document so updates re-apply it
-            if let Some(ref config) = enc_config {
-                store_doc_encryption(&doc_id.to_string(), config.clone());
-            }
-
             // Bundle the doc blob + index write with the counter-store seeding so
             // the authoritative CRDT accumulation store is always seeded on create
             // (#1021 single-store invariant) — enforced by construction in

--- a/crates/db/src/auto_commit_mutator/create_many.rs
+++ b/crates/db/src/auto_commit_mutator/create_many.rs
@@ -213,10 +213,6 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
             .await?;
             doc.set_id(doc_id.clone());
 
-            if let Some(ref config) = enc_config {
-                store_doc_encryption(&doc_id.to_string(), config.clone());
-            }
-
             write_local_create(
                 &datastore,
                 &collection,

--- a/crates/db/src/auto_commit_mutator/mod.rs
+++ b/crates/db/src/auto_commit_mutator/mod.rs
@@ -32,7 +32,7 @@ use crate::lensed_fetcher::LensedDocFetcher;
 /// Captured per-mutation commit data: the document block (cid + bytes) plus,
 /// for branchable collections, the collection block (cid + bytes).
 pub(super) type CommitArtifacts = (Cid, Vec<u8>, Option<(Cid, Vec<u8>)>);
-use defra_core::encryption::{get_doc_encryption, get_encryption_config, store_doc_encryption};
+use defra_core::encryption::get_encryption_config;
 use defra_core::signing::get_signing_config;
 
 pub use batch::BatchMutator;

--- a/crates/db/src/auto_commit_mutator/update.rs
+++ b/crates/db/src/auto_commit_mutator/update.rs
@@ -237,11 +237,11 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
 
                     // Use version_id for collectionVersionID (matches Go's VersionID())
                     let schema_version_id = collection.version_id();
-                    // Get encryption config: first try thread-local (explicit in mutation),
-                    // then fall back to per-document stored config (from create with encryption).
-                    // This matches Go's behavior where encryption propagates through the DAG.
-                    let enc_config = get_encryption_config()
-                        .or_else(|| doc.id().and_then(|id| get_doc_encryption(&id.to_string())));
+                    // Explicit config from the mutation only. A document created
+                    // encrypted keeps its encryption because the block writer
+                    // inherits it from the previous block, matching Go's
+                    // determineBlockEncryption.
+                    let enc_config = get_encryption_config();
                     // Get signing config from thread-local (set by FFI exec_request)
                     let sign_config = get_signing_config();
 

--- a/crates/db/src/doc_mutator.rs
+++ b/crates/db/src/doc_mutator.rs
@@ -16,7 +16,7 @@ use crate::database::DB;
 use crate::event_emission::register_update_event_callback;
 use crate::txn::DbTxn;
 use db_blocks::DocStorageIdentity;
-use defra_core::encryption::{get_doc_encryption, get_encryption_config, store_doc_encryption};
+use defra_core::encryption::get_encryption_config;
 use defra_core::signing::get_signing_config;
 
 fn document_json_value(doc: &Document) -> Option<serde_json::Value> {
@@ -258,10 +258,6 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
             .await?;
             doc.set_id(doc_id.clone());
 
-            if let Some(ref config) = enc_config {
-                store_doc_encryption(&doc_id.to_string(), config.clone());
-            }
-
             let mut col_block_data: Option<(Cid, Vec<u8>)> = None;
             if collection.schema().is_branchable {
                 let short_id = collection.resolved_root_id();
@@ -476,8 +472,7 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
             })?;
 
             let schema_version_id = collection.version_id();
-            let enc_config = get_encryption_config()
-                .or_else(|| doc.id().and_then(|id| get_doc_encryption(&id.to_string())));
+            let enc_config = get_encryption_config();
             let sign_config = get_signing_config();
             let kms = self.db.kms();
 

--- a/crates/defra-core/src/encryption.rs
+++ b/crates/defra-core/src/encryption.rs
@@ -21,10 +21,12 @@
 //! `inherited_encryption`, mirroring Go's `determineBlockEncryption` in
 //! `internal/core/block/store.go`.
 //!
-//! Inheritance is per field and requires a previous head, so a field first
-//! written by an update inherits nothing and is stored in plaintext even on a
-//! document created with `encrypt_doc`. Go behaves the same way; see
-//! `db-blocks`' `field_added_by_update_is_written_plaintext_matching_go`.
+//! Inheritance is per field and requires a previous head. A field first
+//! written by an update has none, so on a document encrypted as a whole it
+//! falls back to the document-level policy recorded by the composite block's
+//! encryption link, which mints it a key rather than leaving it in the clear.
+//! Go writes that field in plaintext instead (its head set is per-field,
+//! `internal/core/block/store.go`); this is a deliberate divergence.
 //!
 //! Reusing one key across a field's history is sound because every delta is
 //! sealed with a fresh random 96-bit nonce (see `crypto::encryption::nonce`).

--- a/crates/defra-core/src/encryption.rs
+++ b/crates/defra-core/src/encryption.rs
@@ -5,13 +5,31 @@
 //!
 //! # Key generation model
 //!
-//! Each encrypted write generates a fresh random AES-256 key via
-//! [`generate_encryption_key`]. The key is stored alongside its ciphertext
-//! in a separate `Encryption` block (see
+//! A write that explicitly requests encryption generates a fresh random
+//! AES-256 key via [`generate_encryption_key`]. The key is stored alongside
+//! its ciphertext in a separate `Encryption` block (see
 //! [`crate::block_signature::Encryption`]), and the data block links to it
 //! via its `encryption: Option<Cid>` field. Decryption loads the
 //! `Encryption` block by CID and reads the key directly — no master key
 //! is needed at the receiver.
+//!
+//! A write that carries no config does not turn encryption off: the block
+//! writer inherits the previous block's key and `Encryption` link, so a field
+//! created encrypted stays encrypted under one key for its whole history until
+//! a new explicit request rotates it. The DAG, not any process-local state, is
+//! what records that a document is encrypted — see `db-blocks`'
+//! `inherited_encryption`, mirroring Go's `determineBlockEncryption` in
+//! `internal/core/block/store.go`.
+//!
+//! Inheritance is per field and requires a previous head, so a field first
+//! written by an update inherits nothing and is stored in plaintext even on a
+//! document created with `encrypt_doc`. Go behaves the same way; see
+//! `db-blocks`' `field_added_by_update_is_written_plaintext_matching_go`.
+//!
+//! Reusing one key across a field's history is sound because every delta is
+//! sealed with a fresh random 96-bit nonce (see `crypto::encryption::nonce`).
+//! That uniqueness is load-bearing under this model: a deterministic or
+//! counter-based nonce would repeat a (key, nonce) pair across updates.
 //!
 //! This matches Go DefraDB's `internal/encryption/encryptor.go` exactly.
 //! The previous Rust implementation derived keys deterministically from
@@ -27,9 +45,7 @@
 
 use rand::RngCore;
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Mutex;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 const DETERMINISTIC_TEST_CRYPTO_ENV: &str = "DEFRA_ALLOW_DETERMINISTIC_TEST_CRYPTO";
@@ -81,9 +97,10 @@ impl AsRef<[u8]> for EncryptionKey {
 /// Encryption policy for a CRDT document mutation.
 ///
 /// Carries which fields should be encrypted; does NOT carry any key
-/// material. Each encrypted write generates a fresh random key via
-/// [`generate_encryption_key`] and stores it in the per-block
-/// `Encryption` metadata.
+/// material. A write that supplies this config generates a fresh random key
+/// via [`generate_encryption_key`] and stores it in the per-block
+/// `Encryption` metadata; a write without one inherits the previous block's
+/// key instead of dropping to plaintext.
 #[derive(Debug, Clone, Default)]
 pub struct EncryptionConfig {
     pub encrypt_doc: bool,
@@ -184,43 +201,6 @@ pub fn set_encryption_config(config: Option<EncryptionConfig>) {
 /// Get the current encryption config for this thread.
 pub fn get_encryption_config() -> Option<EncryptionConfig> {
     CURRENT_ENCRYPTION_CONFIG.with(|c| c.borrow().clone())
-}
-
-/// Global per-document encryption store.
-/// Maps docID → EncryptionConfig so updates can re-apply encryption
-/// that was set during document creation.
-static DOC_ENCRYPTION_STORE: std::sync::OnceLock<Mutex<HashMap<String, EncryptionConfig>>> =
-    std::sync::OnceLock::new();
-
-fn doc_encryption_store() -> &'static Mutex<HashMap<String, EncryptionConfig>> {
-    DOC_ENCRYPTION_STORE.get_or_init(|| Mutex::new(HashMap::new()))
-}
-
-const MAX_DOC_ENCRYPTION_ENTRIES: usize = 10_000;
-
-/// Store encryption config for a document.
-pub fn store_doc_encryption(doc_id: &str, config: EncryptionConfig) {
-    if let Ok(mut store) = doc_encryption_store().lock() {
-        if store.len() >= MAX_DOC_ENCRYPTION_ENTRIES {
-            store.clear();
-        }
-        store.insert(doc_id.to_string(), config);
-    }
-}
-
-/// Retrieve stored encryption config for a document.
-pub fn get_doc_encryption(doc_id: &str) -> Option<EncryptionConfig> {
-    doc_encryption_store()
-        .lock()
-        .ok()
-        .and_then(|store| store.get(doc_id).cloned())
-}
-
-/// Clear all stored encryption configs (for node cleanup).
-pub fn clear_doc_encryption_store() {
-    if let Ok(mut store) = doc_encryption_store().lock() {
-        store.clear();
-    }
 }
 
 #[cfg(test)]

--- a/tools/integration-test/tests/encryption.rs
+++ b/tools/integration-test/tests/encryption.rs
@@ -4,6 +4,8 @@ mod acp;
 mod block_verify;
 #[path = "encryption/cross_runtime_p2p.rs"]
 mod cross_runtime_p2p;
+#[path = "encryption/document_policy.rs"]
+mod document_policy;
 #[path = "encryption/index.rs"]
 mod index;
 #[path = "encryption/key_management.rs"]

--- a/tools/integration-test/tests/encryption/document_policy.rs
+++ b/tools/integration-test/tests/encryption/document_policy.rs
@@ -1,0 +1,135 @@
+use base64::Engine;
+use integration_test::{for_each_runtime, TestCluster};
+use serde_json::Value;
+
+const SECRET: &str = "ssn 123-45-6789";
+
+fn doc_id_of(data: &Value, mutation: &str) -> String {
+    data[mutation]
+        .as_array()
+        .and_then(|arr| arr.first())
+        .and_then(|v| v["_docID"].as_str())
+        .or_else(|| data[mutation]["_docID"].as_str())
+        .expect("missing _docID")
+        .to_string()
+}
+
+/// The raw delta bytes of the newest commit for `field`.
+///
+/// `fieldName` is a commit field rather than a `_commits` argument, so the
+/// filtering happens here.
+fn newest_delta(node: &integration_test::DefraClient, doc_id: &str, field: &str) -> Vec<u8> {
+    let query = format!(
+        r#"query {{ _commits(docID: "{}") {{ height fieldName delta }} }}"#,
+        doc_id
+    );
+    let result = node.query(&query).expect("commits query");
+    let commits = result
+        .get("_commits")
+        .or_else(|| result.get("commits"))
+        .and_then(|v| v.as_array())
+        .unwrap_or_else(|| panic!("no commits array in {}", result));
+
+    let newest = commits
+        .iter()
+        .filter(|c| c["fieldName"].as_str() == Some(field))
+        .max_by_key(|c| c["height"].as_i64().unwrap_or(0))
+        .unwrap_or_else(|| panic!("no commits for field `{}` in {}", field, result));
+
+    let delta = newest["delta"].as_str().expect("commit delta");
+    base64::engine::general_purpose::STANDARD
+        .decode(delta)
+        .expect("delta is base64")
+}
+
+/// A field introduced by an update on a document encrypted as a whole must be
+/// stored as ciphertext, across separate requests — the create and the update
+/// run in different transactions, so nothing in-process carries the policy
+/// between them.
+///
+/// This is the end-to-end form of `db-blocks`'
+/// `field_added_by_update_inherits_document_encryption`, and Rust-only on
+/// purpose: run against a Go node this same body fails, because Go derives
+/// encryption from the field's own heads (`internal/core/block/store.go`) and a
+/// field introduced by an update has none. Asserting Go's behaviour here would
+/// pin an upstream defect, so the divergence is documented rather than tested.
+async fn document_policy_covers_new_field_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+
+    node.schema_add("type Vault { name: String, notes: String }")
+        .expect("add Vault schema");
+
+    let created = node
+        .query(r#"mutation { add_Vault(input: {name: "Alice"}, encrypt: true) { _docID } }"#)
+        .expect("create encrypted document");
+    let doc_id = doc_id_of(&created, "add_Vault");
+
+    node.query(&format!(
+        r#"mutation {{ update_Vault(docID: "{}", input: {{notes: "{}"}}) {{ _docID }} }}"#,
+        doc_id, SECRET
+    ))
+    .expect("update adding a new field");
+
+    let delta = newest_delta(&node, &doc_id, "notes");
+    assert!(
+        !delta.windows(SECRET.len()).any(|w| w == SECRET.as_bytes()),
+        "`notes` was introduced by an update on an `encrypt: true` document and \
+         must be ciphertext, but its delta contains the plaintext value"
+    );
+
+    // The value is still readable through the normal query path.
+    let read = node
+        .query(&format!(
+            r#"query {{ Vault(docID: "{}") {{ notes }} }}"#,
+            doc_id
+        ))
+        .expect("read back the document");
+    assert_eq!(
+        read["Vault"][0]["notes"].as_str(),
+        Some(SECRET),
+        "the encrypted field must still decrypt for an authorized reader"
+    );
+}
+
+/// The mirror case: an unencrypted document must not acquire encryption when a
+/// field is added to it.
+async fn unencrypted_document_new_field_stays_plaintext_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+
+    node.schema_add("type Ledger { name: String, notes: String }")
+        .expect("add Ledger schema");
+
+    let created = node
+        .query(r#"mutation { add_Ledger(input: {name: "Alice"}) { _docID } }"#)
+        .expect("create plaintext document");
+    let doc_id = doc_id_of(&created, "add_Ledger");
+
+    node.query(&format!(
+        r#"mutation {{ update_Ledger(docID: "{}", input: {{notes: "public note"}}) {{ _docID }} }}"#,
+        doc_id
+    ))
+    .expect("update adding a new field");
+
+    let delta = newest_delta(&node, &doc_id, "notes");
+    assert!(
+        delta
+            .windows("public note".len())
+            .any(|w| w == b"public note"),
+        "an unencrypted document must not acquire encryption from a new field"
+    );
+}
+
+#[tokio::test]
+async fn rust_document_policy_covers_new_field() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(1)
+        .build()
+        .await
+        .expect("build rust cluster");
+    document_policy_covers_new_field_test(cluster).await;
+}
+
+for_each_runtime!(
+    unencrypted_document_new_field_stays_plaintext,
+    unencrypted_document_new_field_stays_plaintext_test
+);


### PR DESCRIPTION
Closes #1292.

## Problem

The document encryption store treated "at capacity" as "discard everything": at 10,000 entries
`store_doc_encryption` called `store.clear()`. Reproduced before touching anything, crossing the
threshold left 0 of 9,999 entries alive.

The stored `EncryptionConfig` was what told a later update to keep encrypting a document created
encrypted. A lost entry raised no error: the update path fell back to `None`, and `None` is
indistinguishable from "encryption was never requested", so the delta was written in plaintext. One
insert past the threshold silently turned encryption off for every encrypted document the process
had seen. Process restart had the same effect, since the store lived only in memory.

Go carries no such cache. `determineBlockEncryption` (`internal/core/block/store.go:144-198`) reads
the document's head blocks on every write and inherits the previous block's encryption when the
request supplies none. The Rust store stood in for a mechanism that was simply never ported, and
every input it needed was already available: head CIDs from `DocHeadsSnapshot`, and
`Block.encryption: Option<Cid>`. Bounding the eviction would have reduced the blast radius from
~10,000 documents to one per eviction while leaving the silent-plaintext hazard in place.

Note: the issue cites lines 192-199; the defect had drifted to 199-205.

## What changed

- Add `inherited_encryption_cid` / `inherited_encryption` in `crates/db-blocks/src/write.rs`, wired
  into both the per-field and composite encryption sites. When a write carries no explicit config,
  the field's heads are consulted and the previous block's key and `Encryption` link are reused
  as-is, with no new encryption block written, matching `store.go:192-195`.
- Delete the process-global store outright: the static, the accessor, `MAX_DOC_ENCRYPTION_ENTRIES`,
  `store_doc_encryption`, `get_doc_encryption` and `clear_doc_encryption_store`, plus all seven call
  sites in `crates/db`.
- Add `NamespaceView::sibling` so the encryption-block lookup checks the encstore before the
  blockstore, matching every other read path in the codebase
  (`db-merge/src/merge_handler/encryption.rs`, `versioned_fetcher.rs`, `kms_adapters.rs`).
- Derive the inherited link in `write_delete_block` too, so a delete tombstone on an encrypted
  document carries the same `Encryption` link as the composite it supersedes. Go's delete path runs
  through the same `addDelta` as every other write (`internal/db/document_delete.go:181-195`).
- Document the nonce-uniqueness invariant that the inherited-key model now depends on, at both the
  module and function level.
- Add eight unit tests in `crates/db-blocks/src/write_encryption_tests.rs`, the first coverage this
  behavior has had.

The comment in `update.rs` claiming to "match Go's behavior where encryption propagates through the
DAG" is now actually true.

## Behavior changes worth reviewing

**Key lifecycle.** Previously every encrypted write minted a fresh random key and wrote a new
`Encryption` block, so a field updated N times had N keys and N blocks. It now has one key and one
block referenced N times, and keys rotate only when a request explicitly supplies a config. This is
Go's model and the point of the port, not a side effect.

Reusing a key across a field's history is sound because every delta is sealed with a fresh random
96-bit nonce (`crates/crypto/src/encryption/aes.rs`, `nonce.rs`); the birthday bound of roughly 2^32
messages per key is unreachable for one field. That uniqueness is now load-bearing in a way it was
not under fresh-key-per-write, hence the added documentation: a deterministic or counter-based nonce
would repeat a (key, nonce) pair across updates.

**A missing head block is now an error, not a miss.** Guessing "not encrypted" is precisely the
silent downgrade this change exists to remove, and Go returns `ErrCouldNotFindBlock` in the same
spot.

**Known gap, deliberately matching Go.** A field first written by an update has no heads of its own,
so it inherits nothing and is stored in plaintext even on a document created with
`encrypt_doc: true`. Go behaves identically: `addDelta` builds its head set from the field's own
prefix (`store.go:82-86`), so `determineBlockEncryption` sees no heads. This chooses parity over a
unilateral divergence and pins the behavior with a characterization test,
`field_added_by_update_is_written_plaintext_matching_go`. It is being disclosed upstream to the Go
team rather than silently patched on one side.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --all-targets -- -D warnings`
- [x] `cargo test -p db-blocks -p defra-core -p db` (18 / 85 / 165)
- [x] `cargo test -p integration-test --test basic` (34)
- [x] `cargo test -p integration-test --test encryption` (12 passing, 4 known environmental)
- [x] `cargo test -p integration-test --test acp` (198, 16 ignored)
- [x] `cargo test -p integration-test --test p2p` (98, 11 ignored)
- [x] `git diff --check`

All boxes were run on this branch's tree and re-run after rebasing onto `e419da0f`.

Two suites cannot be verified locally. The 4 encryption cross-runtime tests and the Go-compat FFI
suite both need a Go binary at a hardcoded path that is absent on this machine; confirmed
pre-existing by reproducing the identical 4 failures on a clean tree. **CI must confirm the FFI
compat suite.** It is expected to pass unchanged: in deterministic mode the key is a pure function of
(docRef, field), so inheriting and regenerating produce identical bytes, which is also why this
divergence went unnoticed.

