### PR TITLE
fix(db-merge): retry rate-limited replay nacks with backoff instead of abandoning the document

### DIFF
--- a/crates/db-merge/src/push_docs.rs
+++ b/crates/db-merge/src/push_docs.rs
@@ -305,7 +305,9 @@ pub async fn push_existing_docs_with_config<S: storage::corekv::Store + 'static>
                     for req in requests {
                         let cid = req.cid.clone();
                         match gate
-                            .send_pushlog(&peer_key, push_h.send_two_stream_request(peer_id, req))
+                            .send_pushlog_with_rate_limit_retry(&peer_key, || {
+                                push_h.send_two_stream_request(peer_id, req.clone())
+                            })
                             .await
                         {
                             Ok(reply) if reply.err_message.is_some() => {

--- a/crates/db-merge/src/push_docs.rs
+++ b/crates/db-merge/src/push_docs.rs
@@ -8,7 +8,9 @@ use storage::corekv::{IterOptions, Reader, Store};
 
 use crate::push_docs_common::{load_latest_composite_head_cids, load_push_dag_blocks};
 use crate::push_docs_creator::resolve_push_creator;
-use crate::push_docs_replay::{ReplayPushConfig, ReplayPushGate};
+use crate::push_docs_replay::{
+    persist_replay_failures, ReplayDocumentFailure, ReplayPushConfig, ReplayPushGate,
+};
 use db::database::DB;
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -294,61 +296,68 @@ pub async fn push_existing_docs_with_config<S: storage::corekv::Store + 'static>
                 let push_h = handle.clone();
                 let gate = replay_gate.clone();
                 let peer_key = peer_key.clone();
+                let replay_doc_id = doc_id.clone();
+                let replay_collection_id = collection.collection_id().to_string();
                 let total_blocks = requests.len();
                 let permit = replay_gate
                     .acquire_document_task()
                     .await
                     .map_err(|e| format!("replay gate closed before scheduling push: {e}"))?;
-                push_handles.push(tokio::spawn(async move {
-                    let _permit = permit;
-                    let mut completed_blocks = 0usize;
-                    for req in requests {
-                        let cid = req.cid.clone();
-                        match gate
-                            .send_pushlog_with_rate_limit_retry(&peer_key, || {
-                                push_h.send_two_stream_request(peer_id, req.clone())
-                            })
-                            .await
-                        {
-                            Ok(reply) if reply.err_message.is_some() => {
-                                tracing::warn!(
-                                    peer_id = %peer_id,
-                                    completed_blocks,
-                                    total_blocks,
-                                    cid_len = cid.len(),
-                                    error = %reply.err_message.as_deref().unwrap_or("unknown pushlog error"),
-                                    "Existing document replay PushLog was rejected; stopping replay for this document"
-                                );
-                                break;
-                            }
-                            Ok(_) => {
-                                completed_blocks += 1;
-                            }
-                            Err(e) => {
-                                if e.is_connection_like() {
-                                    tracing::debug!(
-                                        peer_id = %peer_id,
-                                        completed_blocks,
-                                        total_blocks,
-                                        cid_len = cid.len(),
-                                        error = %e,
-                                        "Existing document replay stopped because the connection became unavailable"
-                                    );
-                                } else {
+                push_handles.push((
+                    replay_doc_id,
+                    replay_collection_id,
+                    tokio::spawn(async move {
+                        let _permit = permit;
+                        let mut completed_blocks = 0usize;
+                        for req in requests {
+                            let cid = req.cid.clone();
+                            match gate
+                                .send_pushlog_with_rate_limit_retry(&peer_key, || {
+                                    push_h.send_two_stream_request(peer_id, req.clone())
+                                })
+                                .await
+                            {
+                                Ok(reply) if reply.err_message.is_some() => {
                                     tracing::warn!(
                                         peer_id = %peer_id,
                                         completed_blocks,
                                         total_blocks,
                                         cid_len = cid.len(),
-                                        error = %e,
-                                        "Existing document replay PushLog failed; stopping replay for this document"
+                                        error = %reply.err_message.as_deref().unwrap_or("unknown pushlog error"),
+                                        "Existing document replay PushLog was rejected; deferring document to persisted retry"
                                     );
+                                    return false;
                                 }
-                                break;
+                                Ok(_) => {
+                                    completed_blocks += 1;
+                                }
+                                Err(e) => {
+                                    if e.is_connection_like() {
+                                        tracing::debug!(
+                                            peer_id = %peer_id,
+                                            completed_blocks,
+                                            total_blocks,
+                                            cid_len = cid.len(),
+                                            error = %e,
+                                            "Existing document replay stopped because the connection became unavailable"
+                                        );
+                                    } else {
+                                        tracing::warn!(
+                                            peer_id = %peer_id,
+                                            completed_blocks,
+                                            total_blocks,
+                                            cid_len = cid.len(),
+                                            error = %e,
+                                            "Existing document replay PushLog failed; deferring document to persisted retry"
+                                        );
+                                    }
+                                    return false;
+                                }
                             }
                         }
-                    }
-                }));
+                        true
+                    }),
+                ));
             }
         }
     }
@@ -357,10 +366,25 @@ pub async fn push_existing_docs_with_config<S: storage::corekv::Store + 'static>
     // The Go test framework copies expected heads on ReplicatorCompleted, then
     // waits for merge events -- if pushes haven't landed yet, we get timeouts.
     tracing::debug!(task_count = push_handles.len(), "awaiting push tasks");
-    for jh in push_handles {
-        let _ = jh.await;
+    let mut replay_failures = Vec::new();
+    for (doc_id, collection_id, jh) in push_handles {
+        match jh.await {
+            Ok(true) => {}
+            Ok(false) => replay_failures.push(ReplayDocumentFailure {
+                doc_id,
+                collection_id,
+            }),
+            Err(error) => {
+                tracing::error!(%error, %doc_id, "Replay push task panicked or was cancelled");
+                replay_failures.push(ReplayDocumentFailure {
+                    doc_id,
+                    collection_id,
+                });
+            }
+        }
     }
     tracing::debug!("all push tasks completed");
+    persist_replay_failures(db.store().clone(), &peer_key, &replay_failures).await?;
 
     if skipped_creator_docs > 0 {
         return Err(format!(

--- a/crates/db-merge/src/push_docs_replay.rs
+++ b/crates/db-merge/src/push_docs_replay.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::fmt;
 use std::future::Future;
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -26,6 +27,11 @@ pub const DEFAULT_REPLAY_RATE_LIMIT_RATE: f64 = p2p::sync::DEFAULT_RATE_LIMIT_RA
 /// Default timeout for a single replay PushLog request.
 pub const DEFAULT_REPLAY_SEND_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Retries to make immediately before durable replay takes ownership.
+const MAX_RATE_LIMITED_RETRIES: u32 = 6;
+/// Ceiling on the per-attempt rate-limit backoff.
+const RATE_LIMIT_RETRY_BACKOFF_CAP: Duration = Duration::from_secs(5);
+
 #[derive(Debug, Clone)]
 pub struct ReplayPushConfig {
     /// Maximum number of documents whose DAG blocks may be replayed concurrently.
@@ -42,6 +48,102 @@ pub struct ReplayPushConfig {
 
     /// Timeout for one outbound replay PushLog request.
     pub send_timeout: Duration,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ReplayDocumentFailure {
+    pub(crate) doc_id: String,
+    pub(crate) collection_id: String,
+}
+
+/// Persist documents that did not finish their initial replay so the normal
+/// jittered retry sweep owns them after the bounded in-memory attempt.
+pub(crate) async fn persist_replay_failures<S: storage::corekv::Store>(
+    store: Arc<S>,
+    peer_id: &PeerId,
+    failures: &[ReplayDocumentFailure],
+) -> Result<(), String> {
+    if failures.is_empty() {
+        return Ok(());
+    }
+
+    let peerstore = storage::stores::Peerstore::new(store);
+    let Some(_retry_guard) = peerstore
+        .acquire_replicator_retry_guard(peer_id.as_str())
+        .await
+        .map_err(|error| format!("failed to coordinate replay failure recording: {error}"))?
+    else {
+        tracing::debug!(
+            peer_id = %peer_id,
+            failure_count = failures.len(),
+            "Replicator was removed before replay failures could be recorded"
+        );
+        return Ok(());
+    };
+    let retry_info = storage::stores::RetryInfo::new_initial()
+        .to_bytes()
+        .map_err(|error| format!("failed to serialize replay retry state: {error}"))?;
+
+    for failure in failures {
+        // Initial replay resolves the current document heads again on retry, so
+        // this is deliberately versionless. If a live-send watermark exists,
+        // record_push_failure activates that exact newer version instead.
+        peerstore
+            .record_push_failure(
+                peer_id.as_str(),
+                &failure.doc_id,
+                &failure.collection_id,
+                "",
+                0,
+                &retry_info,
+            )
+            .await
+            .map_err(|error| {
+                format!(
+                    "failed to persist replay retry for document {}: {error}",
+                    failure.doc_id
+                )
+            })?;
+    }
+
+    // Match the live-push failure recorder's observable state. Retry records
+    // remain authoritative even if legacy/invalid replicator bytes prevent the
+    // status update.
+    if let Some(bytes) = peerstore
+        .get_replicator(peer_id.as_str())
+        .await
+        .map_err(|error| format!("failed to load persisted replicator status: {error}"))?
+    {
+        match p2p::ReplicatorInfo::from_bytes(&bytes) {
+            Ok(mut info) => {
+                if info.set_status_if_changed_now(p2p::ReplicatorStatus::Inactive) {
+                    let bytes = info.to_bytes().map_err(|error| {
+                        format!("failed to encode inactive replicator status: {error}")
+                    })?;
+                    peerstore
+                        .create_replicator(peer_id.as_str(), &bytes)
+                        .await
+                        .map_err(|error| {
+                            format!("failed to persist inactive replicator status: {error}")
+                        })?;
+                }
+            }
+            Err(error) => {
+                tracing::warn!(
+                    peer_id = %peer_id,
+                    %error,
+                    "Replay retries were recorded but replicator status could not be decoded"
+                );
+            }
+        }
+    }
+
+    tracing::warn!(
+        peer_id = %peer_id,
+        failure_count = failures.len(),
+        "Initial replay left unfinished documents; deferred them to persisted retry"
+    );
+    Ok(())
 }
 
 impl Default for ReplayPushConfig {
@@ -131,8 +233,8 @@ impl ReplayPushGate {
     where
         F: Future<Output = p2p::Result<PushLogReply>>,
     {
-        while !self.peer_pacer.try_consume(peer_id.as_str()) {
-            tokio::time::sleep(self.rate_retry_delay).await;
+        while let Some(delay) = self.peer_pacer.consume_or_delay(peer_id.as_str()) {
+            tokio::time::sleep(delay).await;
         }
 
         let _permit = self
@@ -154,14 +256,12 @@ impl ReplayPushGate {
     /// exponential backoff instead of being surfaced to the caller.
     ///
     /// The peer's admission control says, verbatim, "retry later" — the
-    /// replay paths previously treated that nack like a hard rejection and
-    /// abandoned the document, leaving the peer permanently stale until the
-    /// doc next changed (the live sync path already honors this nack with a
-    /// retry ladder; this brings replay to parity). Only the rate-limit
-    /// sentinel is retried: hard rejections and transport errors surface
-    /// unchanged on the first occurrence. After `RATE_LIMIT_RETRY_MAX`
-    /// exhausted attempts the last nacked reply is returned, so callers'
-    /// existing give-up handling still fires.
+    /// replay paths previously treated that nack like a hard rejection. Only
+    /// the rate-limit sentinel is retried: hard rejections and transport errors
+    /// surface unchanged on the first occurrence. A nack also pauses and drains
+    /// the shared peer bucket, so concurrent document tasks cannot keep sending
+    /// through the receiver's peer-wide cooldown. After the bounded immediate
+    /// attempts, callers hand the document to persisted retry.
     pub(crate) async fn send_pushlog_with_rate_limit_retry<F, Fut>(
         &self,
         peer_id: &PeerId,
@@ -178,33 +278,39 @@ impl ReplayPushGate {
                 .err_message
                 .as_deref()
                 .is_some_and(p2p::error::is_rate_limited_message);
-            if !rate_limited || attempt >= RATE_LIMIT_RETRY_MAX {
+            if !rate_limited || attempt >= MAX_RATE_LIMITED_RETRIES {
                 return Ok(reply);
             }
             attempt += 1;
-            // Exponential from the pacer's own cadence, capped: the peer's
-            // token bucket refills at the same configured rate this gate
-            // paces with, so a few doublings spans a full bucket refill.
-            let backoff = self
-                .rate_retry_delay
-                .saturating_mul(1u32 << attempt.min(RATE_LIMIT_RETRY_MAX))
-                .min(RATE_LIMIT_RETRY_BACKOFF_CAP);
+            let backoff = self.rate_limited_backoff(peer_id, attempt);
+            self.peer_pacer.defer(peer_id.as_str(), backoff);
             tracing::debug!(
                 peer_id = %peer_id,
                 attempt,
                 backoff_ms = backoff.as_millis() as u64,
-                "replay push rate-limited by peer; backing off and retrying"
+                "Replay push rate-limited by peer; pausing peer sends before retry"
             );
-            tokio::time::sleep(backoff).await;
         }
     }
-}
 
-/// Attempts to spend on a `RATE_LIMITED_MESSAGE` nack before giving the
-/// document up (the caller's existing rejected-reply handling then fires).
-const RATE_LIMIT_RETRY_MAX: u32 = 6;
-/// Ceiling on the per-attempt exponential backoff.
-const RATE_LIMIT_RETRY_BACKOFF_CAP: Duration = Duration::from_secs(5);
+    fn rate_limited_backoff(&self, peer_id: &PeerId, attempt: u32) -> Duration {
+        let base = self
+            .rate_retry_delay
+            .saturating_mul(1u32 << attempt.min(MAX_RATE_LIMITED_RETRIES))
+            .min(RATE_LIMIT_RETRY_BACKOFF_CAP);
+        let jitter_window = base / 4;
+        let jitter_micros = jitter_window.as_micros().min(u64::MAX as u128) as u64;
+        if jitter_micros == 0 || base >= RATE_LIMIT_RETRY_BACKOFF_CAP {
+            return base;
+        }
+
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        peer_id.as_str().hash(&mut hasher);
+        attempt.hash(&mut hasher);
+        base.saturating_add(Duration::from_micros(hasher.finish() % (jitter_micros + 1)))
+            .min(RATE_LIMIT_RETRY_BACKOFF_CAP)
+    }
+}
 
 #[derive(Debug)]
 struct ReplayPeerPacer {
@@ -222,12 +328,20 @@ impl ReplayPeerPacer {
         }
     }
 
-    fn try_consume(&self, peer_id: &str) -> bool {
+    fn consume_or_delay(&self, peer_id: &str) -> Option<Duration> {
         let mut buckets = self.buckets.lock();
         buckets
             .entry(peer_id.to_string())
             .or_insert_with(|| ReplayPeerBucket::new(self.capacity))
-            .try_consume(self.capacity, self.refill_rate)
+            .consume_or_delay(self.capacity, self.refill_rate)
+    }
+
+    fn defer(&self, peer_id: &str, delay: Duration) {
+        let mut buckets = self.buckets.lock();
+        buckets
+            .entry(peer_id.to_string())
+            .or_insert_with(|| ReplayPeerBucket::new(self.capacity))
+            .defer(delay);
     }
 }
 
@@ -235,6 +349,7 @@ impl ReplayPeerPacer {
 struct ReplayPeerBucket {
     tokens: f64,
     last_refill: Instant,
+    blocked_until: Option<Instant>,
 }
 
 impl ReplayPeerBucket {
@@ -242,21 +357,44 @@ impl ReplayPeerBucket {
         Self {
             tokens: capacity as f64,
             last_refill: Instant::now(),
+            blocked_until: None,
         }
     }
 
-    fn try_consume(&mut self, capacity: u32, refill_rate: f64) -> bool {
+    fn consume_or_delay(&mut self, capacity: u32, refill_rate: f64) -> Option<Duration> {
         let now = Instant::now();
+        if let Some(blocked_until) = self.blocked_until {
+            if blocked_until > now {
+                return Some(blocked_until.duration_since(now));
+            }
+            self.blocked_until = None;
+        }
+
         let elapsed = now.duration_since(self.last_refill).as_secs_f64();
         self.tokens = (self.tokens + elapsed * refill_rate).min(capacity as f64);
         self.last_refill = now;
 
         if self.tokens >= 1.0 {
             self.tokens -= 1.0;
-            true
+            None
         } else {
-            false
+            let refill_delay = (1.0 - self.tokens) / refill_rate;
+            Some(Duration::from_secs_f64(refill_delay.clamp(0.001, 1.0)))
         }
+    }
+
+    fn defer(&mut self, delay: Duration) {
+        let now = Instant::now();
+        let blocked_until = now + delay;
+        self.blocked_until = Some(
+            self.blocked_until
+                .map_or(blocked_until, |current| current.max(blocked_until)),
+        );
+        // The sender's mirrored bucket may still be full while unrelated
+        // traffic has drained the receiver. Forget that stale credit after an
+        // explicit nack and resume at the configured refill rate.
+        self.tokens = 0.0;
+        self.last_refill = now;
     }
 }
 
@@ -387,7 +525,7 @@ mod rate_limit_retry_tests {
     }
 
     #[tokio::test]
-    async fn exhausted_rate_limit_retries_surface_the_nack() {
+    async fn exhausted_rate_limit_retries_surface_the_nack_for_durable_handoff() {
         let g = gate();
         let peer = PeerId::new("peer-rl-exhaust".to_string());
         let attempts = AtomicUsize::new(0);
@@ -407,7 +545,7 @@ mod rate_limit_retry_tests {
         );
         assert_eq!(
             attempts.load(Ordering::SeqCst) as u32,
-            RATE_LIMIT_RETRY_MAX + 1,
+            MAX_RATE_LIMITED_RETRIES + 1,
             "initial attempt plus the bounded retries"
         );
     }
@@ -432,5 +570,72 @@ mod rate_limit_retry_tests {
             1,
             "a hard rejection must surface on the first attempt"
         );
+    }
+
+    #[tokio::test]
+    async fn observed_nack_pauses_and_drains_the_shared_peer_bucket() {
+        let g = gate();
+        let peer = PeerId::new("peer-shared-cooldown".to_string());
+        g.peer_pacer
+            .defer(peer.as_str(), Duration::from_millis(100));
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let task_attempts = attempts.clone();
+        let task = tokio::spawn(async move {
+            g.send_pushlog(&peer, async move {
+                task_attempts.fetch_add(1, Ordering::SeqCst);
+                Ok(PushLogReply::success("accepted"))
+            })
+            .await
+            .unwrap();
+        });
+
+        tokio::task::yield_now().await;
+        assert_eq!(attempts.load(Ordering::SeqCst), 0);
+        tokio::time::sleep(Duration::from_millis(90)).await;
+        assert_eq!(attempts.load(Ordering::SeqCst), 0);
+        task.await.unwrap();
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn unfinished_replay_is_persisted_and_marks_replicator_inactive() {
+        use storage::backends::MemoryStore;
+
+        let store = Arc::new(MemoryStore::new());
+        let peerstore = storage::stores::Peerstore::new(store.clone());
+        let peer = PeerId::new("peer-durable".to_string());
+        let info = p2p::ReplicatorInfo::from_raw(
+            peer.to_string(),
+            vec!["collection".to_string()],
+            Vec::new(),
+        );
+        peerstore
+            .create_replicator(peer.as_str(), &info.to_bytes().unwrap())
+            .await
+            .unwrap();
+
+        persist_replay_failures(
+            store,
+            &peer,
+            &[ReplayDocumentFailure {
+                doc_id: "doc-1".to_string(),
+                collection_id: "collection".to_string(),
+            }],
+        )
+        .await
+        .unwrap();
+
+        let retries = peerstore.get_retry_documents(peer.as_str()).await.unwrap();
+        assert_eq!(retries.len(), 1);
+        assert_eq!(retries[0].doc_id, "doc-1");
+        assert!(retries[0].pending);
+        assert!(!retries[0].retry_info.is_due());
+        let saved = peerstore
+            .get_replicator(peer.as_str())
+            .await
+            .unwrap()
+            .unwrap();
+        let saved = p2p::ReplicatorInfo::from_bytes(&saved).unwrap();
+        assert_eq!(saved.status, p2p::ReplicatorStatus::Inactive);
     }
 }

--- a/crates/db-merge/src/push_docs_replay.rs
+++ b/crates/db-merge/src/push_docs_replay.rs
@@ -149,7 +149,62 @@ impl ReplayPushGate {
             })?
             .map_err(ReplayPushSendError::Transport)
     }
+
+    /// `send_pushlog`, but a `RATE_LIMITED_MESSAGE` nack is retried with
+    /// exponential backoff instead of being surfaced to the caller.
+    ///
+    /// The peer's admission control says, verbatim, "retry later" — the
+    /// replay paths previously treated that nack like a hard rejection and
+    /// abandoned the document, leaving the peer permanently stale until the
+    /// doc next changed (the live sync path already honors this nack with a
+    /// retry ladder; this brings replay to parity). Only the rate-limit
+    /// sentinel is retried: hard rejections and transport errors surface
+    /// unchanged on the first occurrence. After `RATE_LIMIT_RETRY_MAX`
+    /// exhausted attempts the last nacked reply is returned, so callers'
+    /// existing give-up handling still fires.
+    pub(crate) async fn send_pushlog_with_rate_limit_retry<F, Fut>(
+        &self,
+        peer_id: &PeerId,
+        mut make_send: F,
+    ) -> Result<PushLogReply, ReplayPushSendError>
+    where
+        F: FnMut() -> Fut,
+        Fut: Future<Output = p2p::Result<PushLogReply>>,
+    {
+        let mut attempt: u32 = 0;
+        loop {
+            let reply = self.send_pushlog(peer_id, make_send()).await?;
+            let rate_limited = reply
+                .err_message
+                .as_deref()
+                .is_some_and(p2p::error::is_rate_limited_message);
+            if !rate_limited || attempt >= RATE_LIMIT_RETRY_MAX {
+                return Ok(reply);
+            }
+            attempt += 1;
+            // Exponential from the pacer's own cadence, capped: the peer's
+            // token bucket refills at the same configured rate this gate
+            // paces with, so a few doublings spans a full bucket refill.
+            let backoff = self
+                .rate_retry_delay
+                .saturating_mul(1u32 << attempt.min(RATE_LIMIT_RETRY_MAX))
+                .min(RATE_LIMIT_RETRY_BACKOFF_CAP);
+            tracing::debug!(
+                peer_id = %peer_id,
+                attempt,
+                backoff_ms = backoff.as_millis() as u64,
+                "replay push rate-limited by peer; backing off and retrying"
+            );
+            tokio::time::sleep(backoff).await;
+        }
+    }
 }
+
+/// Attempts to spend on a `RATE_LIMITED_MESSAGE` nack before giving the
+/// document up (the caller's existing rejected-reply handling then fires).
+const RATE_LIMIT_RETRY_MAX: u32 = 6;
+/// Ceiling on the per-attempt exponential backoff.
+const RATE_LIMIT_RETRY_BACKOFF_CAP: Duration = Duration::from_secs(5);
 
 #[derive(Debug)]
 struct ReplayPeerPacer {
@@ -278,5 +333,104 @@ mod tests {
                 Err(current) => observed = current,
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod rate_limit_retry_tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn gate() -> ReplayPushGate {
+        ReplayPushGate::new(ReplayPushConfig {
+            max_concurrent_document_tasks: 4,
+            max_concurrent_outbound_pushes: 4,
+            per_peer_rate_limit_burst: 1000,
+            per_peer_rate_limit_rate: 1000.0,
+            send_timeout: Duration::from_secs(1),
+        })
+    }
+
+    fn rate_limited_reply() -> PushLogReply {
+        PushLogReply::error("nacked", p2p::error::RATE_LIMITED_MESSAGE)
+    }
+
+    #[tokio::test]
+    async fn rate_limited_nacks_are_retried_until_success() {
+        let g = gate();
+        let peer = PeerId::new("peer-rl".to_string());
+        let attempts = AtomicUsize::new(0);
+
+        let reply = g
+            .send_pushlog_with_rate_limit_retry(&peer, || {
+                let n = attempts.fetch_add(1, Ordering::SeqCst);
+                async move {
+                    if n < 3 {
+                        Ok(rate_limited_reply())
+                    } else {
+                        Ok(PushLogReply::success("merged"))
+                    }
+                }
+            })
+            .await
+            .unwrap();
+
+        assert!(
+            reply.err_message.is_none(),
+            "retry must surface the success"
+        );
+        assert_eq!(
+            attempts.load(Ordering::SeqCst),
+            4,
+            "three rate-limited nacks then the success"
+        );
+    }
+
+    #[tokio::test]
+    async fn exhausted_rate_limit_retries_surface_the_nack() {
+        let g = gate();
+        let peer = PeerId::new("peer-rl-exhaust".to_string());
+        let attempts = AtomicUsize::new(0);
+
+        let reply = g
+            .send_pushlog_with_rate_limit_retry(&peer, || {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                async { Ok(rate_limited_reply()) }
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(
+            reply.err_message.as_deref(),
+            Some(p2p::error::RATE_LIMITED_MESSAGE),
+            "after exhaustion the caller's existing rejected-reply handling must fire"
+        );
+        assert_eq!(
+            attempts.load(Ordering::SeqCst) as u32,
+            RATE_LIMIT_RETRY_MAX + 1,
+            "initial attempt plus the bounded retries"
+        );
+    }
+
+    #[tokio::test]
+    async fn hard_rejections_are_not_retried() {
+        let g = gate();
+        let peer = PeerId::new("peer-hard".to_string());
+        let attempts = AtomicUsize::new(0);
+
+        let reply = g
+            .send_pushlog_with_rate_limit_retry(&peer, || {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                async { Ok(PushLogReply::error("nacked", "schema mismatch")) }
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(reply.err_message.as_deref(), Some("schema mismatch"));
+        assert_eq!(
+            attempts.load(Ordering::SeqCst),
+            1,
+            "a hard rejection must surface on the first attempt"
+        );
     }
 }

--- a/crates/db-merge/src/push_docs_transport.rs
+++ b/crates/db-merge/src/push_docs_transport.rs
@@ -10,7 +10,9 @@ use storage::corekv::{IterOptions, Reader, Store};
 
 use crate::push_docs_common::{load_latest_composite_head_cids, load_push_dag_blocks};
 use crate::push_docs_creator::resolve_push_creator;
-use crate::push_docs_replay::{ReplayPushConfig, ReplayPushGate};
+use crate::push_docs_replay::{
+    persist_replay_failures, ReplayDocumentFailure, ReplayPushConfig, ReplayPushGate,
+};
 use db::database::DB;
 
 async fn document_matches_filter<R: Reader + ?Sized>(
@@ -278,72 +280,92 @@ pub async fn push_existing_docs_via_transport_with_config<S: Store + 'static, T:
                 let pid = peer_id.clone();
                 let gate = replay_gate.clone();
                 let peer_key = pid.clone();
+                let replay_doc_id = doc_id.clone();
+                let replay_collection_id = collection.collection_id().to_string();
                 let total_blocks = requests.len();
                 let permit = replay_gate
                     .acquire_document_task()
                     .await
                     .map_err(|e| format!("replay gate closed before scheduling push: {e}"))?;
-                push_handles.push(tokio::spawn(async move {
-                    let _permit = permit;
-                    let mut completed_blocks = 0usize;
-                    for req in requests {
-                        let cid = req.cid.clone();
-                        match gate
-                            .send_pushlog_with_rate_limit_retry(&peer_key, || {
-                                t.send_two_stream_request(&pid, req.clone())
-                            })
-                            .await
-                        {
-                            Ok(reply) if reply.err_message.is_some() => {
-                                tracing::warn!(
-                                    peer_id = %pid,
-                                    completed_blocks,
-                                    total_blocks,
-                                    cid_len = cid.len(),
-                                    error = %reply.err_message.as_deref().unwrap_or("unknown pushlog error"),
-                                    "Existing document replay PushLog was rejected; stopping replay for this document"
-                                );
-                                break;
-                            }
-                            Ok(_) => {
-                                completed_blocks += 1;
-                            }
-                            Err(e) => {
-                                if e.is_connection_like() {
-                                    tracing::debug!(
-                                        peer_id = %pid,
-                                        completed_blocks,
-                                        total_blocks,
-                                        cid_len = cid.len(),
-                                        error = %e,
-                                        "Existing document replay stopped because the connection became unavailable"
-                                    );
-                                } else {
+                push_handles.push((
+                    replay_doc_id,
+                    replay_collection_id,
+                    tokio::spawn(async move {
+                        let _permit = permit;
+                        let mut completed_blocks = 0usize;
+                        for req in requests {
+                            let cid = req.cid.clone();
+                            match gate
+                                .send_pushlog_with_rate_limit_retry(&peer_key, || {
+                                    t.send_two_stream_request(&pid, req.clone())
+                                })
+                                .await
+                            {
+                                Ok(reply) if reply.err_message.is_some() => {
                                     tracing::warn!(
                                         peer_id = %pid,
                                         completed_blocks,
                                         total_blocks,
                                         cid_len = cid.len(),
-                                        error = %e,
-                                        "Existing document replay PushLog failed; stopping replay for this document"
+                                        error = %reply.err_message.as_deref().unwrap_or("unknown pushlog error"),
+                                        "Existing document replay PushLog was rejected; deferring document to persisted retry"
                                     );
+                                    return false;
                                 }
-                                break;
+                                Ok(_) => {
+                                    completed_blocks += 1;
+                                }
+                                Err(e) => {
+                                    if e.is_connection_like() {
+                                        tracing::debug!(
+                                            peer_id = %pid,
+                                            completed_blocks,
+                                            total_blocks,
+                                            cid_len = cid.len(),
+                                            error = %e,
+                                            "Existing document replay stopped because the connection became unavailable"
+                                        );
+                                    } else {
+                                        tracing::warn!(
+                                            peer_id = %pid,
+                                            completed_blocks,
+                                            total_blocks,
+                                            cid_len = cid.len(),
+                                            error = %e,
+                                            "Existing document replay PushLog failed; deferring document to persisted retry"
+                                        );
+                                    }
+                                    return false;
+                                }
                             }
                         }
-                    }
-                }));
+                        true
+                    }),
+                ));
             }
         }
     }
 
     tracing::debug!(task_count = push_handles.len(), "awaiting push tasks");
-    for jh in push_handles {
-        if let Err(e) = jh.await {
-            tracing::error!(error = %e, "Replay push task panicked or was cancelled");
+    let mut replay_failures = Vec::new();
+    for (doc_id, collection_id, jh) in push_handles {
+        match jh.await {
+            Ok(true) => {}
+            Ok(false) => replay_failures.push(ReplayDocumentFailure {
+                doc_id,
+                collection_id,
+            }),
+            Err(error) => {
+                tracing::error!(%error, %doc_id, "Replay push task panicked or was cancelled");
+                replay_failures.push(ReplayDocumentFailure {
+                    doc_id,
+                    collection_id,
+                });
+            }
         }
     }
     tracing::debug!("all push tasks completed");
+    persist_replay_failures(db.store().clone(), peer_id, &replay_failures).await?;
 
     if skipped_creator_docs > 0 {
         return Err(format!(

--- a/crates/db-merge/src/push_docs_transport.rs
+++ b/crates/db-merge/src/push_docs_transport.rs
@@ -289,7 +289,9 @@ pub async fn push_existing_docs_via_transport_with_config<S: Store + 'static, T:
                     for req in requests {
                         let cid = req.cid.clone();
                         match gate
-                            .send_pushlog(&peer_key, t.send_two_stream_request(&pid, req))
+                            .send_pushlog_with_rate_limit_retry(&peer_key, || {
+                                t.send_two_stream_request(&pid, req.clone())
+                            })
                             .await
                         {
                             Ok(reply) if reply.err_message.is_some() => {

--- a/tools/integration-test/tests/p2p_deep_catchup.rs
+++ b/tools/integration-test/tests/p2p_deep_catchup.rs
@@ -1,15 +1,13 @@
-//! #1088 W4 liveness: a deep full-DAG push must complete under intake rate
-//! limiting instead of sawtoothing against a lockout ladder.
+//! #1088 W4 / source-inc/gents#1049 liveness: initial replay and live deep-DAG
+//! pushes must complete under intake rate limiting instead of abandoning the
+//! document or sawtoothing against a lockout ladder.
 //!
-//! Filtered replicators receive the full transitive DAG on every update with
-//! no client-side pacer (unlike the initial-replay path, whose ReplayPushGate
-//! self-paces). With the pre-split limiter, the first over-budget block armed
-//! a 30s lockout: the pusher's ~2.3s of in-batch retries all fell inside it,
-//! the batch aborted, and every ladder-spaced re-push restarted from block one
-//! — re-burning the burst on already-sent blocks — so any DAG deeper than
-//! roughly the burst never converged. The request-intake limiter now paces at
-//! the token-refill horizon, so the push throttles to the refill rate and
-//! completes.
+//! Initial replay has a client-side pacer, but its defaults can exceed a
+//! receiver's configured bucket or start with stale credit after unrelated
+//! resync traffic. A `RATE_LIMITED_MESSAGE` nack must therefore pause the
+//! peer-wide replay gate and retry the rejected block. This test asserts that
+//! initial replay itself converges; a later mutation must not be required to
+//! rescue a silently stale document.
 //!
 //! Own test binary: the burst/rate env overrides must not leak into other
 //! tests' clusters.
@@ -55,9 +53,9 @@ fn add_filtered_replicator(cluster: &TestCluster, node: usize, addr: &str) {
 }
 
 #[tokio::test]
-async fn deep_dag_push_completes_under_intake_rate_limiting() {
-    // Hub bucket far smaller than the DAG so the live full-DAG push must be
-    // paced across many refill windows: ~150 blocks vs a 50-token burst.
+async fn initial_replay_completes_under_intake_rate_limiting() {
+    // Hub bucket far smaller than the DAG and slower than ReplayPushGate's
+    // defaults: ~150 blocks vs a 50-token burst at 20 tokens/s.
     std::env::set_var("DEFRA_P2P_RATE_LIMIT_BURST", "50");
     std::env::set_var("DEFRA_P2P_RATE_LIMIT_RATE", "20");
 
@@ -107,18 +105,6 @@ async fn deep_dag_push_completes_under_intake_rate_limiting() {
     }
 
     add_filtered_replicator(&cluster, 0, &hub_addr);
-    // Let the initial replay attempt (client-paced at defaults, which exceed
-    // this hub's shrunken bucket) finish nacking and the bucket refill.
-    tokio::time::sleep(Duration::from_secs(3)).await;
-
-    // One live update pushes the ENTIRE transitive DAG (~3 blocks per update
-    // deep by now) through send_ordered_pushlogs_via_transport: it must pace
-    // through the limiter and converge, not wedge.
-    let final_age = 999;
-    let mutation = format!(
-        r#"mutation {{ update_User(docID: "{doc_id}", input: {{age: {final_age}}}) {{ _docID }} }}"#
-    );
-    pusher.query(&mutation).expect("final update");
 
     let deadline = Instant::now() + Duration::from_secs(120);
     loop {
@@ -128,7 +114,7 @@ async fn deep_dag_push_completes_under_intake_rate_limiting() {
         let converged = result["User"].as_array().is_some_and(|rows| {
             rows.iter().any(|row| {
                 row["_docID"].as_str() == Some(doc_id.as_str())
-                    && row["age"].as_i64() == Some(final_age)
+                    && row["age"].as_i64() == Some(UPDATES as i64)
             })
         });
         if converged {
@@ -136,7 +122,7 @@ async fn deep_dag_push_completes_under_intake_rate_limiting() {
         }
         assert!(
             Instant::now() < deadline,
-            "deep-DAG push did not converge under intake rate limiting (sawtooth/wedge): {}",
+            "initial replay did not converge under intake rate limiting: {}",
             serde_json::to_string_pretty(&result).unwrap()
         );
         tokio::time::sleep(Duration::from_millis(500)).await;


### PR DESCRIPTION
Fixes the replay half of the staleness bug reported downstream (source-inc/gents#1049): a paired client can reopen into a resync burst, receive `RATE_LIMITED_MESSAGE` nacks, and otherwise remain silently stale.

## Root cause

The nack is retryable flow control, not a hard rejection. Initial replay originally stopped the affected document immediately; the first version of this PR added bounded per-request retries, but concurrent document tasks could still send through the same peer-wide receiver cooldown. After those retries were exhausted, the document was still abandoned and the replay completion event could be emitted without any component owning another attempt.

## Fix

- Keep bounded exponential retry with deterministic jitter for rate-limit nacks only.
- Apply an observed receiver cooldown to the shared per-peer replay gate and discard stale sender-bucket credit.
- Hand any incomplete, failed, cancelled, or panicked document replay to the persisted retry ledger after the bounded in-memory attempt.
- Mark the persisted replicator inactive while deferred work remains, matching live-push failure behavior.
- Apply the same outcome handling to both libp2p and generic transport replay paths.
- Rewrite the deep-catchup regression to assert convergence from initial replay itself; it no longer performs a later live mutation that can mask an abandoned replay.

Hard rejections and transport errors are not retried in memory. Persisted retries re-resolve the document's current heads, so the handoff cannot strand a stale historical version.

## Validation

- `cargo test -p db-merge` — 115 passed
- `cargo test -p integration-test --test p2p_deep_catchup -- --nocapture` — passed
- `cargo clippy -p db-merge --all-targets -- -D warnings` — passed
- `cargo clippy -p integration-test --test p2p_deep_catchup -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed
