### PR TITLE
ci: parallelize studio jobs via host pinning + cancel superseded PR runs

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,6 +5,9 @@ self-hosted-runner:
     - studio
     - studio-1
     - studio-2
+    - studio-1-b
+    - studio-2-b
+    - defra-light
     - ARM64
     - X64
     - macOS

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,11 @@
+self-hosted-runner:
+  # Self-hosted fleet labels (see amygdala infra/services/github-runners):
+  # studio-N are Apple Silicon Mac Studio hosts; spark/vps are Linux.
+  labels:
+    - studio
+    - studio-1
+    - studio-2
+    - ARM64
+    - X64
+    - macOS
+    - Linux

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -8,6 +8,9 @@ self-hosted-runner:
     - studio-1-b
     - studio-2-b
     - defra-light
+    - spark
+    - spark-1
+    - spark-2
     - ARM64
     - X64
     - macOS

--- a/.github/scripts/rustc-direct.sh
+++ b/.github/scripts/rustc-direct.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Cargo treats an empty RUSTC_WRAPPER as unset and falls back to the host's
+# build.rustc-wrapper setting (sccache on the studio/spark hosts, which
+# rejects incremental rustc invocations). Execute Cargo's rustc command
+# directly so incremental suites cannot accidentally re-enable sccache
+# through host config.
+exec "$@"

--- a/.github/scripts/show-sccache-stats.sh
+++ b/.github/scripts/show-sccache-stats.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if command -v sccache >/dev/null 2>&1; then
+  sccache --show-stats || true
+fi
+
+if [[ -n "${SCCACHE_ERROR_LOG:-}" && -f "${SCCACHE_ERROR_LOG}" ]]; then
+  echo "::group::sccache error log"
+  cat "${SCCACHE_ERROR_LOG}"
+  echo "::endgroup::"
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,7 +248,7 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64, studio, studio-2]
     timeout-minutes: 45
     env:
-      DEFRA_CONFORMANCE_BINARY: ${{ github.workspace }}/target/release/defra
+      DEFRA_CONFORMANCE_BINARY: ${{ github.workspace }}/target/release-fast/defra
       DEFRA_WORKSPACE_ROOT: ${{ github.workspace }}
       # The conformance harness waits on INFO-level node readiness/P2P log lines.
       # Pin the child-node filter so an inherited runner-level RUST_LOG=warn
@@ -267,9 +267,12 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
+      # release-fast (thin LTO, 16 CGUs) exists exactly for this: measured
+      # 1m40s cold vs 6m44s for the fat-LTO release profile, and this binary
+      # is test-only — release.yml still ships full-release artifacts.
       - name: Build release binary under test
         run: |
-          cargo build --release -p cli
+          cargo build --profile release-fast -p cli
           "$DEFRA_CONFORMANCE_BINARY" version --format json
 
       # The behavioral conformance tests drive real `defra` subprocesses. Run
@@ -301,6 +304,7 @@ jobs:
           git checkout -- .
           git clean -fd
           rm -rf target/e2e
+          pkill -f "target/release-fast/defra" || true
           pkill -f "target/release/defra" || true
           pkill -f "target/debug/defra" || true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,10 @@ jobs:
       - run: cargo clippy -p defra-node --features p2p --all-targets -- -D warnings
       - run: cargo clippy -p db --features p2p --all-targets -- -D warnings
 
+      - name: Show sccache stats
+        if: always()
+        run: .github/scripts/show-sccache-stats.sh
+
       - name: Cleanup
         if: always()
         run: |
@@ -84,7 +88,12 @@ jobs:
 
   wasm-check:
     name: WASM Build Check
-    runs-on: [self-hosted, Linux, X64]
+    # spark-1: the wasm32 target doesn't care about host arch, and pinning
+    # here takes this job off the vps (which now serves release.yml's x86_64
+    # builds only) and out of p2p-linux's way. No GitHub-hosted rust-cache:
+    # the runner workspace persists between jobs, so the warm target dir plus
+    # host-local sccache beat cache download/upload round-trips.
+    runs-on: [self-hosted, Linux, ARM64, spark, spark-1]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -97,11 +106,6 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
           components: clippy
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: "v1-ci"
-          shared-key: "wasm32"
 
       - name: Install system dependencies
         # clang is needed because lz4-sys (transitive C dep) builds
@@ -123,6 +127,10 @@ jobs:
       - name: Build WASM
         run: CARGO_PROFILE_RELEASE_OPT_LEVEL=z wasm-pack build crates/wasm --release --target web --out-dir ../../pkg/wasm
 
+      - name: Show sccache stats
+        if: always()
+        run: .github/scripts/show-sccache-stats.sh
+
       - name: Cleanup
         if: always()
         run: |
@@ -132,6 +140,18 @@ jobs:
   build:
     name: Build & Test
     runs-on: [self-hosted, macOS, ARM64, studio, studio-1]
+    env:
+      # Warm-incremental beats sccache for the hot edit path (gents A/B on
+      # these hosts: 14.6s vs 5m54s for a representative source edit). The
+      # host-wide sccache rejects incremental invocations, and an empty
+      # RUSTC_WRAPPER falls back to host config, so route rustc through the
+      # pass-through wrapper. CARGO_BUILD_RUSTC_WRAPPER covers recursive
+      # Cargo invocations from build scripts. The rust/signed-docs suites on
+      # this runner use the same settings so the shared target tree never
+      # flip-flops flags.
+      CARGO_INCREMENTAL: "1"
+      RUSTC_WRAPPER: .github/scripts/rustc-direct.sh
+      CARGO_BUILD_RUSTC_WRAPPER: .github/scripts/rustc-direct.sh
     steps:
       - uses: actions/checkout@v4
         with:
@@ -270,6 +290,10 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
+      - name: Show sccache stats
+        if: always()
+        run: .github/scripts/show-sccache-stats.sh
+
       - name: Cleanup
         if: always()
         run: |
@@ -296,15 +320,25 @@ jobs:
       # suites self-build on miss into their own host-local cache.
       matrix:
         include:
+          # studio-1 suites share the build job's incremental target tree, so
+          # they carry the same incremental + pass-through wrapper settings;
+          # studio-2 suites stay on the host sccache (incremental off) so the
+          # target tree they share with conformance keeps consistent flags.
           - suite: rust
             needs_go: false
             host: studio-1
+            cargo_incremental: "1"
+            rustc_wrapper: .github/scripts/rustc-direct.sh
           - suite: go-compat
             needs_go: true
             host: studio-2
+            cargo_incremental: "0"
+            rustc_wrapper: sccache
           - suite: iroh
             needs_go: false
             host: studio-2
+            cargo_incremental: "0"
+            rustc_wrapper: sccache
           # #978: re-run the rust integration suite with
           # DEFRA_MULTIPLIERS=signed-docs so every cluster gets
           # .with_signing() auto-applied. Catches regressions in
@@ -314,10 +348,15 @@ jobs:
             needs_go: false
             multipliers: signed-docs
             host: studio-1
+            cargo_incremental: "1"
+            rustc_wrapper: .github/scripts/rustc-direct.sh
     env:
       DEFRA_RUST_BINARY: ${{ github.workspace }}/target/ci/defra
       DEFRA_IROH_BINARY: ${{ github.workspace }}/target/ci/defra-iroh
       DEFRA_MULTIPLIERS: ${{ matrix.multipliers || '' }}
+      CARGO_INCREMENTAL: ${{ matrix.cargo_incremental }}
+      RUSTC_WRAPPER: ${{ matrix.rustc_wrapper }}
+      CARGO_BUILD_RUSTC_WRAPPER: ${{ matrix.rustc_wrapper }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -553,11 +592,16 @@ jobs:
     # The macOS `integration` matrix above only runs the P2P suite on the studio
     # host. Several P2P sync races are exposed only by Linux's socket/thread
     # scheduling (e.g. duplicate connections that form under multi-core
-    # kqueue-vs-epoll timing), so mirror the pure-Rust P2P leg on the self-hosted
+    # kqueue-vs-epoll timing), so mirror the pure-Rust P2P leg on a self-hosted
     # Linux runner. Builds its own binary — the `build` job caches Mach-O
     # binaries that cannot run here.
+    #
+    # spark-2: dedicated host so this node-spawning job runs in parallel with
+    # wasm-check (spark-1) instead of serializing behind it on the vps, which
+    # now serves release.yml's x86_64 builds only. Still Linux/epoll — the
+    # scheduling-race coverage is arch-independent.
     name: P2P Integration (Linux)
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [self-hosted, Linux, ARM64, spark, spark-2]
     timeout-minutes: 45
     env:
       # The workflow-level PROTOC points at a macOS Homebrew path; override it
@@ -581,11 +625,6 @@ jobs:
         run: git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
 
       - uses: dtolnay/rust-toolchain@stable
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: "v1-ci"
-          shared-key: "p2p-linux"
 
       - name: Install system dependencies
         # protobuf-compiler: prost-build. clang/libclang-dev: bindgen (rocksdb).
@@ -627,6 +666,10 @@ jobs:
           path: target/e2e/**/logs/*.log
           retention-days: 7
           if-no-files-found: ignore
+
+      - name: Show sccache stats
+        if: always()
+        run: .github/scripts/show-sccache-stats.sh
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,14 +6,31 @@ on:
   pull_request:
     branches: [main]
 
+# Superseded PR pushes release the studio fleet immediately; main pushes are
+# never cancelled so every main commit gets full validation and artifacts.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 env:
   CARGO_TERM_COLOR: always
   PROTOC: /opt/homebrew/bin/protoc
 
 jobs:
+  # Studio jobs are pinned to a host so each job's incremental target state
+  # stays warm on one machine (a suite that bounces between hosts turns a
+  # small rebuild into a full one) and so same-host exclusivity is
+  # deterministic: each host runs ONE defradb.rs runner process, which takes
+  # one job at a time, so two node-spawning jobs can only co-run on DIFFERENT
+  # hosts — where they cannot contend on localhost ports. Layout balances the
+  # measured serial chains: studio-1 carries build → rust → signed-docs
+  # (consumers of build's host-local binary cache); studio-2 carries lint,
+  # conformance, go-compat, and iroh (each self-builds on cache miss). If a
+  # host is offline its jobs queue until the runner returns — deliberate
+  # tradeoff, same as the gents fleet.
   lint:
     name: Lint
-    runs-on: [self-hosted, macOS, ARM64, studio]
+    runs-on: [self-hosted, macOS, ARM64, studio, studio-2]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -102,7 +119,7 @@ jobs:
 
   build:
     name: Build & Test
-    runs-on: [self-hosted, macOS, ARM64, studio]
+    runs-on: [self-hosted, macOS, ARM64, studio, studio-1]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -189,15 +206,14 @@ jobs:
 
   conformance:
     name: Conformance
-    # Serialized after `integration` (not just `build`) so it never co-runs
-    # with the integration matrix on the single studio host. Both jobs spawn
-    # real `defra` nodes and the studio harness port allocator has a TOCTOU
-    # bind race ("failed to start rust-0") when node-spawning jobs run
-    # concurrently — the same reason the integration matrix pins
-    # `max-parallel: 1`. The dependency edge is the strict-ordering fix; it
-    # does not affect correctness, only scheduling.
-    needs: [build, integration]
-    runs-on: [self-hosted, macOS, ARM64, studio]
+    # Spawns real `defra` nodes, so it must never co-run with another
+    # node-spawning job on the SAME host (harness port allocator TOCTOU bind
+    # race — "failed to start rust-0"). Host pinning provides that: this job
+    # runs on studio-2, whose single runner process serializes it against the
+    # go-compat/iroh suites, while the studio-1 suites run on a different
+    # host and cannot contend on its localhost ports. No `needs` edge — the
+    # job builds its own release binary and starts as soon as a slot frees.
+    runs-on: [self-hosted, macOS, ARM64, studio, studio-2]
     timeout-minutes: 45
     env:
       DEFRA_CONFORMANCE_BINARY: ${{ github.workspace }}/target/release/defra
@@ -255,21 +271,28 @@ jobs:
   integration:
     name: Integration (${{ matrix.suite }})
     needs: build
-    runs-on: [self-hosted, macOS, ARM64, studio]
+    runs-on: [self-hosted, macOS, ARM64, studio, "${{ matrix.host }}"]
     strategy:
       fail-fast: false
       # The harness still allocates localhost ports via a release-then-spawn
-      # sequence, so matrix fan-out multiplies bind races on the same studio
-      # host. Keep integration suites single-file until the allocator is fixed.
-      max-parallel: 1
+      # sequence, so two suites on the SAME host can hit a bind race. Each
+      # host runs one defradb.rs runner process (one job at a time), so
+      # pinning suites to hosts serializes same-host suites for free while
+      # letting the two hosts run in parallel — replacing the old
+      # `max-parallel: 1` whole-matrix serialization. studio-1 suites consume
+      # the binary cache the `build` job (also studio-1) populated; studio-2
+      # suites self-build on miss into their own host-local cache.
       matrix:
         include:
           - suite: rust
             needs_go: false
+            host: studio-1
           - suite: go-compat
             needs_go: true
+            host: studio-2
           - suite: iroh
             needs_go: false
+            host: studio-2
           # #978: re-run the rust integration suite with
           # DEFRA_MULTIPLIERS=signed-docs so every cluster gets
           # .with_signing() auto-applied. Catches regressions in
@@ -278,6 +301,7 @@ jobs:
           - suite: signed-docs
             needs_go: false
             multipliers: signed-docs
+            host: studio-1
     env:
       DEFRA_RUST_BINARY: ${{ github.workspace }}/target/ci/defra
       DEFRA_IROH_BINARY: ${{ github.workspace }}/target/ci/defra-iroh
@@ -305,11 +329,17 @@ jobs:
             cp "$CACHE_DIR/defra" target/ci/defra
             cp "$CACHE_DIR/defra-iroh" target/ci/defra-iroh
           else
+            # The build job populates this cache on studio-1 only; suites
+            # pinned to the other host self-build once per commit and
+            # populate their own host-local cache so the sibling suite and
+            # any re-run hit it.
             echo "Cache miss — building binaries"
             cargo build -p cli
             cp target/debug/defra target/ci/defra
+            cp target/debug/defra "$CACHE_DIR/defra"
             cargo build -p cli --features iroh
             cp target/debug/defra target/ci/defra-iroh
+            cp target/debug/defra "$CACHE_DIR/defra-iroh"
           fi
 
           chmod +x target/ci/defra target/ci/defra-iroh
@@ -597,7 +627,9 @@ jobs:
 
   artifacts:
     name: Release Artifacts
-    runs-on: [self-hosted, macOS, ARM64, studio]
+    # studio-2: shares warm target/release state with the conformance job's
+    # release build on the same host.
+    runs-on: [self-hosted, macOS, ARM64, studio, studio-2]
     needs: [build]
     if: github.event_name == 'push'
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,23 +14,35 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  # Two defradb.rs runner slots per studio host can now co-run jobs (plus
+  # other repos' runners on the same hosts). Bound each Cargo process so two
+  # simultaneous compiles fit inside a 32-core host with room for linking and
+  # sibling services — same allocation the gents fleet runs. Override without
+  # a workflow edit: gh variable set CARGO_BUILD_JOBS --body <n>
+  CARGO_BUILD_JOBS: ${{ vars.CARGO_BUILD_JOBS || '12' }}
   PROTOC: /opt/homebrew/bin/protoc
 
 jobs:
-  # Studio jobs are pinned to a host so each job's incremental target state
-  # stays warm on one machine (a suite that bounces between hosts turns a
-  # small rebuild into a full one) and so same-host exclusivity is
-  # deterministic: each host runs ONE defradb.rs runner process, which takes
-  # one job at a time, so two node-spawning jobs can only co-run on DIFFERENT
-  # hosts — where they cannot contend on localhost ports. Layout balances the
-  # measured serial chains: studio-1 carries build → rust → signed-docs
-  # (consumers of build's host-local binary cache); studio-2 carries lint,
-  # conformance, go-compat, and iroh (each self-builds on cache miss). If a
-  # host is offline its jobs queue until the runner returns — deliberate
-  # tradeoff, same as the gents fleet.
+  # Studio jobs are pinned to a runner slot so each job's incremental target
+  # state stays warm on one machine (a suite that bounces between hosts turns
+  # a small rebuild into a full one) and so same-host exclusivity is
+  # deterministic. Each host runs two defradb.rs runner processes:
+  #
+  #   primary (labels ...,studio,studio-N) — one job at a time, so two
+  #   node-spawning jobs can only co-run on DIFFERENT hosts, where they
+  #   cannot contend on localhost ports. studio-1 carries build → rust →
+  #   signed-docs (consumers of build's host-local binary cache); studio-2
+  #   carries conformance, go-compat, and iroh (each self-builds on miss).
+  #
+  #   light (labels ...,defra-light,studio-N-b) — deliberately NOT labeled
+  #   `studio`/`studio-N`, so node-spawning jobs can never land there. Serves
+  #   the non-node jobs: lint (studio-1-b) and artifacts (studio-2-b).
+  #
+  # If a slot is offline its jobs queue until an operator restores the runner
+  # or moves its label — deliberate tradeoff, same as the gents fleet.
   lint:
     name: Lint
-    runs-on: [self-hosted, macOS, ARM64, studio, studio-2]
+    runs-on: [self-hosted, macOS, ARM64, defra-light, studio-1-b]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -627,9 +639,9 @@ jobs:
 
   artifacts:
     name: Release Artifacts
-    # studio-2: shares warm target/release state with the conformance job's
-    # release build on the same host.
-    runs-on: [self-hosted, macOS, ARM64, studio, studio-2]
+    # Light slot: no nodes spawned here, and running beside (not behind) the
+    # studio-2 primary chain gets main-push artifacts out without queueing.
+    runs-on: [self-hosted, macOS, ARM64, defra-light, studio-2-b]
     needs: [build]
     if: github.event_name == 'push'
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,13 @@ jobs:
           clean: false
 
       - name: Configure private repo access
-        run: git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
+        run: |
+          # Org-wide PAT rewrite for private sourcenetwork deps.
+          git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
+          # backbone is public. Fine-grained PATs that omit it make GitHub
+          # treat authenticated fetches as "not our ref" for new commits;
+          # longest-prefix insteadOf wins, so this keeps backbone unauthenticated.
+          git config --global url."https://github.com/sourcenetwork/backbone".insteadOf "https://github.com/sourcenetwork/backbone"
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -85,6 +91,7 @@ jobs:
         if: always()
         run: |
           git config --global --remove-section "url.https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/" 2>/dev/null || true
+          git config --global --remove-section "url.https://github.com/sourcenetwork/backbone" 2>/dev/null || true
 
   wasm-check:
     name: WASM Build Check
@@ -100,7 +107,13 @@ jobs:
           clean: false
 
       - name: Configure private repo access
-        run: git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
+        run: |
+          # Org-wide PAT rewrite for private sourcenetwork deps.
+          git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
+          # backbone is public. Fine-grained PATs that omit it make GitHub
+          # treat authenticated fetches as "not our ref" for new commits;
+          # longest-prefix insteadOf wins, so this keeps backbone unauthenticated.
+          git config --global url."https://github.com/sourcenetwork/backbone".insteadOf "https://github.com/sourcenetwork/backbone"
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -115,8 +128,10 @@ jobs:
           bash .github/scripts/apt-update-without-nodesource.sh
           sudo apt-get install -y protobuf-compiler clang
 
-      - name: Exclude tools with private deps from workspace
-        run: sed -i '/"tools\/integration-test"/d; /"tools\/ffi-test"/d' Cargo.toml
+      - name: Exclude packages that pull private/public git harness deps
+        # wasm doesn't need integration-test, ffi-test, or proofs (defra-harness).
+        # Stripping them keeps cargo from resolving backbone during wasm clippy.
+        run: sed -i '/"tools\/integration-test"/d; /"tools\/ffi-test"/d; /"proofs"/d' Cargo.toml
 
       - name: Clippy (wasm32)
         run: cargo clippy -p defra-wasm --target wasm32-unknown-unknown --all-targets -- -D warnings
@@ -135,6 +150,7 @@ jobs:
         if: always()
         run: |
           git config --global --remove-section "url.https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/" 2>/dev/null || true
+          git config --global --remove-section "url.https://github.com/sourcenetwork/backbone" 2>/dev/null || true
           git checkout -- Cargo.toml
 
   build:
@@ -158,7 +174,13 @@ jobs:
           clean: false
 
       - name: Configure private repo access
-        run: git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
+        run: |
+          # Org-wide PAT rewrite for private sourcenetwork deps.
+          git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
+          # backbone is public. Fine-grained PATs that omit it make GitHub
+          # treat authenticated fetches as "not our ref" for new commits;
+          # longest-prefix insteadOf wins, so this keeps backbone unauthenticated.
+          git config --global url."https://github.com/sourcenetwork/backbone".insteadOf "https://github.com/sourcenetwork/backbone"
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -197,6 +219,7 @@ jobs:
         if: always()
         run: |
           git config --global --remove-section "url.https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/" 2>/dev/null || true
+          git config --global --remove-section "url.https://github.com/sourcenetwork/backbone" 2>/dev/null || true
           git checkout -- .
           git clean -fd
           pkill -f "target/debug/defra" || true
@@ -212,6 +235,8 @@ jobs:
         run: |
           git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
           git config --global --add url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "ssh://git@github.com/sourcenetwork/"
+          # Public backbone: keep unauthenticated (see comment on other jobs).
+          git config --global url."https://github.com/sourcenetwork/backbone".insteadOf "https://github.com/sourcenetwork/backbone"
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -234,7 +259,9 @@ jobs:
 
       - name: Cleanup
         if: always()
-        run: git config --global --remove-section "url.https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/" 2>/dev/null || true
+        run: |
+          git config --global --remove-section "url.https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/" 2>/dev/null || true
+          git config --global --remove-section "url.https://github.com/sourcenetwork/backbone" 2>/dev/null || true
 
   conformance:
     name: Conformance
@@ -263,7 +290,13 @@ jobs:
           clean: false
 
       - name: Configure private repo access
-        run: git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
+        run: |
+          # Org-wide PAT rewrite for private sourcenetwork deps.
+          git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
+          # backbone is public. Fine-grained PATs that omit it make GitHub
+          # treat authenticated fetches as "not our ref" for new commits;
+          # longest-prefix insteadOf wins, so this keeps backbone unauthenticated.
+          git config --global url."https://github.com/sourcenetwork/backbone".insteadOf "https://github.com/sourcenetwork/backbone"
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -301,6 +334,7 @@ jobs:
         if: always()
         run: |
           git config --global --remove-section "url.https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/" 2>/dev/null || true
+          git config --global --remove-section "url.https://github.com/sourcenetwork/backbone" 2>/dev/null || true
           git checkout -- .
           git clean -fd
           rm -rf target/e2e
@@ -367,7 +401,13 @@ jobs:
           clean: false
 
       - name: Configure private repo access
-        run: git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
+        run: |
+          # Org-wide PAT rewrite for private sourcenetwork deps.
+          git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
+          # backbone is public. Fine-grained PATs that omit it make GitHub
+          # treat authenticated fetches as "not our ref" for new commits;
+          # longest-prefix insteadOf wins, so this keeps backbone unauthenticated.
+          git config --global url."https://github.com/sourcenetwork/backbone".insteadOf "https://github.com/sourcenetwork/backbone"
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -588,6 +628,7 @@ jobs:
         if: always()
         run: |
           git config --global --remove-section "url.https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/" 2>/dev/null || true
+          git config --global --remove-section "url.https://github.com/sourcenetwork/backbone" 2>/dev/null || true
           git checkout -- .
           git clean -fd
           pkill -f "target/(debug|ci)/defra" || true
@@ -626,7 +667,13 @@ jobs:
           clean: false
 
       - name: Configure private repo access
-        run: git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
+        run: |
+          # Org-wide PAT rewrite for private sourcenetwork deps.
+          git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
+          # backbone is public. Fine-grained PATs that omit it make GitHub
+          # treat authenticated fetches as "not our ref" for new commits;
+          # longest-prefix insteadOf wins, so this keeps backbone unauthenticated.
+          git config --global url."https://github.com/sourcenetwork/backbone".insteadOf "https://github.com/sourcenetwork/backbone"
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -679,6 +726,7 @@ jobs:
         if: always()
         run: |
           git config --global --remove-section "url.https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/" 2>/dev/null || true
+          git config --global --remove-section "url.https://github.com/sourcenetwork/backbone" 2>/dev/null || true
           git checkout -- .
           git clean -fd
           rm -rf target/e2e
@@ -697,7 +745,13 @@ jobs:
           clean: false
 
       - name: Configure private repo access
-        run: git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
+        run: |
+          # Org-wide PAT rewrite for private sourcenetwork deps.
+          git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
+          # backbone is public. Fine-grained PATs that omit it make GitHub
+          # treat authenticated fetches as "not our ref" for new commits;
+          # longest-prefix insteadOf wins, so this keeps backbone unauthenticated.
+          git config --global url."https://github.com/sourcenetwork/backbone".insteadOf "https://github.com/sourcenetwork/backbone"
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -727,5 +781,6 @@ jobs:
         if: always()
         run: |
           git config --global --remove-section "url.https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/" 2>/dev/null || true
+          git config --global --remove-section "url.https://github.com/sourcenetwork/backbone" 2>/dev/null || true
           git checkout -- .
           git clean -fd

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -606,7 +606,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -617,7 +617,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3546,7 +3546,7 @@ dependencies = [
 [[package]]
 name = "defra-harness"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/backbone.git?rev=d141721#d14172101436e5a3f62c967c34e7db8bc230aa79"
+source = "git+https://github.com/sourcenetwork/backbone.git?rev=d14172101436e5a3f62c967c34e7db8bc230aa79#d14172101436e5a3f62c967c34e7db8bc230aa79"
 dependencies = [
  "eyre",
  "futures",
@@ -4255,7 +4255,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5372,7 +5372,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 [[package]]
 name = "hub-harness"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/backbone.git?rev=d141721#d14172101436e5a3f62c967c34e7db8bc230aa79"
+source = "git+https://github.com/sourcenetwork/backbone.git?rev=d14172101436e5a3f62c967c34e7db8bc230aa79#d14172101436e5a3f62c967c34e7db8bc230aa79"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5547,7 +5547,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -7892,7 +7892,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10416,7 +10416,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10508,7 +10508,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10804,7 +10804,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11329,7 +11329,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11392,7 +11392,7 @@ dependencies = [
 [[package]]
 name = "sourcehub-harness"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/backbone.git?rev=d141721#d14172101436e5a3f62c967c34e7db8bc230aa79"
+source = "git+https://github.com/sourcenetwork/backbone.git?rev=d14172101436e5a3f62c967c34e7db8bc230aa79#d14172101436e5a3f62c967c34e7db8bc230aa79"
 dependencies = [
  "cosmrs",
  "eyre",
@@ -11840,7 +11840,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11947,7 +11947,7 @@ dependencies = [
 [[package]]
 name = "test-infra"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/backbone.git?rev=d141721#d14172101436e5a3f62c967c34e7db8bc230aa79"
+source = "git+https://github.com/sourcenetwork/backbone.git?rev=d14172101436e5a3f62c967c34e7db8bc230aa79#d14172101436e5a3f62c967c34e7db8bc230aa79"
 dependencies = [
  "eyre",
  "futures",
@@ -12644,7 +12644,7 @@ checksum = "51b70b87d15e91f553711b40df3048faf27a7a04e01e0ddc0cf9309f0af7c2ca"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13392,7 +13392,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -606,7 +606,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -617,7 +617,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3546,7 +3546,7 @@ dependencies = [
 [[package]]
 name = "defra-harness"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/backbone.git?rev=d14172101436e5a3f62c967c34e7db8bc230aa79#d14172101436e5a3f62c967c34e7db8bc230aa79"
+source = "git+https://github.com/sourcenetwork/backbone.git?rev=defra-harness%2F2026-08-07-port-conflict#d14172101436e5a3f62c967c34e7db8bc230aa79"
 dependencies = [
  "eyre",
  "futures",
@@ -4255,7 +4255,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5372,7 +5372,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 [[package]]
 name = "hub-harness"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/backbone.git?rev=d14172101436e5a3f62c967c34e7db8bc230aa79#d14172101436e5a3f62c967c34e7db8bc230aa79"
+source = "git+https://github.com/sourcenetwork/backbone.git?rev=defra-harness%2F2026-08-07-port-conflict#d14172101436e5a3f62c967c34e7db8bc230aa79"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5547,7 +5547,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -7892,7 +7892,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10416,7 +10416,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10508,7 +10508,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10804,7 +10804,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11329,7 +11329,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11392,7 +11392,7 @@ dependencies = [
 [[package]]
 name = "sourcehub-harness"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/backbone.git?rev=d14172101436e5a3f62c967c34e7db8bc230aa79#d14172101436e5a3f62c967c34e7db8bc230aa79"
+source = "git+https://github.com/sourcenetwork/backbone.git?rev=defra-harness%2F2026-08-07-port-conflict#d14172101436e5a3f62c967c34e7db8bc230aa79"
 dependencies = [
  "cosmrs",
  "eyre",
@@ -11840,7 +11840,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11947,7 +11947,7 @@ dependencies = [
 [[package]]
 name = "test-infra"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/backbone.git?rev=d14172101436e5a3f62c967c34e7db8bc230aa79#d14172101436e5a3f62c967c34e7db8bc230aa79"
+source = "git+https://github.com/sourcenetwork/backbone.git?rev=defra-harness%2F2026-08-07-port-conflict#d14172101436e5a3f62c967c34e7db8bc230aa79"
 dependencies = [
  "eyre",
  "futures",
@@ -12644,7 +12644,7 @@ checksum = "51b70b87d15e91f553711b40df3048faf27a7a04e01e0ddc0cf9309f0af7c2ca"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13392,7 +13392,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -606,7 +606,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -617,7 +617,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3546,7 +3546,7 @@ dependencies = [
 [[package]]
 name = "defra-harness"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/backbone.git?rev=adaf59d#adaf59db7aaea3e8d48a9b5e14846c24e59d2456"
+source = "git+https://github.com/sourcenetwork/backbone.git?rev=d141721#d14172101436e5a3f62c967c34e7db8bc230aa79"
 dependencies = [
  "eyre",
  "futures",
@@ -4255,7 +4255,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5372,7 +5372,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 [[package]]
 name = "hub-harness"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/backbone.git?rev=adaf59d#adaf59db7aaea3e8d48a9b5e14846c24e59d2456"
+source = "git+https://github.com/sourcenetwork/backbone.git?rev=d141721#d14172101436e5a3f62c967c34e7db8bc230aa79"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5547,7 +5547,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -7892,7 +7892,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8048,7 +8048,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -9343,7 +9343,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -10416,7 +10416,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10508,7 +10508,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10804,7 +10804,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11329,7 +11329,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11392,7 +11392,7 @@ dependencies = [
 [[package]]
 name = "sourcehub-harness"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/backbone.git?rev=adaf59d#adaf59db7aaea3e8d48a9b5e14846c24e59d2456"
+source = "git+https://github.com/sourcenetwork/backbone.git?rev=d141721#d14172101436e5a3f62c967c34e7db8bc230aa79"
 dependencies = [
  "cosmrs",
  "eyre",
@@ -11840,7 +11840,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11947,7 +11947,7 @@ dependencies = [
 [[package]]
 name = "test-infra"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/backbone.git?rev=adaf59d#adaf59db7aaea3e8d48a9b5e14846c24e59d2456"
+source = "git+https://github.com/sourcenetwork/backbone.git?rev=d141721#d14172101436e5a3f62c967c34e7db8bc230aa79"
 dependencies = [
  "eyre",
  "futures",
@@ -12644,7 +12644,7 @@ checksum = "51b70b87d15e91f553711b40df3048faf27a7a04e01e0ddc0cf9309f0af7c2ca"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13392,7 +13392,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/proofs/Cargo.toml
+++ b/proofs/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = "1.0"
 anyhow = "1.0"
 
 [dev-dependencies]
-defra-harness = { git = "https://github.com/sourcenetwork/backbone.git", rev = "adaf59d" }
+defra-harness = { git = "https://github.com/sourcenetwork/backbone.git", rev = "d141721" }
 tokio = { version = "1.35", features = ["full"] }
 serial_test = "3"
 

--- a/proofs/Cargo.toml
+++ b/proofs/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = "1.0"
 anyhow = "1.0"
 
 [dev-dependencies]
-defra-harness = { git = "https://github.com/sourcenetwork/backbone.git", rev = "d14172101436e5a3f62c967c34e7db8bc230aa79" }
+defra-harness = { git = "https://github.com/sourcenetwork/backbone.git", rev = "defra-harness/2026-08-07-port-conflict" }
 tokio = { version = "1.35", features = ["full"] }
 serial_test = "3"
 

--- a/proofs/Cargo.toml
+++ b/proofs/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = "1.0"
 anyhow = "1.0"
 
 [dev-dependencies]
-defra-harness = { git = "https://github.com/sourcenetwork/backbone.git", rev = "d141721" }
+defra-harness = { git = "https://github.com/sourcenetwork/backbone.git", rev = "d14172101436e5a3f62c967c34e7db8bc230aa79" }
 tokio = { version = "1.35", features = ["full"] }
 serial_test = "3"
 

--- a/tools/integration-test/Cargo.toml
+++ b/tools/integration-test/Cargo.toml
@@ -99,8 +99,8 @@ name = "cursor"
 path = "tests/cursor.rs"
 
 [dependencies]
-hub-harness = { git = "https://github.com/sourcenetwork/backbone.git", rev = "d141721" }
-defra-harness = { git = "https://github.com/sourcenetwork/backbone.git", rev = "d141721" }
+hub-harness = { git = "https://github.com/sourcenetwork/backbone.git", rev = "d14172101436e5a3f62c967c34e7db8bc230aa79" }
+defra-harness = { git = "https://github.com/sourcenetwork/backbone.git", rev = "d14172101436e5a3f62c967c34e7db8bc230aa79" }
 document = { path = "../../crates/document" }
 tokio = { version = "1.35", features = ["full"] }
 reqwest = { version = "0.12", features = ["json", "stream"] }

--- a/tools/integration-test/Cargo.toml
+++ b/tools/integration-test/Cargo.toml
@@ -99,8 +99,8 @@ name = "cursor"
 path = "tests/cursor.rs"
 
 [dependencies]
-hub-harness = { git = "https://github.com/sourcenetwork/backbone.git", rev = "adaf59d" }
-defra-harness = { git = "https://github.com/sourcenetwork/backbone.git", rev = "adaf59d" }
+hub-harness = { git = "https://github.com/sourcenetwork/backbone.git", rev = "d141721" }
+defra-harness = { git = "https://github.com/sourcenetwork/backbone.git", rev = "d141721" }
 document = { path = "../../crates/document" }
 tokio = { version = "1.35", features = ["full"] }
 reqwest = { version = "0.12", features = ["json", "stream"] }

--- a/tools/integration-test/Cargo.toml
+++ b/tools/integration-test/Cargo.toml
@@ -99,8 +99,8 @@ name = "cursor"
 path = "tests/cursor.rs"
 
 [dependencies]
-hub-harness = { git = "https://github.com/sourcenetwork/backbone.git", rev = "d14172101436e5a3f62c967c34e7db8bc230aa79" }
-defra-harness = { git = "https://github.com/sourcenetwork/backbone.git", rev = "d14172101436e5a3f62c967c34e7db8bc230aa79" }
+hub-harness = { git = "https://github.com/sourcenetwork/backbone.git", rev = "defra-harness/2026-08-07-port-conflict" }
+defra-harness = { git = "https://github.com/sourcenetwork/backbone.git", rev = "defra-harness/2026-08-07-port-conflict" }
 document = { path = "../../crates/document" }
 tokio = { version = "1.35", features = ["full"] }
 reqwest = { version = "0.12", features = ["json", "stream"] }


### PR DESCRIPTION
## Problem

PR CI wall-clock has been 2–3 hours while actual job compute is ~58 minutes (measured on run 31193513540: Integration (rust) queued 55 min before starting; Conformance started 2h07m into the run). Three compounding causes:

- Every studio job from every concurrent run competes for the two studio runner slots, with no cancellation of superseded runs
- The integration matrix pins `max-parallel: 1`, serializing all four suites even across two hosts
- `conformance` has a `needs: [build, integration]` edge purely for anti-co-run scheduling, queueing it behind the whole matrix

## Change

Mirrors the gents fleet's CI-latency work (source-inc/gents#1011):

- **`concurrency` group** cancels superseded PR runs; main pushes are never cancelled (full validation + artifacts for every main commit)
- **Host pinning**: studio-1 carries `build → integration(rust) → integration(signed-docs)` — the consumers of build's host-local binary cache; studio-2 carries `lint`, `conformance`, `integration(go-compat)`, `integration(iroh)`
- **`max-parallel: 1` and the conformance needs-edge removed**: each host runs exactly one defradb.rs runner process (one job at a time), so same-host node-spawning jobs serialize for free, and cross-host jobs cannot contend on localhost ports. Pinning also keeps each suite's incremental target state warm on one machine (a suite that bounces between hosts turns a small rebuild into a full one)
- **Cache-miss suites populate the per-host binary cache** so the sibling studio-2 suite and re-runs hit instead of rebuilding
- `.github/actionlint.yaml` declares the self-hosted labels (actionlint-clean)

Expected steady-state PR latency: ~20 min per studio chain (vs ~35–40 min serialized), with the queueing collapse from cancellation being the larger win under concurrent-PR load.

## Tradeoff

If a studio host is offline, its pinned jobs queue until an operator restores the runner (or moves the label) — same deliberate tradeoff as the gents fleet. Follow-up: register a second defradb.rs runner slot per host (amygdala `infra/services/github-runners`) to double studio throughput.

🤖 Generated with [Claude Code](https://claude.com/claude-code)