### PR TITLE
Run signed embedded transactions on a node-owned runtime

### DIFF
--- a/crates/db/src/block_verify.rs
+++ b/crates/db/src/block_verify.rs
@@ -6,6 +6,106 @@ use storage::corekv::Store;
 use crate::database::DB;
 use crate::txn::DbTxn;
 
+/// Verify a block's embedded signature and return the signer's DID.
+///
+/// The public key and algorithm are read from the signed block's signature
+/// header. The DID is returned only after the signature has been verified over
+/// the canonical DAG-CBOR block bytes.
+pub async fn verified_block_signer_did<S: Store>(
+    database: &Arc<DB<S>>,
+    document_acp: &dyn acp::DocumentACP,
+    cid_str: &str,
+    caller_identity: &acp::Identity,
+) -> Result<String, String> {
+    let txn = database
+        .new_txn(true)
+        .await
+        .map_err(|e| format!("failed to create transaction: {}", e))?;
+    let blockstore = txn
+        .blockstore()
+        .map_err(|e| format!("failed to get blockstore: {}", e))?;
+    let systemstore = txn
+        .systemstore()
+        .map_err(|e| format!("failed to get systemstore: {}", e))?;
+
+    verified_block_signer_did_with_blockstore(
+        database,
+        document_acp,
+        blockstore,
+        systemstore,
+        cid_str,
+        caller_identity,
+    )
+    .await
+}
+
+/// Verify a block visible inside an active transaction and return its signer DID.
+pub async fn verified_block_signer_did_in_txn<S: Store>(
+    database: &Arc<DB<S>>,
+    document_acp: &dyn acp::DocumentACP,
+    txn: &DbTxn<S>,
+    cid_str: &str,
+    caller_identity: &acp::Identity,
+) -> Result<String, String> {
+    let blockstore = txn
+        .blockstore()
+        .map_err(|e| format!("failed to get blockstore: {}", e))?;
+    let systemstore = txn
+        .systemstore()
+        .map_err(|e| format!("failed to get systemstore: {}", e))?;
+
+    verified_block_signer_did_with_blockstore(
+        database,
+        document_acp,
+        blockstore,
+        systemstore,
+        cid_str,
+        caller_identity,
+    )
+    .await
+}
+
+pub(crate) async fn verified_block_signer_did_with_blockstore<S: Store>(
+    database: &Arc<DB<S>>,
+    document_acp: &dyn acp::DocumentACP,
+    blockstore: NamespaceView,
+    systemstore: NamespaceView,
+    cid_str: &str,
+    caller_identity: &acp::Identity,
+) -> Result<String, String> {
+    let (block, signature) = load_authorized_block_signature(
+        database,
+        document_acp,
+        blockstore,
+        systemstore,
+        cid_str,
+        caller_identity,
+    )
+    .await?;
+    verified_signature_signer_did(&block, &signature)
+}
+
+fn verified_signature_signer_did(
+    block: &defra_core::block::Block,
+    signature: &defra_core::block::Signature,
+) -> Result<String, String> {
+    let signature_identity = std::str::from_utf8(&signature.header.identity)
+        .map_err(|e| format!("signature identity is not valid UTF-8: {}", e))?;
+    let key_type = match signature.header.sig_type {
+        defra_core::block::SignatureType::ES256K => crypto::KeyType::Secp256k1,
+        defra_core::block::SignatureType::ES256 => crypto::KeyType::Secp256r1,
+        defra_core::block::SignatureType::EdDSA => crypto::KeyType::Ed25519,
+        defra_core::block::SignatureType::BLS => crypto::KeyType::Bls12381,
+    };
+    let public_key = crypto::public_key_from_string(key_type, signature_identity)
+        .map_err(|e| format!("invalid signature identity: {}", e))?;
+
+    verify_signature_bytes(block, signature, public_key.as_ref())?;
+    public_key
+        .did()
+        .map_err(|e| format!("failed to derive signer DID: {}", e))
+}
+
 /// Verify the signature of a block.
 ///
 /// Loads a block from the blockstore by CID, checks that it has a signature,
@@ -92,30 +192,54 @@ async fn verify_block_signature_with_blockstore<S: Store>(
     public_key_hex: &str,
     caller_identity: &acp::Identity,
 ) -> Result<(), String> {
+    let (block, signature) = load_authorized_block_signature(
+        database,
+        document_acp,
+        blockstore,
+        systemstore,
+        cid_str,
+        caller_identity,
+    )
+    .await?;
+
+    let sig_identity = std::str::from_utf8(&signature.header.identity)
+        .map_err(|e| format!("signature identity is not valid UTF-8: {}", e))?;
+    if sig_identity != public_key_hex {
+        return Err("signature was created by a different key".to_string());
+    }
+
+    verify_signature_bytes(&block, &signature, pub_key)
+}
+
+async fn load_authorized_block_signature<S: Store>(
+    database: &Arc<DB<S>>,
+    document_acp: &dyn acp::DocumentACP,
+    blockstore: NamespaceView,
+    systemstore: NamespaceView,
+    cid_str: &str,
+    caller_identity: &acp::Identity,
+) -> Result<(defra_core::block::Block, defra_core::block::Signature), String> {
     let parsed_cid: cid::Cid = cid_str.parse().map_err(|e| format!("invalid CID: {}", e))?;
-    let (block, signature) = {
-        let block_bytes = blockstore
-            .get(&parsed_cid.to_bytes())
-            .await
-            .map_err(|e| format!("failed to load block: {}", e))?
-            .ok_or_else(|| format!("could not find block: {}", cid_str))?;
+    let block_bytes = blockstore
+        .get(&parsed_cid.to_bytes())
+        .await
+        .map_err(|e| format!("failed to load block: {}", e))?
+        .ok_or_else(|| format!("could not find block: {}", cid_str))?;
+    blockstore::verify_block_cid(&parsed_cid, &block_bytes)
+        .map_err(|e| format!("block CID verification failed: {}", e))?;
 
-        let block = defra_core::block::Block::from_dag_cbor(&block_bytes)
-            .map_err(|e| format!("failed to decode block: {}", e))?;
-
-        let sig_cid = block.signature.ok_or("block has no signature")?;
-
-        let sig_bytes = blockstore
-            .get(&sig_cid.to_bytes())
-            .await
-            .map_err(|e| format!("failed to load signature block: {}", e))?
-            .ok_or_else(|| format!("signature block not found: {}", sig_cid))?;
-
-        let signature = defra_core::block::Signature::from_dag_cbor(&sig_bytes)
-            .map_err(|e| format!("failed to decode signature block: {}", e))?;
-
-        (block, signature)
-    };
+    let block = defra_core::block::Block::from_dag_cbor(&block_bytes)
+        .map_err(|e| format!("failed to decode block: {}", e))?;
+    let sig_cid = block.signature.ok_or("block has no signature")?;
+    let sig_bytes = blockstore
+        .get(&sig_cid.to_bytes())
+        .await
+        .map_err(|e| format!("failed to load signature block: {}", e))?
+        .ok_or_else(|| format!("signature block not found: {}", sig_cid))?;
+    blockstore::verify_block_cid(&sig_cid, &sig_bytes)
+        .map_err(|e| format!("signature block CID verification failed: {}", e))?;
+    let signature = defra_core::block::Signature::from_dag_cbor(&sig_bytes)
+        .map_err(|e| format!("failed to decode signature block: {}", e))?;
 
     // Check document/collection-level ACP permission (Read) if the block has
     // collection metadata.
@@ -173,20 +297,21 @@ async fn verify_block_signature_with_blockstore<S: Store>(
         }
     }
 
-    // Verify that the identity matches the signature's identity
-    let sig_identity = String::from_utf8_lossy(&signature.header.identity);
-    if sig_identity.as_ref() != public_key_hex {
-        return Err("signature was created by a different key".to_string());
-    }
+    Ok((block, signature))
+}
 
-    // Get the bytes to verify (block serialized without signature)
+fn verify_signature_bytes(
+    block: &defra_core::block::Block,
+    signature: &defra_core::block::Signature,
+    public_key: &dyn crypto::PublicKey,
+) -> Result<(), String> {
     let mut block_to_verify = block.clone();
     block_to_verify.signature = None;
     let signed_bytes = block_to_verify
         .to_dag_cbor()
         .map_err(|e| format!("failed to serialize block for verification: {}", e))?;
 
-    let valid = pub_key
+    let valid = public_key
         .verify(&signed_bytes, &signature.value)
         .map_err(|e| format!("signature verification error: {}", e))?;
 
@@ -195,4 +320,71 @@ async fn verify_block_signature_with_blockstore<S: Store>(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crypto::PrivateKey;
+    use defra_core::block::{
+        Block, CrdtDelta, LwwDeltaPayload, Signature, SignatureHeader, SignatureType,
+    };
+
+    use super::verified_signature_signer_did;
+
+    fn test_block() -> Block {
+        Block {
+            delta: CrdtDelta::Lww(LwwDeltaPayload {
+                field_name: "name".to_string(),
+                schema_version_id: "v1".to_string(),
+                priority: 1,
+                data: b"original".to_vec(),
+            }),
+            heads: None,
+            links: None,
+            encryption: None,
+            signature: None,
+        }
+    }
+
+    fn sign_block(block: &Block) -> (Signature, String) {
+        let private_key = crypto::generate_ed25519().expect("generate Ed25519 key");
+        let public_key = private_key.public_key();
+        let signer_did = public_key.did().expect("derive signer DID");
+        let signature = Signature::new(
+            SignatureHeader::new(
+                SignatureType::EdDSA,
+                hex::encode(public_key.raw()).into_bytes(),
+            ),
+            private_key
+                .sign(&block.to_dag_cbor().expect("encode block"))
+                .expect("sign block"),
+        );
+        (signature, signer_did)
+    }
+
+    #[test]
+    fn verified_signer_rejects_tampered_block() {
+        let block = test_block();
+        let (signature, _) = sign_block(&block);
+        let mut tampered = block;
+        let CrdtDelta::Lww(payload) = &mut tampered.delta else {
+            panic!("expected LWW delta");
+        };
+        payload.data = b"tampered".to_vec();
+
+        let error = verified_signature_signer_did(&tampered, &signature)
+            .expect_err("tampered block must fail verification");
+        assert!(error.contains("signature verification"), "{error}");
+    }
+
+    #[test]
+    fn verified_signer_rejects_invalid_identity() {
+        let block = test_block();
+        let (mut signature, _) = sign_block(&block);
+        signature.header.identity = b"not hex".to_vec();
+
+        let error = verified_signature_signer_did(&block, &signature)
+            .expect_err("invalid identity must fail verification");
+        assert!(error.contains("invalid signature identity"), "{error}");
+    }
 }

--- a/crates/db/src/txn_registry.rs
+++ b/crates/db/src/txn_registry.rs
@@ -666,6 +666,40 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
         .map_err(Error::Other)
     }
 
+    /// Verify a block's embedded signature inside an active transaction and
+    /// return the signer DID.
+    pub async fn verified_block_signer_did_in_txn(
+        &self,
+        txn_id: &str,
+        document_acp: &dyn acp::DocumentACP,
+        cid_str: &str,
+        caller_identity: &acp::Identity,
+    ) -> Result<String> {
+        let ctx = self
+            .get_ctx(txn_id)?
+            .ok_or_else(|| Error::TransactionNotFound(txn_id.to_string()))?;
+        let action_lock = ctx.action_lock();
+        let _action_guard = action_lock.lock().await;
+
+        let (blockstore, systemstore) = {
+            let shared_txn = ctx.fetcher_shared_txn();
+            let txn_guard = shared_txn.lock().await;
+            let txn = txn_guard.as_ref().ok_or(Error::TxnNotActive)?;
+            (txn.blockstore()?, txn.systemstore()?)
+        };
+
+        crate::block_verify::verified_block_signer_did_with_blockstore(
+            &self.db,
+            document_acp,
+            blockstore,
+            systemstore,
+            cid_str,
+            caller_identity,
+        )
+        .await
+        .map_err(Error::Other)
+    }
+
     /// List all lenses visible within a transaction.
     pub async fn list_lenses_in_txn(
         &self,

--- a/crates/defra-node/src/db_impls.rs
+++ b/crates/defra-node/src/db_impls.rs
@@ -6,7 +6,60 @@ use identity::Did;
 use lens::{LensConfig, TransformId};
 use schema::CollectionVersion;
 
-use crate::SchemaOps;
+use crate::{BlockOps, SchemaOps};
+
+pub(crate) struct DbBlockOps<S: storage::corekv::Store + 'static> {
+    database: Arc<db::DB<S>>,
+    document_acp: Arc<dyn acp::DocumentACP>,
+    transaction_registry: Arc<db::DbTransactionRegistry<S>>,
+    caller_identity: acp::Identity,
+}
+
+impl<S: storage::corekv::Store + 'static> DbBlockOps<S> {
+    pub(crate) fn new(
+        database: Arc<db::DB<S>>,
+        document_acp: Arc<dyn acp::DocumentACP>,
+        transaction_registry: Arc<db::DbTransactionRegistry<S>>,
+    ) -> Self {
+        let caller_identity = database.node_did().into();
+        Self {
+            database,
+            document_acp,
+            transaction_registry,
+            caller_identity,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl<S: storage::corekv::Store + 'static> BlockOps for DbBlockOps<S> {
+    async fn verified_signer_did(&self, cid: &str) -> anyhow::Result<String> {
+        db::block_verify::verified_block_signer_did(
+            &self.database,
+            self.document_acp.as_ref(),
+            cid,
+            &self.caller_identity,
+        )
+        .await
+        .map_err(anyhow::Error::msg)
+    }
+
+    async fn verified_signer_did_in_txn(
+        &self,
+        cid: &str,
+        transaction: &query::TransactionHandle,
+    ) -> anyhow::Result<String> {
+        self.transaction_registry
+            .verified_block_signer_did_in_txn(
+                transaction.as_str(),
+                self.document_acp.as_ref(),
+                cid,
+                &self.caller_identity,
+            )
+            .await
+            .map_err(anyhow::Error::new)
+    }
+}
 
 pub(crate) struct DbSchemaOps<S: storage::corekv::Store + 'static> {
     database: Arc<db::DB<S>>,

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -689,7 +689,7 @@ impl Drop for SignedQueryPermit {
         if self
             .state
             .active_queries
-            .fetch_sub(1, std::sync::atomic::Ordering::AcqRel)
+            .fetch_sub(1, std::sync::atomic::Ordering::SeqCst)
             == 1
         {
             self.state.active_queries_drained.notify_waiters();
@@ -708,7 +708,7 @@ impl Drop for SignedQueryRuntimeClosedGuard {
     fn drop(&mut self) {
         self.state
             .closed
-            .store(true, std::sync::atomic::Ordering::Release);
+            .store(true, std::sync::atomic::Ordering::SeqCst);
         self.state.closed_notify.notify_waiters();
     }
 }
@@ -783,21 +783,13 @@ impl SignedQueryRuntime {
     }
 
     fn admit(&self) -> Option<SignedQueryPermit> {
-        if self
-            .state
-            .closing
-            .load(std::sync::atomic::Ordering::Acquire)
-        {
+        if self.state.closing.load(std::sync::atomic::Ordering::SeqCst) {
             return None;
         }
         self.state
             .active_queries
-            .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
-        if self
-            .state
-            .closing
-            .load(std::sync::atomic::Ordering::Acquire)
-        {
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        if self.state.closing.load(std::sync::atomic::Ordering::SeqCst) {
             drop(SignedQueryPermit {
                 state: self.state.clone(),
             });
@@ -811,13 +803,13 @@ impl SignedQueryRuntime {
     fn active_queries(&self) -> usize {
         self.state
             .active_queries
-            .load(std::sync::atomic::Ordering::Acquire)
+            .load(std::sync::atomic::Ordering::SeqCst)
     }
 
     fn close_admission(&self) {
         self.state
             .closing
-            .store(true, std::sync::atomic::Ordering::Release);
+            .store(true, std::sync::atomic::Ordering::SeqCst);
     }
 
     async fn wait_for_active_queries(&self) {
@@ -849,7 +841,7 @@ impl SignedQueryRuntime {
         } else {
             loop {
                 let notified = self.state.closed_notify.notified();
-                if self.state.closed.load(std::sync::atomic::Ordering::Acquire) {
+                if self.state.closed.load(std::sync::atomic::Ordering::SeqCst) {
                     break;
                 }
                 notified.await;
@@ -894,7 +886,7 @@ fn wait_for_active_signed_queries(state: &SignedQueryRuntimeState, timeout: Dura
     loop {
         if state
             .active_queries
-            .load(std::sync::atomic::Ordering::Acquire)
+            .load(std::sync::atomic::Ordering::SeqCst)
             == 0
         {
             return true;
@@ -910,7 +902,7 @@ fn wait_for_active_signed_queries(state: &SignedQueryRuntimeState, timeout: Dura
         if wait_result.timed_out() {
             return state
                 .active_queries
-                .load(std::sync::atomic::Ordering::Acquire)
+                .load(std::sync::atomic::Ordering::SeqCst)
                 == 0;
         }
     }

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -595,7 +595,6 @@ fn signed_query_runtime() -> Result<&'static tokio::runtime::Runtime, String> {
     RUNTIME
         .get_or_init(|| {
             tokio::runtime::Builder::new_multi_thread()
-                .worker_threads(1)
                 .thread_name("defra-signed-query")
                 .enable_all()
                 .build()

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -121,6 +121,8 @@ pub struct EmbeddedNode {
     embedding_config: db::EmbeddingClientConfig,
     node_identity_did: Option<String>,
     #[cfg(not(target_arch = "wasm32"))]
+    signed_query_runtime: Option<SignedQueryRuntime>,
+    #[cfg(not(target_arch = "wasm32"))]
     transaction_stats: Option<storage::TransactionStatsHandle>,
     #[cfg(feature = "rocksdb")]
     rocksdb_stats: Option<storage::RocksDbStatsHandle>,
@@ -188,6 +190,15 @@ impl EmbeddedNode {
         let Some(signing_config) = signing_config else {
             return unavailable_node_signer_response(node_identity_did);
         };
+        #[cfg(not(target_arch = "wasm32"))]
+        let Some(signed_query_permit) = self
+            .signed_query_runtime
+            .as_ref()
+            .expect("signed node owns a query runtime")
+            .admit()
+        else {
+            return QueryResponse::error("signed query runtime is shutting down");
+        };
 
         execute_with_signing_context(
             self.runner.clone(),
@@ -195,6 +206,13 @@ impl EmbeddedNode {
             None,
             signing_config,
             node_identity_did.to_string(),
+            #[cfg(not(target_arch = "wasm32"))]
+            self.signed_query_runtime
+                .as_ref()
+                .expect("signed node owns a query runtime")
+                .handle(),
+            #[cfg(not(target_arch = "wasm32"))]
+            signed_query_permit,
         )
         .await
     }
@@ -221,6 +239,15 @@ impl EmbeddedNode {
         let Some(signing_config) = signing_config else {
             return unavailable_node_signer_response(node_identity_did);
         };
+        #[cfg(not(target_arch = "wasm32"))]
+        let Some(signed_query_permit) = self
+            .signed_query_runtime
+            .as_ref()
+            .expect("signed node owns a query runtime")
+            .admit()
+        else {
+            return QueryResponse::error("signed query runtime is shutting down");
+        };
 
         execute_with_signing_context(
             self.runner.clone(),
@@ -228,6 +255,13 @@ impl EmbeddedNode {
             Some(handle),
             signing_config,
             node_identity_did.to_string(),
+            #[cfg(not(target_arch = "wasm32"))]
+            self.signed_query_runtime
+                .as_ref()
+                .expect("signed node owns a query runtime")
+                .handle(),
+            #[cfg(not(target_arch = "wasm32"))]
+            signed_query_permit,
         )
         .await
     }
@@ -439,9 +473,28 @@ impl EmbeddedNode {
             let _ = tokio::time::timeout(Duration::from_secs(1), task).await;
         }
 
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Some(runtime) = &self.signed_query_runtime {
+            if !runtime
+                .close_admission_and_wait_for(SIGNED_QUERY_DRAIN_TIMEOUT)
+                .await
+            {
+                tracing::warn!(
+                    active_queries = runtime.active_queries(),
+                    timeout_secs = SIGNED_QUERY_DRAIN_TIMEOUT.as_secs(),
+                    "timed out draining signed queries during node shutdown"
+                );
+            }
+        }
+
         #[cfg(feature = "p2p")]
         if let Some(lifecycle) = &self.p2p_lifecycle {
             lifecycle.shutdown().await;
+        }
+
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Some(runtime) = &self.signed_query_runtime {
+            runtime.shutdown().await;
         }
 
         // Flush buffered spans / metrics. Done after P2P shutdown so trailing
@@ -512,17 +565,18 @@ async fn execute_with_signing_context(
     txn_handle: Option<TransactionHandle>,
     signing_config: SigningConfig,
     node_did: String,
+    #[cfg(not(target_arch = "wasm32"))] runtime_handle: tokio::runtime::Handle,
+    #[cfg(not(target_arch = "wasm32"))] signed_query_permit: SignedQueryPermit,
 ) -> QueryResponse {
     #[cfg(target_arch = "wasm32")]
-    let handle = tokio::runtime::Handle::current();
+    let runtime_handle = tokio::runtime::Handle::current();
+    #[cfg(not(target_arch = "wasm32"))]
+    let spawn_handle = runtime_handle.clone();
     let batch_session_key = Some(signing_config.public_key_hex.clone());
 
-    match tokio::task::spawn_blocking(move || {
+    let run_query = move || {
         #[cfg(not(target_arch = "wasm32"))]
-        let runtime = match signed_query_runtime() {
-            Ok(runtime) => runtime,
-            Err(error) => return QueryResponse::error(error),
-        };
+        let _signed_query_permit = signed_query_permit;
         let _signing_guard = ThreadSigningContextGuard::install(signing_config, batch_session_key);
         // Install the node identity as the ambient acting identity so DB-layer
         // NAC checks resolve to the node itself. The pool thread is reused, so
@@ -530,7 +584,7 @@ async fn execute_with_signing_context(
         let _id_guard = defra_core::current_identity::scoped_current_identity(Some(node_did));
         #[cfg(not(target_arch = "wasm32"))]
         {
-            runtime.block_on(async {
+            runtime_handle.block_on(async {
                 match txn_handle {
                     Some(txn_handle) => executor.execute_in_txn(request, &txn_handle).await,
                     None => executor.execute(request).await,
@@ -539,16 +593,20 @@ async fn execute_with_signing_context(
         }
         #[cfg(target_arch = "wasm32")]
         {
-            handle.block_on(async {
+            runtime_handle.block_on(async {
                 match txn_handle {
                     Some(txn_handle) => executor.execute_in_txn(request, &txn_handle).await,
                     None => executor.execute(request).await,
                 }
             })
         }
-    })
-    .await
-    {
+    };
+    #[cfg(not(target_arch = "wasm32"))]
+    let result = spawn_handle.spawn_blocking(run_query).await;
+    #[cfg(target_arch = "wasm32")]
+    let result = tokio::task::spawn_blocking(run_query).await;
+
+    match result {
         Ok(response) => response,
         Err(join_error) => {
             QueryResponse::error(format!("query execution task failed: {join_error}"))
@@ -588,20 +646,274 @@ impl Drop for ThreadSigningContextGuard {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn signed_query_runtime() -> Result<&'static tokio::runtime::Runtime, String> {
-    static RUNTIME: std::sync::OnceLock<Result<tokio::runtime::Runtime, String>> =
-        std::sync::OnceLock::new();
+struct SignedQueryRuntime {
+    handle: tokio::runtime::Handle,
+    state: Arc<SignedQueryRuntimeState>,
+    shutdown_tx: std::sync::Mutex<Option<std::sync::mpsc::Sender<()>>>,
+    owner_thread: std::sync::Mutex<Option<std::thread::JoinHandle<()>>>,
+}
 
-    RUNTIME
-        .get_or_init(|| {
-            tokio::runtime::Builder::new_multi_thread()
-                .thread_name("defra-signed-query")
-                .enable_all()
-                .build()
-                .map_err(|error| format!("failed to create signed query runtime: {error}"))
+#[cfg(not(target_arch = "wasm32"))]
+struct SignedQueryRuntimeState {
+    closing: std::sync::atomic::AtomicBool,
+    active_queries: std::sync::atomic::AtomicUsize,
+    active_queries_drained: tokio::sync::Notify,
+    active_queries_mutex: std::sync::Mutex<()>,
+    active_queries_changed: std::sync::Condvar,
+    closed: std::sync::atomic::AtomicBool,
+    closed_notify: tokio::sync::Notify,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+const SIGNED_QUERY_DRAIN_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[cfg(not(target_arch = "wasm32"))]
+const SIGNED_QUERY_DROP_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[cfg(not(target_arch = "wasm32"))]
+const SIGNED_QUERY_RUNTIME_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[cfg(not(target_arch = "wasm32"))]
+struct SignedQueryPermit {
+    state: Arc<SignedQueryRuntimeState>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl Drop for SignedQueryPermit {
+    fn drop(&mut self) {
+        let _active_queries_guard = self
+            .state
+            .active_queries_mutex
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if self
+            .state
+            .active_queries
+            .fetch_sub(1, std::sync::atomic::Ordering::AcqRel)
+            == 1
+        {
+            self.state.active_queries_drained.notify_waiters();
+        }
+        self.state.active_queries_changed.notify_all();
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+struct SignedQueryRuntimeClosedGuard {
+    state: Arc<SignedQueryRuntimeState>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl Drop for SignedQueryRuntimeClosedGuard {
+    fn drop(&mut self) {
+        self.state
+            .closed
+            .store(true, std::sync::atomic::Ordering::Release);
+        self.state.closed_notify.notify_waiters();
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl SignedQueryRuntime {
+    fn new() -> Result<Self, String> {
+        let state = Arc::new(SignedQueryRuntimeState {
+            closing: std::sync::atomic::AtomicBool::new(false),
+            active_queries: std::sync::atomic::AtomicUsize::new(0),
+            active_queries_drained: tokio::sync::Notify::new(),
+            active_queries_mutex: std::sync::Mutex::new(()),
+            active_queries_changed: std::sync::Condvar::new(),
+            closed: std::sync::atomic::AtomicBool::new(false),
+            closed_notify: tokio::sync::Notify::new(),
+        });
+        let (shutdown_tx, shutdown_rx) = std::sync::mpsc::channel();
+        let (startup_tx, startup_rx) = std::sync::mpsc::sync_channel(1);
+        let owner_state = state.clone();
+        let owner_thread = std::thread::Builder::new()
+            .name("defra-signed-query-owner".to_string())
+            .spawn(move || {
+                let runtime = match tokio::runtime::Builder::new_multi_thread()
+                    .worker_threads(2)
+                    .thread_name("defra-signed-query")
+                    .enable_all()
+                    .build()
+                {
+                    Ok(runtime) => runtime,
+                    Err(error) => {
+                        let _ = startup_tx.send(Err(format!(
+                            "failed to create signed query runtime: {error}"
+                        )));
+                        return;
+                    }
+                };
+                if startup_tx.send(Ok(runtime.handle().clone())).is_err() {
+                    runtime.shutdown_background();
+                    return;
+                }
+                let _closed_guard = SignedQueryRuntimeClosedGuard {
+                    state: owner_state.clone(),
+                };
+                let _ = shutdown_rx.recv();
+                wait_for_active_signed_queries(&owner_state, SIGNED_QUERY_DROP_DRAIN_TIMEOUT);
+                runtime.shutdown_timeout(SIGNED_QUERY_RUNTIME_SHUTDOWN_TIMEOUT);
+            })
+            .map_err(|error| format!("failed to start signed query runtime owner: {error}"))?;
+        let handle = match startup_rx.recv() {
+            Ok(Ok(handle)) => handle,
+            Ok(Err(error)) => {
+                let _ = owner_thread.join();
+                return Err(error);
+            }
+            Err(error) => {
+                let _ = owner_thread.join();
+                return Err(format!(
+                    "signed query runtime owner exited during startup: {error}"
+                ));
+            }
+        };
+        Ok(Self {
+            handle,
+            state,
+            shutdown_tx: std::sync::Mutex::new(Some(shutdown_tx)),
+            owner_thread: std::sync::Mutex::new(Some(owner_thread)),
         })
-        .as_ref()
-        .map_err(Clone::clone)
+    }
+
+    fn handle(&self) -> tokio::runtime::Handle {
+        self.handle.clone()
+    }
+
+    fn admit(&self) -> Option<SignedQueryPermit> {
+        if self
+            .state
+            .closing
+            .load(std::sync::atomic::Ordering::Acquire)
+        {
+            return None;
+        }
+        self.state
+            .active_queries
+            .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+        if self
+            .state
+            .closing
+            .load(std::sync::atomic::Ordering::Acquire)
+        {
+            drop(SignedQueryPermit {
+                state: self.state.clone(),
+            });
+            return None;
+        }
+        Some(SignedQueryPermit {
+            state: self.state.clone(),
+        })
+    }
+
+    fn active_queries(&self) -> usize {
+        self.state
+            .active_queries
+            .load(std::sync::atomic::Ordering::Acquire)
+    }
+
+    fn close_admission(&self) {
+        self.state
+            .closing
+            .store(true, std::sync::atomic::Ordering::Release);
+    }
+
+    async fn wait_for_active_queries(&self) {
+        loop {
+            let notified = self.state.active_queries_drained.notified();
+            if self.active_queries() == 0 {
+                return;
+            }
+            notified.await;
+        }
+    }
+
+    async fn close_admission_and_wait_for(&self, timeout: Duration) -> bool {
+        self.close_admission();
+        tokio::time::timeout(timeout, self.wait_for_active_queries())
+            .await
+            .is_ok()
+    }
+
+    async fn shutdown(&self) {
+        self.signal_shutdown();
+        let owner_thread = self
+            .owner_thread
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
+        if let Some(owner_thread) = owner_thread {
+            let _ = tokio::task::spawn_blocking(move || owner_thread.join()).await;
+        } else {
+            loop {
+                let notified = self.state.closed_notify.notified();
+                if self.state.closed.load(std::sync::atomic::Ordering::Acquire) {
+                    break;
+                }
+                notified.await;
+            }
+        }
+    }
+
+    fn signal_shutdown(&self) {
+        self.close_admission();
+        let shutdown_tx = self
+            .shutdown_tx
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
+        if let Some(shutdown_tx) = shutdown_tx {
+            let _ = shutdown_tx.send(());
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl Drop for SignedQueryRuntime {
+    fn drop(&mut self) {
+        self.signal_shutdown();
+        // Dropping a Tokio runtime from an async context panics because shutdown
+        // may block. The owner thread owns the runtime and performs shutdown;
+        // detaching here keeps ordinary EmbeddedNode drop non-blocking.
+        self.owner_thread
+            .get_mut()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn wait_for_active_signed_queries(state: &SignedQueryRuntimeState, timeout: Duration) -> bool {
+    let deadline = std::time::Instant::now() + timeout;
+    let mut guard = state
+        .active_queries_mutex
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    loop {
+        if state
+            .active_queries
+            .load(std::sync::atomic::Ordering::Acquire)
+            == 0
+        {
+            return true;
+        }
+        let Some(remaining) = deadline.checked_duration_since(std::time::Instant::now()) else {
+            return false;
+        };
+        let (next_guard, wait_result) = state
+            .active_queries_changed
+            .wait_timeout(guard, remaining)
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        guard = next_guard;
+        if wait_result.timed_out() {
+            return state
+                .active_queries
+                .load(std::sync::atomic::Ordering::Acquire)
+                == 0;
+        }
+    }
 }
 
 fn is_transaction_conflict_response(response: &QueryResponse) -> bool {
@@ -1301,6 +1613,16 @@ impl NodeBuilder {
             database.set_nac_manager(nac_manager);
         }
 
+        // Build the node-owned signed-query runtime before starting P2P. If
+        // runtime construction fails, the builder can return without leaving
+        // already-started network tasks behind.
+        #[cfg(not(target_arch = "wasm32"))]
+        let signed_query_runtime = node_identity_did
+            .as_ref()
+            .map(|_| SignedQueryRuntime::new())
+            .transpose()
+            .map_err(anyhow::Error::msg)?;
+
         // P2P setup (affects mutator choice)
         #[cfg(feature = "p2p")]
         let mut p2p_result = if let Some(p2p_cfg) = p2p_config {
@@ -1401,6 +1723,8 @@ impl NodeBuilder {
             block_ops,
             embedding_config,
             node_identity_did,
+            #[cfg(not(target_arch = "wasm32"))]
+            signed_query_runtime,
             #[cfg(not(target_arch = "wasm32"))]
             transaction_stats,
             #[cfg(feature = "rocksdb")]
@@ -1601,6 +1925,68 @@ mod tests {
         completed: std::sync::Mutex<Option<std::sync::mpsc::Sender<()>>>,
     }
 
+    struct ContextObservingSigningExecutor {
+        expected_did: String,
+        expected_public_key_hex: String,
+    }
+
+    #[async_trait::async_trait]
+    impl QueryExecutor for ContextObservingSigningExecutor {
+        async fn execute(&self, _request: QueryRequest) -> query::QueryResponse {
+            for _ in 0..3 {
+                let signing_config = defra_core::signing::get_signing_config();
+                let current_identity = defra_core::current_identity::get_current_identity();
+                let batch_session_key = defra_core::batch_signing::get_batch_session_key();
+                if signing_config
+                    .as_ref()
+                    .map(|config| config.public_key_hex.as_str())
+                    != Some(self.expected_public_key_hex.as_str())
+                    || current_identity.as_deref() != Some(self.expected_did.as_str())
+                    || batch_session_key.as_deref() != Some(self.expected_public_key_hex.as_str())
+                {
+                    return query::QueryResponse::error(
+                        "signed query context did not survive an await boundary",
+                    );
+                }
+                tokio::task::yield_now().await;
+            }
+            query::QueryResponse::success(serde_json::json!({"ok": true}))
+        }
+
+        async fn execute_in_txn(
+            &self,
+            request: QueryRequest,
+            _handle: &TransactionHandle,
+        ) -> query::QueryResponse {
+            self.execute(request).await
+        }
+
+        async fn begin_txn(
+            &self,
+            _readonly: bool,
+        ) -> std::result::Result<TransactionHandle, TransactionError> {
+            Err(TransactionError::not_supported("test executor"))
+        }
+
+        async fn commit_txn(
+            &self,
+            _handle: &TransactionHandle,
+        ) -> std::result::Result<(), TransactionError> {
+            Err(TransactionError::not_supported("test executor"))
+        }
+
+        async fn rollback_txn(
+            &self,
+            _handle: &TransactionHandle,
+        ) -> std::result::Result<(), TransactionError> {
+            Err(TransactionError::not_supported("test executor"))
+        }
+
+        async fn schema(&self) -> query::Result<String> {
+            Ok(String::new())
+        }
+    }
+
     #[async_trait::async_trait]
     impl QueryExecutor for SpawningSigningExecutor {
         async fn execute(&self, _request: QueryRequest) -> query::QueryResponse {
@@ -1723,6 +2109,9 @@ mod tests {
             .enable_all()
             .build()
             .expect("caller runtime");
+        let signed_runtime = super::SignedQueryRuntime::new().expect("signed runtime");
+        let signed_runtime_handle = signed_runtime.handle();
+        let signed_query_permit = signed_runtime.admit().expect("query admission");
 
         caller_runtime.block_on(async {
             let task = tokio::spawn(async move {
@@ -1732,6 +2121,8 @@ mod tests {
                     None,
                     test_signing_config(),
                     "did:key:zCancellationTest".to_string(),
+                    signed_runtime_handle,
+                    signed_query_permit,
                 )
                 .await
             });
@@ -1742,10 +2133,11 @@ mod tests {
             let _ = task.await;
         });
         drop(caller_runtime);
+        drop(signed_runtime);
 
         completed_rx
             .recv_timeout(std::time::Duration::from_secs(2))
-            .expect("signed query must complete after its caller runtime is dropped");
+            .expect("signed query must complete after its caller and node runtimes are dropped");
     }
 
     #[test]
@@ -1758,6 +2150,7 @@ mod tests {
             .enable_all()
             .build()
             .expect("caller runtime");
+        let signed_runtime = super::SignedQueryRuntime::new().expect("signed runtime");
 
         let response = caller_runtime.block_on(super::execute_with_signing_context(
             executor,
@@ -1765,6 +2158,8 @@ mod tests {
             None,
             test_signing_config(),
             "did:key:zSpawnTest".to_string(),
+            signed_runtime.handle(),
+            signed_runtime.admit().expect("query admission"),
         ));
         assert!(
             !response.has_errors(),
@@ -1776,6 +2171,156 @@ mod tests {
         completed_rx
             .recv_timeout(std::time::Duration::from_secs(2))
             .expect("work spawned by a signed query must outlive query completion");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn signed_query_context_survives_awaits_on_node_owned_runtime() {
+        let expected_did = "did:key:zContextTest".to_string();
+        let signing_config = test_signing_config();
+        let executor: Arc<dyn QueryExecutor> = Arc::new(ContextObservingSigningExecutor {
+            expected_did: expected_did.clone(),
+            expected_public_key_hex: signing_config.public_key_hex.clone(),
+        });
+        let signed_runtime = super::SignedQueryRuntime::new().expect("signed runtime");
+
+        let response = super::execute_with_signing_context(
+            executor,
+            QueryRequest::new("{ observeContext }"),
+            None,
+            signing_config,
+            expected_did,
+            signed_runtime.handle(),
+            signed_runtime.admit().expect("query admission"),
+        )
+        .await;
+
+        assert!(
+            !response.has_errors(),
+            "signed query context failed: {:?}",
+            response.errors
+        );
+        assert!(
+            signed_runtime
+                .close_admission_and_wait_for(std::time::Duration::from_secs(2))
+                .await,
+            "signed query context permit did not drain"
+        );
+        signed_runtime.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn signed_query_runtime_closes_admission_and_drains_in_flight_queries() {
+        let runtime = Arc::new(super::SignedQueryRuntime::new().expect("signed runtime"));
+        let permit = runtime.admit().expect("initial query admission");
+        let closing_runtime = runtime.clone();
+        let mut close_task = tokio::spawn(async move {
+            closing_runtime
+                .close_admission_and_wait_for(std::time::Duration::from_secs(2))
+                .await
+        });
+
+        while !runtime.state.closing.load(Ordering::Acquire) {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            runtime.admit().is_none(),
+            "queries that race shutdown must fail admission"
+        );
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(25), &mut close_task)
+                .await
+                .is_err(),
+            "shutdown admission drain returned while a query permit was live"
+        );
+
+        drop(permit);
+        let drained = tokio::time::timeout(std::time::Duration::from_secs(2), close_task)
+            .await
+            .expect("admission drain timed out")
+            .expect("admission drain task panicked");
+        assert!(drained, "admission drain reported a timeout");
+        runtime.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn signed_query_runtime_admission_drain_has_a_deadline() {
+        let runtime = super::SignedQueryRuntime::new().expect("signed runtime");
+        let permit = runtime.admit().expect("query admission");
+
+        assert!(
+            !runtime
+                .close_admission_and_wait_for(std::time::Duration::from_millis(25))
+                .await,
+            "admission drain ignored its deadline"
+        );
+
+        drop(permit);
+        runtime.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn signed_query_runtime_shutdown_is_idempotent_and_node_scoped() {
+        let runtime_a = Arc::new(super::SignedQueryRuntime::new().expect("runtime A"));
+        let runtime_b = Arc::new(super::SignedQueryRuntime::new().expect("runtime B"));
+        assert!(
+            runtime_a
+                .close_admission_and_wait_for(std::time::Duration::from_secs(2))
+                .await
+        );
+
+        let first = {
+            let runtime = runtime_a.clone();
+            tokio::spawn(async move { runtime.shutdown().await })
+        };
+        let second = {
+            let runtime = runtime_a.clone();
+            tokio::spawn(async move { runtime.shutdown().await })
+        };
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            first.await.expect("first shutdown caller panicked");
+            second.await.expect("second shutdown caller panicked");
+        })
+        .await
+        .expect("concurrent shutdown callers did not converge");
+
+        let permit_b = runtime_b
+            .admit()
+            .expect("shutting down runtime A must not close runtime B");
+        drop(permit_b);
+        assert!(
+            runtime_b
+                .close_admission_and_wait_for(std::time::Duration::from_secs(2))
+                .await
+        );
+        runtime_b.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn signed_query_runtime_drop_is_nonblocking_inside_async_context() {
+        let runtime = super::SignedQueryRuntime::new().expect("signed runtime");
+        let state = runtime.state.clone();
+        let permit = runtime.admit().expect("query admission");
+        drop(runtime);
+        assert!(
+            state.closing.load(Ordering::Acquire),
+            "drop must close query admission"
+        );
+        assert!(
+            !state.closed.load(Ordering::Acquire),
+            "runtime closed while an admitted query was still live"
+        );
+        drop(permit);
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                let notified = state.closed_notify.notified();
+                if state.closed.load(Ordering::Acquire) {
+                    break;
+                }
+                notified.await;
+            }
+        })
+        .await
+        .expect("dropped signed runtime did not close after its query drained");
     }
 
     #[tokio::test]

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -513,22 +513,47 @@ async fn execute_with_signing_context(
     signing_config: SigningConfig,
     node_did: String,
 ) -> QueryResponse {
+    #[cfg(target_arch = "wasm32")]
     let handle = tokio::runtime::Handle::current();
     let batch_session_key = Some(signing_config.public_key_hex.clone());
 
     match tokio::task::spawn_blocking(move || {
+        #[cfg(not(target_arch = "wasm32"))]
+        let runtime = match tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+        {
+            Ok(runtime) => runtime,
+            Err(error) => {
+                return QueryResponse::error(format!(
+                    "failed to create signed query runtime: {error}"
+                ));
+            }
+        };
         defra_core::signing::set_signing_config(Some(signing_config));
         defra_core::batch_signing::set_batch_session_key(batch_session_key);
         // Install the node identity as the ambient acting identity so DB-layer
         // NAC checks resolve to the node itself. The pool thread is reused, so
         // the guard clears it when the closure ends to prevent cross-request leak.
         let _id_guard = defra_core::current_identity::scoped_current_identity(Some(node_did));
-        handle.block_on(async {
-            match txn_handle {
-                Some(txn_handle) => executor.execute_in_txn(request, &txn_handle).await,
-                None => executor.execute(request).await,
-            }
-        })
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            runtime.block_on(async {
+                match txn_handle {
+                    Some(txn_handle) => executor.execute_in_txn(request, &txn_handle).await,
+                    None => executor.execute(request).await,
+                }
+            })
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            handle.block_on(async {
+                match txn_handle {
+                    Some(txn_handle) => executor.execute_in_txn(request, &txn_handle).await,
+                    None => executor.execute(request).await,
+                }
+            })
+        }
     })
     .await
     {
@@ -1364,14 +1389,14 @@ fn resolve_rocksdb_options(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::{Arc, LazyLock};
 
     use defra_core::signing::{RemoteSigner, SigningConfig, SigningKeyType};
-    use query::{QueryRequest, QueryResponseError};
+    use query::{QueryRequest, QueryResponseError, TransactionError, TransactionHandle};
     use tokio::sync::Mutex;
 
-    use super::{EmbeddedNode, ExecuteRetryPolicy};
+    use super::{EmbeddedNode, ExecuteRetryPolicy, QueryExecutor};
 
     #[cfg(feature = "http")]
     use axum::{routing::get, Router};
@@ -1525,6 +1550,104 @@ mod tests {
             )],
         );
         assert!(!super::is_transaction_conflict_response(&partial));
+    }
+
+    struct SlowSigningExecutor {
+        started: Arc<AtomicBool>,
+        completed: std::sync::Mutex<Option<std::sync::mpsc::Sender<()>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl QueryExecutor for SlowSigningExecutor {
+        async fn execute(&self, _request: QueryRequest) -> query::QueryResponse {
+            self.started.store(true, Ordering::SeqCst);
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            self.completed
+                .lock()
+                .expect("completion sender poisoned")
+                .take()
+                .expect("completion sender missing")
+                .send(())
+                .expect("completion receiver dropped");
+            query::QueryResponse::success(serde_json::json!({"ok": true}))
+        }
+
+        async fn execute_in_txn(
+            &self,
+            request: QueryRequest,
+            _handle: &TransactionHandle,
+        ) -> query::QueryResponse {
+            self.execute(request).await
+        }
+
+        async fn begin_txn(
+            &self,
+            _readonly: bool,
+        ) -> std::result::Result<TransactionHandle, TransactionError> {
+            Err(TransactionError::not_supported("test executor"))
+        }
+
+        async fn commit_txn(
+            &self,
+            _handle: &TransactionHandle,
+        ) -> std::result::Result<(), TransactionError> {
+            Err(TransactionError::not_supported("test executor"))
+        }
+
+        async fn rollback_txn(
+            &self,
+            _handle: &TransactionHandle,
+        ) -> std::result::Result<(), TransactionError> {
+            Err(TransactionError::not_supported("test executor"))
+        }
+
+        async fn schema(&self) -> query::Result<String> {
+            Ok(String::new())
+        }
+    }
+
+    #[test]
+    fn cancelled_caller_runtime_does_not_own_signed_query_runtime() {
+        let started = Arc::new(AtomicBool::new(false));
+        let (completed_tx, completed_rx) = std::sync::mpsc::channel();
+        let executor: Arc<dyn QueryExecutor> = Arc::new(SlowSigningExecutor {
+            started: started.clone(),
+            completed: std::sync::Mutex::new(Some(completed_tx)),
+        });
+        let caller_runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("caller runtime");
+
+        caller_runtime.block_on(async {
+            let task = tokio::spawn(async move {
+                super::execute_with_signing_context(
+                    executor,
+                    QueryRequest::new("{ delayed }"),
+                    None,
+                    SigningConfig {
+                        key_type: SigningKeyType::Secp256r1,
+                        private_key_bytes: vec![1],
+                        public_key_bytes: vec![2],
+                        public_key_hex: "02".to_string(),
+                        remote_signer: None,
+                        signing_authorization: None,
+                    },
+                    "did:key:zCancellationTest".to_string(),
+                )
+                .await
+            });
+            while !started.load(Ordering::SeqCst) {
+                tokio::task::yield_now().await;
+            }
+            task.abort();
+            let _ = task.await;
+        });
+        drop(caller_runtime);
+
+        completed_rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .expect("signed query must complete after its caller runtime is dropped");
     }
 
     #[tokio::test]

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -102,11 +102,22 @@ trait SchemaOps: Send + Sync {
     async fn get_all_collection_versions(&self) -> anyhow::Result<Vec<CollectionVersion>>;
 }
 
+#[async_trait::async_trait]
+trait BlockOps: Send + Sync {
+    async fn verified_signer_did(&self, cid: &str) -> anyhow::Result<String>;
+    async fn verified_signer_did_in_txn(
+        &self,
+        cid: &str,
+        transaction: &TransactionHandle,
+    ) -> anyhow::Result<String>;
+}
+
 /// An embedded DefraDB node with query execution and event subscription.
 pub struct EmbeddedNode {
     runner: Arc<dyn QueryExecutor>,
     event_bus: Arc<dyn events::Bus>,
     schema_ops: Arc<dyn SchemaOps>,
+    block_ops: Arc<dyn BlockOps>,
     embedding_config: db::EmbeddingClientConfig,
     node_identity_did: Option<String>,
     #[cfg(not(target_arch = "wasm32"))]
@@ -236,6 +247,29 @@ impl EmbeddedNode {
     /// DID used as the embedded node identity for signing, when configured.
     pub fn node_identity_did(&self) -> Option<&str> {
         self.node_identity_did.as_deref()
+    }
+
+    /// Cryptographically verify a committed block and return its signer DID.
+    ///
+    /// This reads the signature linked by `cid`, verifies it over the
+    /// canonical DAG-CBOR block bytes, and derives the DID from the verified
+    /// public key. Unsigned, malformed, missing, or invalid blocks fail closed.
+    pub async fn verified_block_signer_did(&self, cid: &str) -> anyhow::Result<String> {
+        self.block_ops.verified_signer_did(cid).await
+    }
+
+    /// Cryptographically verify a block visible inside an active transaction.
+    ///
+    /// This variant can verify uncommitted blocks before the caller commits or
+    /// rolls back the transaction.
+    pub async fn verified_block_signer_did_in_txn(
+        &self,
+        cid: &str,
+        transaction: &TransactionHandle,
+    ) -> anyhow::Result<String> {
+        self.block_ops
+            .verified_signer_did_in_txn(cid, transaction)
+            .await
     }
 
     /// Add a schema from a GraphQL SDL type definition.
@@ -1268,7 +1302,7 @@ impl NodeBuilder {
 
         // Assemble query runner
         let query_runner =
-            query::QueryRunner::with_arc_registry_and_provider(fetcher, provider, registry)
+            query::QueryRunner::with_arc_registry_and_provider(fetcher, provider, registry.clone())
                 .with_mutator(mutator)
                 .with_acp(document_acp.clone())
                 .with_node_did(database.node_did())
@@ -1284,8 +1318,10 @@ impl NodeBuilder {
         let schema_ops: Arc<dyn SchemaOps> = Arc::new(db_impls::DbSchemaOps::new(
             database.clone(),
             query_limits,
-            document_acp,
+            document_acp.clone(),
         ));
+        let block_ops: Arc<dyn BlockOps> =
+            Arc::new(db_impls::DbBlockOps::new(database, document_acp, registry));
 
         #[cfg(feature = "p2p")]
         let (p2p_ops, p2p_lifecycle) = match p2p_result {
@@ -1297,6 +1333,7 @@ impl NodeBuilder {
             runner,
             event_bus,
             schema_ops,
+            block_ops,
             embedding_config,
             node_identity_did,
             #[cfg(not(target_arch = "wasm32"))]

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -732,7 +732,11 @@ impl SignedQueryRuntime {
             .name("defra-signed-query-owner".to_string())
             .spawn(move || {
                 let runtime = match tokio::runtime::Builder::new_multi_thread()
-                    .worker_threads(2)
+                    // Root signed queries run on this runtime's blocking pool
+                    // and drive their futures with `Handle::block_on`; one
+                    // async worker is therefore reserved for spawned query/P2P
+                    // work without multiplying threads for every embedded node.
+                    .worker_threads(1)
                     .thread_name("defra-signed-query")
                     .enable_all()
                     .build()

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -42,7 +42,7 @@ pub use dense_search::{DenseHybridSearchHit, DenseHybridSearchRequest, DenseHybr
 pub use events::EventName;
 pub use lens::{LensConfig, LensModule, TransformId};
 pub use query::QueryLimits;
-pub use query::{QueryExecutor, QueryRequest, QueryResponse};
+pub use query::{QueryExecutor, QueryRequest, QueryResponse, TransactionHandle};
 pub use schema::CollectionVersion;
 pub use telemetry::{ConflictMetricsSnapshot, RetryLayerSnapshot};
 #[cfg(feature = "otel")]
@@ -181,6 +181,40 @@ impl EmbeddedNode {
         execute_with_signing_context(
             self.runner.clone(),
             request,
+            None,
+            signing_config,
+            node_identity_did.to_string(),
+        )
+        .await
+    }
+
+    /// Execute a prepared query request within an existing transaction.
+    ///
+    /// When the node has a configured identity, the same signing and ambient
+    /// identity context used by [`Self::execute`] is applied to this request.
+    pub async fn execute_request_in_txn(
+        &self,
+        request: QueryRequest,
+        handle: &TransactionHandle,
+    ) -> QueryResponse {
+        let handle = handle.clone();
+        let Some(node_identity_did) = self.node_identity_did.as_deref() else {
+            return self.runner.execute_in_txn(request, &handle).await;
+        };
+
+        let signing_config = defra_core::signing::resolve_signing_config_with_flag(
+            None,
+            Some(node_identity_did),
+            true,
+        );
+        let Some(signing_config) = signing_config else {
+            return self.runner.execute_in_txn(request, &handle).await;
+        };
+
+        execute_with_signing_context(
+            self.runner.clone(),
+            request,
+            Some(handle),
             signing_config,
             node_identity_did.to_string(),
         )
@@ -441,6 +475,7 @@ where
 async fn execute_with_signing_context(
     executor: Arc<dyn QueryExecutor>,
     request: QueryRequest,
+    txn_handle: Option<TransactionHandle>,
     signing_config: SigningConfig,
     node_did: String,
 ) -> QueryResponse {
@@ -454,7 +489,12 @@ async fn execute_with_signing_context(
         // NAC checks resolve to the node itself. The pool thread is reused, so
         // the guard clears it when the closure ends to prevent cross-request leak.
         let _id_guard = defra_core::current_identity::scoped_current_identity(Some(node_did));
-        handle.block_on(async { executor.execute(request).await })
+        handle.block_on(async {
+            match txn_handle {
+                Some(txn_handle) => executor.execute_in_txn(request, &txn_handle).await,
+                None => executor.execute(request).await,
+            }
+        })
     })
     .await
     {

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -186,7 +186,7 @@ impl EmbeddedNode {
             true,
         );
         let Some(signing_config) = signing_config else {
-            return self.runner.execute(request).await;
+            return unavailable_node_signer_response(node_identity_did);
         };
 
         execute_with_signing_context(
@@ -219,7 +219,7 @@ impl EmbeddedNode {
             true,
         );
         let Some(signing_config) = signing_config else {
-            return self.runner.execute_in_txn(request, &handle).await;
+            return unavailable_node_signer_response(node_identity_did);
         };
 
         execute_with_signing_context(
@@ -519,19 +519,11 @@ async fn execute_with_signing_context(
 
     match tokio::task::spawn_blocking(move || {
         #[cfg(not(target_arch = "wasm32"))]
-        let runtime = match tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-        {
+        let runtime = match signed_query_runtime() {
             Ok(runtime) => runtime,
-            Err(error) => {
-                return QueryResponse::error(format!(
-                    "failed to create signed query runtime: {error}"
-                ));
-            }
+            Err(error) => return QueryResponse::error(error),
         };
-        defra_core::signing::set_signing_config(Some(signing_config));
-        defra_core::batch_signing::set_batch_session_key(batch_session_key);
+        let _signing_guard = ThreadSigningContextGuard::install(signing_config, batch_session_key);
         // Install the node identity as the ambient acting identity so DB-layer
         // NAC checks resolve to the node itself. The pool thread is reused, so
         // the guard clears it when the closure ends to prevent cross-request leak.
@@ -562,6 +554,55 @@ async fn execute_with_signing_context(
             QueryResponse::error(format!("query execution task failed: {join_error}"))
         }
     }
+}
+
+fn unavailable_node_signer_response(node_did: &str) -> QueryResponse {
+    QueryResponse::error(format!(
+        "configured node signing identity {node_did} is unavailable"
+    ))
+}
+
+struct ThreadSigningContextGuard {
+    previous_signing_config: Option<SigningConfig>,
+    previous_batch_session_key: Option<String>,
+}
+
+impl ThreadSigningContextGuard {
+    fn install(signing_config: SigningConfig, batch_session_key: Option<String>) -> Self {
+        let previous_signing_config = defra_core::signing::get_signing_config();
+        let previous_batch_session_key = defra_core::batch_signing::get_batch_session_key();
+        defra_core::signing::set_signing_config(Some(signing_config));
+        defra_core::batch_signing::set_batch_session_key(batch_session_key);
+        Self {
+            previous_signing_config,
+            previous_batch_session_key,
+        }
+    }
+}
+
+impl Drop for ThreadSigningContextGuard {
+    fn drop(&mut self) {
+        defra_core::signing::set_signing_config(self.previous_signing_config.take());
+        defra_core::batch_signing::set_batch_session_key(self.previous_batch_session_key.take());
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn signed_query_runtime() -> Result<&'static tokio::runtime::Runtime, String> {
+    static RUNTIME: std::sync::OnceLock<Result<tokio::runtime::Runtime, String>> =
+        std::sync::OnceLock::new();
+
+    RUNTIME
+        .get_or_init(|| {
+            tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(1)
+                .thread_name("defra-signed-query")
+                .enable_all()
+                .build()
+                .map_err(|error| format!("failed to create signed query runtime: {error}"))
+        })
+        .as_ref()
+        .map_err(Clone::clone)
 }
 
 fn is_transaction_conflict_response(response: &QueryResponse) -> bool {
@@ -1557,6 +1598,71 @@ mod tests {
         completed: std::sync::Mutex<Option<std::sync::mpsc::Sender<()>>>,
     }
 
+    struct SpawningSigningExecutor {
+        completed: std::sync::Mutex<Option<std::sync::mpsc::Sender<()>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl QueryExecutor for SpawningSigningExecutor {
+        async fn execute(&self, _request: QueryRequest) -> query::QueryResponse {
+            let completed = self
+                .completed
+                .lock()
+                .expect("completion sender poisoned")
+                .take()
+                .expect("completion sender missing");
+            tokio::spawn(async move {
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                completed.send(()).expect("completion receiver dropped");
+            });
+            query::QueryResponse::success(serde_json::json!({"ok": true}))
+        }
+
+        async fn execute_in_txn(
+            &self,
+            request: QueryRequest,
+            _handle: &TransactionHandle,
+        ) -> query::QueryResponse {
+            self.execute(request).await
+        }
+
+        async fn begin_txn(
+            &self,
+            _readonly: bool,
+        ) -> std::result::Result<TransactionHandle, TransactionError> {
+            Err(TransactionError::not_supported("test executor"))
+        }
+
+        async fn commit_txn(
+            &self,
+            _handle: &TransactionHandle,
+        ) -> std::result::Result<(), TransactionError> {
+            Err(TransactionError::not_supported("test executor"))
+        }
+
+        async fn rollback_txn(
+            &self,
+            _handle: &TransactionHandle,
+        ) -> std::result::Result<(), TransactionError> {
+            Err(TransactionError::not_supported("test executor"))
+        }
+
+        async fn schema(&self) -> query::Result<String> {
+            Ok(String::new())
+        }
+    }
+
+    fn test_signing_config() -> SigningConfig {
+        SigningConfig {
+            key_type: SigningKeyType::Secp256r1,
+            private_key_bytes: vec![1],
+            public_key_bytes: vec![2],
+            public_key_hex: "02".to_string(),
+            remote_signer: None,
+            signing_authorization: None,
+        }
+    }
+
     #[async_trait::async_trait]
     impl QueryExecutor for SlowSigningExecutor {
         async fn execute(&self, _request: QueryRequest) -> query::QueryResponse {
@@ -1625,14 +1731,7 @@ mod tests {
                     executor,
                     QueryRequest::new("{ delayed }"),
                     None,
-                    SigningConfig {
-                        key_type: SigningKeyType::Secp256r1,
-                        private_key_bytes: vec![1],
-                        public_key_bytes: vec![2],
-                        public_key_hex: "02".to_string(),
-                        remote_signer: None,
-                        signing_authorization: None,
-                    },
+                    test_signing_config(),
                     "did:key:zCancellationTest".to_string(),
                 )
                 .await
@@ -1648,6 +1747,36 @@ mod tests {
         completed_rx
             .recv_timeout(std::time::Duration::from_secs(2))
             .expect("signed query must complete after its caller runtime is dropped");
+    }
+
+    #[test]
+    fn signed_query_runtime_keeps_spawned_work_alive_after_query_returns() {
+        let (completed_tx, completed_rx) = std::sync::mpsc::channel();
+        let executor: Arc<dyn QueryExecutor> = Arc::new(SpawningSigningExecutor {
+            completed: std::sync::Mutex::new(Some(completed_tx)),
+        });
+        let caller_runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("caller runtime");
+
+        let response = caller_runtime.block_on(super::execute_with_signing_context(
+            executor,
+            QueryRequest::new("{ spawnBackgroundWork }"),
+            None,
+            test_signing_config(),
+            "did:key:zSpawnTest".to_string(),
+        ));
+        assert!(
+            !response.has_errors(),
+            "query failed: {:?}",
+            response.errors
+        );
+        drop(caller_runtime);
+
+        completed_rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .expect("work spawned by a signed query must outlive query completion");
     }
 
     #[tokio::test]

--- a/crates/defra-node/tests/transaction_signing_test.rs
+++ b/crates/defra-node/tests/transaction_signing_test.rs
@@ -60,11 +60,37 @@ async fn embedded_transaction_mutation_uses_node_signer() {
         .and_then(serde_json::Value::as_str)
         .unwrap_or_else(|| panic!("created document id missing from {create_data}"))
         .to_string();
+
+    let commits_in_txn = node
+        .execute_request_in_txn(
+            QueryRequest::new(format!(
+                r#"query {{ _commits(docID: "{doc_id}", filter: {{fieldName: {{_eq: "_C"}}}}) {{ cid }} }}"#
+            )),
+            &txn,
+        )
+        .await;
+    assert!(
+        commits_in_txn.errors.is_empty(),
+        "commit query in transaction failed: {:?}",
+        commits_in_txn.errors
+    );
+    let uncommitted_composite_cid = commits_in_txn
+        .data
+        .as_ref()
+        .and_then(|data| data.pointer("/_commits/0/cid"))
+        .and_then(serde_json::Value::as_str)
+        .expect("uncommitted composite CID");
+    let uncommitted_verified_did = node
+        .verified_block_signer_did_in_txn(uncommitted_composite_cid, &txn)
+        .await
+        .expect("verify uncommitted embedded block signature");
+    assert_eq!(uncommitted_verified_did, did);
+
     node.runner().commit_txn(&txn).await.expect("commit txn");
 
     let commits = node
         .execute(&format!(
-            r#"query {{ _commits(docID: "{doc_id}", filter: {{fieldName: {{_eq: "_C"}}}}) {{ signature {{ type identity }} }} }}"#
+            r#"query {{ _commits(docID: "{doc_id}", filter: {{fieldName: {{_eq: "_C"}}}}) {{ cid signature {{ type identity }} }} }}"#
         ))
         .await;
     assert!(
@@ -91,6 +117,79 @@ async fn embedded_transaction_mutation_uses_node_signer() {
         "composite commit was not signed by the configured node: {rows:?}"
     );
 
+    let composite_cid = rows
+        .iter()
+        .find_map(|row| row.get("cid").and_then(serde_json::Value::as_str))
+        .expect("composite commit CID");
+    let verified_did = node
+        .verified_block_signer_did(composite_cid)
+        .await
+        .expect("verify embedded block signature");
+    assert_eq!(verified_did, did);
+
     node.shutdown().await;
     defra_core::signing::clear_identity_store();
+
+    let node = EmbeddedNode::builder()
+        .build()
+        .await
+        .expect("build unsigned node");
+    node.add_schema("type UnsignedWidget { name: String }")
+        .await
+        .expect("add schema");
+
+    let create = node
+        .execute(r#"mutation { create_UnsignedWidget(input: {name: "unsigned"}) { _docID } }"#)
+        .await;
+    assert!(
+        create.errors.is_empty(),
+        "create failed: {:?}",
+        create.errors
+    );
+    let doc_id = create
+        .data
+        .as_ref()
+        .and_then(|data| {
+            data.pointer("/add_UnsignedWidget/0/_docID")
+                .or_else(|| data.pointer("/create_UnsignedWidget/0/_docID"))
+                .or_else(|| data.pointer("/create_UnsignedWidget/_docID"))
+        })
+        .and_then(serde_json::Value::as_str)
+        .expect("created document ID");
+    let commits = node
+        .execute(&format!(
+            r#"query {{ _commits(docID: "{doc_id}", filter: {{fieldName: {{_eq: "_C"}}}}) {{ cid }} }}"#
+        ))
+        .await;
+    let composite_cid = commits
+        .data
+        .as_ref()
+        .and_then(|data| data.pointer("/_commits/0/cid"))
+        .and_then(serde_json::Value::as_str)
+        .expect("unsigned composite CID");
+
+    let unsigned_error = node
+        .verified_block_signer_did(composite_cid)
+        .await
+        .expect_err("unsigned block must fail verification");
+    assert!(
+        unsigned_error
+            .to_string()
+            .contains("block has no signature"),
+        "unexpected unsigned error: {unsigned_error:#}"
+    );
+
+    let missing_cid = defra_core::block::generate_cid_from_bytes(b"missing block")
+        .expect("generate missing CID")
+        .to_string();
+    let missing_error = node
+        .verified_block_signer_did(&missing_cid)
+        .await
+        .expect_err("missing block must fail verification");
+    assert!(
+        missing_error.to_string().contains("could not find block"),
+        "unexpected missing-block error: {missing_error:#}"
+    );
+
+    node.shutdown().await;
 }

--- a/crates/defra-node/tests/transaction_signing_test.rs
+++ b/crates/defra-node/tests/transaction_signing_test.rs
@@ -127,8 +127,48 @@ async fn embedded_transaction_mutation_uses_node_signer() {
         .expect("verify embedded block signature");
     assert_eq!(verified_did, did);
 
-    node.shutdown().await;
     defra_core::signing::clear_identity_store();
+    let create_without_signer = node
+        .execute(r#"mutation { create_Widget(input: {name: "must-fail"}) { _docID } }"#)
+        .await;
+    assert!(
+        create_without_signer.has_errors()
+            && create_without_signer.errors[0]
+                .message
+                .contains("configured node signing identity")
+            && create_without_signer.errors[0]
+                .message
+                .contains("is unavailable"),
+        "configured node must fail closed when its signer disappears: {:?}",
+        create_without_signer.errors
+    );
+
+    let txn_without_signer = node.runner().begin_txn(false).await.expect("begin txn");
+    let create_in_txn_without_signer = node
+        .execute_request_in_txn(
+            QueryRequest::new(
+                r#"mutation { create_Widget(input: {name: "must-also-fail"}) { _docID } }"#,
+            ),
+            &txn_without_signer,
+        )
+        .await;
+    assert!(
+        create_in_txn_without_signer.has_errors()
+            && create_in_txn_without_signer.errors[0]
+                .message
+                .contains("configured node signing identity")
+            && create_in_txn_without_signer.errors[0]
+                .message
+                .contains("is unavailable"),
+        "configured transactional execute must fail closed when its signer disappears: {:?}",
+        create_in_txn_without_signer.errors
+    );
+    node.runner()
+        .rollback_txn(&txn_without_signer)
+        .await
+        .expect("rollback txn");
+
+    node.shutdown().await;
 
     let node = EmbeddedNode::builder()
         .build()

--- a/crates/defra-node/tests/transaction_signing_test.rs
+++ b/crates/defra-node/tests/transaction_signing_test.rs
@@ -1,0 +1,96 @@
+use crypto::Key;
+use defra_core::signing::{SigningConfig, SigningKeyType};
+use defra_node::{EmbeddedNode, QueryRequest};
+use identity::{Identity as _, RawIdentity};
+
+fn register_local_node_identity() -> (String, String) {
+    let private_key = crypto::generate_ed25519().expect("generate ed25519 key");
+    let identity =
+        RawIdentity::from_ed25519(private_key.clone()).expect("build raw identity from key");
+    let did = identity.did().expect("derive DID").to_string();
+    let public_key_bytes = identity.public_key_bytes();
+    let public_key_hex = hex::encode(&public_key_bytes);
+
+    defra_core::signing::store_identity(
+        &did,
+        SigningConfig {
+            key_type: SigningKeyType::Ed25519,
+            private_key_bytes: private_key.raw().to_vec(),
+            public_key_bytes,
+            public_key_hex: public_key_hex.clone(),
+            remote_signer: None,
+            signing_authorization: None,
+        },
+    );
+
+    (did, public_key_hex)
+}
+
+#[tokio::test]
+async fn embedded_transaction_mutation_uses_node_signer() {
+    defra_core::signing::clear_identity_store();
+    let (did, expected_identity) = register_local_node_identity();
+
+    let node = EmbeddedNode::builder()
+        .with_node_identity_did(&did)
+        .build()
+        .await
+        .expect("build signed node");
+    node.add_schema("type Widget { name: String }")
+        .await
+        .expect("add schema");
+
+    let txn = node.runner().begin_txn(false).await.expect("begin txn");
+    let create = node
+        .execute_request_in_txn(
+            QueryRequest::new(r#"mutation { create_Widget(input: {name: "gadget"}) { _docID } }"#),
+            &txn,
+        )
+        .await;
+    assert!(
+        create.errors.is_empty(),
+        "create failed: {:?}",
+        create.errors
+    );
+    let create_data = create.data.as_ref().expect("create response data");
+    let doc_id = create_data
+        .pointer("/add_Widget/0/_docID")
+        .or_else(|| create_data.pointer("/create_Widget/0/_docID"))
+        .or_else(|| create_data.pointer("/create_Widget/_docID"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_else(|| panic!("created document id missing from {create_data}"))
+        .to_string();
+    node.runner().commit_txn(&txn).await.expect("commit txn");
+
+    let commits = node
+        .execute(&format!(
+            r#"query {{ _commits(docID: "{doc_id}", filter: {{fieldName: {{_eq: "_C"}}}}) {{ signature {{ type identity }} }} }}"#
+        ))
+        .await;
+    assert!(
+        commits.errors.is_empty(),
+        "commit query failed: {:?}",
+        commits.errors
+    );
+    let rows = commits
+        .data
+        .as_ref()
+        .and_then(|data| data.get("_commits"))
+        .and_then(serde_json::Value::as_array)
+        .expect("commit rows");
+    assert!(
+        rows.iter().any(|row| {
+            row.pointer("/signature/type")
+                .and_then(serde_json::Value::as_str)
+                == Some("EdDSA")
+                && row
+                    .pointer("/signature/identity")
+                    .and_then(serde_json::Value::as_str)
+                    == Some(expected_identity.as_str())
+        }),
+        "composite commit was not signed by the configured node: {rows:?}"
+    );
+
+    node.shutdown().await;
+    defra_core::signing::clear_identity_store();
+}

--- a/crates/http/src/handlers/utility.rs
+++ b/crates/http/src/handlers/utility.rs
@@ -22,6 +22,9 @@ pub struct NodeIdentityResponse {
     /// The node's peer ID (if P2P is enabled).
     #[serde(rename = "PeerID", skip_serializing_if = "Option::is_none")]
     pub peer_id: Option<String>,
+    /// DID used by the node to sign database mutations, when configured.
+    #[serde(rename = "DID", skip_serializing_if = "Option::is_none")]
+    pub did: Option<String>,
 }
 
 /// GET /api/v0/node/identity
@@ -41,7 +44,10 @@ pub async fn get_node_identity(
         None
     };
 
-    Ok(Json(NodeIdentityResponse { peer_id }))
+    Ok(Json(NodeIdentityResponse {
+        peer_id,
+        did: state.node_identity_did.clone(),
+    }))
 }
 
 /// GET /api/v0/debug/dump
@@ -105,17 +111,24 @@ mod tests {
     fn test_node_identity_response_serialize() {
         let response = NodeIdentityResponse {
             peer_id: Some("12D3KooWtest".to_string()),
+            did: Some("did:key:zNodeSigner".to_string()),
         };
         let json = serde_json::to_string(&response).unwrap();
         assert!(json.contains("\"PeerID\""));
         assert!(json.contains("12D3KooWtest"));
+        assert!(json.contains("\"DID\""));
+        assert!(json.contains("did:key:zNodeSigner"));
     }
 
     #[test]
     fn test_node_identity_response_empty() {
-        let response = NodeIdentityResponse { peer_id: None };
+        let response = NodeIdentityResponse {
+            peer_id: None,
+            did: None,
+        };
         let json = serde_json::to_string(&response).unwrap();
         // PeerID should be omitted when None
         assert!(!json.contains("PeerID"));
+        assert!(!json.contains("DID"));
     }
 }


### PR DESCRIPTION
## Summary

- expose EmbeddedNode::execute_request_in_txn
- apply the configured node signer and ambient identity context to explicit transaction requests
- run signed root queries on a node-owned Tokio runtime so caller cancellation cannot invalidate spawned query work
- close admission and drain signed queries before P2P shutdown
- bound native signed-node runtime threads to one async worker per node
- cover cancellation, spawned work, TLS context across awaits, deadlines, concurrent shutdown, node isolation, and async Drop

## Why

EmbeddedNode::execute installs the node signer for auto-commit work, but explicit transactions previously went through raw QueryExecutor::execute_in_txn and could silently create unsigned commits.

The initial transaction wrapper also exposed a lifecycle boundary: query futures and their spawned tasks could outlive the caller runtime or be cancelled while DefraDB still needed to finalize signed state. The node now owns the execution runtime and admission/drain protocol. Root signed work is either admitted and counted before shutdown closes, or rejected after close; admitted work has bounded drain semantics.

The caller-provided QueryRequest is preserved, including its ACP actor identity. Signing identity and query identity remain separate.

This is required by source-inc/gents#1065 for atomic request ingest, signed claim ancestry, and exact CID provenance.

## Shutdown contract

1. close signed-query admission;
2. wait up to 30 seconds for admitted root queries;
3. stop P2P while the signed runtime is still alive;
4. signal and join the runtime owner;
5. bound owner/runtime shutdown with five-second deadlines.

Drop uses the same close/signal path without attempting to drop a Tokio runtime from an async context.

## Validation

Green:

- cargo test -p defra-node
- cargo clippy -p defra-node --all-targets -- -D warnings
- cargo fmt --all -- --check
- GitHub: Build & Test
- GitHub: Integration (rust)
- GitHub: Integration (signed-docs)
- GitHub: P2P Integration (Linux)
- GitHub: Lint, WASM Build Check, Lean Conformance, Conformance
- independent Claude and Grok lifecycle reviews: no P0/P1 blockers

Two macOS integration jobs currently fail after successful CLI builds because their shared runner script copies into a host cache directory it never creates. That is CI infrastructure, not a signed-query test failure; no workflow change is included here.
