### PR TITLE
ci: cancel superseded main runs and PR CI on close

### DIFF
--- a/.github/workflows/cancel-pr-ci.yml
+++ b/.github/workflows/cancel-pr-ci.yml
@@ -1,0 +1,47 @@
+name: Cancel PR CI on close
+
+# When a PR is merged or closed without merge, any still-queued / in-progress
+# CI runs for that head branch keep holding self-hosted slots forever — GitHub
+# does not invalidate them. Cancel them so the fleet is free for tip-of-main
+# and open PRs. Complements concurrency.cancel-in-progress on ci.yml (which
+# only covers same-ref supersession while the PR is open).
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  actions: write
+
+jobs:
+  cancel:
+    name: Cancel outstanding CI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel queued and in-progress CI runs for this branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: ${{ github.head_ref }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ -z "$BRANCH" ]; then
+            echo "No head_ref; nothing to cancel"
+            exit 0
+          fi
+          cancelled=0
+          for status in in_progress queued; do
+            ids=$(gh run list \
+              --repo "$REPO" \
+              --branch "$BRANCH" \
+              --workflow CI \
+              --status "$status" \
+              --limit 50 \
+              --json databaseId \
+              --jq '.[].databaseId' || true)
+            for id in $ids; do
+              echo "Cancelling $status run $id on $BRANCH"
+              gh run cancel "$id" --repo "$REPO" || true
+              cancelled=$((cancelled + 1))
+            done
+          done
+          echo "Cancelled $cancelled run(s) for branch $BRANCH"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,13 @@ on:
   pull_request:
     branches: [main]
 
-# Superseded PR pushes release the studio fleet immediately; main pushes are
-# never cancelled so every main commit gets full validation and artifacts.
+# Only the tip of each ref keeps a run. Superseded PR pushes and main merge
+# trains cancel prior work so intermediate SHAs cannot stack the self-hosted
+# fleet. PR close is handled by cancel-pr-ci.yml (closed events do not re-enter
+# this concurrency group once the merge ref is gone).
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary

- Enable `concurrency.cancel-in-progress: true` for **all** refs (including `main`), so only the tip of each branch keeps a CI run. Main merge trains no longer stack intermediate SHAs on the self-hosted fleet.
- Add `cancel-pr-ci.yml` to cancel queued/in-progress `CI` runs for a PR’s head branch when the PR is closed (merged or abandoned). GitHub does not auto-invalidate those runs.

## Why

#1324 already cancelled superseded **PR pushes**, but left main never-cancel and left closed-PR runs alive. That was the backlog amplifier we just had to drain by hand.

## Test plan

- [ ] Merge this PR; tip-of-main CI should run under the new concurrency rule
- [ ] Next main push while a prior main CI is running should cancel the prior run
- [ ] Closing/merging any PR should fire `Cancel PR CI on close` and clear leftover CI for that branch