### PR TITLE
Attach node identity and expose signed block material

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3571,6 +3571,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
+ "base64 0.22.1",
  "cid",
  "criterion 0.6.0",
  "crypto",

--- a/crates/cli/src/block_adapter.rs
+++ b/crates/cli/src/block_adapter.rs
@@ -26,6 +26,23 @@ impl<S: Store + 'static> BlockAdapter<S> {
 
 #[async_trait]
 impl<S: Store + 'static> BlockOperations for BlockAdapter<S> {
+    async fn signed_block_bytes(
+        &self,
+        cid: &str,
+        caller_did: Option<&str>,
+    ) -> Result<(Vec<u8>, Vec<u8>), String> {
+        let caller_identity: acp::Identity = caller_did
+            .and_then(|did| identity::Did::try_from(did.to_string()).ok())
+            .into();
+        db::block_verify::authorized_signed_block_bytes(
+            &self.database,
+            self.document_acp.as_ref(),
+            cid,
+            &caller_identity,
+        )
+        .await
+    }
+
     async fn verify_signature(
         &self,
         cid: &str,

--- a/crates/cli/src/block_adapter.rs
+++ b/crates/cli/src/block_adapter.rs
@@ -31,9 +31,11 @@ impl<S: Store + 'static> BlockOperations for BlockAdapter<S> {
         cid: &str,
         caller_did: Option<&str>,
     ) -> Result<(Vec<u8>, Vec<u8>), String> {
-        let caller_identity: acp::Identity = caller_did
-            .and_then(|did| identity::Did::try_from(did.to_string()).ok())
-            .into();
+        let caller_did = caller_did
+            .map(|did| identity::Did::try_from(did.to_string()))
+            .transpose()
+            .map_err(|error| format!("invalid caller DID: {error}"))?;
+        let caller_identity: acp::Identity = caller_did.into();
         db::block_verify::authorized_signed_block_bytes(
             &self.database,
             self.document_acp.as_ref(),
@@ -57,9 +59,11 @@ impl<S: Store + 'static> BlockOperations for BlockAdapter<S> {
             other => return Err(format!("unsupported key type: {}", other)),
         };
 
-        let caller_identity: acp::Identity = caller_did
-            .and_then(|d| identity::Did::try_from(d.to_string()).ok())
-            .into();
+        let caller_did = caller_did
+            .map(|did| identity::Did::try_from(did.to_string()))
+            .transpose()
+            .map_err(|error| format!("invalid caller DID: {error}"))?;
+        let caller_identity: acp::Identity = caller_did.into();
 
         db::block_verify::verify_block_signature(
             &self.database,

--- a/crates/db/src/block_verify.rs
+++ b/crates/db/src/block_verify.rs
@@ -39,6 +39,43 @@ pub async fn verified_block_signer_did<S: Store>(
     .await
 }
 
+/// Load one authorized signed block and its detached signature block as
+/// canonical DAG-CBOR bytes. Remote clients use this to verify CID integrity
+/// and authorship locally instead of trusting a server-side yes/no verdict.
+pub async fn authorized_signed_block_bytes<S: Store>(
+    database: &Arc<DB<S>>,
+    document_acp: &dyn acp::DocumentACP,
+    cid_str: &str,
+    caller_identity: &acp::Identity,
+) -> Result<(Vec<u8>, Vec<u8>), String> {
+    let txn = database
+        .new_txn(true)
+        .await
+        .map_err(|e| format!("failed to create transaction: {}", e))?;
+    let blockstore = txn
+        .blockstore()
+        .map_err(|e| format!("failed to get blockstore: {}", e))?;
+    let systemstore = txn
+        .systemstore()
+        .map_err(|e| format!("failed to get systemstore: {}", e))?;
+    let (block, signature) = load_authorized_block_signature(
+        database,
+        document_acp,
+        blockstore,
+        systemstore,
+        cid_str,
+        caller_identity,
+    )
+    .await?;
+    let block_bytes = block
+        .to_dag_cbor()
+        .map_err(|error| format!("failed to encode authorized block: {error}"))?;
+    let signature_bytes = signature
+        .to_dag_cbor()
+        .map_err(|error| format!("failed to encode authorized signature block: {error}"))?;
+    Ok((block_bytes, signature_bytes))
+}
+
 /// Verify a block visible inside an active transaction and return its signer DID.
 pub async fn verified_block_signer_did_in_txn<S: Store>(
     database: &Arc<DB<S>>,

--- a/crates/defra-node/src/db_impls.rs
+++ b/crates/defra-node/src/db_impls.rs
@@ -33,6 +33,25 @@ impl<S: storage::corekv::Store + 'static> DbBlockOps<S> {
 
 #[async_trait::async_trait]
 impl<S: storage::corekv::Store + 'static> BlockOps for DbBlockOps<S> {
+    async fn signed_block_bytes(
+        &self,
+        cid: &str,
+        caller_did: Option<&str>,
+    ) -> anyhow::Result<(Vec<u8>, Vec<u8>)> {
+        let caller_did = caller_did
+            .map(|did| Did::try_from(did.to_string()))
+            .transpose()?;
+        let caller_identity: acp::Identity = caller_did.into();
+        db::block_verify::authorized_signed_block_bytes(
+            &self.database,
+            self.document_acp.as_ref(),
+            cid,
+            &caller_identity,
+        )
+        .await
+        .map_err(anyhow::Error::msg)
+    }
+
     async fn verified_signer_did(&self, cid: &str) -> anyhow::Result<String> {
         db::block_verify::verified_block_signer_did(
             &self.database,

--- a/crates/defra-node/src/embedded_query_identity_tests.rs
+++ b/crates/defra-node/src/embedded_query_identity_tests.rs
@@ -106,6 +106,32 @@ fn no_retry() -> ExecuteRetryPolicy {
 }
 
 #[tokio::test]
+async fn builder_rejects_invalid_node_identity_did() {
+    let _serial = SIGNING_STORE_GUARD.lock().await;
+    defra_core::signing::clear_identity_store();
+    let invalid_did = "invalid:key:zNode";
+    register_test_remote_node_identity(invalid_did);
+
+    let result = EmbeddedNode::builder()
+        .with_node_identity_did(invalid_did)
+        .build()
+        .await;
+    let error = match result {
+        Ok(node) => {
+            node.shutdown().await;
+            panic!("invalid node identity DID must be rejected")
+        }
+        Err(error) => error,
+    };
+
+    assert!(
+        error.to_string().contains("invalid node identity DID"),
+        "{error:#}"
+    );
+    defra_core::signing::clear_identity_store();
+}
+
+#[tokio::test]
 async fn embedded_execute_defaults_node_identity_and_preserves_explicit_actor() {
     let _serial = SIGNING_STORE_GUARD.lock().await;
     defra_core::signing::clear_identity_store();

--- a/crates/defra-node/src/embedded_query_identity_tests.rs
+++ b/crates/defra-node/src/embedded_query_identity_tests.rs
@@ -1,0 +1,218 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use defra_core::signing::{SigningConfig, SigningKeyType};
+use query::{QueryRequest, TransactionError, TransactionHandle};
+
+use super::tests::{TestRemoteSigner, SIGNING_STORE_GUARD};
+use super::{EmbeddedNode, ExecuteRetryPolicy, QueryExecutor};
+
+struct IdentityRecordingExecutor {
+    identities: std::sync::Mutex<Vec<Option<String>>>,
+    remaining_conflicts: AtomicUsize,
+}
+
+impl IdentityRecordingExecutor {
+    fn new(remaining_conflicts: usize) -> Self {
+        Self {
+            identities: std::sync::Mutex::new(Vec::new()),
+            remaining_conflicts: AtomicUsize::new(remaining_conflicts),
+        }
+    }
+
+    fn identities(&self) -> Vec<Option<String>> {
+        self.identities
+            .lock()
+            .expect("recorded identities poisoned")
+            .clone()
+    }
+
+    fn record(&self, request: &QueryRequest) {
+        self.identities
+            .lock()
+            .expect("recorded identities poisoned")
+            .push(request.identity.as_ref().map(ToString::to_string));
+    }
+}
+
+#[async_trait::async_trait]
+impl QueryExecutor for IdentityRecordingExecutor {
+    async fn execute(&self, request: QueryRequest) -> query::QueryResponse {
+        self.record(&request);
+        if self.remaining_conflicts.load(Ordering::SeqCst) > 0 {
+            self.remaining_conflicts.fetch_sub(1, Ordering::SeqCst);
+            query::QueryResponse::transaction_conflict("test transaction conflict")
+        } else {
+            query::QueryResponse::success(serde_json::json!({"ok": true}))
+        }
+    }
+
+    async fn execute_in_txn(
+        &self,
+        request: QueryRequest,
+        _handle: &TransactionHandle,
+    ) -> query::QueryResponse {
+        self.record(&request);
+        query::QueryResponse::success(serde_json::json!({"ok": true}))
+    }
+
+    async fn begin_txn(&self, _readonly: bool) -> Result<TransactionHandle, TransactionError> {
+        Ok(TransactionHandle::new("identity-test-txn".to_string()))
+    }
+
+    async fn commit_txn(&self, _handle: &TransactionHandle) -> Result<(), TransactionError> {
+        Ok(())
+    }
+
+    async fn rollback_txn(&self, _handle: &TransactionHandle) -> Result<(), TransactionError> {
+        Ok(())
+    }
+
+    async fn schema(&self) -> query::Result<String> {
+        Ok(String::new())
+    }
+}
+
+fn register_test_remote_node_identity(did: &str) {
+    defra_core::signing::store_identity(
+        did,
+        SigningConfig {
+            key_type: SigningKeyType::Secp256r1,
+            private_key_bytes: Vec::new(),
+            public_key_bytes: vec![2, 3, 4],
+            public_key_hex: "020304".to_string(),
+            remote_signer: Some(Arc::new(TestRemoteSigner)),
+            signing_authorization: None,
+        },
+    );
+}
+
+async fn signed_node_with_executor(
+    did: &str,
+    executor: Arc<IdentityRecordingExecutor>,
+) -> EmbeddedNode {
+    register_test_remote_node_identity(did);
+    let mut node = EmbeddedNode::builder()
+        .with_node_identity_did(did)
+        .build()
+        .await
+        .expect("build signed identity-observing node");
+    node.runner = executor;
+    node
+}
+
+fn no_retry() -> ExecuteRetryPolicy {
+    ExecuteRetryPolicy::new(0, std::time::Duration::ZERO, std::time::Duration::ZERO)
+}
+
+#[tokio::test]
+async fn embedded_execute_defaults_node_identity_and_preserves_explicit_actor() {
+    let _serial = SIGNING_STORE_GUARD.lock().await;
+    defra_core::signing::clear_identity_store();
+    let node_did = "did:key:zEmbeddedNodeActor";
+    let explicit_did = identity::Did::new("did:key:zExplicitActor").unwrap();
+    let executor = Arc::new(IdentityRecordingExecutor::new(0));
+    let node = signed_node_with_executor(node_did, executor.clone()).await;
+
+    let defaulted = node.execute("query { defaulted }").await;
+    assert!(!defaulted.has_errors(), "defaulted query failed");
+    let explicit = node
+        .execute_request_with_retry(
+            QueryRequest::new("query { explicit }").with_identity(Some(explicit_did.clone())),
+            no_retry(),
+        )
+        .await;
+    assert!(!explicit.has_errors(), "explicit-actor query failed");
+    assert_eq!(
+        executor.identities(),
+        vec![Some(node_did.to_string()), Some(explicit_did.to_string())]
+    );
+
+    node.shutdown().await;
+    defra_core::signing::clear_identity_store();
+}
+
+#[tokio::test]
+async fn embedded_retry_keeps_node_identity_on_every_attempt() {
+    let _serial = SIGNING_STORE_GUARD.lock().await;
+    defra_core::signing::clear_identity_store();
+    let node_did = "did:key:zEmbeddedRetryActor";
+    let executor = Arc::new(IdentityRecordingExecutor::new(2));
+    let node = signed_node_with_executor(node_did, executor.clone()).await;
+
+    let response = node
+        .execute_with_retry(
+            "mutation { retry }",
+            ExecuteRetryPolicy::new(2, std::time::Duration::ZERO, std::time::Duration::ZERO),
+        )
+        .await;
+    assert!(!response.has_errors(), "retry query failed");
+    assert_eq!(
+        executor.identities(),
+        vec![
+            Some(node_did.to_string()),
+            Some(node_did.to_string()),
+            Some(node_did.to_string()),
+        ]
+    );
+
+    node.shutdown().await;
+    defra_core::signing::clear_identity_store();
+}
+
+#[tokio::test]
+async fn embedded_transaction_defaults_node_identity_and_preserves_explicit_actor() {
+    let _serial = SIGNING_STORE_GUARD.lock().await;
+    defra_core::signing::clear_identity_store();
+    let node_did = "did:key:zEmbeddedTransactionActor";
+    let explicit_did = identity::Did::new("did:key:zExplicitTransactionActor").unwrap();
+    let executor = Arc::new(IdentityRecordingExecutor::new(0));
+    let node = signed_node_with_executor(node_did, executor.clone()).await;
+    let handle = TransactionHandle::new("identity-test-txn".to_string());
+
+    let defaulted = node
+        .execute_request_in_txn(QueryRequest::new("query { defaulted }"), &handle)
+        .await;
+    assert!(
+        !defaulted.has_errors(),
+        "defaulted transaction query failed"
+    );
+    let explicit = node
+        .execute_request_in_txn(
+            QueryRequest::new("query { explicit }").with_identity(Some(explicit_did.clone())),
+            &handle,
+        )
+        .await;
+    assert!(!explicit.has_errors(), "explicit transaction query failed");
+    assert_eq!(
+        executor.identities(),
+        vec![Some(node_did.to_string()), Some(explicit_did.to_string())]
+    );
+
+    node.shutdown().await;
+    defra_core::signing::clear_identity_store();
+}
+
+#[tokio::test]
+async fn unsigned_embedded_execution_remains_anonymous() {
+    let executor = Arc::new(IdentityRecordingExecutor::new(0));
+    let mut node = EmbeddedNode::builder()
+        .build()
+        .await
+        .expect("build unsigned identity-observing node");
+    node.runner = executor.clone();
+    let handle = TransactionHandle::new("anonymous-test-txn".to_string());
+
+    let direct = node.execute("query { direct }").await;
+    let retry = node.execute_with_retry("query { retry }", no_retry()).await;
+    let transactional = node
+        .execute_request_in_txn(QueryRequest::new("query { transaction }"), &handle)
+        .await;
+
+    assert!(!direct.has_errors());
+    assert!(!retry.has_errors());
+    assert!(!transactional.has_errors());
+    assert_eq!(executor.identities(), vec![None, None, None]);
+
+    node.shutdown().await;
+}

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -15,6 +15,8 @@ pub mod coding_search;
 pub mod config;
 mod db_impls;
 pub mod dense_search;
+#[cfg(test)]
+mod embedded_query_identity_tests;
 mod node_acp;
 #[cfg(feature = "p2p")]
 mod p2p_runtime;
@@ -120,6 +122,7 @@ pub struct EmbeddedNode {
     block_ops: Arc<dyn BlockOps>,
     embedding_config: db::EmbeddingClientConfig,
     node_identity_did: Option<String>,
+    node_query_identity: Option<identity::Did>,
     #[cfg(not(target_arch = "wasm32"))]
     signed_query_runtime: Option<SignedQueryRuntime>,
     #[cfg(not(target_arch = "wasm32"))]
@@ -150,12 +153,18 @@ impl EmbeddedNode {
     }
 
     /// Execute a GraphQL query or mutation.
+    ///
+    /// A configured node identity is used as the document ACP actor. Prepared
+    /// requests with an explicit identity retain that actor instead.
     pub async fn execute(&self, query_str: &str) -> QueryResponse {
         self.execute_request_once(QueryRequest::new(query_str))
             .await
     }
 
     /// Execute a GraphQL query or mutation, retrying transient transaction conflicts.
+    ///
+    /// A configured node identity is used as the document ACP actor on every
+    /// attempt.
     pub async fn execute_with_retry(
         &self,
         query_str: &str,
@@ -166,6 +175,9 @@ impl EmbeddedNode {
     }
 
     /// Execute a prepared query request, retrying transient transaction conflicts.
+    ///
+    /// Requests without an identity use the configured node identity for
+    /// document ACP. An explicit request identity takes precedence.
     pub async fn execute_request_with_retry(
         &self,
         request: QueryRequest,
@@ -178,6 +190,7 @@ impl EmbeddedNode {
     }
 
     async fn execute_request_once(&self, request: QueryRequest) -> QueryResponse {
+        let request = self.with_default_query_identity(request);
         let Some(node_identity_did) = self.node_identity_did.as_deref() else {
             return self.runner.execute(request).await;
         };
@@ -221,11 +234,13 @@ impl EmbeddedNode {
     ///
     /// When the node has a configured identity, the same signing and ambient
     /// identity context used by [`Self::execute`] is applied to this request.
+    /// It is also the document ACP actor unless the request supplies one.
     pub async fn execute_request_in_txn(
         &self,
         request: QueryRequest,
         handle: &TransactionHandle,
     ) -> QueryResponse {
+        let request = self.with_default_query_identity(request);
         let handle = handle.clone();
         let Some(node_identity_did) = self.node_identity_did.as_deref() else {
             return self.runner.execute_in_txn(request, &handle).await;
@@ -264,6 +279,13 @@ impl EmbeddedNode {
             signed_query_permit,
         )
         .await
+    }
+
+    fn with_default_query_identity(&self, mut request: QueryRequest) -> QueryRequest {
+        if request.identity.is_none() {
+            request.identity.clone_from(&self.node_query_identity);
+        }
+        request
     }
 
     /// Run `op` with the node's own identity installed as the ambient acting
@@ -1565,6 +1587,12 @@ impl NodeBuilder {
             telemetry_handle,
         } = args;
 
+        let node_query_identity = node_identity_did
+            .as_ref()
+            .map(|did| identity::Did::new(did.clone()))
+            .transpose()
+            .map_err(|error| anyhow::anyhow!("invalid node identity DID: {error}"))?;
+
         let embedding_config = db_options.embedding_config();
         #[cfg(not(target_arch = "wasm32"))]
         let transaction_stats = store.transaction_stats_handle();
@@ -1719,6 +1747,7 @@ impl NodeBuilder {
             block_ops,
             embedding_config,
             node_identity_did,
+            node_query_identity,
             #[cfg(not(target_arch = "wasm32"))]
             signed_query_runtime,
             #[cfg(not(target_arch = "wasm32"))]
@@ -1764,7 +1793,7 @@ mod tests {
     #[cfg(feature = "http")]
     use super::HttpConfig;
 
-    static SIGNING_STORE_GUARD: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+    pub(super) static SIGNING_STORE_GUARD: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
     #[cfg(feature = "rocksdb")]
     static ROCKS_ENV_GUARD: LazyLock<std::sync::Mutex<()>> =
         LazyLock::new(|| std::sync::Mutex::new(()));
@@ -2407,7 +2436,7 @@ mod tests {
         defra_core::signing::clear_identity_store();
     }
 
-    struct TestRemoteSigner;
+    pub(super) struct TestRemoteSigner;
 
     impl RemoteSigner for TestRemoteSigner {
         fn sign_sync(

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -106,6 +106,11 @@ trait SchemaOps: Send + Sync {
 
 #[async_trait::async_trait]
 trait BlockOps: Send + Sync {
+    async fn signed_block_bytes(
+        &self,
+        cid: &str,
+        caller_did: Option<&str>,
+    ) -> anyhow::Result<(Vec<u8>, Vec<u8>)>;
     async fn verified_signer_did(&self, cid: &str) -> anyhow::Result<String>;
     async fn verified_signer_did_in_txn(
         &self,
@@ -312,6 +317,17 @@ impl EmbeddedNode {
     /// public key. Unsigned, malformed, missing, or invalid blocks fail closed.
     pub async fn verified_block_signer_did(&self, cid: &str) -> anyhow::Result<String> {
         self.block_ops.verified_signer_did(cid).await
+    }
+
+    /// Load canonical signed-block material after applying document ACP for
+    /// the supplied caller. The caller must independently verify both CIDs and
+    /// the detached signature before trusting the returned signer.
+    pub async fn authorized_signed_block_bytes(
+        &self,
+        cid: &str,
+        caller_did: Option<&str>,
+    ) -> anyhow::Result<(Vec<u8>, Vec<u8>)> {
+        self.block_ops.signed_block_bytes(cid, caller_did).await
     }
 
     /// Cryptographically verify a block visible inside an active transaction.

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -26,6 +26,7 @@ db = { path = "../db", default-features = false, features = ["native"] }
 
 # Encoding
 hex = "0.4"
+base64.workspace = true
 cid.workspace = true
 
 # Async runtime

--- a/crates/http/src/handlers/block.rs
+++ b/crates/http/src/handlers/block.rs
@@ -1,6 +1,8 @@
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
-use serde::Deserialize;
+use axum::Json;
+use base64::Engine as _;
+use serde::{Deserialize, Serialize};
 
 use crate::error::{http_error_from_backend_message, HttpError};
 use crate::identity_extractor::ExtractIdentity;
@@ -15,6 +17,40 @@ pub struct VerifySignatureParams {
     pub public_key: String,
     #[serde(rename = "type")]
     pub key_type: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SignedBlockParams {
+    pub cid: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SignedBlockResponse {
+    pub cid: String,
+    pub block: String,
+    pub signature: String,
+}
+
+/// Return canonical signed-block material after document ACP authorization.
+/// The client must still verify both CIDs and the signature locally.
+pub async fn signed_block(
+    State(state): State<AppState>,
+    identity: ExtractIdentity,
+    Query(params): Query<SignedBlockParams>,
+) -> Result<Json<SignedBlockResponse>, HttpError> {
+    require_permission(&state, &identity, NodePermission::SignatureVerify).await?;
+    let block = state.require_block()?;
+    let caller_did = identity.did().map(|did| did.to_string());
+    let (block_bytes, signature_bytes) = block
+        .signed_block_bytes(&params.cid, caller_did.as_deref())
+        .await
+        .map_err(http_error_from_backend_message)?;
+    let encoder = base64::engine::general_purpose::STANDARD;
+    Ok(Json(SignedBlockResponse {
+        cid: params.cid,
+        block: encoder.encode(block_bytes),
+        signature: encoder.encode(signature_bytes),
+    }))
 }
 
 /// Verify the signature of a block.
@@ -42,3 +78,7 @@ pub async fn verify_signature(
         .map_err(http_error_from_backend_message)?;
     Ok(StatusCode::OK)
 }
+
+#[cfg(test)]
+#[path = "block_tests.rs"]
+mod tests;

--- a/crates/http/src/handlers/block_tests.rs
+++ b/crates/http/src/handlers/block_tests.rs
@@ -1,0 +1,82 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use axum::body::{to_bytes, Body};
+use axum::http::{Request, StatusCode};
+use query::executor::QueryExecutor;
+use serde_json::Value;
+use tower::ServiceExt;
+
+use crate::mock::MockQueryExecutor;
+use crate::router::{create_router_with_state, AppStateBuilder, BlockOperations};
+
+#[derive(Default)]
+struct RecordingBlock {
+    calls: Mutex<Vec<(String, Option<String>)>>,
+}
+
+#[async_trait]
+impl BlockOperations for RecordingBlock {
+    async fn signed_block_bytes(
+        &self,
+        cid: &str,
+        caller_did: Option<&str>,
+    ) -> Result<(Vec<u8>, Vec<u8>), String> {
+        self.calls
+            .lock()
+            .expect("recording block lock")
+            .push((cid.to_string(), caller_did.map(str::to_string)));
+        Ok((b"canonical block".to_vec(), b"detached signature".to_vec()))
+    }
+
+    async fn verify_signature(
+        &self,
+        _cid: &str,
+        _public_key: &str,
+        _key_type: Option<&str>,
+        _caller_did: Option<&str>,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn signed_block_route_returns_canonical_material() {
+    let executor = Arc::new(MockQueryExecutor::new()) as Arc<dyn QueryExecutor>;
+    let block = Arc::new(RecordingBlock::default());
+    let state = AppStateBuilder::new(executor)
+        .with_block(block.clone() as Arc<dyn BlockOperations>)
+        .build();
+
+    for path in [
+        "/api/v0/block/signed?cid=bafy-test",
+        "/api/v1/block/signed?cid=bafy-test",
+    ] {
+        let response = create_router_with_state(state.clone())
+            .oneshot(
+                Request::builder()
+                    .uri(path)
+                    .body(Body::empty())
+                    .expect("request should build"),
+            )
+            .await
+            .expect("router should respond");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("response body should be readable");
+        let value: Value = serde_json::from_slice(&body).expect("valid JSON response");
+        assert_eq!(value["cid"], "bafy-test");
+        assert_eq!(value["block"], "Y2Fub25pY2FsIGJsb2Nr");
+        assert_eq!(value["signature"], "ZGV0YWNoZWQgc2lnbmF0dXJl");
+    }
+
+    assert_eq!(
+        *block.calls.lock().expect("recording block lock"),
+        vec![
+            ("bafy-test".to_string(), None),
+            ("bafy-test".to_string(), None),
+        ]
+    );
+}

--- a/crates/http/src/mock/block.rs
+++ b/crates/http/src/mock/block.rs
@@ -14,6 +14,14 @@ impl MockBlockOperations {
 
 #[async_trait]
 impl BlockOperations for MockBlockOperations {
+    async fn signed_block_bytes(
+        &self,
+        _cid: &str,
+        _caller_did: Option<&str>,
+    ) -> Result<(Vec<u8>, Vec<u8>), String> {
+        Err("mock signed block bytes unavailable".to_string())
+    }
+
     async fn verify_signature(
         &self,
         _cid: &str,

--- a/crates/http/src/route_permissions.rs
+++ b/crates/http/src/route_permissions.rs
@@ -244,7 +244,7 @@ pub fn route_permission(path: &str, method: &Method) -> RoutePermission {
         // =====================================================================
         // Block
         // =====================================================================
-        "/api/v0/block/verify-signature" => {
+        "/api/v0/block/verify-signature" | "/api/v0/block/signed" => {
             RoutePermission::Required(NodePermission::SignatureVerify)
         }
 
@@ -600,6 +600,17 @@ mod tests {
                 Method::POST,
                 RoutePermission::Required(NodePermission::DocumentUpdate),
             ),
+            // Block
+            (
+                "/api/v0/block/verify-signature",
+                Method::GET,
+                RoutePermission::Required(NodePermission::SignatureVerify),
+            ),
+            (
+                "/api/v0/block/signed",
+                Method::GET,
+                RoutePermission::Required(NodePermission::SignatureVerify),
+            ),
             // Views
             (
                 "/api/v0/views",
@@ -648,6 +659,7 @@ mod tests {
             ("/api/v0/p2p/replicators", Method::DELETE),
             ("/api/v0/acp/node/disable", Method::POST),
             ("/api/v0/backup/export", Method::POST),
+            ("/api/v0/block/signed", Method::GET),
         ] {
             let v1_path = v0_path.replacen("/api/v0", "/api/v1", 1);
             assert_eq!(

--- a/crates/http/src/router/routes.rs
+++ b/crates/http/src/router/routes.rs
@@ -193,8 +193,9 @@ pub(crate) fn create_router_with_state_and_sync_body_limit(
         .route("/import", post(handlers::backup::import));
 
     // Block routes
-    let block_routes =
-        Router::new().route("/verify-signature", get(handlers::block::verify_signature));
+    let block_routes = Router::new()
+        .route("/verify-signature", get(handlers::block::verify_signature))
+        .route("/signed", get(handlers::block::signed_block));
 
     // Lens migration routes
     let lens_routes = Router::new()

--- a/crates/http/src/router/traits.rs
+++ b/crates/http/src/router/traits.rs
@@ -548,6 +548,15 @@ pub struct EncryptedIndexInfo {
 /// DAG-CBOR blocks stored in the blockstore.
 #[async_trait::async_trait]
 pub trait BlockOperations: Send + Sync {
+    /// Return canonical bytes for an authorized signed block and its detached
+    /// signature so clients can verify content addressing and authorship
+    /// locally.
+    async fn signed_block_bytes(
+        &self,
+        cid: &str,
+        caller_did: Option<&str>,
+    ) -> Result<(Vec<u8>, Vec<u8>), String>;
+
     /// Verify the signature of a block.
     ///
     /// Loads a block by CID, checks its signature, and verifies using the


### PR DESCRIPTION
## What changed

Embedded node queries without an explicit document actor now default to the configured node DID. Prepared requests with an explicit identity keep that actor, retry attempts preserve it, and transactional execution follows the same rule. Unsigned nodes remain anonymous, and HTTP behavior is unchanged.

The block API now also exposes an ACP-authorized `/api/v0/block/signed?cid=...` endpoint that returns the canonical DAG-CBOR bytes for a commit and its detached signature. Clients can verify the requested CID, signature CID, cryptographic signature, and signer DID locally instead of trusting a server-side verification verdict.

## Why

A signed embedded node previously signed commits as the node while submitting document-ACP queries without an actor. Runtime clients therefore could not rely on node identity being attached to every embedded read and write. Remote provenance clients also lacked the signed source material needed to verify authorship independently.

## Impact

Embedded applications can use the node DID as their default ACP principal without rebuilding every query as a prepared request. Explicit actor delegation remains possible inside the trusted embedded application boundary. Authorized remote readers can independently verify commit provenance without receiving block material they cannot read.

This PR is stacked on #1352 because it uses that series per-node signing runtime and configured node identity.

## Validation

- focused embedded identity seam tests
- signed-block HTTP route and permission tests
- block signature verification tests
- cargo test -p defra-node
- cargo test -p query
- cargo check --workspace --all-targets
- cargo check -p defra-http -p cli
- cargo fmt --all --check
- git diff --check