### PR TITLE
fix(db): make branchable mutation provenance atomic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -419,7 +419,7 @@ jobs:
         run: |
           HASH=$(git rev-parse HEAD)
           CACHE_DIR="$HOME/.sourcenetwork/bin/defradb.rs/$HASH"
-          mkdir -p target/ci
+          mkdir -p "$CACHE_DIR" target/ci
 
           if [ -f "$CACHE_DIR/defra" ] && [ -f "$CACHE_DIR/defra-iroh" ]; then
             echo "Cache hit — restoring from $CACHE_DIR"

--- a/crates/db/src/auto_commit_mutator/batch.rs
+++ b/crates/db/src/auto_commit_mutator/batch.rs
@@ -9,13 +9,12 @@ use query::mutator::{
 use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
 use storage::corekv::Store;
-use tracing::warn;
 
 use super::helpers::{
     ensure_collection_is_active, register_block_doc_id_mappings, register_created_doc,
-    write_local_create, write_local_update,
+    write_branchable_collection_block, write_local_create, write_local_update,
 };
-use crate::block_builder::{write_collection_block, write_delete_block, write_document_blocks};
+use crate::block_builder::{write_delete_block, write_document_blocks};
 use crate::collection_loader::{get_collection_with_index_manager, get_collection_with_lazy_load};
 use crate::database::DB;
 use crate::event_emission::register_update_event_callback;
@@ -253,30 +252,15 @@ impl<S: Store + 'static> DocMutator for BatchMutator<S> {
 
             write_local_create(&datastore, &collection, &doc, doc_short_id, &index_manager).await?;
 
-            let mut col_block_data: Option<(Cid, Vec<u8>)> = None;
-            if collection.schema().is_branchable {
-                match write_collection_block(
-                    &blockstore,
-                    &headstore,
-                    short_id,
-                    schema_version_id,
-                    block_result.cid,
-                    sign_config.as_ref(),
-                )
-                .await
-                {
-                    Ok((col_cid, col_bytes)) => {
-                        col_block_data = Some((col_cid, col_bytes));
-                    }
-                    Err(e) => {
-                        warn!(
-                            collection = %collection_name,
-                            error = %e,
-                            "Failed to write collection block for branchable create"
-                        );
-                    }
-                }
-            }
+            let col_block_data = write_branchable_collection_block(
+                collection_name,
+                &collection,
+                &blockstore,
+                &headstore,
+                block_result.cid,
+                sign_config.as_ref(),
+            )
+            .await?;
 
             (doc_id, block_result.cid, block_result.block, col_block_data)
         };
@@ -403,30 +387,15 @@ impl<S: Store + 'static> DocMutator for BatchMutator<S> {
             )
             .await?;
 
-            let mut col_block_data: Option<(Cid, Vec<u8>)> = None;
-            if collection.schema().is_branchable {
-                match write_collection_block(
-                    &blockstore,
-                    &headstore,
-                    short_id,
-                    schema_version_id,
-                    block_result.cid,
-                    sign_config.as_ref(),
-                )
-                .await
-                {
-                    Ok((col_cid, col_bytes)) => {
-                        col_block_data = Some((col_cid, col_bytes));
-                    }
-                    Err(e) => {
-                        warn!(
-                            collection = %collection_name,
-                            error = %e,
-                            "Failed to write collection block for branchable update"
-                        );
-                    }
-                }
-            }
+            let col_block_data = write_branchable_collection_block(
+                collection_name,
+                &collection,
+                &blockstore,
+                &headstore,
+                block_result.cid,
+                sign_config.as_ref(),
+            )
+            .await?;
 
             (block_result.cid, block_result.block, col_block_data)
         };
@@ -484,7 +453,6 @@ impl<S: Store + 'static> DocMutator for BatchMutator<S> {
             return Ok(DeleteResult::new(canonical_doc_id, existed));
         }
 
-        let short_id = collection.resolved_root_id();
         let schema_version_id = collection.version_id();
         let sign_config = get_signing_config();
 
@@ -517,30 +485,15 @@ impl<S: Store + 'static> DocMutator for BatchMutator<S> {
             .await
             .map_err(|e| query::error::QueryError::execution(e.to_string()))?;
 
-            let mut col_block_data: Option<(Cid, Vec<u8>)> = None;
-            if collection.schema().is_branchable {
-                match write_collection_block(
-                    &blockstore,
-                    &headstore,
-                    short_id,
-                    schema_version_id,
-                    composite_cid,
-                    sign_config.as_ref(),
-                )
-                .await
-                {
-                    Ok((col_cid, col_bytes)) => {
-                        col_block_data = Some((col_cid, col_bytes));
-                    }
-                    Err(e) => {
-                        warn!(
-                            collection = %collection_name,
-                            error = %e,
-                            "Failed to write collection block for branchable delete"
-                        );
-                    }
-                }
-            }
+            let col_block_data = write_branchable_collection_block(
+                collection_name,
+                &collection,
+                &blockstore,
+                &headstore,
+                composite_cid,
+                sign_config.as_ref(),
+            )
+            .await?;
 
             (composite_cid, block_result.block, col_block_data)
         };

--- a/crates/db/src/auto_commit_mutator/create.rs
+++ b/crates/db/src/auto_commit_mutator/create.rs
@@ -1,4 +1,7 @@
-use super::helpers::{ensure_collection_is_active, register_created_doc, write_local_create};
+use super::helpers::{
+    ensure_collection_is_active, register_created_doc, write_branchable_collection_block,
+    write_local_create,
+};
 use super::*;
 
 use db_blocks::DocStorageIdentity;
@@ -140,31 +143,15 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
             // `write_local_create`.
             write_local_create(&datastore, &collection, &doc, doc_short_id, &index_manager).await?;
 
-            // For branchable collections, create a collection-level block
-            let mut col_block_data: Option<(Cid, Vec<u8>)> = None;
-            if collection.schema().is_branchable {
-                match write_collection_block(
-                    &blockstore,
-                    &headstore,
-                    short_id,
-                    schema_version_id,
-                    block_result.cid,
-                    sign_config.as_ref(),
-                )
-                .await
-                {
-                    Ok((col_cid, col_bytes)) => {
-                        col_block_data = Some((col_cid, col_bytes));
-                    }
-                    Err(e) => {
-                        warn!(
-                            collection = %collection_name,
-                            error = %e,
-                            "Failed to write collection block for branchable create"
-                        );
-                    }
-                }
-            }
+            let col_block_data = write_branchable_collection_block(
+                collection_name,
+                &collection,
+                &blockstore,
+                &headstore,
+                block_result.cid,
+                sign_config.as_ref(),
+            )
+            .await?;
 
             Ok((doc_id, block_result.cid, block_result.block, col_block_data))
         }

--- a/crates/db/src/auto_commit_mutator/create_many.rs
+++ b/crates/db/src/auto_commit_mutator/create_many.rs
@@ -1,4 +1,7 @@
-use super::helpers::{ensure_collection_is_active, register_created_doc, write_local_create};
+use super::helpers::{
+    ensure_collection_is_active, register_created_doc, write_branchable_collection_block,
+    write_local_create,
+};
 use super::*;
 
 use crate::block_builder::{compute_document_blocks, insert_computed_blocks, ComputedBlocks};
@@ -222,30 +225,15 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
             )
             .await?;
 
-            let mut col_block_data: Option<(Cid, Vec<u8>)> = None;
-            if collection.schema().is_branchable {
-                match write_collection_block(
-                    &blockstore,
-                    &headstore,
-                    short_id,
-                    &schema_version_id,
-                    computed.block_result.cid,
-                    sign_config.as_ref(),
-                )
-                .await
-                {
-                    Ok((col_cid, col_bytes)) => {
-                        col_block_data = Some((col_cid, col_bytes));
-                    }
-                    Err(e) => {
-                        warn!(
-                            collection = %collection_name,
-                            error = %e,
-                            "Failed to write collection block for branchable create"
-                        );
-                    }
-                }
-            }
+            let col_block_data = write_branchable_collection_block(
+                collection_name,
+                &collection,
+                &blockstore,
+                &headstore,
+                computed.block_result.cid,
+                sign_config.as_ref(),
+            )
+            .await?;
 
             results.push((
                 doc_id,

--- a/crates/db/src/auto_commit_mutator/delete.rs
+++ b/crates/db/src/auto_commit_mutator/delete.rs
@@ -1,4 +1,4 @@
-use super::helpers::ensure_collection_is_active;
+use super::helpers::{ensure_collection_is_active, write_branchable_collection_block};
 use super::*;
 
 impl<S: Store + 'static> AutoCommitMutator<S> {
@@ -94,8 +94,7 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                 let existed = true;
 
                 // Build delete block (composite with status=2) in a scoped block
-                let mut ownership_error: Option<String> = None;
-                let commit_result: Option<CommitArtifacts> = {
+                let commit_result: CommitArtifacts = {
                     let blockstore = txn.blockstore().map_err(|e| {
                         query::error::QueryError::execution(format!(
                             "failed to get blockstore: {}",
@@ -114,7 +113,7 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                     // Get signing config from thread-local (set by FFI exec_request)
                     let sign_config = get_signing_config();
 
-                    match write_delete_block(
+                    let block_result = write_delete_block(
                         &blockstore,
                         &headstore,
                         &doc_id_str,
@@ -123,69 +122,40 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                         sign_config.as_ref(),
                     )
                     .await
-                    {
-                        Ok(block_result) => {
-                            let composite_cid = block_result.cid;
+                    .map_err(|e| {
+                        query::error::QueryError::execution(format!(
+                            "failed to write delete block for collection {}: {}",
+                            collection_name, e
+                        ))
+                    })?;
+                    let composite_cid = block_result.cid;
 
-                            match txn.systemstore() {
-                                Ok(systemstore) => {
-                                    if let Err(e) = crate::doc_id_map::set_block_doc_id_mapping(
-                                        &systemstore,
-                                        &composite_cid.to_string(),
-                                        &doc_id_str,
-                                    )
-                                    .await
-                                    {
-                                        ownership_error = Some(e.to_string());
-                                    }
-                                }
-                                Err(e) => ownership_error = Some(e.to_string()),
-                            }
+                    let systemstore = txn.systemstore().map_err(|e| {
+                        query::error::QueryError::execution(format!(
+                            "failed to get systemstore: {}",
+                            e
+                        ))
+                    })?;
+                    crate::doc_id_map::set_block_doc_id_mapping(
+                        &systemstore,
+                        &composite_cid.to_string(),
+                        &doc_id_str,
+                    )
+                    .await
+                    .map_err(|e| query::error::QueryError::execution(e.to_string()))?;
 
-                            let mut col_block_data: Option<(Cid, Vec<u8>)> = None;
-                            if collection.schema().is_branchable {
-                                let short_id = collection.resolved_root_id();
-                                match write_collection_block(
-                                    &blockstore,
-                                    &headstore,
-                                    short_id,
-                                    schema_version_id,
-                                    composite_cid,
-                                    sign_config.as_ref(),
-                                )
-                                .await
-                                {
-                                    Ok((col_cid, col_bytes)) => {
-                                        col_block_data = Some((col_cid, col_bytes));
-                                    }
-                                    Err(e) => {
-                                        warn!(
-                                            collection = %collection_name,
-                                            error = %e,
-                                            "Failed to write collection block for branchable delete"
-                                        );
-                                    }
-                                }
-                            }
+                    let col_block_data = write_branchable_collection_block(
+                        collection_name,
+                        &collection,
+                        &blockstore,
+                        &headstore,
+                        composite_cid,
+                        sign_config.as_ref(),
+                    )
+                    .await?;
 
-                            Some((composite_cid, block_result.block, col_block_data))
-                        }
-                        Err(e) => {
-                            warn!(
-                                collection = %collection_name,
-                                error = %e,
-                                "Failed to write delete block - commits queries may not work"
-                            );
-                            None
-                        }
-                    }
+                    (composite_cid, block_result.block, col_block_data)
                 }; // blockstore and headstore dropped here
-
-                if let Some(e) = ownership_error {
-                    return Err(query::error::QueryError::execution(format!(
-                        "failed to record block ownership mapping for delete: {e}"
-                    )));
-                }
 
                 // Commit the transaction (datastore reference is now dropped)
                 if let Err(e) = txn.commit().await {
@@ -197,33 +167,21 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                     return Err(crate::error::commit_query_error(e));
                 }
 
-                // Emit update event for subscriptions when blocks were written.
-                if let Some((cid, block, col_data)) = commit_result.as_ref() {
-                    self.emit_update_events(
-                        &collection,
-                        &canonical_doc_id.to_string(),
-                        *cid,
-                        block.clone(),
-                        col_data.clone(),
-                    );
-                }
+                let (cid, block, col_data) = commit_result;
+                self.emit_update_events(
+                    &collection,
+                    &canonical_doc_id.to_string(),
+                    cid,
+                    block.clone(),
+                    col_data.clone(),
+                );
 
-                match commit_result {
-                    Some((cid, block, col_data)) => {
-                        let mut result = DeleteResult::with_commit(
-                            canonical_doc_id.clone(),
-                            existed,
-                            cid,
-                            block,
-                        );
-                        if let Some((col_cid, col_bytes)) = col_data {
-                            result.broadcast_cid = Some(col_cid);
-                            result.broadcast_block = Some(col_bytes);
-                        }
-                        Ok(result)
-                    }
-                    None => Ok(DeleteResult::new(canonical_doc_id, existed)),
+                let mut result = DeleteResult::with_commit(canonical_doc_id, existed, cid, block);
+                if let Some((col_cid, col_bytes)) = col_data {
+                    result.broadcast_cid = Some(col_cid);
+                    result.broadcast_block = Some(col_bytes);
                 }
+                Ok(result)
             }
             Err(e) => {
                 // Discard the transaction on error

--- a/crates/db/src/auto_commit_mutator/delete_many.rs
+++ b/crates/db/src/auto_commit_mutator/delete_many.rs
@@ -1,4 +1,4 @@
-use super::helpers::ensure_collection_is_active;
+use super::helpers::{ensure_collection_is_active, write_branchable_collection_block};
 use super::*;
 
 impl<S: Store + 'static> AutoCommitMutator<S> {
@@ -49,10 +49,6 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
             query::error::QueryError::execution(format!("failed to create txn: {}", e))
         })?;
 
-        // Block-ownership registration is correctness-critical; a failure must
-        // abort the whole batch rather than commit a tombstone with no owner
-        // (which would break P2P serve, KMS, and ACP resolution).
-        let mut ownership_error: Option<String> = None;
         let mut results: Vec<(DocID, bool, Option<CommitArtifacts>)> =
             Vec::with_capacity(doc_ids.len());
 
@@ -122,7 +118,7 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                     query::error::QueryError::execution(format!("failed to get headstore: {}", e))
                 })?;
 
-                match write_delete_block(
+                let block_result = write_delete_block(
                     &blockstore,
                     &headstore,
                     &canonical_doc_id.to_string(),
@@ -131,73 +127,39 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                     sign_config.as_ref(),
                 )
                 .await
-                {
-                    Ok(block_result) => {
-                        let composite_cid = block_result.cid;
+                .map_err(|e| {
+                    query::error::QueryError::execution(format!(
+                        "failed to write delete block for collection {}: {}",
+                        collection_name, e
+                    ))
+                })?;
+                let composite_cid = block_result.cid;
 
-                        match txn.systemstore() {
-                            Ok(systemstore) => {
-                                if let Err(e) = crate::doc_id_map::set_block_doc_id_mapping(
-                                    &systemstore,
-                                    &composite_cid.to_string(),
-                                    &canonical_doc_id.to_string(),
-                                )
-                                .await
-                                {
-                                    ownership_error = Some(e.to_string());
-                                }
-                            }
-                            Err(e) => ownership_error = Some(e.to_string()),
-                        }
+                let systemstore = txn.systemstore().map_err(|e| {
+                    query::error::QueryError::execution(format!("failed to get systemstore: {}", e))
+                })?;
+                crate::doc_id_map::set_block_doc_id_mapping(
+                    &systemstore,
+                    &composite_cid.to_string(),
+                    &canonical_doc_id.to_string(),
+                )
+                .await
+                .map_err(|e| query::error::QueryError::execution(e.to_string()))?;
 
-                        let mut col_block_data: Option<(Cid, Vec<u8>)> = None;
-                        if collection.schema().is_branchable {
-                            match write_collection_block(
-                                &blockstore,
-                                &headstore,
-                                short_id,
-                                &schema_version_id,
-                                composite_cid,
-                                sign_config.as_ref(),
-                            )
-                            .await
-                            {
-                                Ok((col_cid, col_bytes)) => {
-                                    col_block_data = Some((col_cid, col_bytes));
-                                }
-                                Err(e) => {
-                                    warn!(
-                                        collection = %collection_name,
-                                        error = %e,
-                                        "Failed to write collection block for branchable delete"
-                                    );
-                                }
-                            }
-                        }
+                let col_block_data = write_branchable_collection_block(
+                    collection_name,
+                    &collection,
+                    &blockstore,
+                    &headstore,
+                    composite_cid,
+                    sign_config.as_ref(),
+                )
+                .await?;
 
-                        Some((composite_cid, block_result.block, col_block_data))
-                    }
-                    Err(e) => {
-                        warn!(
-                            collection = %collection_name,
-                            doc_id = %canonical_doc_id,
-                            error = %e,
-                            "Failed to write delete block in batch"
-                        );
-                        None
-                    }
-                }
+                Some((composite_cid, block_result.block, col_block_data))
             };
 
             results.push((canonical_doc_id, existed, commit_result));
-        }
-
-        // A failed ownership registration must not commit a partial index for
-        // the batch; drop the txn (rolls back) and surface the error.
-        if let Some(e) = ownership_error {
-            return Err(query::error::QueryError::execution(format!(
-                "failed to record block ownership mapping for delete: {e}"
-            )));
         }
 
         // Single commit for entire batch

--- a/crates/db/src/auto_commit_mutator/helpers.rs
+++ b/crates/db/src/auto_commit_mutator/helpers.rs
@@ -9,6 +9,36 @@ use defra_core::types::DocId as CrdtDocId;
 use document::NormalValue;
 use schema::{FieldKind, ScalarKind};
 
+pub(crate) async fn write_branchable_collection_block(
+    collection_name: &str,
+    collection: &Collection,
+    blockstore: &NamespaceView,
+    headstore: &NamespaceView,
+    doc_cid: Cid,
+    signing_config: Option<&defra_core::signing::SigningConfig>,
+) -> query::error::Result<Option<(Cid, Vec<u8>)>> {
+    if !collection.schema().is_branchable {
+        return Ok(None);
+    }
+
+    write_collection_block(
+        blockstore,
+        headstore,
+        collection.resolved_root_id(),
+        collection.version_id(),
+        doc_cid,
+        signing_config,
+    )
+    .await
+    .map(Some)
+    .map_err(|error| {
+        query::error::QueryError::execution(format!(
+            "failed to write collection block for branchable mutation on collection {}: {}",
+            collection_name, error
+        ))
+    })
+}
+
 /// Persist a local UPDATE: apply CRDT field deltas to the authoritative store
 /// (the counter RMW, #1021) and then write the document + maintain indexes. These
 /// are bundled so no mutator can write a document blob without first advancing the

--- a/crates/db/src/auto_commit_mutator/update.rs
+++ b/crates/db/src/auto_commit_mutator/update.rs
@@ -1,5 +1,6 @@
 use super::helpers::{
-    ensure_collection_is_active, register_block_doc_id_mappings, write_local_update,
+    ensure_collection_is_active, register_block_doc_id_mappings, write_branchable_collection_block,
+    write_local_update,
 };
 use super::*;
 
@@ -216,12 +217,7 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                 // Build blocks and write to blockstore/headstore in a scoped block
                 // This enables _commits queries to find the document's version history
                 // (composite_cid, composite_bytes, optional (collection_cid, collection_bytes))
-                // Block-ownership registration is correctness-critical (P2P
-                // serve, KMS, and ACP resolution all read the index), so unlike
-                // the best-effort commits-query block writes below its failure
-                // is fatal: surfaced here and routed through the discard path.
-                let mut ownership_error: Option<String> = None;
-                let commit_result: Option<(Cid, Vec<u8>, Option<(Cid, Vec<u8>)>)> = {
+                let commit_result: CommitArtifacts = {
                     let blockstore = txn.blockstore().map_err(|e| {
                         query::error::QueryError::execution(format!(
                             "failed to get blockstore: {}",
@@ -250,7 +246,7 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
 
                     // For update operations, pass the modified fields to only create blocks
                     // for the fields that actually changed
-                    match write_document_blocks(
+                    let block_result = write_document_blocks(
                         &blockstore,
                         &headstore,
                         &doc,
@@ -262,71 +258,40 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                         None,
                     )
                     .await
-                    {
-                        Ok(block_result) => {
-                            if let Some(doc_id) = doc.id() {
-                                match txn.systemstore() {
-                                    Ok(systemstore) => {
-                                        if let Err(e) = register_block_doc_id_mappings(
-                                            &systemstore,
-                                            &block_result,
-                                            &doc_id.to_string(),
-                                        )
-                                        .await
-                                        {
-                                            ownership_error = Some(e.to_string());
-                                        }
-                                    }
-                                    Err(e) => ownership_error = Some(e.to_string()),
-                                }
-                            }
-                            // For branchable collections, create a collection-level block
-                            let mut col_block_data: Option<(Cid, Vec<u8>)> = None;
-                            if collection.schema().is_branchable {
-                                let short_id = collection.resolved_root_id();
-                                match write_collection_block(
-                                    &blockstore,
-                                    &headstore,
-                                    short_id,
-                                    schema_version_id,
-                                    block_result.cid,
-                                    sign_config.as_ref(),
-                                )
-                                .await
-                                {
-                                    Ok((col_cid, col_bytes)) => {
-                                        col_block_data = Some((col_cid, col_bytes));
-                                    }
-                                    Err(e) => {
-                                        warn!(
-                                            collection = %collection_name,
-                                            error = %e,
-                                            "Failed to write collection block for branchable update"
-                                        );
-                                    }
-                                }
-                            }
-                            Some((block_result.cid, block_result.block, col_block_data))
-                        }
-                        Err(e) => {
-                            warn!(
-                                collection = %collection_name,
-                                error = %e,
-                                "Failed to write document blocks - commits queries may not work"
-                            );
-                            // Don't fail the mutation, just log the warning
-                            None
-                        }
-                    }
-                }; // blockstore and headstore dropped here
+                    .map_err(|e| {
+                        query::error::QueryError::execution(format!(
+                            "failed to write document blocks for update on collection {}: {}",
+                            collection_name, e
+                        ))
+                    })?;
 
-                // A failed ownership registration must not commit a partial
-                // index; drop the txn (rolls back) and surface the error.
-                if let Some(e) = ownership_error {
-                    return Err(query::error::QueryError::execution(format!(
-                        "failed to record block ownership mappings for update: {e}"
-                    )));
-                }
+                    if let Some(doc_id) = doc.id() {
+                        let systemstore = txn.systemstore().map_err(|e| {
+                            query::error::QueryError::execution(format!(
+                                "failed to get systemstore: {}",
+                                e
+                            ))
+                        })?;
+                        register_block_doc_id_mappings(
+                            &systemstore,
+                            &block_result,
+                            &doc_id.to_string(),
+                        )
+                        .await?;
+                    }
+
+                    let col_block_data = write_branchable_collection_block(
+                        collection_name,
+                        &collection,
+                        &blockstore,
+                        &headstore,
+                        block_result.cid,
+                        sign_config.as_ref(),
+                    )
+                    .await?;
+
+                    (block_result.cid, block_result.block, col_block_data)
+                }; // blockstore and headstore dropped here
 
                 // Commit the transaction (all store references now dropped)
                 if let Err(e) = txn.commit().await {
@@ -338,10 +303,8 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                     return Err(crate::error::commit_query_error(e));
                 }
 
-                // Emit update event for subscriptions when blocks were written.
-                if let (Some(doc_id), Some((cid, block, col_data))) =
-                    (doc.id(), commit_result.as_ref())
-                {
+                if let Some(doc_id) = doc.id() {
+                    let (cid, block, col_data) = &commit_result;
                     self.emit_update_events(
                         &collection,
                         &doc_id.to_string(),
@@ -353,18 +316,13 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
 
                 // Count modified fields
                 let fields_modified = doc.values().len();
-                match commit_result {
-                    Some((cid, block, col_data)) => {
-                        let mut result =
-                            UpdateResult::with_commit(doc, fields_modified, cid, block);
-                        if let Some((col_cid, col_bytes)) = col_data {
-                            result.broadcast_cid = Some(col_cid);
-                            result.broadcast_block = Some(col_bytes);
-                        }
-                        Ok(result)
-                    }
-                    None => Ok(UpdateResult::new(doc, fields_modified)),
+                let (cid, block, col_data) = commit_result;
+                let mut result = UpdateResult::with_commit(doc, fields_modified, cid, block);
+                if let Some((col_cid, col_bytes)) = col_data {
+                    result.broadcast_cid = Some(col_cid);
+                    result.broadcast_block = Some(col_bytes);
                 }
+                Ok(result)
             }
             Err(e) => {
                 // Discard the transaction on error

--- a/crates/db/src/doc_mutator.rs
+++ b/crates/db/src/doc_mutator.rs
@@ -7,9 +7,9 @@ use document::{DocID, Document};
 use query::mutator::{CreateResult, DeleteResult, DocMutator, UpdateResult};
 use std::sync::Arc;
 use storage::corekv::Store;
-use tracing::warn;
 
-use crate::block_builder::{write_collection_block, write_delete_block, write_document_blocks};
+use crate::auto_commit_mutator::helpers::write_branchable_collection_block;
+use crate::block_builder::{write_delete_block, write_document_blocks};
 use crate::collection::Collection;
 use crate::collection_loader::{get_collection_with_index_manager, get_collection_with_lazy_load};
 use crate::database::DB;
@@ -258,31 +258,15 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
             .await?;
             doc.set_id(doc_id.clone());
 
-            let mut col_block_data: Option<(Cid, Vec<u8>)> = None;
-            if collection.schema().is_branchable {
-                let short_id = collection.resolved_root_id();
-                match write_collection_block(
-                    &blockstore,
-                    &headstore,
-                    short_id,
-                    schema_version_id,
-                    block_result.cid,
-                    sign_config.as_ref(),
-                )
-                .await
-                {
-                    Ok((col_cid, col_bytes)) => {
-                        col_block_data = Some((col_cid, col_bytes));
-                    }
-                    Err(error) => {
-                        warn!(
-                            collection = %collection_name,
-                            error = %error,
-                            "Failed to write collection block for transaction create"
-                        );
-                    }
-                }
-            }
+            let col_block_data = write_branchable_collection_block(
+                collection_name,
+                &collection,
+                &blockstore,
+                &headstore,
+                block_result.cid,
+                sign_config.as_ref(),
+            )
+            .await?;
 
             (doc_id, block_result.cid, block_result.block, col_block_data)
         };
@@ -502,31 +486,15 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
             )
             .await?;
 
-            let mut col_block_data: Option<(Cid, Vec<u8>)> = None;
-            if collection.schema().is_branchable {
-                let short_id = collection.resolved_root_id();
-                match write_collection_block(
-                    &blockstore,
-                    &headstore,
-                    short_id,
-                    schema_version_id,
-                    block_result.cid,
-                    sign_config.as_ref(),
-                )
-                .await
-                {
-                    Ok((col_cid, col_bytes)) => {
-                        col_block_data = Some((col_cid, col_bytes));
-                    }
-                    Err(error) => {
-                        warn!(
-                            collection = %collection_name,
-                            error = %error,
-                            "Failed to write collection block for transaction update"
-                        );
-                    }
-                }
-            }
+            let col_block_data = write_branchable_collection_block(
+                collection_name,
+                &collection,
+                &blockstore,
+                &headstore,
+                block_result.cid,
+                sign_config.as_ref(),
+            )
+            .await?;
 
             (block_result.cid, block_result.block, col_block_data)
         };
@@ -628,31 +596,15 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
             .await
             .map_err(|e| query::error::QueryError::execution(e.to_string()))?;
 
-            let mut col_block_data: Option<(Cid, Vec<u8>)> = None;
-            if collection.schema().is_branchable {
-                let short_id = collection.resolved_root_id();
-                match write_collection_block(
-                    &blockstore,
-                    &headstore,
-                    short_id,
-                    schema_version_id,
-                    block_result.cid,
-                    sign_config.as_ref(),
-                )
-                .await
-                {
-                    Ok((col_cid, col_bytes)) => {
-                        col_block_data = Some((col_cid, col_bytes));
-                    }
-                    Err(error) => {
-                        warn!(
-                            collection = %collection_name,
-                            error = %error,
-                            "Failed to write collection block for transaction delete"
-                        );
-                    }
-                }
-            }
+            let col_block_data = write_branchable_collection_block(
+                collection_name,
+                &collection,
+                &blockstore,
+                &headstore,
+                block_result.cid,
+                sign_config.as_ref(),
+            )
+            .await?;
 
             (block_result.cid, block_result.block, col_block_data)
         };

--- a/crates/db/src/doc_mutator_tests.rs
+++ b/crates/db/src/doc_mutator_tests.rs
@@ -3,6 +3,7 @@ use acp::{DocumentACP, LocalDocumentACP, MemoryAcpStore};
 use document::NormalValue;
 use events::{Bus, ChannelBus, EventName};
 use query::mutator::DocMutator;
+use query::runner::DocFetcher;
 use schema::{CType, CollectionVersion, FieldDescription, FieldKind, PolicyDescription};
 use storage::backends::MemoryStore;
 
@@ -23,6 +24,113 @@ fn test_collection() -> CollectionVersion {
             FieldDescription::new("2", "x", FieldKind::int()),
         ],
     )
+}
+
+fn branchable_collection() -> CollectionVersion {
+    CollectionVersion::new(
+        "Branchable",
+        "branchable-v1",
+        "col-branchable",
+        vec![
+            FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+            FieldDescription::new("2", "x", FieldKind::int()),
+        ],
+    )
+    .as_branchable()
+}
+
+struct FailingCollectionSigner;
+
+impl defra_core::signing::RemoteSigner for FailingCollectionSigner {
+    fn sign_sync(
+        &self,
+        data: &[u8],
+        _authorization: Option<&defra_core::signing::SigningAuthorization>,
+    ) -> Result<Vec<u8>, String> {
+        let block =
+            defra_core::block::Block::from_dag_cbor(data).map_err(|error| error.to_string())?;
+        if matches!(block.delta, defra_core::block::CrdtDelta::Collection(_)) {
+            return Err("injected collection signing failure".to_string());
+        }
+        Ok(vec![0; 64])
+    }
+}
+
+fn failing_collection_signing_config() -> defra_core::signing::SigningConfig {
+    defra_core::signing::SigningConfig {
+        key_type: defra_core::signing::SigningKeyType::Ed25519,
+        private_key_bytes: Vec::new(),
+        public_key_bytes: Vec::new(),
+        public_key_hex: "test".to_string(),
+        remote_signer: Some(Arc::new(FailingCollectionSigner)),
+        signing_authorization: None,
+    }
+}
+
+#[tokio::test]
+async fn branchable_create_rolls_back_when_collection_block_fails() {
+    let (db, _bus) = make_test_db_with_bus().await;
+    db.create_collection(branchable_collection()).await.unwrap();
+    let mutator = crate::AutoCommitMutator::new(Arc::clone(&db));
+
+    defra_core::signing::set_signing_config(Some(failing_collection_signing_config()));
+    let result = mutator
+        .create(
+            "Branchable",
+            Document::from_json_str(r#"{"x": 1}"#).unwrap(),
+        )
+        .await;
+    defra_core::signing::set_signing_config(None);
+
+    let error = result.expect_err("collection block failure must fail create");
+    assert!(error
+        .to_string()
+        .contains("injected collection signing failure"));
+
+    let fetcher = crate::LensedAutoCommitFetcher::new(Arc::clone(&db));
+    assert!(fetcher.get_all("Branchable").await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn branchable_update_rolls_back_when_collection_block_fails() {
+    let (db, _bus) = make_test_db_with_bus().await;
+    db.create_collection(branchable_collection()).await.unwrap();
+    let mutator = crate::AutoCommitMutator::new(Arc::clone(&db));
+    let created = mutator
+        .create(
+            "Branchable",
+            Document::from_json_str(r#"{"x": 1}"#).unwrap(),
+        )
+        .await
+        .unwrap();
+    let mut doc = mutator
+        .get_for_update("Branchable", &created.doc_id)
+        .await
+        .unwrap()
+        .unwrap();
+    doc.set("x", NormalValue::Int(2));
+
+    defra_core::signing::set_signing_config(Some(failing_collection_signing_config()));
+    let result = mutator
+        .update(
+            "Branchable",
+            doc,
+            std::iter::once("x".to_string()).collect(),
+        )
+        .await;
+    defra_core::signing::set_signing_config(None);
+
+    let error = result.expect_err("collection block failure must fail update");
+    assert!(error
+        .to_string()
+        .contains("injected collection signing failure"));
+
+    let persisted = mutator
+        .get_for_update("Branchable", &created.doc_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(persisted.get("x"), Some(&NormalValue::Int(1)));
 }
 
 fn counter_collection() -> CollectionVersion {


### PR DESCRIPTION
Closes #1351.

## Problem

Branchable mutations treated collection-DAG block failures as warnings and still committed their logical document changes. Auto-commit updates and deletes could also swallow document provenance failures, allowing successful mutations whose state was not CID-addressable or discoverable through durable branch catch-up.

## What changed

- Make branchable collection-block publication part of the mutation success boundary.
- Propagate document and delete block failures instead of returning successful results without commit artifacts.
- Apply the same provenance contract across auto-commit, multi-document, batch, and explicit transaction mutation paths.
- Centralize branchable collection-block error handling so every mutation mode uses the same behavior.
- Add fault-injection regressions proving failed branchable creates leave no document and failed updates preserve the previously committed value.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test -p db --lib` (188 passed)
- [x] `cargo test --workspace --lib`
- [x] Focused branchable provenance rollback tests
- [x] `git diff --check`