### PR TITLE
fix(p2p): drain pending-DAG sweeps on shutdown so the store unlocks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,16 @@ jobs:
       - run: cargo test -p telemetry --features otlp
       - run: cargo test -p cli --features otel --test telemetry_dedup
 
+      # defra-node's p2p suite is feature-gated, so the default-feature
+      # `cargo test --workspace` above skips it entirely and the only other
+      # reference to it is a clippy compile. Its restart/shutdown tests were
+      # therefore type-checked and discarded, which is how #1309 (sweep tasks
+      # outliving shutdown and holding the store lock) shipped green. Runs
+      # after caching, with the other feature-on steps, so a feature build
+      # never becomes the cached "standard" binary. Nodes bind port 0, so this
+      # is safe on the shared studio-1 slot.
+      - run: cargo test -p defra-node --features p2p
+
       - name: Cleanup
         if: always()
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,8 @@ tools/otel-smoke/output/
 
 # Claude (user-specific)
 .claude/
+.mcp.json
+AGENTS.md
+
+# Local docs
+docs/

--- a/crates/cli/src/commands/start/server_p2p/iroh.rs
+++ b/crates/cli/src/commands/start/server_p2p/iroh.rs
@@ -81,8 +81,11 @@ impl Node {
         coordinator
             .install_pending_dag_store(Arc::new(p2p::sync::PendingDagStore::new(store.clone())))
             .await;
+        // Spawned through the coordinator so shutdown drains them before the
+        // coordinator (and through it the store) is dropped; a bare
+        // tokio::spawn here outlives shutdown and keeps the store held (#1309).
         let coordinator_for_restore = coordinator.clone();
-        tokio::spawn(async move {
+        coordinator.spawn_background_task("pending_dag_resync", async move {
             coordinator_for_restore
                 .run_pending_dag_resync(std::time::Duration::from_secs(60))
                 .await;
@@ -91,7 +94,7 @@ impl Node {
         // Receiver's re-arm loop (#1116 stage 2): dispatches due pending
         // roots at a tight cadence. Sibling of the resync sweep above.
         let coordinator_for_retry_clock = coordinator.clone();
-        tokio::spawn(async move {
+        coordinator.spawn_background_task("pending_dag_retry_clock", async move {
             coordinator_for_retry_clock
                 .run_pending_dag_retry_clock(std::time::Duration::from_secs(2))
                 .await;

--- a/crates/cli/src/commands/start/server_p2p/iroh.rs
+++ b/crates/cli/src/commands/start/server_p2p/iroh.rs
@@ -81,24 +81,6 @@ impl Node {
         coordinator
             .install_pending_dag_store(Arc::new(p2p::sync::PendingDagStore::new(store.clone())))
             .await;
-        // Spawned through the coordinator so shutdown drains them before the
-        // coordinator (and through it the store) is dropped; a bare
-        // tokio::spawn here outlives shutdown and keeps the store held (#1309).
-        let coordinator_for_restore = coordinator.clone();
-        coordinator.spawn_background_task("pending_dag_resync", async move {
-            coordinator_for_restore
-                .run_pending_dag_resync(std::time::Duration::from_secs(60))
-                .await;
-        });
-
-        // Receiver's re-arm loop (#1116 stage 2): dispatches due pending
-        // roots at a tight cadence. Sibling of the resync sweep above.
-        let coordinator_for_retry_clock = coordinator.clone();
-        coordinator.spawn_background_task("pending_dag_retry_clock", async move {
-            coordinator_for_retry_clock
-                .run_pending_dag_retry_clock(std::time::Duration::from_secs(2))
-                .await;
-        });
         let coordinator_for_acp = coordinator.clone();
         let serve_acp_for_acp = serve_acp.clone();
         let database_for_acp = database.clone();
@@ -177,6 +159,28 @@ impl Node {
             )
             .await;
             info!("Replication loop stopped (iroh)");
+        });
+
+        // Started here, not earlier, for two reasons (#1309). These are managed
+        // tasks: nothing can drain them until the caller owns a shutdown handle,
+        // so spawning them before the last fallible step above would leak both
+        // sweeps (and through them the store) on any early return. And the sync
+        // event channel only has its consumer once the replication loop above is
+        // running, which is the same ordering defra-node's setup_p2p documents.
+        let coordinator_for_restore = coordinator.clone();
+        coordinator.spawn_background_task("pending_dag_resync", async move {
+            coordinator_for_restore
+                .run_pending_dag_resync(std::time::Duration::from_secs(60))
+                .await;
+        });
+
+        // Receiver's re-arm loop (#1116 stage 2): dispatches due pending
+        // roots at a tight cadence. Sibling of the resync sweep above.
+        let coordinator_for_retry_clock = coordinator.clone();
+        coordinator.spawn_background_task("pending_dag_retry_clock", async move {
+            coordinator_for_retry_clock
+                .run_pending_dag_retry_clock(std::time::Duration::from_secs(2))
+                .await;
         });
 
         let coordinator_for_events = coordinator.clone();

--- a/crates/cli/src/commands/start/server_p2p/libp2p.rs
+++ b/crates/cli/src/commands/start/server_p2p/libp2p.rs
@@ -76,8 +76,11 @@ impl Node {
         coordinator
             .install_pending_dag_store(Arc::new(p2p::sync::PendingDagStore::new(store.clone())))
             .await;
+        // Spawned through the coordinator so shutdown drains them before the
+        // coordinator (and through it the store) is dropped; a bare
+        // tokio::spawn here outlives shutdown and keeps the store held (#1309).
         let coordinator_for_restore = coordinator.clone();
-        tokio::spawn(async move {
+        coordinator.spawn_background_task("pending_dag_resync", async move {
             coordinator_for_restore
                 .run_pending_dag_resync(std::time::Duration::from_secs(60))
                 .await;
@@ -86,7 +89,7 @@ impl Node {
         // Receiver's re-arm loop (#1116 stage 2): dispatches due pending
         // roots at a tight cadence. Sibling of the resync sweep above.
         let coordinator_for_retry_clock = coordinator.clone();
-        tokio::spawn(async move {
+        coordinator.spawn_background_task("pending_dag_retry_clock", async move {
             coordinator_for_retry_clock
                 .run_pending_dag_retry_clock(std::time::Duration::from_secs(2))
                 .await;

--- a/crates/cli/src/commands/start/server_p2p/libp2p.rs
+++ b/crates/cli/src/commands/start/server_p2p/libp2p.rs
@@ -76,24 +76,6 @@ impl Node {
         coordinator
             .install_pending_dag_store(Arc::new(p2p::sync::PendingDagStore::new(store.clone())))
             .await;
-        // Spawned through the coordinator so shutdown drains them before the
-        // coordinator (and through it the store) is dropped; a bare
-        // tokio::spawn here outlives shutdown and keeps the store held (#1309).
-        let coordinator_for_restore = coordinator.clone();
-        coordinator.spawn_background_task("pending_dag_resync", async move {
-            coordinator_for_restore
-                .run_pending_dag_resync(std::time::Duration::from_secs(60))
-                .await;
-        });
-
-        // Receiver's re-arm loop (#1116 stage 2): dispatches due pending
-        // roots at a tight cadence. Sibling of the resync sweep above.
-        let coordinator_for_retry_clock = coordinator.clone();
-        coordinator.spawn_background_task("pending_dag_retry_clock", async move {
-            coordinator_for_retry_clock
-                .run_pending_dag_retry_clock(std::time::Duration::from_secs(2))
-                .await;
-        });
         let coordinator_for_acp = coordinator.clone();
         let serve_acp_for_acp = serve_acp.clone();
         let handle_for_acp = handle.clone();
@@ -233,6 +215,28 @@ impl Node {
             )
             .await;
             info!("Replication loop stopped");
+        });
+
+        // Started here, not earlier, for two reasons (#1309). These are managed
+        // tasks: nothing can drain them until the caller owns a shutdown handle,
+        // so spawning them before the last fallible step above would leak both
+        // sweeps (and through them the store) on any early return. And the sync
+        // event channel only has its consumer once the replication loop above is
+        // running, which is the same ordering defra-node's setup_p2p documents.
+        let coordinator_for_restore = coordinator.clone();
+        coordinator.spawn_background_task("pending_dag_resync", async move {
+            coordinator_for_restore
+                .run_pending_dag_resync(std::time::Duration::from_secs(60))
+                .await;
+        });
+
+        // Receiver's re-arm loop (#1116 stage 2): dispatches due pending
+        // roots at a tight cadence. Sibling of the resync sweep above.
+        let coordinator_for_retry_clock = coordinator.clone();
+        coordinator.spawn_background_task("pending_dag_retry_clock", async move {
+            coordinator_for_retry_clock
+                .run_pending_dag_retry_clock(std::time::Duration::from_secs(2))
+                .await;
         });
 
         let coordinator_for_events = coordinator.clone();

--- a/crates/defra-node/src/p2p_runtime.rs
+++ b/crates/defra-node/src/p2p_runtime.rs
@@ -264,8 +264,11 @@ pub(super) async fn setup_p2p<S: storage::corekv::Store + 'static>(
     // shutdown/crash, then keep sweeping periodically as the bounded
     // drain for records skipped at capacity or TTL-evicted (#1099).
     // Spawned so the sync-event channel already has its consumer above.
+    // Spawned through the coordinator so shutdown drains them before the
+    // coordinator (and through it the store) is dropped; a bare tokio::spawn
+    // here outlives shutdown and keeps the data path locked (#1309).
     let coord_for_restore = coordinator.clone();
-    tokio::spawn(async move {
+    coordinator.spawn_background_task("pending_dag_resync", async move {
         coord_for_restore
             .run_pending_dag_resync(std::time::Duration::from_secs(60))
             .await;
@@ -274,7 +277,7 @@ pub(super) async fn setup_p2p<S: storage::corekv::Store + 'static>(
     // Receiver's re-arm loop (#1116 stage 2): dispatches due pending
     // roots at a tight cadence. Sibling of the resync sweep above.
     let coord_for_retry_clock = coordinator.clone();
-    tokio::spawn(async move {
+    coordinator.spawn_background_task("pending_dag_retry_clock", async move {
         coord_for_retry_clock
             .run_pending_dag_retry_clock(std::time::Duration::from_secs(2))
             .await;

--- a/crates/defra-node/src/p2p_tests.rs
+++ b/crates/defra-node/src/p2p_tests.rs
@@ -1735,3 +1735,59 @@ async fn filtered_backfill_via_transport_pusher_respects_predicate() {
     sender.shutdown().await;
     receiver.shutdown().await;
 }
+
+/// #1309: `shutdown()` must release the store before it returns.
+///
+/// The pending-DAG resync sweep (60s) and retry clock (2s) each held an
+/// `Arc<SyncCoordinator>`, and through it the storage handle, because their
+/// task handles were discarded at spawn. Shutdown could not reach them, so
+/// reopening the same data path failed with the backend reporting the file
+/// locked for up to a sweep interval. No retry and no sleep here on purpose:
+/// a bounded-deadline reopen would pass either way and prove nothing.
+#[tokio::test]
+async fn p2p_shutdown_releases_store_for_immediate_reopen() {
+    init_tracing();
+
+    let data_path = unique_data_path("p2p-shutdown-reopen");
+    let secret_key_path = data_path.join("p2p.key");
+
+    let node = build_persistent_p2p_node(data_path.clone(), secret_key_path.clone()).await;
+
+    // The sweeps must be visible to the coordinator's task registry, which is
+    // what shutdown drains. Before the fix they were spawned bare and appeared
+    // in no accounting at all.
+    let status = node
+        .p2p()
+        .expect("p2p")
+        .sync_status()
+        .await
+        .expect("sync status");
+    let retained = status["retained_background_tasks"]
+        .as_u64()
+        .expect("retained_background_tasks");
+    assert!(
+        retained >= 2,
+        "the resync sweep and retry clock must be registered, got {retained}"
+    );
+
+    node.shutdown().await;
+    drop(node);
+
+    let reopened = EmbeddedNode::builder()
+        .data_path(data_path.clone())
+        .with_p2p(persistent_p2p_config(secret_key_path))
+        .build()
+        .await;
+
+    let reopened = match reopened {
+        Ok(node) => node,
+        Err(error) => {
+            let _ = std::fs::remove_dir_all(&data_path);
+            panic!("reopen after shutdown must not race the pending-DAG sweeps: {error}");
+        }
+    };
+
+    reopened.shutdown().await;
+    drop(reopened);
+    let _ = std::fs::remove_dir_all(&data_path);
+}

--- a/crates/p2p/src/sync/coordinator/mod.rs
+++ b/crates/p2p/src/sync/coordinator/mod.rs
@@ -70,7 +70,7 @@ use acp::DocumentACP;
 use blockstore::Blockstore;
 use cid::Cid;
 use parking_lot::Mutex;
-use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio::sync::{Notify, OwnedSemaphorePermit, Semaphore};
 use tokio::task::JoinHandle;
 
 use crate::bitswap::{AccessMode, ReplicatorRegistry};
@@ -157,6 +157,12 @@ pub struct SyncStatus {
 
 struct SyncShutdownState {
     is_shutting_down: AtomicBool,
+    /// Wakes tasks parked in [`SyncShutdownHandle::cancelled`] the moment
+    /// shutdown begins, so a periodic loop exits on the signal instead of at
+    /// the end of its sleep. Carries no state of its own; `is_shutting_down`
+    /// remains the single source of truth and stays a plain atomic because it
+    /// is read on hot paths.
+    shutdown_notify: Notify,
     background_tasks: Mutex<Vec<JoinHandle<()>>>,
     /// Long-lived poll fetches keyed by pending-DAG root. The retry clock may
     /// re-emit a root before its previous bounded fetch has exhausted all
@@ -236,6 +242,7 @@ impl SyncShutdownHandle {
         Self {
             inner: Arc::new(SyncShutdownState {
                 is_shutting_down: AtomicBool::new(false),
+                shutdown_notify: Notify::new(),
                 background_tasks: Mutex::new(Vec::new()),
                 pending_dag_fetch_tasks: Mutex::new(HashMap::new()),
             }),
@@ -243,11 +250,40 @@ impl SyncShutdownHandle {
     }
 
     fn begin_shutdown(&self) -> bool {
-        !self.inner.is_shutting_down.swap(true, Ordering::AcqRel)
+        let won = !self.inner.is_shutting_down.swap(true, Ordering::AcqRel);
+        if won {
+            // Wake every parked `cancelled()` waiter. Ordering matters: the
+            // flag is set first, so a waiter that registers between the swap
+            // and this call observes the flag and never parks.
+            self.inner.shutdown_notify.notify_waiters();
+        }
+        won
     }
 
     pub fn is_shutting_down(&self) -> bool {
         self.inner.is_shutting_down.load(Ordering::Acquire)
+    }
+
+    /// Resolves as soon as shutdown begins, and immediately if it already has.
+    ///
+    /// Periodic loops select on this against their sleep so they exit on the
+    /// signal rather than at the end of an interval, matching Go's
+    /// `select { case <-ctx.Done(): ... }` shape in
+    /// `internal/db/p2p/replicator.go`.
+    pub async fn cancelled(&self) {
+        // Register before observing the flag: a `notify_waiters` that lands
+        // after this point wakes us, and one that landed before it is
+        // reflected in the flag we are about to read. Checking first would
+        // leave a window where neither happens and the caller parks forever.
+        let notified = self.inner.shutdown_notify.notified();
+        tokio::pin!(notified);
+        notified.as_mut().enable();
+
+        if self.is_shutting_down() {
+            return;
+        }
+
+        notified.await;
     }
 
     pub async fn shutdown(&self) {
@@ -531,7 +567,10 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 return;
             }
             self.manager.resync_persisted_pending_dags().await;
-            tokio::time::sleep(interval).await;
+            tokio::select! {
+                _ = tokio::time::sleep(interval) => {}
+                _ = self.runtime.shutdown.cancelled() => return,
+            }
         }
     }
 
@@ -547,7 +586,10 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             if self.runtime.shutdown.is_shutting_down() {
                 return;
             }
-            tokio::time::sleep(interval).await;
+            tokio::select! {
+                _ = tokio::time::sleep(interval) => {}
+                _ = self.runtime.shutdown.cancelled() => return,
+            }
             let due = self
                 .manager
                 .claim_due_pending_dag_retries(tokio::time::Instant::now());
@@ -833,5 +875,79 @@ mod shutdown_tests {
             "shutdown should use one shared deadline, got {:?}",
             elapsed
         );
+    }
+
+    /// #1309: a periodic loop must exit on the shutdown signal, not at the end
+    /// of its sleep. The pending-DAG sweeps used a bare `sleep(interval)`, so a
+    /// task spawned before shutdown kept its `Arc<SyncCoordinator>` (and through
+    /// it the store) alive for up to the interval: 60s for the resync sweep.
+    ///
+    /// The interval here is an hour on purpose. Without the cancellation arm
+    /// this test cannot pass by waiting; it can only pass by being woken.
+    #[tokio::test]
+    async fn periodic_loop_exits_on_the_signal_not_the_interval() {
+        let shutdown = SyncShutdownHandle::new();
+        let exited = Arc::new(AtomicBool::new(false));
+
+        let loop_shutdown = shutdown.clone();
+        let loop_exited = Arc::clone(&exited);
+        let task = tokio::spawn(async move {
+            loop {
+                if loop_shutdown.is_shutting_down() {
+                    break;
+                }
+                tokio::select! {
+                    _ = tokio::time::sleep(Duration::from_secs(3600)) => {}
+                    _ = loop_shutdown.cancelled() => break,
+                }
+            }
+            loop_exited.store(true, Ordering::SeqCst);
+        });
+
+        // Let the loop reach its sleep so the wakeup, not the entry check, is
+        // what ends it.
+        tokio::task::yield_now().await;
+        assert!(
+            !exited.load(Ordering::SeqCst),
+            "loop must still be parked before shutdown is signalled"
+        );
+
+        shutdown.shutdown().await;
+
+        tokio::time::timeout(Duration::from_secs(5), task)
+            .await
+            .expect("loop must wake on the signal, not wait out its interval")
+            .expect("loop task should not panic");
+        assert!(exited.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn cancelled_returns_immediately_when_shutdown_already_began() {
+        let shutdown = SyncShutdownHandle::new();
+        shutdown.shutdown().await;
+
+        tokio::time::timeout(Duration::from_secs(5), shutdown.cancelled())
+            .await
+            .expect("cancelled() must not park once shutdown has begun");
+    }
+
+    /// The register-then-check ordering in `cancelled()` is what makes this
+    /// pass: a waiter that observed the flag as false must still be woken by
+    /// the `notify_waiters` that follows the flag store.
+    #[tokio::test]
+    async fn cancelled_does_not_miss_a_shutdown_racing_its_registration() {
+        for _ in 0..256 {
+            let shutdown = SyncShutdownHandle::new();
+            let waiter_shutdown = shutdown.clone();
+            let waiter = tokio::spawn(async move { waiter_shutdown.cancelled().await });
+
+            let signaller = tokio::spawn(async move { shutdown.shutdown().await });
+
+            tokio::time::timeout(Duration::from_secs(5), waiter)
+                .await
+                .expect("cancelled() lost the wakeup and parked forever")
+                .expect("waiter should not panic");
+            signaller.await.expect("signaller should not panic");
+        }
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "stable"
+components = ["rustfmt", "clippy", "rust-src"]
+profile = "default"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "stable"
-components = ["rustfmt", "clippy", "rust-src"]
+components = ["rustfmt", "clippy"]
 profile = "default"


### PR DESCRIPTION
Fixes #1309.

## Problem

The two pending-DAG sweep loops were spawned with a bare `tokio::spawn` and their
handles discarded, so `shutdown()` could not reach them. Each kept an
`Arc<SyncCoordinator>`, and through it the storage handle, until its next wake:
up to 60s for the resync sweep. Reopening the same data path right after
shutdown failed with the backend reporting the file locked.

Both loops also checked the shutdown flag only at the top of each iteration and
then slept, so the flag could not fire during the sleep.

## Fix

Cancel, then wait, matching the Go reference. Go's `internal/db/db.go:70` names
the same hazard ("so the worker does not outlive the rootstore") and pairs
`ctxCancel()` with `recoveryWG.Wait()`; its loops select on `ctx.Done()`
(`internal/db/p2p/replicator.go:445`).

- **Cancel**: a `Notify` on `SyncShutdownState`, signalled by `begin_shutdown`,
  exposed as `SyncShutdownHandle::cancelled()`. Both sweeps now `select!` on it
  against their sleep. `cancelled()` registers before reading the flag so a
  shutdown racing the call cannot be missed; `is_shutting_down()` stays a plain
  atomic because it is read on hot paths.
- **Wait**: both sweeps are spawned via `SyncCoordinator::spawn_background_task`,
  the existing public API whose registry `coordinator.shutdown()` already drains
  before the coordinator is dropped. No new lifecycle machinery.

## Scope is wider than the issue states

`run_pending_dag_resync` has five callers, not one. `crates/embedded` already
tracked both handles and stopped them with `abort_and_join`, so it was correct
and is unchanged. Three sites discarded them and are fixed here:

| Site | Before |
|---|---|
| `defra-node/src/p2p_runtime.rs` | discarded |
| `cli/.../server_p2p/iroh.rs` | discarded |
| `cli/.../server_p2p/libp2p.rs` | discarded |

## Verification

Red before, green after, demonstrated by stashing only the two fix files:

```
failed to open redb store: backend error: database '/tmp/.../data.redb'
is locked by another process
```

| Test | on `main` | here |
|---|---|---|
| `p2p_document_subscriptions_survive_restart_and_delete` (existing) | FAILED | ok |
| `p2p_replicator_survives_embedded_restart` (existing) | FAILED | ok |
| `p2p_shutdown_releases_store_for_immediate_reopen` (new) | FAILED | ok |

The two existing tests were **already failing on `main`**. Nothing in CI has
ever executed them: `cargo test --workspace` runs with default features and
`defra-node`'s `p2p` feature is off, while `ci.yml:85` only clippy-compiles the
module. This PR adds `cargo test -p defra-node --features p2p` so the suite
actually runs. Same shape as #1349, in a second crate.

Also added in `crates/p2p`: a loop test with a one hour interval, so it can only
pass by being woken rather than by waiting, and a 256-iteration probe for the
`cancelled()` registration race.

## Deferred

In-flight cancellation of `resync_persisted_pending_dags()` is not included: it
takes no cancellation parameter, so a sweep already inside the walk finishes it.
The drain bounds that to one walk rather than one interval. Tracked with the
other uninterruptible-sleep sites in #1356.

## Notes for review

- `cargo fmt --all --check` clean. `cargo test -p p2p` 444 passed. `cargo test
  -p defra-node --features p2p` green. `cargo clippy -p defra-node --features
  p2p --all-targets` clean.
- `cargo clippy --all --all-targets` is red on three pre-existing
  `useless_borrows_in_formatting` errors in `tools/integration-test`, unrelated
  to this branch and untouched here. CI does not catch them because `ci.yml:66`
  omits `--all-targets`.
- The third commit pins `rust-toolchain.toml` and adds local tooling ignores. It
  declares no `targets`, so a fresh clone still needs `rustup target add
  wasm32-unknown-unknown` to reproduce the wasm clippy job.
