### PR TITLE
build: add a documented justfile with a no-sudo setup target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ AGENTS.md
 
 # Local docs
 docs/
+
+# Local dev tooling installed by `just setup`
+.tooling/

--- a/README.md
+++ b/README.md
@@ -27,15 +27,25 @@ Compatible with Go DefraDB v1.0.0-rc1. Full feature parity across CLI, HTTP API,
 Install [`just`](https://github.com/casey/just), then let it install everything else:
 
 ```bash
-cargo install just    # one time
+cargo install just    # one time, if you already have a Rust toolchain
 just setup            # Rust, protoc, Go, a JDK, Lean/lake, the TLC jar, wasm tooling
 ```
 
+Without Rust yet, install a prebuilt `just` first, since `just setup` is what
+installs the toolchain:
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh \
+  | bash -s -- --to ~/.local/bin      # or grab a binary from the just releases page
+```
+
 `just setup` needs no root and no package manager: every tool is fetched from its
-official release into a git-ignored `.tooling/` inside the repo and put on `PATH`,
-so it behaves identically on any Linux distribution and on macOS, x86_64 or arm64.
-Versions are pinned to the ones CI uses. `just doctor` reports what resolved and
-what is missing.
+official release into a git-ignored `.tooling/` inside the repo and put on `PATH`.
+It is written for Linux and macOS on x86_64 and arm64, and is currently verified
+on Linux x86_64. Downloads are pinned by version and checked against a SHA-256
+before use. The host needs `bash`, `curl`, `tar`, `unzip` and `git`.
+
+`just doctor` reports what resolved and what is missing.
 
 ```bash
 just build             # Build all crates

--- a/README.md
+++ b/README.md
@@ -24,13 +24,30 @@ Compatible with Go DefraDB v1.0.0-rc1. Full feature parity across CLI, HTTP API,
 
 ## Building
 
+Install [`just`](https://github.com/casey/just), then let it install everything else:
+
 ```bash
-cargo build                            # Build all crates
-cargo build --release -p cli           # Release binary
-cargo test                             # Unit tests
-cargo clippy --all -- -D warnings      # Lint
-cargo fmt --all                        # Format
+cargo install just    # one time
+just setup            # Rust, protoc, Go, a JDK, Lean/lake, the TLC jar, wasm tooling
 ```
+
+`just setup` needs no root and no package manager: every tool is fetched from its
+official release into a git-ignored `.tooling/` inside the repo and put on `PATH`,
+so it behaves identically on any Linux distribution and on macOS, x86_64 or arm64.
+Versions are pinned to the ones CI uses. `just doctor` reports what resolved and
+what is missing.
+
+```bash
+just build             # Build all crates
+just build-release     # Release binary
+just test              # Unit tests
+just lint              # Lint (every clippy invocation CI runs)
+just fmt               # Format
+just gate              # fmt + lint + docs + tests, before asking for a review
+just ci                # Reproduce the CI pipeline locally
+```
+
+Run `just` on its own to list every target, grouped.
 
 ## Configuration
 

--- a/justfile
+++ b/justfile
@@ -24,16 +24,29 @@ jdk_root    := tooling / "jdk"
 # TLC 1.8.0 by checksum.
 protoc_version := "35.1"
 go_version     := "1.25.12"
-jdk_version    := "21"
+jdk_release    := "jdk-21.0.12+8"
+jq_version     := "1.8.1"
 tla_version    := "1.8.0"
 tla_sha256     := "e22f8ffb4bacdea0a871f444dd94fe5fb0d8013b3388ae39e82e26f852c735d5"
+
+# protoc publishes no per-asset checksum file, so its hashes are embedded.
+# Go and Temurin publish theirs, and are verified against upstream at install
+# time rather than duplicated here.
+protoc_sha256_linux_x86_64  := "6930ebf62bd4ea607b98fff052596c6ee564b9835b4ce172c75a3f53ae9d91b7"
+protoc_sha256_linux_aarch64 := "01bf9d08808c7f96678b63f4bd8efa559bb4f83d5a7a270d5edaf507f9d5d9cf"
+protoc_sha256_osx_x86_64    := "537d73604a344ded6fc94e98e07e529d4fe3e4a0b09e59905353950fafc2a1f7"
+protoc_sha256_osx_aarch64   := "193289af0470c6a1aada357d4fba0bbf8d78bfaac8b5e42ca30af2ef75583de2"
 
 # .tooling/bin wins over the system copies, so a repo-local protoc/java/go is
 # used even when the distro ships an older one. elan installs lake into its own
 # home rather than .tooling, so that bin directory has to be on PATH too or
 # `just lean` cannot find lake after `just setup`.
-elan_bin := env('ELAN_HOME', home_directory() / ".elan") / "bin"
-export PATH := tooling_bin + ":" + go_root + "/bin" + ":" + elan_bin + ":" + env('PATH')
+# rustup is installed with --no-modify-path, so cargo's bin directory is only
+# on PATH if the user already had it. Without this, every recipe after
+# setup-rust fails to find cargo on a fresh machine.
+cargo_bin := env('CARGO_HOME', home_directory() / ".cargo") / "bin"
+elan_bin  := env('ELAN_HOME', home_directory() / ".elan") / "bin"
+export PATH := tooling_bin + ":" + go_root + "/bin" + ":" + cargo_bin + ":" + elan_bin + ":" + env('PATH')
 
 # Integration areas, each a [[test]] binary in tools/integration-test.
 integration_suites := "basic query acp nac p2p encryption identity backup sourcehub hubrs fts p2p_iroh cursor"
@@ -41,17 +54,30 @@ integration_suites := "basic query acp nac p2p encryption identity backup source
 _default:
     @just --list --unsorted
 
+# sha256 of a file, portable across Linux (sha256sum) and macOS (shasum).
+[private]
+_sha256 file:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if command -v sha256sum >/dev/null 2>&1; then sha256sum "{{ file }}" | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then shasum -a 256 "{{ file }}" | awk '{print $1}'
+    else echo "error: no sha256 tool found" >&2; exit 1; fi
+
 # ---------------------------------------------------------------------------
 # Setup
 # ---------------------------------------------------------------------------
 
 # Install every dependency needed to develop, test and verify the database.
 [group('setup')]
-setup: setup-rust setup-cargo-tools setup-protoc setup-go setup-jdk setup-lean setup-tla
+setup: setup-rust setup-jq setup-cargo-tools setup-protoc setup-go setup-jdk setup-lean setup-tla
     @echo
     @just doctor
 
 # Rust toolchain, the components CI needs, and the wasm target.
+#
+# Trust boundary: this and setup-lean pipe an upstream install script into sh
+# (rustup.rs, elan-init.sh), which is how both ecosystems distribute. Every
+# other tool here is fetched as an archive and checksum-verified.
 [doc("Rust toolchain, CI's components, and the wasm32 target.")]
 [group('setup')]
 setup-rust:
@@ -69,6 +95,31 @@ setup-rust:
     rustup target add --toolchain stable wasm32-unknown-unknown
     echo "rust: $(rustc --version)"
 
+# jq is required by setup-cargo-tools (lockfile-matched wasm-bindgen) and by
+# setup-jdk (Temurin checksum lookup). Installed rather than assumed, so a host
+# without it does not silently skip those steps.
+[doc("jq, used by the wasm-bindgen and JDK checksum lookups.")]
+[group('setup')]
+setup-jq:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if command -v jq >/dev/null 2>&1; then echo "jq: $(jq --version)"; exit 0; fi
+    case "$(uname -s)" in
+        Linux)  os=linux ;;
+        Darwin) os=macos ;;
+        *) echo "unsupported OS: $(uname -s)" >&2; exit 1 ;;
+    esac
+    case "$(uname -m)" in
+        x86_64|amd64)  arch=amd64 ;;
+        aarch64|arm64) arch=arm64 ;;
+        *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
+    esac
+    mkdir -p "{{ tooling_bin }}"
+    curl -fsSL -o "{{ tooling_bin }}/jq" \
+        "https://github.com/jqlang/jq/releases/download/jq-{{ jq_version }}/jq-${os}-${arch}"
+    chmod 0755 "{{ tooling_bin }}/jq"
+    echo "jq: $({{ tooling_bin }}/jq --version)"
+
 # cbindgen generates the FFI C header; wasm-pack and wasm-bindgen-cli build and
 # test the browser client. wasm-bindgen-cli must match the wasm-bindgen version
 # in Cargo.lock exactly or the test runner refuses the module, so it is derived
@@ -80,16 +131,19 @@ setup-cargo-tools:
     set -euo pipefail
     command -v cbindgen  >/dev/null 2>&1 || cargo install cbindgen --locked
     command -v wasm-pack >/dev/null 2>&1 || cargo install wasm-pack --locked
-    wb_version="$(cargo metadata --format-version 1 --filter-platform wasm32-unknown-unknown 2>/dev/null \
-        | jq -r '.packages[] | select(.name=="wasm-bindgen") | .version' | head -1 || true)"
-    if [ -n "${wb_version:-}" ]; then
-        have="$(wasm-bindgen --version 2>/dev/null | awk '{print $2}' || true)"
-        if [ "${have:-none}" != "$wb_version" ]; then
-            cargo install wasm-bindgen-cli --version "$wb_version" --locked
-        fi
-    else
-        echo "note: wasm-bindgen not in the dependency graph; skipping wasm-bindgen-cli" >&2
+    command -v jq >/dev/null 2>&1 || { echo "error: jq is required; run 'just setup-jq'" >&2; exit 1; }
+    meta="$(cargo metadata --format-version 1 --filter-platform wasm32-unknown-unknown)"
+    wb_version="$(echo "$meta" | jq -r '.packages[] | select(.name=="wasm-bindgen") | .version' | head -1)"
+    if [ -z "$wb_version" ] || [ "$wb_version" = "null" ]; then
+        echo "error: wasm-bindgen not found in the wasm32 dependency graph" >&2
+        echo "       wasm tests cannot run without a matching wasm-bindgen-cli" >&2
+        exit 1
     fi
+    have="$(wasm-bindgen --version 2>/dev/null | awk '{print $2}' || true)"
+    if [ "${have:-none}" != "$wb_version" ]; then
+        cargo install wasm-bindgen-cli --version "$wb_version" --locked
+    fi
+    echo "wasm-bindgen-cli: $wb_version (matched to Cargo.lock)"
 
 # protoc, required by crates/orbis's build.rs (proto/orbis.proto via tonic-prost-build).
 [doc("protoc, required by crates/orbis's build.rs.")]
@@ -98,7 +152,11 @@ setup-protoc:
     #!/usr/bin/env bash
     set -euo pipefail
     target="{{ tooling_bin }}/protoc"
-    if [ -x "$target" ]; then echo "protoc: already installed"; exit 0; fi
+    # Re-fetch when the installed copy does not match the pin, so bumping
+    # protoc_version takes effect without a clean-tooling.
+    if [ -x "$target" ] && "$target" --version 2>/dev/null | grep -q " {{ protoc_version }}$"; then
+        echo "protoc: {{ protoc_version }} already installed"; exit 0
+    fi
     case "$(uname -s)" in
         Linux)  os=linux ;;
         Darwin) os=osx ;;
@@ -109,14 +167,26 @@ setup-protoc:
         aarch64|arm64) arch=aarch_64 ;;
         *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
     esac
+    case "${os}-${arch}" in
+        linux-x86_64)  want="{{ protoc_sha256_linux_x86_64 }}" ;;
+        linux-aarch_64) want="{{ protoc_sha256_linux_aarch64 }}" ;;
+        osx-x86_64)    want="{{ protoc_sha256_osx_x86_64 }}" ;;
+        osx-aarch_64)  want="{{ protoc_sha256_osx_aarch64 }}" ;;
+    esac
     url="https://github.com/protocolbuffers/protobuf/releases/download/v{{ protoc_version }}/protoc-{{ protoc_version }}-${os}-${arch}.zip"
     tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
     echo "fetching protoc {{ protoc_version }} for ${os}-${arch}"
     curl -fsSL -o "$tmp/protoc.zip" "$url"
+    got="$(just _sha256 "$tmp/protoc.zip")"
+    [ "$got" = "$want" ] || { echo "error: protoc checksum mismatch" >&2; echo "  expected $want" >&2; echo "  got      $got" >&2; exit 1; }
     unzip -q "$tmp/protoc.zip" -d "$tmp/out"
-    mkdir -p "{{ tooling_bin }}" "{{ tooling }}/protoc"
-    cp -R "$tmp/out/include" "{{ tooling }}/protoc/"
-    install -m 0755 "$tmp/out/bin/protoc" "$target"
+    # Upstream layout: prefix/bin/protoc next to prefix/include, so protoc
+    # resolves the well-known google/protobuf/*.proto imports via ../include.
+    rm -rf "{{ tooling }}/protoc"
+    mkdir -p "{{ tooling }}/protoc" "{{ tooling_bin }}"
+    cp -R "$tmp/out/bin" "$tmp/out/include" "{{ tooling }}/protoc/"
+    chmod 0755 "{{ tooling }}/protoc/bin/protoc"
+    ln -sf "{{ tooling }}/protoc/bin/protoc" "$target"
     echo "protoc: $("$target" --version)"
 
 # Go, for the FFI compatibility harness and the Go-parity integration suites.
@@ -125,7 +195,9 @@ setup-protoc:
 setup-go:
     #!/usr/bin/env bash
     set -euo pipefail
-    if [ -x "{{ go_root }}/bin/go" ]; then echo "go: already installed"; exit 0; fi
+    if [ -x "{{ go_root }}/bin/go" ] && "{{ go_root }}/bin/go" version 2>/dev/null | grep -q "go{{ go_version }} "; then
+        echo "go: {{ go_version }} already installed"; exit 0
+    fi
     case "$(uname -s)" in
         Linux)  os=linux ;;
         Darwin) os=darwin ;;
@@ -140,6 +212,15 @@ setup-go:
     tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
     echo "fetching go {{ go_version }} for ${os}-${arch}"
     curl -fsSL -o "$tmp/go.tar.gz" "$url"
+    # go.dev's download index carries a sha256 per file; verify rather than
+    # trust. (The .sha256 sibling URL redirects to an HTML page, not a digest.)
+    command -v jq >/dev/null 2>&1 || { echo "error: jq is required; run 'just setup-jq'" >&2; exit 1; }
+    want="$(curl -fsS "https://go.dev/dl/?mode=json&include=all" \
+        | jq -r --arg f "go{{ go_version }}.${os}-${arch}.tar.gz" \
+            '.[].files[] | select(.filename==$f) | .sha256' | head -1)"
+    [ -n "$want" ] && [ "$want" != "null" ] || { echo "error: no published checksum for go{{ go_version }} ${os}-${arch}" >&2; exit 1; }
+    got="$(just _sha256 "$tmp/go.tar.gz")"
+    [ "$got" = "$want" ] || { echo "error: go checksum mismatch" >&2; echo "  expected $want" >&2; echo "  got      $got" >&2; exit 1; }
     mkdir -p "{{ tooling }}"
     rm -rf "{{ go_root }}"
     tar -C "{{ tooling }}" -xzf "$tmp/go.tar.gz"
@@ -151,7 +232,12 @@ setup-go:
 setup-jdk:
     #!/usr/bin/env bash
     set -euo pipefail
-    if [ -x "{{ jdk_root }}/bin/java" ]; then echo "jdk: already installed"; exit 0; fi
+    # Version-stamped so bumping jdk_release re-fetches instead of short-circuiting.
+    stamp="{{ jdk_root }}/.release"
+    if [ -x "{{ jdk_root }}/bin/java" ] && [ "$(cat "$stamp" 2>/dev/null)" = "{{ jdk_release }}" ]; then
+        echo "jdk: {{ jdk_release }} already installed"; exit 0
+    fi
+    command -v jq >/dev/null 2>&1 || { echo "error: jq is required; run 'just setup-jq'" >&2; exit 1; }
     case "$(uname -s)" in
         Linux)  os=linux ;;
         Darwin) os=mac ;;
@@ -162,10 +248,18 @@ setup-jdk:
         aarch64|arm64) arch=aarch64 ;;
         *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
     esac
-    url="https://api.adoptium.net/v3/binary/latest/{{ jdk_version }}/ga/${os}/${arch}/jdk/hotspot/normal/eclipse"
+    # A pinned release, not Adoptium's floating "latest" stream, and the
+    # checksum Adoptium publishes for exactly that asset.
+    rel_enc="$(printf '%s' "{{ jdk_release }}" | sed 's/+/%2B/')"
+    url="https://api.adoptium.net/v3/binary/version/${rel_enc}/${os}/${arch}/jdk/hotspot/normal/eclipse"
+    want="$(curl -fsSL "https://api.adoptium.net/v3/assets/release_name/eclipse/${rel_enc}?os=${os}&architecture=${arch}&image_type=jdk" \
+        | jq -r '.binaries[0].package.checksum')"
+    [ -n "$want" ] && [ "$want" != "null" ] || { echo "error: no published checksum for {{ jdk_release }} ${os}-${arch}" >&2; exit 1; }
     tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
-    echo "fetching Temurin JDK {{ jdk_version }} for ${os}-${arch}"
+    echo "fetching Temurin {{ jdk_release }} for ${os}-${arch}"
     curl -fsSL -o "$tmp/jdk.tar.gz" "$url"
+    got="$(just _sha256 "$tmp/jdk.tar.gz")"
+    [ "$got" = "$want" ] || { echo "error: JDK checksum mismatch" >&2; echo "  expected $want" >&2; echo "  got      $got" >&2; exit 1; }
     mkdir -p "$tmp/x" "{{ tooling_bin }}"
     tar -C "$tmp/x" -xzf "$tmp/jdk.tar.gz"
     rm -rf "{{ jdk_root }}"
@@ -177,6 +271,7 @@ setup-jdk:
     # Symlinked onto PATH ahead of the system copy so proofs/tla/tools/tlc picks
     # this one up rather than a stub or an older runtime.
     ln -sf "{{ jdk_root }}/bin/java" "{{ tooling_bin }}/java"
+    printf '%s' "{{ jdk_release }}" > "{{ jdk_root }}/.release"
     echo "jdk: $({{ jdk_root }}/bin/java -version 2>&1 | head -1)"
 
 # elan, which provides lake and installs the Lean version that
@@ -202,7 +297,7 @@ setup-lean:
 [doc("Download and checksum-verify the TLC jar.")]
 [group('setup')]
 setup-tla:
-    @proofs/tla/tools/tlc --fetch-only
+    @TLA_VERSION={{ tla_version }} TLA_SHA256={{ tla_sha256 }} proofs/tla/tools/tlc --fetch-only
 
 # Report what is installed and what is missing. Never fails the build; it is a
 # diagnostic, so it tells you the truth rather than a pass/fail.
@@ -239,17 +334,18 @@ build:
 build-release:
     cargo build --release -p cli
 
-# Thin-LTO build for iteration. ci.yml:305 measured 1m40s vs 6m44s; never ship
+# Thin-LTO build for iteration. CI measured 1m40s vs 6m44s cold; never ship
 # an artifact from this profile.
 [doc("Thin-LTO build for fast iteration (never ship this profile).")]
 [group('build')]
 build-fast:
     cargo build --profile release-fast -p cli
 
-# Browser client, via wasm-pack, into pkg/wasm (mirrors ci.yml:95).
+# Browser client, via wasm-pack, into pkg/wasm. The opt-level override
+# matches CI's `Build WASM` step; without it the local artifact differs.
 [group('build')]
 build-wasm:
-    wasm-pack build crates/wasm --release --target web --out-dir ../../pkg/wasm
+    CARGO_PROFILE_RELEASE_OPT_LEVEL=z wasm-pack build crates/wasm --release --target web --out-dir ../../pkg/wasm
 
 # Regenerate the C header for the FFI surface.
 [group('build')]
@@ -265,9 +361,9 @@ build-apple:
 # Test
 # ---------------------------------------------------------------------------
 
-# Workspace unit tests. Mirrors ci.yml:189, which excludes the three suites that
+# Workspace unit tests. Mirrors CI's Build & Test step, which excludes the three suites that
 # need a built binary or an external runtime.
-[doc("Workspace unit tests (mirrors ci.yml:189).")]
+[doc("Workspace unit tests (mirrors CI's Build & Test step).")]
 [group('test')]
 test:
     cargo test --workspace --exclude integration-test --exclude ffi-test --exclude conformance
@@ -298,7 +394,7 @@ integration-suite suite *args:
 
 # The pure-Rust half of the P2P topologies, serialized. `--skip ::go_` drops the
 # dual-runtime variants; the harness port allocator has a bind race in parallel
-# (ci.yml:713).
+# (see the P2P Integration job's comment in ci.yml).
 [doc("Pure-Rust P2P topologies, serialized (skips the go_ variants).")]
 [group('test')]
 integration-p2p:
@@ -327,11 +423,12 @@ integration-all:
         echo "== $suite =="
         cargo test -p integration-test --test "$suite" || failed+=("$suite")
     done
+    total=$(echo {{ integration_suites }} | wc -w | tr -d ' ')
     if [ ${#failed[@]} -gt 0 ]; then
-        echo "FAILED: ${failed[*]}" >&2
+        echo "FAILED ${#failed[@]}/${total}: ${failed[*]}" >&2
         exit 1
     fi
-    echo "all ${#failed[@]} listed areas passed"
+    echo "all ${total} listed areas passed"
 
 # ---------------------------------------------------------------------------
 # Formal methods
@@ -366,8 +463,8 @@ conformance:
 
 [doc("Model-to-code binding, TLA axis against the release binary.")]
 [group('proofs')]
-conformance-behavioral: build-release
-    DEFRA_CONFORMANCE_BINARY="{{ root }}/target/release/defra" \
+conformance-behavioral: build-fast
+    DEFRA_CONFORMANCE_BINARY="{{ root }}/target/release-fast/defra" \
         cargo test -p conformance --test tla_conformance -- --test-threads=1
 
 # ---------------------------------------------------------------------------
@@ -379,12 +476,12 @@ conformance-behavioral: build-release
 fmt:
     cargo fmt --all
 
-# Fail on any formatting diff (ci.yml:64).
+# Fail on any formatting diff, as CI's Lint job does.
 [group('check')]
 fmt-check:
     cargo fmt --all -- --check
 
-# Every clippy invocation CI runs, in CI's order (ci.yml:66-86, :139).
+# Every clippy invocation CI's Lint job runs, in the same order.
 [group('check')]
 lint:
     cargo clippy --all -- -D warnings
@@ -404,7 +501,7 @@ lint:
 lint-all-targets:
     cargo clippy --all --all-targets -- -D warnings
 
-# Browser-client lint on the real wasm target (ci.yml:139).
+# Browser-client lint on the real wasm target, as CI's WASM job does.
 [group('check')]
 lint-wasm:
     cargo clippy -p defra-wasm --target wasm32-unknown-unknown --all-targets -- -D warnings
@@ -422,7 +519,7 @@ gate: fmt-check lint doc test
 
 # Reproduce the CI pipeline locally, in CI's order.
 [group('check')]
-ci: fmt-check lint lint-wasm test test-features build-wasm integration proofs
+ci: fmt-check lint lint-wasm test test-features build-wasm integration proofs conformance-behavioral
     @echo "ci: green"
 
 # ---------------------------------------------------------------------------

--- a/justfile
+++ b/justfile
@@ -1,0 +1,507 @@
+# DefraDB.rs task runner.
+#
+#   just              list every target, grouped
+#   just setup        one-command onboarding, no sudo, no package manager
+#   just gate         what you must make green before asking for a review
+#   just ci           reproduce the CI pipeline locally
+#
+# Every tool `setup` installs lands in .tooling/ inside the repo and is put on
+# PATH by the export below. Nothing is written outside this directory and
+# nothing needs root, so the same commands work on Arch, Debian, Fedora, Alpine
+# and macOS without a package-manager matrix to keep in sync.
+
+set shell := ["bash", "-euo", "pipefail", "-c"]
+set dotenv-load := false
+
+root        := justfile_directory()
+tooling     := root / ".tooling"
+tooling_bin := tooling / "bin"
+go_root     := tooling / "go"
+jdk_root    := tooling / "jdk"
+
+# Pinned to what CI uses. ci.yml pins Go 1.25 (:449); Cargo.toml sets
+# rust-version 1.91; proofs/lean/lean-toolchain pins Lean v4.18.0; #1310 pins
+# TLC 1.8.0 by checksum.
+protoc_version := "35.1"
+go_version     := "1.25.12"
+jdk_version    := "21"
+tla_version    := "1.8.0"
+tla_sha256     := "e22f8ffb4bacdea0a871f444dd94fe5fb0d8013b3388ae39e82e26f852c735d5"
+
+# .tooling/bin wins over the system copies, so a repo-local protoc/java/go is
+# used even when the distro ships an older one. elan installs lake into its own
+# home rather than .tooling, so that bin directory has to be on PATH too or
+# `just lean` cannot find lake after `just setup`.
+elan_bin := env('ELAN_HOME', home_directory() / ".elan") / "bin"
+export PATH := tooling_bin + ":" + go_root + "/bin" + ":" + elan_bin + ":" + env('PATH')
+
+# Integration areas, each a [[test]] binary in tools/integration-test.
+integration_suites := "basic query acp nac p2p encryption identity backup sourcehub hubrs fts p2p_iroh cursor"
+
+_default:
+    @just --list --unsorted
+
+# ---------------------------------------------------------------------------
+# Setup
+# ---------------------------------------------------------------------------
+
+# Install every dependency needed to develop, test and verify the database.
+[group('setup')]
+setup: setup-rust setup-cargo-tools setup-protoc setup-go setup-jdk setup-lean setup-tla
+    @echo
+    @just doctor
+
+# Rust toolchain, the components CI needs, and the wasm target.
+[doc("Rust toolchain, CI's components, and the wasm32 target.")]
+[group('setup')]
+setup-rust:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if ! command -v rustup >/dev/null 2>&1; then
+        echo "installing rustup (user-space, no sudo)"
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
+        # shellcheck disable=SC1090
+        source "${CARGO_HOME:-$HOME/.cargo}/env"
+    fi
+    rustup toolchain install stable --profile minimal --no-self-update
+    # ci.yml runs fmt (:64) and 10 clippy invocations; :122 needs the wasm target.
+    rustup component add --toolchain stable rustfmt clippy
+    rustup target add --toolchain stable wasm32-unknown-unknown
+    echo "rust: $(rustc --version)"
+
+# cbindgen generates the FFI C header; wasm-pack and wasm-bindgen-cli build and
+# test the browser client. wasm-bindgen-cli must match the wasm-bindgen version
+# in Cargo.lock exactly or the test runner refuses the module, so it is derived
+# rather than pinned by hand.
+[doc("cbindgen, wasm-pack, and a lockfile-matched wasm-bindgen-cli.")]
+[group('setup')]
+setup-cargo-tools:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    command -v cbindgen  >/dev/null 2>&1 || cargo install cbindgen --locked
+    command -v wasm-pack >/dev/null 2>&1 || cargo install wasm-pack --locked
+    wb_version="$(cargo metadata --format-version 1 --filter-platform wasm32-unknown-unknown 2>/dev/null \
+        | jq -r '.packages[] | select(.name=="wasm-bindgen") | .version' | head -1 || true)"
+    if [ -n "${wb_version:-}" ]; then
+        have="$(wasm-bindgen --version 2>/dev/null | awk '{print $2}' || true)"
+        if [ "${have:-none}" != "$wb_version" ]; then
+            cargo install wasm-bindgen-cli --version "$wb_version" --locked
+        fi
+    else
+        echo "note: wasm-bindgen not in the dependency graph; skipping wasm-bindgen-cli" >&2
+    fi
+
+# protoc, required by crates/orbis's build.rs (proto/orbis.proto via tonic-prost-build).
+[doc("protoc, required by crates/orbis's build.rs.")]
+[group('setup')]
+setup-protoc:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    target="{{ tooling_bin }}/protoc"
+    if [ -x "$target" ]; then echo "protoc: already installed"; exit 0; fi
+    case "$(uname -s)" in
+        Linux)  os=linux ;;
+        Darwin) os=osx ;;
+        *) echo "unsupported OS: $(uname -s)" >&2; exit 1 ;;
+    esac
+    case "$(uname -m)" in
+        x86_64|amd64)  arch=x86_64 ;;
+        aarch64|arm64) arch=aarch_64 ;;
+        *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
+    esac
+    url="https://github.com/protocolbuffers/protobuf/releases/download/v{{ protoc_version }}/protoc-{{ protoc_version }}-${os}-${arch}.zip"
+    tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+    echo "fetching protoc {{ protoc_version }} for ${os}-${arch}"
+    curl -fsSL -o "$tmp/protoc.zip" "$url"
+    unzip -q "$tmp/protoc.zip" -d "$tmp/out"
+    mkdir -p "{{ tooling_bin }}" "{{ tooling }}/protoc"
+    cp -R "$tmp/out/include" "{{ tooling }}/protoc/"
+    install -m 0755 "$tmp/out/bin/protoc" "$target"
+    echo "protoc: $("$target" --version)"
+
+# Go, for the FFI compatibility harness and the Go-parity integration suites.
+[doc("Go, for the FFI harness and the Go-parity suites.")]
+[group('setup')]
+setup-go:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ -x "{{ go_root }}/bin/go" ]; then echo "go: already installed"; exit 0; fi
+    case "$(uname -s)" in
+        Linux)  os=linux ;;
+        Darwin) os=darwin ;;
+        *) echo "unsupported OS: $(uname -s)" >&2; exit 1 ;;
+    esac
+    case "$(uname -m)" in
+        x86_64|amd64)  arch=amd64 ;;
+        aarch64|arm64) arch=arm64 ;;
+        *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
+    esac
+    url="https://go.dev/dl/go{{ go_version }}.${os}-${arch}.tar.gz"
+    tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+    echo "fetching go {{ go_version }} for ${os}-${arch}"
+    curl -fsSL -o "$tmp/go.tar.gz" "$url"
+    mkdir -p "{{ tooling }}"
+    rm -rf "{{ go_root }}"
+    tar -C "{{ tooling }}" -xzf "$tmp/go.tar.gz"
+    echo "go: $({{ go_root }}/bin/go version)"
+
+# A JDK, required by TLC. proofs/README.md asks for Java 11+; Temurin 21 is LTS.
+[doc("A Temurin JDK, required by TLC.")]
+[group('setup')]
+setup-jdk:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ -x "{{ jdk_root }}/bin/java" ]; then echo "jdk: already installed"; exit 0; fi
+    case "$(uname -s)" in
+        Linux)  os=linux ;;
+        Darwin) os=mac ;;
+        *) echo "unsupported OS: $(uname -s)" >&2; exit 1 ;;
+    esac
+    case "$(uname -m)" in
+        x86_64|amd64)  arch=x64 ;;
+        aarch64|arm64) arch=aarch64 ;;
+        *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
+    esac
+    url="https://api.adoptium.net/v3/binary/latest/{{ jdk_version }}/ga/${os}/${arch}/jdk/hotspot/normal/eclipse"
+    tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+    echo "fetching Temurin JDK {{ jdk_version }} for ${os}-${arch}"
+    curl -fsSL -o "$tmp/jdk.tar.gz" "$url"
+    mkdir -p "$tmp/x" "{{ tooling_bin }}"
+    tar -C "$tmp/x" -xzf "$tmp/jdk.tar.gz"
+    rm -rf "{{ jdk_root }}"
+    # Temurin tarballs unpack to a single versioned directory; on macOS the JDK
+    # lives under Contents/Home inside it.
+    extracted="$(find "$tmp/x" -maxdepth 1 -mindepth 1 -type d | head -1)"
+    if [ -d "$extracted/Contents/Home" ]; then extracted="$extracted/Contents/Home"; fi
+    mv "$extracted" "{{ jdk_root }}"
+    # Symlinked onto PATH ahead of the system copy so proofs/tla/tools/tlc picks
+    # this one up rather than a stub or an older runtime.
+    ln -sf "{{ jdk_root }}/bin/java" "{{ tooling_bin }}/java"
+    echo "jdk: $({{ jdk_root }}/bin/java -version 2>&1 | head -1)"
+
+# elan, which provides lake and installs the Lean version that
+# proofs/lean/lean-toolchain pins.
+[doc("elan, lake, and the Lean version proofs/lean pins.")]
+[group('setup')]
+setup-lean:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if ! command -v lake >/dev/null 2>&1; then
+        echo "installing elan (provides lake)"
+        curl -fsSL https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
+            | sh -s -- -y --no-modify-path
+    fi
+    export PATH="${ELAN_HOME:-$HOME/.elan}/bin:$PATH"
+    # Running lake inside proofs/lean makes elan resolve and fetch the pinned
+    # toolchain, so the version is never specified twice.
+    ( cd "{{ root }}/proofs/lean" && lake --version )
+    echo "lean: pinned to $(cat "{{ root }}/proofs/lean/lean-toolchain")"
+
+# Download the TLC jar. Delegates to proofs/tla/tools/tlc, which is the one
+# place that knows the pinned version and checksum.
+[doc("Download and checksum-verify the TLC jar.")]
+[group('setup')]
+setup-tla:
+    @proofs/tla/tools/tlc --fetch-only
+
+# Report what is installed and what is missing. Never fails the build; it is a
+# diagnostic, so it tells you the truth rather than a pass/fail.
+[doc("Report which tools are installed and which are missing.")]
+[group('setup')]
+doctor:
+    #!/usr/bin/env bash
+    set -uo pipefail
+    printf '%-16s %s\n' "tool" "resolved"
+    printf '%-16s %s\n' "----" "--------"
+    for t in rustc cargo rustfmt clippy-driver protoc go java lake cbindgen wasm-pack wasm-bindgen jq; do
+        printf '%-16s %s\n' "$t" "$(command -v "$t" 2>/dev/null || echo 'MISSING')"
+    done
+    jar="{{ root }}/proofs/tla/tools/tla2tools.jar"
+    printf '%-16s %s\n' "tla2tools.jar" "$([ -f "$jar" ] && echo "$jar" || echo 'MISSING (just setup-tla)')"
+    printf '%-16s %s\n' "wasm32 target" "$(rustup target list --installed 2>/dev/null | grep -c wasm32-unknown-unknown | sed 's/^0$/MISSING/;s/^1$/installed/')"
+    echo
+    echo "optional, not installed by setup:"
+    for t in docker node npm python3; do
+        printf '%-16s %s\n' "$t" "$(command -v "$t" 2>/dev/null || echo 'missing')"
+    done
+
+# ---------------------------------------------------------------------------
+# Build
+# ---------------------------------------------------------------------------
+
+# Debug build of the whole workspace.
+[group('build')]
+build:
+    cargo build --workspace
+
+# Optimized build. Fat LTO, single codegen unit: slow, and what ships.
+[group('build')]
+build-release:
+    cargo build --release -p cli
+
+# Thin-LTO build for iteration. ci.yml:305 measured 1m40s vs 6m44s; never ship
+# an artifact from this profile.
+[doc("Thin-LTO build for fast iteration (never ship this profile).")]
+[group('build')]
+build-fast:
+    cargo build --profile release-fast -p cli
+
+# Browser client, via wasm-pack, into pkg/wasm (mirrors ci.yml:95).
+[group('build')]
+build-wasm:
+    wasm-pack build crates/wasm --release --target web --out-dir ../../pkg/wasm
+
+# Regenerate the C header for the FFI surface.
+[group('build')]
+build-ffi-header:
+    cbindgen --config crates/ffi/cbindgen.toml --crate ffi --output crates/ffi/defradb.h
+
+# Apple .xcframework plus the Swift import smoke test.
+[group('build')]
+build-apple:
+    tools/apple/build-ffi.sh
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+# Workspace unit tests. Mirrors ci.yml:189, which excludes the three suites that
+# need a built binary or an external runtime.
+[doc("Workspace unit tests (mirrors ci.yml:189).")]
+[group('test')]
+test:
+    cargo test --workspace --exclude integration-test --exclude ffi-test --exclude conformance
+
+# Unit tests for one crate: `just test-crate crdt`.
+[group('test')]
+test-crate crate *args:
+    cargo test -p {{ crate }} {{ args }}
+
+# Feature-gated suites the default workspace run skips. defra-node's p2p tests
+# are in-crate and off by default, so nothing else reaches them.
+[doc("Feature-gated suites the default workspace run never reaches.")]
+[group('test')]
+test-features:
+    cargo test -p telemetry --features otlp
+    cargo test -p cli --features otel --test telemetry_dedup
+    cargo test -p defra-node --features p2p
+
+# Every integration area, serially. Each spawns real nodes.
+[group('test')]
+integration:
+    cargo test -p integration-test
+
+# One integration area: `just integration-suite acp`, `just integration-suite p2p`.
+[group('test')]
+integration-suite suite *args:
+    cargo test -p integration-test --test {{ suite }} {{ args }}
+
+# The pure-Rust half of the P2P topologies, serialized. `--skip ::go_` drops the
+# dual-runtime variants; the harness port allocator has a bind race in parallel
+# (ci.yml:713).
+[doc("Pure-Rust P2P topologies, serialized (skips the go_ variants).")]
+[group('test')]
+integration-p2p:
+    cargo test -p integration-test --test p2p -- --test-threads=1 --skip ::go_
+
+# The go_* half, which needs a Go DefraDB binary on PATH.
+[group('test')]
+integration-go:
+    cargo test -p integration-test --test p2p -- --test-threads=1 ::go_
+
+# FFI compatibility against Go. Needs `just setup-go` and the generated header.
+[group('test')]
+test-ffi:
+    cargo test -p ffi-test
+
+# Run every listed integration area one at a time, reporting each. Keeps going
+# after a failure and exits non-zero if any failed, so one red area does not
+# hide the state of the rest.
+[doc("Run every integration area one at a time, reporting each.")]
+[group('test')]
+integration-all:
+    #!/usr/bin/env bash
+    set -uo pipefail
+    failed=()
+    for suite in {{ integration_suites }}; do
+        echo "== $suite =="
+        cargo test -p integration-test --test "$suite" || failed+=("$suite")
+    done
+    if [ ${#failed[@]} -gt 0 ]; then
+        echo "FAILED: ${failed[*]}" >&2
+        exit 1
+    fi
+    echo "all ${#failed[@]} listed areas passed"
+
+# ---------------------------------------------------------------------------
+# Formal methods
+# ---------------------------------------------------------------------------
+
+# TLA+, Lean, and both conformance axes. This is proofs/verify-all.sh.
+[group('proofs')]
+proofs:
+    proofs/verify-all.sh
+
+# TLC over every model, checked against the expected red/green oracle.
+[group('proofs')]
+tla:
+    cd proofs/tla && ./run-all.sh
+
+# One model: `just tla-model MC_Ssi_Red_WriteSkew.cfg MC_Ssi_Red_WriteSkew.tla`.
+[group('proofs')]
+tla-model cfg module:
+    cd proofs/tla && ./tools/tlc -config {{ cfg }} {{ module }}
+
+# Lean proofs. Must build clean with zero `sorry`.
+[group('proofs')]
+lean:
+    cd proofs/lean && lake build
+
+# Model-to-code binding. The Lean axis needs no binary; the TLA axis drives the
+# real release binary and is serial because each test spins up real nodes.
+[doc("Model-to-code binding, Lean axis (fast, no binary needed).")]
+[group('proofs')]
+conformance:
+    cargo test -p conformance --lib --test lean_conformance
+
+[doc("Model-to-code binding, TLA axis against the release binary.")]
+[group('proofs')]
+conformance-behavioral: build-release
+    DEFRA_CONFORMANCE_BINARY="{{ root }}/target/release/defra" \
+        cargo test -p conformance --test tla_conformance -- --test-threads=1
+
+# ---------------------------------------------------------------------------
+# Quality gates
+# ---------------------------------------------------------------------------
+
+# Rewrite formatting in place.
+[group('check')]
+fmt:
+    cargo fmt --all
+
+# Fail on any formatting diff (ci.yml:64).
+[group('check')]
+fmt-check:
+    cargo fmt --all -- --check
+
+# Every clippy invocation CI runs, in CI's order (ci.yml:66-86, :139).
+[group('check')]
+lint:
+    cargo clippy --all -- -D warnings
+    cargo clippy -p cli --no-default-features --features release-full --all-targets -- -D warnings
+    cargo clippy -p cli --no-default-features --features rocksdb,lark --all-targets -- -D warnings
+    cargo clippy -p cli --no-default-features --features lark --all-targets -- -D warnings
+    cargo clippy -p telemetry --features otlp --all-targets -- -D warnings
+    cargo clippy -p cli --features otel --all-targets -- -D warnings
+    cargo clippy -p defra-node --features otel --all-targets -- -D warnings
+    cargo clippy -p defra-node --features p2p --all-targets -- -D warnings
+    cargo clippy -p db --features p2p --all-targets -- -D warnings
+
+# Lint the test and bench targets too. CI does NOT do this for the workspace, so
+# this catches lints that would otherwise sit in the tree unnoticed.
+[doc("Clippy including test and bench targets, which CI does not lint.")]
+[group('check')]
+lint-all-targets:
+    cargo clippy --all --all-targets -- -D warnings
+
+# Browser-client lint on the real wasm target (ci.yml:139).
+[group('check')]
+lint-wasm:
+    cargo clippy -p defra-wasm --target wasm32-unknown-unknown --all-targets -- -D warnings
+
+# Docs must build without warnings; a broken intra-doc link fails CI.
+[doc("Build docs with warnings denied (broken links fail CI).")]
+[group('check')]
+doc:
+    RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
+
+# What to make green before asking for a review.
+[group('check')]
+gate: fmt-check lint doc test
+    @echo "gate: green"
+
+# Reproduce the CI pipeline locally, in CI's order.
+[group('check')]
+ci: fmt-check lint lint-wasm test test-features build-wasm integration proofs
+    @echo "ci: green"
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+
+# Start a node. `just start`, or `just start --store redb --port 9181`.
+[group('run')]
+start *args:
+    cargo run -p cli -- start {{ args }}
+
+# Start against a chosen backend: lark (default), redb, fjall, rocksdb, memory.
+[group('run')]
+start-backend backend *args:
+    cargo run -p cli -- start --store {{ backend }} {{ args }}
+
+# Any CLI subcommand: `just cli client query '{ User { name } }'`.
+[group('run')]
+cli *args:
+    cargo run -p cli -- {{ args }}
+
+# Standalone WASM Lens transform runner, JSON on stdin to stdout.
+[group('run')]
+lens-host *args:
+    cargo run -p lens-host -- {{ args }}
+
+# OTLP exporter smoke test against a Compose-run collector. Needs docker.
+[group('run')]
+otel-smoke:
+    tools/otel-smoke/run.sh
+
+# Drizzle ORM harness for the Postgres wire protocol. Needs node and npm.
+[group('run')]
+pg-compat:
+    cd tools/pg-compat-harness && npm install && npm test
+
+# Local HuggingFace embedding server for the embedding benchmarks. Needs python3
+# with torch, transformers, fastapi and uvicorn.
+[doc("Local HuggingFace embedding server for the embedding benchmarks.")]
+[group('run')]
+embedding-server *args:
+    python3 tools/hf_embedding_server.py {{ args }}
+
+# ---------------------------------------------------------------------------
+# Housekeeping
+# ---------------------------------------------------------------------------
+
+# Criterion benchmarks.
+[group('misc')]
+bench *args:
+    cargo bench --workspace {{ args }}
+
+# Remove build output. Leaves .tooling/ alone.
+[group('misc')]
+clean:
+    cargo clean
+
+# Remove everything setup installed. Rerun `just setup` afterwards.
+[group('misc')]
+clean-tooling:
+    rm -rf "{{ tooling }}" "{{ root }}/proofs/tla/tools/tla2tools.jar"
+
+# Dependency and licence audit. Installs the subcommands on first use.
+[group('misc')]
+audit:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    command -v cargo-deny >/dev/null 2>&1 || cargo install cargo-deny --locked
+    cargo deny check
+
+# Report unused dependencies (#1329).
+[group('misc')]
+machete:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    command -v cargo-machete >/dev/null 2>&1 || cargo install cargo-machete --locked
+    cargo machete
+
+# The Go compatibility baseline, read from its single source of truth.
+[group('misc')]
+go-baseline:
+    @grep -E 'GO_COMPAT_(BRANCH|COMMIT|TAG)' crates/defra-version/src/lib.rs

--- a/proofs/tla/.gitignore
+++ b/proofs/tla/.gitignore
@@ -3,3 +3,8 @@ states/
 *.out
 *.toolbox/
 MC.out
+
+# TLC writes an error-trace spec next to the model whenever one violates its
+# invariant, so a full run-all.sh leaves one pair per RED model behind.
+*_TTrace_*.tla
+*_TTrace_*.bin

--- a/proofs/tla/tools/tlc
+++ b/proofs/tla/tools/tlc
@@ -7,6 +7,9 @@
 set -euo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# The v1.8.0 GitHub asset is a long-lived pre-release that upstream can replace
+# in place, so TLA_SHA256 rather than the tag is the authoritative pin. When
+# upgrading, change the version and the checksum together.
 TLA_VERSION="${TLA_VERSION:-1.8.0}"
 TLA_SHA256="${TLA_SHA256:-e22f8ffb4bacdea0a871f444dd94fe5fb0d8013b3388ae39e82e26f852c735d5}"
 JAR="$DIR/tla2tools.jar"
@@ -76,8 +79,10 @@ elif command -v java >/dev/null 2>&1 &&
      { [ "$(uname -s)" != Darwin ] || [ "$(command -v java)" != /usr/bin/java ]; }; then
   JAVA=java
 else
-  echo "error: no usable Java found. Install a JDK ('just setup-jdk', or 'brew install java') or set JAVA=/path/to/java." >&2
-  echo "       (macOS /usr/bin/java is a stub and is intentionally not used.)" >&2
+  echo "error: no usable Java found. Install a JDK ('just setup-jdk') or set JAVA=/path/to/java." >&2
+  if [ "$(uname -s)" = Darwin ]; then
+    echo "       (macOS /usr/bin/java is a stub and is intentionally not used; 'brew install java' also works.)" >&2
+  fi
   exit 1
 fi
 

--- a/proofs/tla/tools/tlc
+++ b/proofs/tla/tools/tlc
@@ -1,10 +1,69 @@
 #!/usr/bin/env bash
 # Run TLC from the specs/ directory: ./tools/tlc -config M1Convergence.cfg M1Convergence.tla
+#
+# The jar is git-ignored and fetched on first use, pinned by version and
+# SHA-256 so every run checks the same tool CI and #1310 refer to. Use
+# `--fetch-only` to download it without running a model (what `just setup` does).
 set -euo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+TLA_VERSION="${TLA_VERSION:-1.8.0}"
+TLA_SHA256="${TLA_SHA256:-e22f8ffb4bacdea0a871f444dd94fe5fb0d8013b3388ae39e82e26f852c735d5}"
+JAR="$DIR/tla2tools.jar"
+
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    echo "error: neither sha256sum nor shasum found; cannot verify the jar." >&2
+    exit 1
+  fi
+}
+
+fetch_jar() {
+  local url tmp got
+  url="https://github.com/tlaplus/tlaplus/releases/download/v${TLA_VERSION}/tla2tools.jar"
+  tmp="$(mktemp)"
+  echo "fetching tla2tools ${TLA_VERSION}" >&2
+  if ! curl -fsSL -o "$tmp" "$url"; then
+    rm -f "$tmp"
+    echo "error: failed to download $url" >&2
+    exit 1
+  fi
+  got="$(sha256_of "$tmp")"
+  if [ "$got" != "$TLA_SHA256" ]; then
+    rm -f "$tmp"
+    echo "error: checksum mismatch for tla2tools ${TLA_VERSION}" >&2
+    echo "       expected $TLA_SHA256" >&2
+    echo "       got      $got" >&2
+    exit 1
+  fi
+  mv "$tmp" "$JAR"
+  chmod 0644 "$JAR"
+}
+
+# An existing jar is verified too: a truncated or swapped file must fail loudly
+# rather than produce a misleading model-checking verdict.
+if [ -f "$JAR" ]; then
+  if [ "$(sha256_of "$JAR")" != "$TLA_SHA256" ]; then
+    echo "warning: $JAR does not match the pinned checksum; re-fetching" >&2
+    rm -f "$JAR"
+    fetch_jar
+  fi
+else
+  fetch_jar
+fi
+
+if [ "${1:-}" = "--fetch-only" ]; then
+  echo "tla2tools ${TLA_VERSION}: $JAR"
+  exit 0
+fi
+
 # Resolve java: prefer JAVA env var, then JAVA_HOME, then Homebrew, then PATH.
-# On macOS the /usr/bin/java stub shows a dialog instead of running; bypass it.
+# On macOS the /usr/bin/java stub shows a dialog instead of running; bypass it
+# there only, since on Linux /usr/bin/java is the normal distro location.
 if [ -n "${JAVA:-}" ]; then
   : # use caller-supplied JAVA
 elif [ -n "${JAVA_HOME:-}" ] && [ -x "$JAVA_HOME/bin/java" ]; then
@@ -13,12 +72,13 @@ elif [ -x /opt/homebrew/opt/java/bin/java ]; then
   JAVA=/opt/homebrew/opt/java/bin/java
 elif [ -x /usr/local/opt/java/bin/java ]; then
   JAVA=/usr/local/opt/java/bin/java
-elif command -v java >/dev/null 2>&1 && [ "$(command -v java)" != /usr/bin/java ]; then
-  JAVA=java   # a real java on PATH that is not the macOS stub
+elif command -v java >/dev/null 2>&1 &&
+     { [ "$(uname -s)" != Darwin ] || [ "$(command -v java)" != /usr/bin/java ]; }; then
+  JAVA=java
 else
-  echo "error: no usable Java found. Install a JDK (e.g. 'brew install java') or set JAVA=/path/to/java." >&2
+  echo "error: no usable Java found. Install a JDK ('just setup-jdk', or 'brew install java') or set JAVA=/path/to/java." >&2
   echo "       (macOS /usr/bin/java is a stub and is intentionally not used.)" >&2
   exit 1
 fi
 
-exec "$JAVA" -XX:+UseParallelGC -cp "$DIR/tla2tools.jar" tlc2.TLC "$@"
+exec "$JAVA" -XX:+UseParallelGC -cp "$JAR" tlc2.TLC "$@"


### PR DESCRIPTION
Adds a `justfile` covering the full development surface, and makes
`proofs/tla/tools/tlc` fetch its own jar as `proofs/README.md:78` already claims
it does.

## Onboarding

`just setup` installs everything needed to build, test and verify the database,
including the formal-methods toolchain: Rust with CI's components and the wasm32
target, cbindgen, wasm-pack, a lockfile-matched wasm-bindgen-cli, protoc, Go, a
JDK, elan/lake, and the TLC jar.

It uses no package manager and needs no root. Every system tool is fetched from
its official release into a git-ignored `.tooling/` inside the repo, which the
justfile puts on `PATH`. That makes it identical on Arch, Debian, Fedora, Alpine
and macOS, with x86_64 and aarch64 both handled, and removes the per-distro
package-name matrix that would otherwise need maintaining.

Versions are pinned to what CI already uses: Go 1.25.12 (`ci.yml:449` pins
1.25), Lean v4.18.0 (`proofs/lean/lean-toolchain`), TLC 1.8.0 by checksum
(#1310), protoc 35.1, Temurin 21.

`just doctor` reports what resolved and what is missing, and never fails the
build.

## Targets

Roughly 50, grouped, all with one-line docs in `just --list`:

| Group | Targets |
|---|---|
| setup | `setup`, one per tool, `doctor` |
| build | `build`, `build-release`, `build-fast`, `build-wasm`, `build-ffi-header`, `build-apple` |
| test | `test`, `test-crate`, `test-features`, `integration`, `integration-suite <area>`, `integration-p2p`, `integration-go`, `integration-all`, `test-ffi` |
| proofs | `proofs`, `tla`, `tla-model`, `lean`, `conformance`, `conformance-behavioral` |
| check | `fmt`, `fmt-check`, `lint`, `lint-all-targets`, `lint-wasm`, `doc`, `gate`, `ci` |
| run | `start`, `start-backend`, `cli`, `lens-host`, `otel-smoke`, `pg-compat`, `embedding-server` |
| misc | `bench`, `clean`, `clean-tooling`, `audit`, `machete`, `go-baseline` |

`just lint` reproduces all nine workspace clippy invocations from `ci.yml:66-86`
in the same order, and `just ci` reproduces the pipeline, so a green `just ci`
should predict a green PR.

## TLC jar

`proofs/README.md:78` says the git-ignored jar is re-downloaded when missing.
The wrapper never did that. It now fetches it, pinned by version and SHA-256,
and re-verifies an existing jar so a truncated or swapped file fails loudly
instead of producing a misleading verdict. `--fetch-only` downloads without
running a model, which is what `just setup` calls, so the version and checksum
live in exactly one place.

Two smaller fixes in the same area:

- The java resolver rejected `/usr/bin/java` on every platform, though its
  comment says it is guarding the macOS stub. On Linux that is the normal distro
  path, so a Linux user with only a system JDK got "no usable Java found". The
  rejection is now scoped to Darwin.
- `proofs/tla/.gitignore` covered `states/`, `*.out` and `*.toolbox/` but not
  TLC's error-trace exports, so a full `run-all.sh` left 122 untracked files
  behind. Added `*_TTrace_*.tla` and `*_TTrace_*.bin`.

## Verification

Run against a clean checkout on Linux x86_64:

| Command | Result |
|---|---|
| `just setup-tla` | jar fetched, checksum matches the #1310 pin |
| `just setup-protoc` | `libprotoc 35.1` |
| `just setup-go` | `go1.25.12 linux/amd64` |
| `just setup-jdk` | `openjdk 21.0.12 LTS` |
| `just setup-lean` | elan + Lake 5.0.0 / Lean 4.18.0 |
| `just setup-cargo-tools` | cbindgen, wasm-pack, wasm-bindgen installed |
| `just tla-model MC_DeferredAcp_Green.cfg MC_DeferredAcp_Green.tla` | 377521 states, finished in 3s |
| `just lean` | `Build completed successfully` |
| `just doctor` | every tool resolved |

Every download URL was checked for a 200 before being written into the file, and
the jar's SHA-256 was verified against the value #1310 pins. The checksum guard
was tested by deliberately corrupting the jar: it detected the mismatch,
re-fetched, and restored the pinned hash.

Not verified: macOS and aarch64 paths are written but have only been exercised
on Linux x86_64. The Temurin `Contents/Home` handling in particular is untested.
