### PR TITLE
fix(wasm): use web-time so opening a transaction does not panic in the browser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,10 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    # Every base branch, not just main. The filter matches the PR's *base*, so
+    # limiting it to main means a stacked PR (one targeting the branch below it)
+    # runs no jobs at all and shows an empty, green-looking check list.
+    branches: ['**']
 
 # Only the tip of each ref keeps a run. Superseded PR pushes and main merge
 # trains cancel prior work so intermediate SHAs cannot stack the self-hosted

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3435,6 +3435,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "web-time",
  "zeroize",
 ]
 
@@ -9626,6 +9627,7 @@ dependencies = [
  "storage",
  "tokio",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
@@ -9665,6 +9667,7 @@ dependencies = [
  "storage",
  "tokio",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
@@ -11660,6 +11663,7 @@ dependencies = [
  "uuid",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "web-time",
  "zeroize",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ serde_json = "1.0"
 serde_cbor = "0.11"
 serde_bytes = "0.11"
 ciborium = "0.2"
+web-time = "1.1"
 
 # P2P networking
 # Keep these on the same libp2p-swarm release line.

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -18,6 +18,7 @@ fjall = ["storage/fjall"]
 wasmtime-runtime = ["lens/wasmtime-runtime"]
 
 [dependencies]
+web-time.workspace = true
 # Async runtime
 async-trait.workspace = true
 async-lock.workspace = true

--- a/crates/db/src/txn_context.rs
+++ b/crates/db/src/txn_context.rs
@@ -6,8 +6,9 @@ use query::runner::DocFetcher;
 use query::txn::{DeferredAcpMutations, TransactionContext};
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use storage::corekv::Store;
+use web_time::Instant;
 
 use crate::collection_provider::TxnCollectionProvider;
 use crate::database::DB;

--- a/crates/db/src/txn_registry.rs
+++ b/crates/db/src/txn_registry.rs
@@ -24,9 +24,10 @@ use query::txn::{
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use storage::corekv::{IterOptions, Key, Store};
 use tracing::{error, warn};
+use web_time::Instant;
 
 use crate::collection::Collection;
 use crate::database::DB;

--- a/crates/query-plan/Cargo.toml
+++ b/crates/query-plan/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 description = "Query plan tree, planner, and fetcher/mutator/txn abstractions for DefraDB"
 
 [dependencies]
+web-time.workspace = true
 # Internal crates
 cursor = { path = "../cursor" }
 query-types = { path = "../query-types" }

--- a/crates/query-plan/src/plan/type_join/type_join_many/children.rs
+++ b/crates/query-plan/src/plan/type_join/type_join_many/children.rs
@@ -1,8 +1,8 @@
 use serde_json::Value as JsonValue;
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
-use std::time::Instant;
 use tracing::{debug, warn};
+use web_time::Instant;
 
 use crate::planner::{Doc, IndexScanParams, IndexScanType};
 use document::NormalValue;

--- a/crates/query-plan/src/plan/type_join/type_join_many/plan_node.rs
+++ b/crates/query-plan/src/plan/type_join/type_join_many/plan_node.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use serde_json::Value as JsonValue;
-use std::time::Instant;
 use tracing::{debug, warn};
+use web_time::Instant;
 
 use crate::planner::{Doc, ExecInfo, PlanNode};
 use query_types::document::DocumentMapping;

--- a/crates/query/Cargo.toml
+++ b/crates/query/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+web-time.workspace = true
 # Internal crates
 query-types = { path = "../query-types" }
 query-parse = { path = "../query-parse" }

--- a/crates/query/src/runner/mutation.rs
+++ b/crates/query/src/runner/mutation.rs
@@ -4,7 +4,8 @@ use acp::DocumentPermission;
 use chrono::{DateTime, FixedOffset, Utc};
 use identity::Did;
 use serde_json::{Map, Value as JsonValue};
-use std::{sync::Arc, time::Instant};
+use std::sync::Arc;
+use web_time::Instant;
 
 use crate::error::{QueryError, Result};
 use crate::mapper::{Mutation, MutationType, Requestable};

--- a/crates/query/src/runner/query/nested.rs
+++ b/crates/query/src/runner/query/nested.rs
@@ -5,8 +5,8 @@ use schema::CollectionVersion;
 use serde_json::Value as JsonValue;
 use std::collections::HashSet;
 use std::sync::Arc;
-use std::time::Instant;
 use tracing::{debug, instrument};
+use web_time::Instant;
 
 use crate::error::Result;
 use crate::mapper::{Requestable, Select};

--- a/crates/query/src/runner/query/nested_fulltext.rs
+++ b/crates/query/src/runner/query/nested_fulltext.rs
@@ -9,7 +9,7 @@ use serde_json::Value as JsonValue;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Instant;
+use web_time::Instant;
 
 use crate::error::{QueryError, Result};
 use crate::mapper::{FullTextSearch, Requestable, Select};

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+web-time.workspace = true
 defra-core = { path = "../defra-core" }
 document = { path = "../document" }
 schema = { path = "../schema" }

--- a/crates/storage/src/stores/retry_info.rs
+++ b/crates/storage/src/stores/retry_info.rs
@@ -2,8 +2,9 @@
 ///
 /// Tracks the number of retries and the next retry time using exponential
 /// backoff intervals matching Go DefraDB's replicator retry behavior.
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 use std::{hash::Hash, hash::Hasher};
+use web_time::{SystemTime, UNIX_EPOCH};
 
 /// Exponential backoff intervals in seconds, matching Go's seconds-to-hours retry ladder.
 pub const RETRY_INTERVALS_SECS: &[u64] = &[


### PR DESCRIPTION
Fixes #1348.

Opening a transaction in the browser panics:

```
panicked at library/std/src/sys/time/unsupported.rs:13:9: time not implemented on this platform
  <std::time::Instant>::now
  DbTransactionContext::new_with_broadcaster
  DbTransactionRegistry::begin
  DefraClient::mutate
```

`std::time` is unimplemented on `wasm32-unknown-unknown`, so every mutation and
every query that opens a transaction aborts.

## Fix

Swap `std::time::Instant`/`SystemTime` for `web_time` equivalents in the crates
that compile to wasm. **`web_time` re-exports `std::time` verbatim on every
native target** — I type-checked that a `web_time::Instant` assigns directly to
a `std::time::Instant` on native — so server and FFI builds are unchanged.

8 files, not the 49 call sites a naive grep suggests: every non-leveldb storage
backend is `#[cfg(not(target_arch = "wasm32"))]` and never compiles for wasm.

Also widens the CI `pull_request` base filter from `[main]` to `['**']`. The
filter matches the PR's *base*, so a stacked PR runs no jobs at all and shows an
empty, green-looking check list. This is the bottom of a 3-PR stack, so the
layers above it need this to be tested at all.

## Verification

Run against a real headless Firefox: the wasm suite goes from **46 passed / 5
failed** to **50 passed / 1 failed**. All four `Instant::now()` failures are
gone; the one remaining failure is a different bug, fixed in #1363.
