### PR TITLE
fix(storage): mark OPFS files dirty on write, not only on open

### DIFF
--- a/crates/storage/src/backends/opfs_env.rs
+++ b/crates/storage/src/backends/opfs_env.rs
@@ -44,7 +44,7 @@ struct FileEntry {
 /// In-memory filesystem with change tracking for OPFS persistence.
 struct InMemoryFS {
     files: HashMap<String, FileEntry>,
-    dirty: HashSet<String>,
+    dirty: Rc<RefCell<HashSet<String>>>,
     deleted: HashSet<String>,
 }
 
@@ -52,7 +52,7 @@ impl InMemoryFS {
     fn new() -> Self {
         Self {
             files: HashMap::new(),
-            dirty: HashSet::new(),
+            dirty: Rc::new(RefCell::new(HashSet::new())),
             deleted: HashSet::new(),
         }
     }
@@ -86,7 +86,7 @@ impl InMemoryFS {
                 locked: false,
             },
         );
-        self.dirty.insert(path.to_string());
+        self.dirty.borrow_mut().insert(path.to_string());
         self.deleted.remove(path);
         Ok(data)
     }
@@ -102,8 +102,13 @@ impl InMemoryFS {
             data.borrow_mut().clear();
         }
         let offset = if append { data.borrow().len() } else { 0 };
-        self.dirty.insert(path.to_string());
-        Ok(Box::new(MemFileWriter { data, offset }))
+        self.dirty.borrow_mut().insert(path.to_string());
+        Ok(Box::new(MemFileWriter {
+            data,
+            offset,
+            path: path.to_string(),
+            dirty: Rc::clone(&self.dirty),
+        }))
     }
 
     fn exists(&self, path: &str) -> bool {
@@ -137,7 +142,7 @@ impl InMemoryFS {
 
     fn delete(&mut self, path: &str) -> Result<()> {
         if self.files.remove(path).is_some() {
-            self.dirty.remove(path);
+            self.dirty.borrow_mut().remove(path);
             self.deleted.insert(path.to_string());
             Ok(())
         } else {
@@ -151,9 +156,9 @@ impl InMemoryFS {
     fn rename(&mut self, from: &str, to: &str) -> Result<()> {
         if let Some(entry) = self.files.remove(from) {
             self.files.insert(to.to_string(), entry);
-            self.dirty.remove(from);
+            self.dirty.borrow_mut().remove(from);
             self.deleted.insert(from.to_string());
-            self.dirty.insert(to.to_string());
+            self.dirty.borrow_mut().insert(to.to_string());
             Ok(())
         } else {
             Err(Status::new(
@@ -259,10 +264,15 @@ impl RandomAccess for MemRandomAccess {
 struct MemFileWriter {
     data: FileData,
     offset: usize,
+    path: String,
+    dirty: Rc<RefCell<HashSet<String>>>,
 }
 
 impl Write for MemFileWriter {
     fn write(&mut self, src: &[u8]) -> io::Result<usize> {
+        // XXX Mark on every write, not just at open: this writer outlives any
+        // number of persist() calls, each of which clears the set.
+        self.dirty.borrow_mut().insert(self.path.clone());
         let mut buf = self.data.borrow_mut();
         if self.offset == buf.len() {
             buf.extend_from_slice(src);
@@ -353,7 +363,7 @@ impl OpfsEnv {
 
         {
             let fs = self.fs.borrow();
-            dirty = fs.dirty.iter().cloned().collect();
+            dirty = fs.dirty.borrow().iter().cloned().collect();
             deleted = fs.deleted.iter().cloned().collect();
 
             // Collect data for dirty files
@@ -391,7 +401,7 @@ impl OpfsEnv {
 
         // Clear tracking sets
         let mut fs = self.fs.borrow_mut();
-        fs.dirty.clear();
+        fs.dirty.borrow_mut().clear();
         fs.deleted.clear();
 
         Ok(())
@@ -400,7 +410,7 @@ impl OpfsEnv {
     /// Check if there are unpersisted changes.
     pub fn has_pending_changes(&self) -> bool {
         let fs = self.fs.borrow();
-        !fs.dirty.is_empty() || !fs.deleted.is_empty()
+        !fs.dirty.borrow().is_empty() || !fs.deleted.is_empty()
     }
 }
 


### PR DESCRIPTION
Fixes #1361.

Create a document in the browser, `persist()`, close, reopen: the document is
gone, no error anywhere.

## Cause

`OpfsEnv` keeps every file in memory and `persist()` copies only the **dirty**
ones to OPFS, then clears the dirty set. But a file is marked dirty when it is
**opened** for writing, never when it is **written to**:

```rust
fn open_writable(...) -> Result<Box<dyn Write>> {
    let data = self.open(path, true)?;
    self.dirty.insert(path.to_string());          // marked once, at open
    Ok(Box::new(MemFileWriter { data, offset }))  // writer cannot mark anything
}
```

LevelDB keeps its WAL writer open for the DB's lifetime, so:

1. `add_schema()` writes, persists, dirty set cleared
2. `mutate()` writes through the *same open handle* — nothing re-marks it
3. `persist()` sees an empty dirty set and returns success having written nothing
4. Reopen: schema present, documents gone

Every write after the first `persist()` is invisible to every later `persist()`.

## Fix

Share the dirty set with live writers and mark on every write.

## Verification

Key counts in the store, measured directly:

| | keys |
|---|---|
| after schema | 8 |
| after mutate (in memory) | 22 |
| persist → close → reopen, before | **8** (14 document keys lost) |
| persist → close → reopen, after | **22** |

Full wasm suite: **51 passed, 0 failed** (was 50/1 on top of #1362).

The storage layer was never at fault — the raw write/persist/reopen test passes
today because it persists only once and so never hits the cleared-set case.

## Not fixed here

Two related defects, filed in #1361, neither of which causes this:

- `DefraClient::mutate_impl` never calls `persist()`, though its test comment
  claims it "auto-persists".
- `LevelDbStore::close()` discards both failure paths and returns `Ok(())`
  regardless, so a failed final save looks identical to a successful one.
