### PR TITLE
ci: run the wasm test suite in a headless browser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,74 @@ jobs:
       - name: Build WASM
         run: CARGO_PROFILE_RELEASE_OPT_LEVEL=z wasm-pack build crates/wasm --release --target web --out-dir ../../pkg/wasm
 
+      # The wasm tests are browser tests: storage_tests.rs exercises OPFS, which
+      # only exists in a browser, so `wasm_bindgen_test_configure!(run_in_browser)`
+      # is load-bearing and node is not an option. Firefox because Chrome ships
+      # no official Linux arm64 build. Both are pinned and cached on the runner.
+      - name: Install headless browser
+        env:
+          FIREFOX_VERSION: "153.0.3"
+          GECKODRIVER_VERSION: "0.37.1"
+        run: |
+          set -euo pipefail
+          CACHE="$HOME/.cache/defra-wasm-browser/${FIREFOX_VERSION}-${GECKODRIVER_VERSION}"
+          echo "BROWSER_CACHE=$CACHE" >> "$GITHUB_ENV"
+          if [ -x "$CACHE/firefox/firefox" ] && [ -x "$CACHE/geckodriver" ]; then
+            echo "Browser cache hit — $CACHE"
+            exit 0
+          fi
+          sudo apt-get install -y libgtk-3-0 libdbus-glib-1-2 libasound2t64 || \
+            sudo apt-get install -y libgtk-3-0 libdbus-glib-1-2 libasound2
+          rm -rf "$CACHE"; mkdir -p "$CACHE"
+          TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+          FF_URL="https://download-installer.cdn.mozilla.net/pub/firefox/releases/${FIREFOX_VERSION}/linux-aarch64/en-US/firefox-${FIREFOX_VERSION}.tar.xz"
+          curl -fsSL -o "$TMP/firefox.tar.xz" "$FF_URL"
+          # Mozilla publishes a digest per release; verify rather than trust.
+          WANT="$(curl -fsSL "https://download-installer.cdn.mozilla.net/pub/firefox/releases/${FIREFOX_VERSION}/SHA256SUMS" \
+                  | awk -v p="linux-aarch64/en-US/firefox-${FIREFOX_VERSION}.tar.xz" '$2 == p {print $1}')"
+          GOT="$(sha256sum "$TMP/firefox.tar.xz" | awk '{print $1}')"
+          if [ "$WANT" != "$GOT" ]; then
+            echo "::error::Firefox checksum mismatch (expected $WANT, got $GOT)"; exit 1
+          fi
+          tar -C "$CACHE" -xJf "$TMP/firefox.tar.xz"
+
+          GD_URL="https://github.com/mozilla/geckodriver/releases/download/v${GECKODRIVER_VERSION}/geckodriver-v${GECKODRIVER_VERSION}-linux-aarch64.tar.gz"
+          curl -fsSL -o "$TMP/gd.tar.gz" "$GD_URL"
+          tar -C "$CACHE" -xzf "$TMP/gd.tar.gz"
+          "$CACHE/firefox/firefox" --version
+          "$CACHE/geckodriver" --version | head -1
+
+      # wasm-bindgen-cli must match the wasm-bindgen crate exactly or the runner
+      # refuses the module ("rust Wasm file schema version" mismatch). Derive it
+      # from the lockfile so it can never drift from what we build against.
+      - name: Install wasm-bindgen-cli (lockfile-matched)
+        run: |
+          set -euo pipefail
+          VER="$(awk '/^name = "wasm-bindgen"$/{getline; gsub(/[",]/,""); print $3; exit}' Cargo.lock)"
+          if [ -z "$VER" ]; then echo "::error::could not read wasm-bindgen version from Cargo.lock"; exit 1; fi
+          if [ "$(wasm-bindgen --version 2>/dev/null | awk '{print $2}')" != "$VER" ]; then
+            cargo install wasm-bindgen-cli --version "$VER" --locked
+          fi
+          echo "wasm-bindgen-cli $VER"
+
+      - name: Run wasm tests (Firefox, headless)
+        env:
+          CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER: wasm-bindgen-test-runner
+        run: |
+          set -euo pipefail
+          export GECKODRIVER="$BROWSER_CACHE/geckodriver"
+          export PATH="$BROWSER_CACHE/firefox:$PATH"
+          cargo test -p defra-wasm --target wasm32-unknown-unknown --lib 2>&1 | tee wasm-test.log
+          # A binary that registers no tests prints "running 0 tests" and exits 0,
+          # which is indistinguishable from success. Fail loudly instead.
+          if grep -q "running 0 tests" wasm-test.log; then
+            echo "::error::a wasm test binary registered zero tests"; exit 1
+          fi
+          if ! grep -qE "^test result: ok\. [1-9][0-9]* passed" wasm-test.log; then
+            echo "::error::no passing wasm tests were reported"; exit 1
+          fi
+
       - name: Show sccache stats
         if: always()
         run: .github/scripts/show-sccache-stats.sh


### PR DESCRIPTION
Fixes #1349.

`crates/wasm` has 51 real browser tests that CI compiles and throws away. This
runs them.

## Why a browser and not node

`storage_tests.rs` exercises OPFS, which only exists in a browser, so
`wasm_bindgen_test_configure!(run_in_browser)` is load-bearing. Firefox because
Google ships no official Chrome for Linux arm64 and the job runs on `spark-1`.

## What the job does

- Installs a **pinned** Firefox 153.0.3 + geckodriver 0.37.1, cached on the
  persistent runner. Firefox is verified against the SHA-256 Mozilla publishes
  for that release.
- Installs `wasm-bindgen-cli` at the version read from `Cargo.lock`. It must
  match the crate exactly or the runner rejects the module, so it is derived
  rather than pinned by hand.
- Runs `cargo test -p defra-wasm --target wasm32-unknown-unknown --lib`.
- **Fails on a zero-test run.** A binary that registers no tests prints
  `running 0 tests` and exits 0, which is indistinguishable from success. Both
  that and "no passing tests reported" are hard errors.

The guards were tested against real output and against both false-green shapes:

| input | verdict |
|---|---|
| `test result: ok. 51 passed` | pass |
| `running 0 tests` | fail |
| `test result: FAILED. 50 passed; 1 failed` | fail |
| empty output | fail |

## Why this is the top of a stack

Turning the job on alone would make CI permanently red: the tests were failing.
Running them for the first time found two real bugs, fixed in the layers below.

| | result |
|---|---|
| `main` | 46 passed, 5 failed |
| with #1362 (clock) | 50 passed, 1 failed |
| with #1363 (OPFS persist) | **51 passed, 0 failed** |
