### PR TITLE
ci: add cargo-machete gate and drop dead db reqwest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,13 @@ jobs:
       - run: cargo clippy -p defra-node --features p2p --all-targets -- -D warnings
       - run: cargo clippy -p db --features p2p --all-targets -- -D warnings
 
+      # Dead-dependency gate (#1329). Matches `just machete`; ignores live in
+      # each crate's [package.metadata.cargo-machete] for known false positives.
+      - name: Unused dependencies (cargo-machete)
+        run: |
+          command -v cargo-machete >/dev/null 2>&1 || cargo install cargo-machete --locked
+          cargo machete
+
       - name: Show sccache stats
         if: always()
         run: .github/scripts/show-sccache-stats.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3423,7 +3423,6 @@ dependencies = [
  "proptest",
  "query",
  "rand 0.8.5",
- "reqwest 0.12.28",
  "schema",
  "serde",
  "serde_bytes",

--- a/crates/blockstore/Cargo.toml
+++ b/crates/blockstore/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 description = "IPFS-compatible blockstore with merge tracking for DefraDB"
 
+[package.metadata.cargo-machete]
+ignored = ["crypto", "defra-core"]
+
 [dependencies]
 # Internal dependencies
 storage = { path = "../storage" }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -7,6 +7,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["anyhow", "bytes", "futures", "getrandom", "openssl-sys", "rand", "serde_bytes", "serde_ipld_dagcbor"]
+
 [lib]
 name = "cli"
 path = "src/lib.rs"

--- a/crates/crdt/Cargo.toml
+++ b/crates/crdt/Cargo.toml
@@ -7,6 +7,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["serde_json", "thiserror"]
+
 [dependencies]
 defra-core = { path = "../defra-core" }
 storage = { path = "../storage" }

--- a/crates/datastore/Cargo.toml
+++ b/crates/datastore/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 description = "Transaction wrapper for DefraDB providing multistore access and callbacks"
 
+[package.metadata.cargo-machete]
+ignored = ["cid"]
+
 [dependencies]
 # Async runtime
 async-trait.workspace = true

--- a/crates/db-backup/Cargo.toml
+++ b/crates/db-backup/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 description = "Database export/import (backup) for DefraDB"
 
+[package.metadata.cargo-machete]
+ignored = ["async-trait"]
+
 [features]
 default = ["native", "wasmtime-runtime"]
 native = ["db/native"]

--- a/crates/db-blocks/Cargo.toml
+++ b/crates/db-blocks/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 description = "IPLD block builder for DefraDB document mutations"
 
+[package.metadata.cargo-machete]
+ignored = ["bytes", "multihash", "serde", "sha2"]
+
 [dependencies]
 # Serialization
 serde.workspace = true

--- a/crates/db-index/Cargo.toml
+++ b/crates/db-index/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 description = "Secondary index manager for DefraDB collections"
 
+[package.metadata.cargo-machete]
+ignored = ["async-trait", "defra-core"]
+
 [dependencies]
 # Internal crates
 datastore = { path = "../datastore" }

--- a/crates/db-merge/Cargo.toml
+++ b/crates/db-merge/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 description = "P2P merge handler, broadcast mutator, and document pushing for DefraDB"
 
+[package.metadata.cargo-machete]
+ignored = ["futures", "serde_bytes"]
+
 [features]
 default = ["native", "wasmtime-runtime"]
 native = ["db/native"]

--- a/crates/db-search/Cargo.toml
+++ b/crates/db-search/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 description = "Vector search, embedding client, and hybrid BM25+dense retrieval for DefraDB"
 
+[package.metadata.cargo-machete]
+ignored = ["thiserror"]
+
 [dependencies]
 # Internal crates
 query = { path = "../query" }

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 description = "DefraDB database and collection management"
 
+[package.metadata.cargo-machete]
+ignored = ["anyhow", "bytes", "libp2p", "multihash", "p2p", "rand", "serde", "serde_bytes", "serde_cbor", "zeroize"]
+
 [features]
 default = ["p2p", "native", "wasmtime-runtime"]
 p2p = ["dep:p2p", "dep:libp2p", "p2p/libp2p-transport"]
@@ -53,9 +56,6 @@ sha2.workspace = true
 
 # Random number generation (for Counter CRDT nonces)
 rand.workspace = true
-
-# HTTP client (for embedding generation API calls)
-reqwest = { version = "0.12", features = ["json"] }
 
 # Encoding
 base64.workspace = true

--- a/crates/defra-core/Cargo.toml
+++ b/crates/defra-core/Cargo.toml
@@ -7,6 +7,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["tracing"]
+
 [dependencies]
 # Error handling
 thiserror.workspace = true

--- a/crates/defra-node/Cargo.toml
+++ b/crates/defra-node/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 license.workspace = true
 description = "Reusable embedded DefraDB node builder"
 
+[package.metadata.cargo-machete]
+ignored = ["thiserror"]
+
 [[bin]]
 name = "coding-session-bench"
 path = "src/bin/coding-session-bench.rs"

--- a/crates/embedded/Cargo.toml
+++ b/crates/embedded/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 description = "Reusable embedded/mobile DefraDB node assembly"
 
+[package.metadata.cargo-machete]
+ignored = ["bytes", "document", "lens", "serde", "serde_bytes", "serde_ipld_dagcbor", "thiserror"]
+
 [dependencies]
 acp = { path = "../acp" }
 blockstore = { path = "../blockstore" }

--- a/crates/events/Cargo.toml
+++ b/crates/events/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 description = "Event bus for DefraDB subscriptions"
 
+[package.metadata.cargo-machete]
+ignored = ["async-trait", "thiserror"]
+
 [features]
 default = ["channel"]
 channel = ["dep:async-channel", "dep:parking_lot"]

--- a/crates/ffi/Cargo.toml
+++ b/crates/ffi/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 description = "FFI bindings for DefraDB Rust implementation"
 
+[package.metadata.cargo-machete]
+ignored = ["cid", "libp2p", "serde_bytes", "serde_ipld_dagcbor", "serde_yaml", "sha2", "thiserror"]
+
 [lib]
 crate-type = ["staticlib", "cdylib", "rlib"]
 

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -7,6 +7,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["futures", "hyper"]
+
 [features]
 default = []
 test-utils = []

--- a/crates/kms/Cargo.toml
+++ b/crates/kms/Cargo.toml
@@ -14,6 +14,9 @@ description = "Key Management Service for DefraDB — DEK generation, wrapping, 
 # Implementation lands across milestones M1–M7 on separate branches.
 # This crate is a stub at design time.
 
+[package.metadata.cargo-machete]
+ignored = ["orbis", "sourcehub"]
+
 [features]
 default = []
 # Threshold (Orbis) backend. M6.

--- a/crates/orbis/Cargo.toml
+++ b/crates/orbis/Cargo.toml
@@ -7,6 +7,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["prost", "tonic-prost"]
+
 [dependencies]
 defra-core = { path = "../defra-core" }
 identity = { path = "../identity" }

--- a/crates/p2p-adapter/Cargo.toml
+++ b/crates/p2p-adapter/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 description = "DefraDB P2P adapters for HTTP-facing operations"
 
+[package.metadata.cargo-machete]
+ignored = ["hex", "serde"]
+
 [dependencies]
 acp = { path = "../acp" }
 blockstore = { path = "../blockstore" }

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -96,7 +96,7 @@ tokio = { workspace = true, features = ["full", "test-util"] }
 p2p = { path = ".", features = ["test-utils"] }
 
 [package.metadata.cargo-machete]
-ignored = ["noq"]
+ignored = ["crdt", "multiaddr", "noq", "rand"]
 
 [lints]
 workspace = true

--- a/crates/pg-compat/Cargo.toml
+++ b/crates/pg-compat/Cargo.toml
@@ -7,6 +7,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["thiserror"]
+
 [dependencies]
 # Internal crates
 query = { path = "../query" }

--- a/crates/schema/Cargo.toml
+++ b/crates/schema/Cargo.toml
@@ -7,6 +7,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["serde_ipld_dagcbor"]
+
 [dependencies]
 defra-core = { path = "../defra-core" }
 thiserror.workspace = true

--- a/crates/sourcehub/Cargo.toml
+++ b/crates/sourcehub/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 description = "SourceHub ACP client for DefraDB"
 
+[package.metadata.cargo-machete]
+ignored = ["alloy-rlp"]
+
 [dependencies]
 # HTTP client for REST/LCD and CometBFT JSON-RPC
 reqwest = { version = "0.12", features = ["json"] }

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 description = "DefraDB browser client - WASM build for browser-based applications"
 
+[package.metadata.cargo-machete]
+ignored = ["async-trait", "getrandom", "sha2"]
+
 [lib]
 crate-type = ["cdylib", "rlib"]
 

--- a/crates/zanzibar/Cargo.toml
+++ b/crates/zanzibar/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 description = "Standalone Zanzibar permission engine with pluggable KV backend"
 
+[package.metadata.cargo-machete]
+ignored = ["tracing"]
+
 [dependencies]
 identity = { path = "../identity" }
 async-trait.workspace = true

--- a/tools/integration-test/Cargo.toml
+++ b/tools/integration-test/Cargo.toml
@@ -6,6 +6,9 @@ description = "Integration test harness for defradb"
 license = "Apache-2.0 OR MIT"
 autotests = false
 
+[package.metadata.cargo-machete]
+ignored = ["anyhow"]
+
 [[test]]
 name = "basic"
 path = "tests/basic.rs"


### PR DESCRIPTION
## Summary

- Add a **cargo-machete** step to the Lint job so unused non-ignored deps fail CI (matches `just machete`).
- Remove the unused direct **`reqwest`** dependency from `crates/db` (embeddings go through `db-search`; no `db` src uses).
- Add `[package.metadata.cargo-machete] ignored = [...]` on crates that machete currently false-positives (serde derives, feature-gated edges, prost via codegen, etc.) so the gate is green on tip.

Part of #1327. Closes #1329.

### Scope note vs issue body

The issue also listed `multicodec` in `crates/document` as dead. On current main that is a **live dev-dependency** used by `crates/document/tests/doc_id_tests.rs` (`Codec::Bin`). It is **not** removed here.

That leave-behind does not affect release binary size: it is test-only. Production `multicodec` remains via `defra-core` and is tracked separately in #1330.

## Test plan

- [x] `cargo machete` exits 0
- [x] `cargo test -p db -p document`
- [x] CI Lint job green (cargo-machete step)