### PR TITLE
fix(embedded): track the libp2p host task so shutdown releases the store

### DIFF
--- a/crates/embedded/src/node_p2p.rs
+++ b/crates/embedded/src/node_p2p.rs
@@ -111,7 +111,7 @@ where
         )
         .await
         .map_err(|error| anyhow!("failed to create P2P host: {error}"))?;
-    tokio::spawn(async move {
+    let host_task = tokio::spawn(async move {
         host.run().await;
     });
 
@@ -302,6 +302,7 @@ where
             handle.clone(),
             coordinator.shutdown_handle(),
             vec![
+                host_task,
                 host_event_task,
                 replication_task,
                 failure_recorder_task,


### PR DESCRIPTION
Fixes #1369.

> This is not going to be visible as a failure in CI. On my local linux this was a hard failure (also because of the scheduler too).

`node_p2p.rs:114` started the libp2p host run loop and threw the handle away:

```rust
tokio::spawn(async move { host.run().await; });
```

`host` owns `bitswap_store`, a `BitswapStoreAdapter { blockstore: Arc<B> }` built
from the store, so that task transitively held the storage `Arc`.
`ShutdownHandle::shutdown()` aborts and joins the tasks it knows about and then
calls `handle.shutdown()` — but it knew about six of the seven. Nothing waited
for the host task, so shutdown returned with the store still held and the next
open hit the backend lock.

Same class as #1309. `crates/embedded` was skipped in #1357 because it *does*
track its sweep handles; it tracked six of seven.

## Fix

Bind the handle and add it to the vector `abort_and_join` drains.

## Verification

`p2p_shutdown_releases_persistent_store` went from **0/10 to 10/10** on Linux.
Strong count of the store `Arc`:

| point | before | after |
|---|---|---|
| after `build_with_store` | 14 | 14 |
| after `shutdown()` returns | 10 | 10 |
| **immediately after `drop(node)`** | **7** | **1** |
| reopen at that instant | fails | ok |
| after +10ms | 1 | 1 |

The six stragglers were released ~10 ms later, which is why a `sleep` made it
pass and why it looked flaky. It is deterministic: the reopen lost the race
every time.

Whole `embedded --test shutdown` suite green, `just fmt-check` clean,
`cargo clippy -p embedded --all-targets -D warnings` clean.

## Note on CI

This is invisible to the current pipeline. `lark` is a default feature so the
test does compile and run, but `Build & Test` runs on
`[self-hosted, macOS, ARM64]` and only two of eight jobs are Linux, neither
running the workspace unit tests. #1369 suggests deciding separately whether the
workspace suite should also run on Linux — every backend taking a filesystem
lock shares this blind spot.
