### PR TITLE
refactor: replace serde_cbor with ciborium across the workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2009,7 +2009,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
- "half 2.7.1",
+ "half",
 ]
 
 [[package]]
@@ -3427,7 +3427,6 @@ dependencies = [
  "schema",
  "serde",
  "serde_bytes",
- "serde_cbor",
  "serde_json",
  "sha2 0.10.9",
  "storage",
@@ -3524,7 +3523,6 @@ dependencies = [
  "schema",
  "serde",
  "serde_bytes",
- "serde_cbor",
  "serde_json",
  "storage",
  "telemetry",
@@ -3611,6 +3609,7 @@ version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
+ "ciborium",
  "cid",
  "criterion 0.6.0",
  "ipld-core",
@@ -5063,12 +5062,6 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
-
-[[package]]
-name = "half"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
 
 [[package]]
 name = "half"
@@ -6578,6 +6571,7 @@ dependencies = [
  "async-lock",
  "async-trait",
  "base64 0.22.1",
+ "ciborium",
  "cid",
  "crypto",
  "defra-core",
@@ -6586,7 +6580,6 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_bytes",
- "serde_cbor",
  "sourcehub",
  "thiserror 2.0.18",
  "tokio",
@@ -8631,7 +8624,6 @@ dependencies = [
  "rlimit",
  "serde",
  "serde_bytes",
- "serde_cbor",
  "serde_ipld_dagcbor",
  "serde_json",
  "sha2 0.10.9",
@@ -10977,16 +10969,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half 1.8.3",
- "serde",
-]
-
-[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11650,7 +11632,6 @@ dependencies = [
  "rusty-leveldb",
  "schema",
  "serde",
- "serde_cbor",
  "serde_json",
  "telemetry",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,6 @@ futures = "0.3"
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_cbor = "0.11"
 serde_bytes = "0.11"
 ciborium = "0.2"
 

--- a/crates/db-merge/Cargo.toml
+++ b/crates/db-merge/Cargo.toml
@@ -22,7 +22,6 @@ futures.workspace = true
 # Serialization
 serde.workspace = true
 serde_json.workspace = true
-serde_cbor.workspace = true
 serde_bytes.workspace = true
 ciborium = "0.2"
 hex.workspace = true

--- a/crates/db-merge/src/se/receiver.rs
+++ b/crates/db-merge/src/se/receiver.rs
@@ -16,7 +16,7 @@ use super::validate::validate_artifact;
 /// Deserialize SE artifacts from a CBOR-encoded PushSEArtifactsRequest.
 ///
 /// Returns the collection_id and a vec of crypto::se::Artifact structs.
-/// Uses serde_cbor for deserialization (same format used in P2P messaging).
+/// Uses CBOR for deserialization (same format used in P2P messaging).
 pub fn deserialize_artifacts(data: &[u8]) -> std::result::Result<ReceivedBatch, DeserializeError> {
     #[derive(serde::Deserialize)]
     struct RawArtifact {
@@ -37,7 +37,7 @@ pub fn deserialize_artifacts(data: &[u8]) -> std::result::Result<ReceivedBatch, 
     }
 
     let raw: RawRequest =
-        serde_cbor::from_slice(data).map_err(|e| DeserializeError(e.to_string()))?;
+        defra_core::cbor::from_slice(data).map_err(|e| DeserializeError(e.to_string()))?;
 
     let artifacts = raw
         .artifacts

--- a/crates/db-merge/src/se/serve.rs
+++ b/crates/db-merge/src/se/serve.rs
@@ -131,7 +131,7 @@ fn extract_push_message_id(data: &[u8]) -> Option<String> {
         #[serde(rename = "MessageID")]
         message_id: String,
     }
-    serde_cbor::from_slice::<MsgIdOnly>(data)
+    defra_core::cbor::from_slice::<MsgIdOnly>(data)
         .ok()
         .map(|m| m.message_id)
 }

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -26,7 +26,6 @@ futures.workspace = true
 # Serialization
 serde.workspace = true
 serde_json.workspace = true
-serde_cbor.workspace = true
 serde_bytes.workspace = true
 ciborium.workspace = true
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/defra-core/Cargo.toml
+++ b/crates/defra-core/Cargo.toml
@@ -15,6 +15,7 @@ thiserror.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_bytes.workspace = true
+ciborium.workspace = true
 uuid.workspace = true
 multibase = "0.9"
 

--- a/crates/defra-core/src/cbor.rs
+++ b/crates/defra-core/src/cbor.rs
@@ -1,0 +1,100 @@
+//! CBOR encode/decode helpers over `ciborium`.
+//!
+//! `ciborium` writes into a `std::io::Write` rather than returning a `Vec`, and
+//! splits its error type across serialization and deserialization. These two
+//! functions give the whole workspace one shape for both, so call sites read the
+//! same everywhere and the error carries which direction failed.
+//!
+//! This is not the dag-cbor stack. `serde_ipld_dagcbor` carries docID/CID parity
+//! and is entirely separate; nothing here touches it.
+
+use serde::{de::DeserializeOwned, Serialize};
+
+/// A CBOR encode or decode failure.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("cbor serialization failed: {0}")]
+    Serialize(String),
+    #[error("cbor deserialization failed: {0}")]
+    Deserialize(String),
+}
+
+/// Encode `value` to a CBOR byte vector.
+pub fn to_vec<T>(value: &T) -> Result<Vec<u8>, Error>
+where
+    T: Serialize + ?Sized,
+{
+    let mut out = Vec::new();
+    ciborium::into_writer(value, &mut out).map_err(|e| Error::Serialize(e.to_string()))?;
+    Ok(out)
+}
+
+/// Decode a CBOR byte slice into `T`.
+///
+/// The whole slice must be consumed. `ciborium` decodes one item and stops, so
+/// without this check `b"hello from some other producer"` decodes as the text
+/// string `"ello fro"` and silently discards the remaining 21 bytes. These
+/// bytes arrive from peers, so trailing data is rejected rather than ignored.
+pub fn from_slice<T>(bytes: &[u8]) -> Result<T, Error>
+where
+    T: DeserializeOwned,
+{
+    let mut cursor = std::io::Cursor::new(bytes);
+    let value =
+        ciborium::from_reader(&mut cursor).map_err(|e| Error::Deserialize(e.to_string()))?;
+    let consumed = cursor.position() as usize;
+    if consumed != bytes.len() {
+        return Err(Error::Deserialize(format!(
+            "trailing data after CBOR item: consumed {consumed} of {} bytes",
+            bytes.len()
+        )));
+    }
+    Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, PartialEq, Serialize, serde::Deserialize)]
+    struct Frame {
+        name: String,
+        #[serde(with = "serde_bytes")]
+        payload: Vec<u8>,
+        count: u32,
+    }
+
+    #[test]
+    fn round_trips() {
+        let frame = Frame {
+            name: "hello".to_string(),
+            payload: vec![1, 2, 3],
+            count: 7,
+        };
+        let bytes = to_vec(&frame).unwrap();
+        assert_eq!(from_slice::<Frame>(&bytes).unwrap(), frame);
+    }
+
+    /// Regression: `ciborium` stops after one item, so a padded or truncated
+    /// frame would otherwise decode successfully and drop the remainder.
+    #[test]
+    fn trailing_data_is_rejected() {
+        let mut bytes = to_vec(&"hi".to_string()).unwrap();
+        assert!(from_slice::<String>(&bytes).is_ok());
+        bytes.extend_from_slice(b"junk");
+        let err = from_slice::<String>(&bytes).unwrap_err();
+        assert!(
+            err.to_string().contains("trailing data"),
+            "expected a trailing-data error, got {err}"
+        );
+
+        // The exact shape that regressed a p2p test: valid CBOR prefix, garbage after.
+        assert!(from_slice::<ciborium::Value>(b"hello from some other producer").is_err());
+    }
+
+    #[test]
+    fn decode_failure_is_reported_as_deserialize() {
+        let err = from_slice::<Frame>(&[0xff, 0xff, 0xff]).unwrap_err();
+        assert!(matches!(err, Error::Deserialize(_)), "got {err:?}");
+    }
+}

--- a/crates/defra-core/src/lib.rs
+++ b/crates/defra-core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod block;
 pub mod block_delta;
 pub mod block_signature;
 pub mod browser_sync;
+pub mod cbor;
 pub mod collection;
 pub mod current_identity;
 pub mod dac_bypass;

--- a/crates/kms/Cargo.toml
+++ b/crates/kms/Cargo.toml
@@ -22,6 +22,7 @@ threshold = ["dep:orbis"]
 sourcehub = ["dep:sourcehub"]
 
 [dependencies]
+ciborium.workspace = true
 defra-core = { path = "../defra-core" }
 crypto = { path = "../crypto" }
 acp = { path = "../acp" }
@@ -36,7 +37,6 @@ async-lock.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 serde = { workspace = true, features = ["derive"] }
-serde_cbor = { workspace = true }
 serde_bytes = "0.11"
 base64 = "0.22"
 zeroize = "1.8"

--- a/crates/kms/src/defra_kms.rs
+++ b/crates/kms/src/defra_kms.rs
@@ -267,7 +267,7 @@ impl KmsService for DefraKms {
                     explicit_replay_capability: ctx.explicit_replay_capability().map(str::to_owned),
                 };
                 let payload =
-                    serde_cbor::to_vec(&req).map_err(|e| Error::WireEncode(e.to_string()))?;
+                    defra_core::cbor::to_vec(&req).map_err(|e| Error::WireEncode(e.to_string()))?;
                 let encoded = EncodedFetchRequest {
                     payload,
                     request_id: uuid::Uuid::new_v4().to_string(),

--- a/crates/kms/src/defra_kms_tests.rs
+++ b/crates/kms/src/defra_kms_tests.rs
@@ -474,7 +474,7 @@ async fn get_keys_identifies_the_requesting_node_on_the_wire() {
         .await
         .clone()
         .expect("transport must receive a request");
-    let request: crate::FetchEncryptionKeyRequest = serde_cbor::from_slice(&payload).unwrap();
+    let request: crate::FetchEncryptionKeyRequest = defra_core::cbor::from_slice(&payload).unwrap();
     assert_eq!(request.identity, node.to_string().into_bytes());
     assert_ne!(request.identity, user.to_string().into_bytes());
 }

--- a/crates/kms/src/wire.rs
+++ b/crates/kms/src/wire.rs
@@ -116,8 +116,8 @@ mod tests {
             ephemeral_public_key: vec![0xee; 32],
             explicit_replay_capability: Some("signed-proof".into()),
         };
-        let bytes = serde_cbor::to_vec(&req).unwrap();
-        let parsed: FetchEncryptionKeyRequest = serde_cbor::from_slice(&bytes).unwrap();
+        let bytes = defra_core::cbor::to_vec(&req).unwrap();
+        let parsed: FetchEncryptionKeyRequest = defra_core::cbor::from_slice(&bytes).unwrap();
         assert_eq!(req, parsed);
     }
 
@@ -128,8 +128,8 @@ mod tests {
             blocks: vec![vec![0xff; 100]],
             ephemeral_public_key: vec![0xdd; 32],
         };
-        let bytes = serde_cbor::to_vec(&reply).unwrap();
-        let parsed: FetchEncryptionKeyReply = serde_cbor::from_slice(&bytes).unwrap();
+        let bytes = defra_core::cbor::to_vec(&reply).unwrap();
+        let parsed: FetchEncryptionKeyReply = defra_core::cbor::from_slice(&bytes).unwrap();
         assert_eq!(reply, parsed);
     }
 
@@ -141,16 +141,16 @@ mod tests {
             ephemeral_public_key: vec![3],
             explicit_replay_capability: None,
         };
-        let bytes = serde_cbor::to_vec(&req).unwrap();
-        let val: serde_cbor::Value = serde_cbor::from_slice(&bytes).unwrap();
+        let bytes = defra_core::cbor::to_vec(&req).unwrap();
+        let val: ciborium::Value = defra_core::cbor::from_slice(&bytes).unwrap();
         let map = match val {
-            serde_cbor::Value::Map(m) => m,
+            ciborium::Value::Map(m) => m,
             _ => panic!(),
         };
         let keys: Vec<String> = map
-            .into_keys()
-            .filter_map(|k| match k {
-                serde_cbor::Value::Text(s) => Some(s),
+            .into_iter()
+            .filter_map(|(k, _)| match k {
+                ciborium::Value::Text(s) => Some(s),
                 _ => None,
             })
             .collect();
@@ -170,7 +170,7 @@ mod tests {
             ephemeral_public_key: vec![],
             explicit_replay_capability: None,
         };
-        let bytes = serde_cbor::to_vec(&req).unwrap();
+        let bytes = defra_core::cbor::to_vec(&req).unwrap();
         // Find the Links field's value in the encoded bytes. We just check that
         // the byte sequence 0x42, 0x01, 0x02 appears (CBOR byte-string-of-len-2,
         // 0x01, 0x02). The wrong (legacy) encoding would emit 0x82, 0x01, 0x02

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -33,7 +33,6 @@ futures = { workspace = true }
 
 # Serialization
 serde = { workspace = true }
-serde_cbor = { workspace = true }
 serde_json = { workspace = true }
 ciborium = { workspace = true }
 serde_bytes = { workspace = true }

--- a/crates/p2p/src/codec.rs
+++ b/crates/p2p/src/codec.rs
@@ -28,12 +28,12 @@ pub const MAX_MESSAGE_SIZE: u64 = 16 * 1024 * 1024;
 
 /// Encode a message to CBOR bytes.
 pub fn encode<T: Serialize>(msg: &T) -> Result<Vec<u8>> {
-    serde_cbor::to_vec(msg).map_err(|e| Error::CborSerialization(e.to_string()))
+    defra_core::cbor::to_vec(msg).map_err(|e| Error::CborSerialization(e.to_string()))
 }
 
 /// Decode a message from CBOR bytes.
 pub fn decode<T: DeserializeOwned>(data: &[u8]) -> Result<T> {
-    serde_cbor::from_slice(data).map_err(|e| Error::CborDeserialization(e.to_string()))
+    defra_core::cbor::from_slice(data).map_err(|e| Error::CborDeserialization(e.to_string()))
 }
 
 /// Read a CBOR message from an async reader with size limit.
@@ -52,7 +52,7 @@ where
         ));
     }
 
-    serde_cbor::from_slice(&buf).map_err(|e| {
+    defra_core::cbor::from_slice(&buf).map_err(|e| {
         io::Error::new(
             io::ErrorKind::InvalidData,
             format!("CBOR deserialization error: {}", e),
@@ -66,7 +66,7 @@ where
     T: Serialize,
     W: AsyncWrite + Unpin + Send,
 {
-    let data = serde_cbor::to_vec(msg).map_err(|e| {
+    let data = defra_core::cbor::to_vec(msg).map_err(|e| {
         io::Error::new(
             io::ErrorKind::InvalidData,
             format!("CBOR serialization error: {}", e),

--- a/crates/p2p/src/error.rs
+++ b/crates/p2p/src/error.rs
@@ -434,12 +434,11 @@ pub fn blockstore_verify_to_p2p(e: blockstore::Error, cid: &cid::Cid) -> Error {
     }
 }
 
-impl From<serde_cbor::Error> for Error {
-    fn from(e: serde_cbor::Error) -> Self {
-        if e.is_io() || e.is_eof() || e.is_syntax() {
-            Error::CborDeserialization(e.to_string())
-        } else {
-            Error::CborSerialization(e.to_string())
+impl From<defra_core::cbor::Error> for Error {
+    fn from(e: defra_core::cbor::Error) -> Self {
+        match e {
+            defra_core::cbor::Error::Deserialize(msg) => Error::CborDeserialization(msg),
+            defra_core::cbor::Error::Serialize(msg) => Error::CborSerialization(msg),
         }
     }
 }

--- a/crates/p2p/src/explicit_replay.rs
+++ b/crates/p2p/src/explicit_replay.rs
@@ -86,7 +86,7 @@ fn now_unix() -> Result<u64> {
 }
 
 fn encode_claims(claims: &ExplicitReplayCapabilityClaims) -> Result<Vec<u8>> {
-    serde_cbor::to_vec(claims).map_err(|error| {
+    defra_core::cbor::to_vec(claims).map_err(|error| {
         Error::ExplicitReplayCapability(format!("failed to encode claims: {error}"))
     })
 }
@@ -114,7 +114,7 @@ fn decode_envelope(capability: &str) -> Result<ExplicitReplayCapabilityEnvelope>
         .decode(capability)
         .map_err(|error| Error::ExplicitReplayCapability(format!("invalid encoding: {error}")))?;
 
-    serde_cbor::from_slice(&bytes)
+    defra_core::cbor::from_slice(&bytes)
         .map_err(|error| Error::ExplicitReplayCapability(format!("invalid payload: {error}")))
 }
 
@@ -248,7 +248,7 @@ pub fn generate_capability_from_claims<I: FullIdentity>(
 
     let envelope = ExplicitReplayCapabilityEnvelope { claims, signature };
 
-    let envelope_bytes = serde_cbor::to_vec(&envelope)
+    let envelope_bytes = defra_core::cbor::to_vec(&envelope)
         .map_err(|error| Error::ExplicitReplayCapability(format!("failed to encode: {error}")))?;
 
     Ok(URL_SAFE_NO_PAD.encode(envelope_bytes))
@@ -382,7 +382,7 @@ mod tests {
         let claims_bytes = encode_claims(&claims).unwrap();
         let signature = authorizer.sign(&claims_bytes).unwrap();
         let envelope = ExplicitReplayCapabilityEnvelope { claims, signature };
-        URL_SAFE_NO_PAD.encode(serde_cbor::to_vec(&envelope).unwrap())
+        URL_SAFE_NO_PAD.encode(defra_core::cbor::to_vec(&envelope).unwrap())
     }
 
     #[test]

--- a/crates/p2p/src/host/p2p_host/two_stream.rs
+++ b/crates/p2p/src/host/p2p_host/two_stream.rs
@@ -256,7 +256,7 @@ impl<S: Store> P2PHost<S> {
                     "Host received SE artifacts via two-stream protocol"
                 );
                 // Re-encode to CBOR for the db layer receiver
-                match serde_cbor::to_vec(&request) {
+                match defra_core::cbor::to_vec(&request) {
                     Ok(data) => {
                         if self
                             .event_tx

--- a/crates/p2p/src/iroh/endpoint_streams.rs
+++ b/crates/p2p/src/iroh/endpoint_streams.rs
@@ -372,7 +372,7 @@ async fn dispatch_stream(
                 artifact_count = request.artifacts.len(),
                 "Received SE artifacts"
             );
-            let data = serde_cbor::to_vec(&request)
+            let data = defra_core::cbor::to_vec(&request)
                 .map_err(|e| crate::error::Error::Codec(e.to_string()))?;
             if event_tx
                 .send(TransportEvent::SEArtifactsReceived {
@@ -557,8 +557,8 @@ where
     let signature = iroh::Signature::try_from(signature).map_err(|_| Error::InvalidSignature)?;
     let mut msg_for_verify = msg.clone();
     msg_for_verify.set_signature(None);
-    let bytes =
-        serde_cbor::to_vec(&msg_for_verify).map_err(|e| Error::CborSerialization(e.to_string()))?;
+    let bytes = defra_core::cbor::to_vec(&msg_for_verify)
+        .map_err(|e| Error::CborSerialization(e.to_string()))?;
 
     pubkey
         .verify(&bytes, &signature)

--- a/crates/p2p/src/iroh/protocols.rs
+++ b/crates/p2p/src/iroh/protocols.rs
@@ -88,7 +88,7 @@ pub async fn read_message<T: serde::de::DeserializeOwned>(
     max_size: usize,
 ) -> crate::error::Result<T> {
     let payload = read_message_bytes(recv, max_size).await?;
-    serde_cbor::from_slice(&payload).map_err(|e| crate::error::Error::Codec(e.to_string()))
+    defra_core::cbor::from_slice(&payload).map_err(|e| crate::error::Error::Codec(e.to_string()))
 }
 
 /// Read only the length-prefixed payload bytes from a QUIC recv stream.
@@ -122,7 +122,7 @@ pub async fn write_message<T: serde::Serialize>(
     value: &T,
 ) -> crate::error::Result<()> {
     let payload =
-        serde_cbor::to_vec(value).map_err(|e| crate::error::Error::Codec(e.to_string()))?;
+        defra_core::cbor::to_vec(value).map_err(|e| crate::error::Error::Codec(e.to_string()))?;
     let len = (payload.len() as u32).to_be_bytes();
 
     send.write_all(&len)

--- a/crates/p2p/src/iroh/transport.rs
+++ b/crates/p2p/src/iroh/transport.rs
@@ -926,7 +926,7 @@ mod tests {
             if let TransportEvent::SEArtifactsReceived { peer_id, data } = event {
                 assert_eq!(peer_id, *transport0.local_peer_id());
                 let received: PushSEArtifactsRequest =
-                    serde_cbor::from_slice(&data).expect("SE artifacts should decode");
+                    defra_core::cbor::from_slice(&data).expect("SE artifacts should decode");
                 assert_eq!(received.sender_id, transport0.local_peer_id().to_string());
                 assert!(received.signature.is_some());
                 assert_eq!(received.collection_id, "collection1");

--- a/crates/p2p/src/kms/pubsub_transport.rs
+++ b/crates/p2p/src/kms/pubsub_transport.rs
@@ -193,7 +193,7 @@ impl<T: P2PTransport> PubsubKeyTransport<T> {
             warn!("KMS request arrived but no handler installed; dropping");
             return;
         };
-        let req: FetchEncryptionKeyRequest = match serde_cbor::from_slice(&payload) {
+        let req: FetchEncryptionKeyRequest = match defra_core::cbor::from_slice(&payload) {
             Ok(r) => r,
             Err(e) => {
                 warn!(error = %e, "KMS dispatch: failed to decode request");
@@ -236,7 +236,7 @@ impl<T: P2PTransport> PubsubKeyTransport<T> {
             )
             .await
         {
-            Ok(reply) => match serde_cbor::to_vec(&reply) {
+            Ok(reply) => match defra_core::cbor::to_vec(&reply) {
                 Ok(b) => (b, String::new()),
                 Err(e) => {
                     warn!(error = %e, "KMS dispatch: failed to encode reply");
@@ -404,7 +404,7 @@ impl<T: P2PTransport> KeyTransport for PubsubKeyTransport<T> {
                             debug!(from = %resp.from, error = %err, "KMS reply carried responder error");
                             continue;
                         }
-                        let reply: FetchEncryptionKeyReply = match serde_cbor::from_slice(&resp.data) {
+                        let reply: FetchEncryptionKeyReply = match defra_core::cbor::from_slice(&resp.data) {
                             Ok(r) => r,
                             Err(e) => {
                                 warn!(
@@ -742,7 +742,7 @@ mod tests {
             blocks: vec![vec![4, 5, 6]],
             ephemeral_public_key: vec![7; 32],
         };
-        let data = serde_cbor::to_vec(&reply).unwrap();
+        let data = defra_core::cbor::to_vec(&reply).unwrap();
         let request_id = crate::pubsub_rpc::derive_request_id(&payload);
         let envelope = InternalResponse {
             id: request_id.to_string(),
@@ -794,7 +794,7 @@ mod tests {
         let empty_envelope = InternalResponse {
             id: request_id.to_string(),
             err: String::new(),
-            data: serde_cbor::to_vec(&empty_reply).unwrap(),
+            data: defra_core::cbor::to_vec(&empty_reply).unwrap(),
             from: Vec::new(),
         };
         kt.dispatch_incoming(
@@ -813,7 +813,7 @@ mod tests {
         let key_envelope = InternalResponse {
             id: request_id.to_string(),
             err: String::new(),
-            data: serde_cbor::to_vec(&key_reply).unwrap(),
+            data: defra_core::cbor::to_vec(&key_reply).unwrap(),
             from: Vec::new(),
         };
         kt.dispatch_incoming(
@@ -847,7 +847,7 @@ mod tests {
             ephemeral_public_key: vec![9; 32],
             explicit_replay_capability: None,
         };
-        let payload = serde_cbor::to_vec(&request).unwrap();
+        let payload = defra_core::cbor::to_vec(&request).unwrap();
         let req = EncodedFetchRequest {
             payload: payload.clone(),
             request_id: "r1".to_string(),
@@ -867,7 +867,7 @@ mod tests {
             let envelope = InternalResponse {
                 id: request_id.to_string(),
                 err: String::new(),
-                data: serde_cbor::to_vec(&reply).unwrap(),
+                data: defra_core::cbor::to_vec(&reply).unwrap(),
                 from: Vec::new(),
             };
             kt.dispatch_incoming(
@@ -914,7 +914,7 @@ mod tests {
             ephemeral_public_key: vec![9; 32],
             explicit_replay_capability: None,
         };
-        let payload = serde_cbor::to_vec(&request).unwrap();
+        let payload = defra_core::cbor::to_vec(&request).unwrap();
         let mut rx = kt
             .send_request(EncodedFetchRequest {
                 payload: payload.clone(),
@@ -933,7 +933,7 @@ mod tests {
             let envelope = InternalResponse {
                 id: request_id.to_string(),
                 err: String::new(),
-                data: serde_cbor::to_vec(&reply).unwrap(),
+                data: defra_core::cbor::to_vec(&reply).unwrap(),
                 from: Vec::new(),
             };
             kt.dispatch_incoming(
@@ -1003,7 +1003,7 @@ mod tests {
         let envelope = InternalResponse {
             id: crate::pubsub_rpc::derive_request_id(&payload).to_string(),
             err: String::new(),
-            data: serde_cbor::to_vec(&reply).unwrap(),
+            data: defra_core::cbor::to_vec(&reply).unwrap(),
             from: Vec::new(),
         };
         kt.dispatch_incoming(
@@ -1110,7 +1110,7 @@ mod tests {
             ephemeral_public_key: vec![2; 32],
             explicit_replay_capability: Some(capability),
         };
-        let req_bytes = serde_cbor::to_vec(&req).unwrap();
+        let req_bytes = defra_core::cbor::to_vec(&req).unwrap();
 
         kt.dispatch_incoming(caller.to_string(), ENCRYPTION_TOPIC.to_string(), req_bytes)
             .await;
@@ -1123,7 +1123,7 @@ mod tests {
             .expect("reply must be published on caller's _response sub-topic");
         let env = InternalResponse::from_cbor(&reply_pub.1).expect("decode envelope");
         let reply: FetchEncryptionKeyReply =
-            serde_cbor::from_slice(&env.data).expect("decode reply");
+            defra_core::cbor::from_slice(&env.data).expect("decode reply");
         assert_eq!(reply.blocks, vec![vec![8]]);
         let from = seen.lock().clone().expect("handler must see peer identity");
         assert_eq!(from.peer_id, caller.to_string());

--- a/crates/p2p/src/message/branchable.rs
+++ b/crates/p2p/src/message/branchable.rs
@@ -10,7 +10,7 @@ use super::traits::Message;
 /// Sent to peers to ask for their head CIDs for a branchable collection.
 /// Uses two-stream protocol (same transport as DocSync).
 ///
-/// Note: We don't use `#[serde(flatten)]` because serde_cbor produces
+/// Note: We don't use `#[serde(flatten)]` because serde's flatten produces
 /// indefinite-length maps when flatten is used (CBOR major type 0xbf).
 /// Go's fxamacker/cbor produces definite-length maps, causing signature
 /// verification to fail. Instead, we duplicate the fields for wire compatibility.

--- a/crates/p2p/src/message/docsync.rs
+++ b/crates/p2p/src/message/docsync.rs
@@ -16,7 +16,7 @@ pub const MAX_DOC_IDS: usize = 1000;
 /// This is used when a node wants to sync specific documents from the network.
 /// Unlike replicator sync (push-based), DocSync is pull-based.
 ///
-/// Note: We don't use `#[serde(flatten)]` because serde_cbor produces
+/// Note: We don't use `#[serde(flatten)]` because serde's flatten produces
 /// indefinite-length maps when flatten is used (CBOR major type 0xbf).
 /// Go's fxamacker/cbor produces definite-length maps, causing signature
 /// verification to fail. Instead, we duplicate the fields for wire compatibility.

--- a/crates/p2p/src/message/manage.rs
+++ b/crates/p2p/src/message/manage.rs
@@ -129,7 +129,7 @@ impl ManageQueryOp {
 /// The six MetaData fields are byte-identical to the SE message envelopes for
 /// compatibility with the shared `signing`/`verify_message` path.
 ///
-/// Note: We don't use `#[serde(flatten)]` because serde_cbor produces
+/// Note: We don't use `#[serde(flatten)]` because serde's flatten produces
 /// indefinite-length maps when flatten is used (CBOR major type 0xbf).
 /// Go's fxamacker/cbor produces definite-length maps, causing signature
 /// verification to fail. Instead, we duplicate the fields for wire compatibility.
@@ -347,7 +347,7 @@ impl Message for ManageReply {
 /// The six MetaData fields are byte-identical to the SE message envelopes for
 /// compatibility with the shared `signing`/`verify_message` path.
 ///
-/// Note: We don't use `#[serde(flatten)]` because serde_cbor produces
+/// Note: We don't use `#[serde(flatten)]` because serde's flatten produces
 /// indefinite-length maps when flatten is used (CBOR major type 0xbf).
 /// Go's fxamacker/cbor produces definite-length maps, causing signature
 /// verification to fail. Instead, we duplicate the fields for wire compatibility.
@@ -576,7 +576,7 @@ mod tests {
         };
         assert_eq!(
             op,
-            serde_cbor::from_slice(&serde_cbor::to_vec(&op).unwrap()).unwrap()
+            defra_core::cbor::from_slice(&defra_core::cbor::to_vec(&op).unwrap()).unwrap()
         );
     }
 
@@ -585,7 +585,7 @@ mod tests {
         let op = ManageQueryOp::ReplicatorList;
         assert_eq!(
             op,
-            serde_cbor::from_slice(&serde_cbor::to_vec(&op).unwrap()).unwrap()
+            defra_core::cbor::from_slice(&defra_core::cbor::to_vec(&op).unwrap()).unwrap()
         );
     }
 
@@ -596,7 +596,7 @@ mod tests {
         };
         assert_eq!(
             result,
-            serde_cbor::from_slice(&serde_cbor::to_vec(&result).unwrap()).unwrap()
+            defra_core::cbor::from_slice(&defra_core::cbor::to_vec(&result).unwrap()).unwrap()
         );
     }
 
@@ -651,7 +651,7 @@ mod tests {
         );
         req.set_message_id("mid-1".into());
         let back: ManageRequest =
-            serde_cbor::from_slice(&serde_cbor::to_vec(&req).unwrap()).unwrap();
+            defra_core::cbor::from_slice(&defra_core::cbor::to_vec(&req).unwrap()).unwrap();
         assert_eq!(back.message_id(), "mid-1");
         assert_eq!(back.auth_token, b"jwt");
     }

--- a/crates/p2p/src/message/pushlog.rs
+++ b/crates/p2p/src/message/pushlog.rs
@@ -16,7 +16,7 @@ fn is_false(value: &bool) -> bool {
 ///
 /// This is the primary message type for CRDT synchronization between nodes.
 ///
-/// Note: We don't use `#[serde(flatten)]` because serde_cbor produces
+/// Note: We don't use `#[serde(flatten)]` because serde's flatten produces
 /// indefinite-length maps when flatten is used (CBOR major type 0xbf).
 /// Go's fxamacker/cbor produces definite-length maps, causing signature
 /// verification to fail. Instead, we duplicate the fields for wire compatibility.
@@ -169,7 +169,7 @@ impl Message for PushLogRequest {
 
 /// PushLog reply message sent in response to a PushLogRequest.
 ///
-/// Note: We don't use `#[serde(flatten)]` because serde_cbor produces
+/// Note: We don't use `#[serde(flatten)]` because serde's flatten produces
 /// indefinite-length maps when flatten is used (CBOR major type 0xbf).
 /// Go's fxamacker/cbor produces definite-length maps, causing signature
 /// verification to fail. Instead, we duplicate the fields for wire compatibility.
@@ -366,13 +366,13 @@ fn truncated_text_prefix(text: &str) -> String {
     not(any(feature = "libp2p-transport", feature = "iroh-transport")),
     allow(dead_code)
 )]
-fn describe_cbor_value(value: &serde_cbor::Value) -> String {
+fn describe_cbor_value(value: &ciborium::Value) -> String {
     match value {
-        serde_cbor::Value::Map(entries) => {
+        ciborium::Value::Map(entries) => {
             let keys: Vec<String> = entries
-                .keys()
-                .filter_map(|key| match key {
-                    serde_cbor::Value::Text(text) => Some(text.clone()),
+                .iter()
+                .filter_map(|(key, _)| match key {
+                    ciborium::Value::Text(text) => Some(text.clone()),
                     _ => None,
                 })
                 .take(10)
@@ -383,16 +383,16 @@ fn describe_cbor_value(value: &serde_cbor::Value) -> String {
                 format!("cbor_map(keys=[{}])", keys.join(","))
             }
         }
-        serde_cbor::Value::Array(items) => format!("cbor_array(len={})", items.len()),
-        serde_cbor::Value::Bytes(bytes) => format!("cbor_bytes(len={})", bytes.len()),
-        serde_cbor::Value::Text(text) => {
+        ciborium::Value::Array(items) => format!("cbor_array(len={})", items.len()),
+        ciborium::Value::Bytes(bytes) => format!("cbor_bytes(len={})", bytes.len()),
+        ciborium::Value::Text(text) => {
             format!("cbor_text(prefix={:?})", truncated_text_prefix(text))
         }
-        serde_cbor::Value::Tag(tag, _) => format!("cbor_tag({tag})"),
-        serde_cbor::Value::Bool(value) => format!("cbor_bool({value})"),
-        serde_cbor::Value::Null => "cbor_null".to_string(),
-        serde_cbor::Value::Integer(_) => "cbor_integer".to_string(),
-        serde_cbor::Value::Float(_) => "cbor_float".to_string(),
+        ciborium::Value::Tag(tag, _) => format!("cbor_tag({tag})"),
+        ciborium::Value::Bool(value) => format!("cbor_bool({value})"),
+        ciborium::Value::Null => "cbor_null".to_string(),
+        ciborium::Value::Integer(_) => "cbor_integer".to_string(),
+        ciborium::Value::Float(_) => "cbor_float".to_string(),
         _ => "cbor_scalar".to_string(),
     }
 }
@@ -406,7 +406,7 @@ fn describe_gossip_payload_shape(payload: &[u8]) -> String {
         return "empty".to_string();
     }
 
-    if let Ok(value) = serde_cbor::from_slice::<serde_cbor::Value>(payload) {
+    if let Ok(value) = defra_core::cbor::from_slice::<ciborium::Value>(payload) {
         return describe_cbor_value(&value);
     }
 
@@ -471,7 +471,7 @@ impl PushLogBroadcast {
     pub fn decode_gossip_payload(
         payload: &[u8],
     ) -> Result<(Self, PushLogGossipPayloadEncoding), String> {
-        serde_cbor::from_slice::<PushLogRequest>(payload)
+        defra_core::cbor::from_slice::<PushLogRequest>(payload)
             .map(|request| {
                 (
                     Self::from_request(&request),
@@ -479,7 +479,7 @@ impl PushLogBroadcast {
                 )
             })
             .or_else(|_| {
-                serde_cbor::from_slice::<Self>(payload)
+                defra_core::cbor::from_slice::<Self>(payload)
                     .map(|broadcast| (broadcast, PushLogGossipPayloadEncoding::CborBroadcast))
             })
             .or_else(|_| {
@@ -490,8 +490,8 @@ impl PushLogBroadcast {
     }
 
     /// Encode a gossip payload using the canonical, self-describing wire format.
-    pub fn encode_gossip_payload(&self) -> Result<Vec<u8>, serde_cbor::Error> {
-        serde_cbor::to_vec(self)
+    pub fn encode_gossip_payload(&self) -> Result<Vec<u8>, defra_core::cbor::Error> {
+        defra_core::cbor::to_vec(self)
     }
 
     #[cfg_attr(
@@ -513,7 +513,7 @@ mod tests {
 
     #[test]
     fn inspect_gossip_payload_identifies_cbor_request_shape() {
-        let payload = serde_cbor::to_vec(&PushLogRequest::new(
+        let payload = defra_core::cbor::to_vec(&PushLogRequest::new(
             "doc-1".to_string(),
             Bytes::from_static(&[1, 2, 3]),
             "collection-1".to_string(),
@@ -617,7 +617,7 @@ mod tests {
             future_field: "ignored by older decoders".to_string(),
         };
 
-        let encoded = serde_cbor::to_vec(&future).expect("future payload should encode");
+        let encoded = defra_core::cbor::to_vec(&future).expect("future payload should encode");
         let (decoded, encoding) = PushLogBroadcast::decode_gossip_payload(&encoded)
             .expect("future payload should decode as broadcast");
 

--- a/crates/p2p/src/message/se.rs
+++ b/crates/p2p/src/message/se.rs
@@ -51,7 +51,7 @@ impl SEFieldQuery {
 ///
 /// Matches Go's QuerySEArtifactsRequest.
 ///
-/// Note: We don't use `#[serde(flatten)]` because serde_cbor produces
+/// Note: We don't use `#[serde(flatten)]` because serde's flatten produces
 /// indefinite-length maps when flatten is used (CBOR major type 0xbf).
 /// Go's fxamacker/cbor produces definite-length maps, causing signature
 /// verification to fail. Instead, we duplicate the fields for wire compatibility.
@@ -310,7 +310,7 @@ impl SEArtifact {
 ///
 /// Matches Go's PushSEArtifactsRequest.
 ///
-/// Note: We don't use `#[serde(flatten)]` because serde_cbor produces
+/// Note: We don't use `#[serde(flatten)]` because serde's flatten produces
 /// indefinite-length maps when flatten is used (CBOR major type 0xbf).
 /// Go's fxamacker/cbor produces definite-length maps, causing signature
 /// verification to fail. Instead, we duplicate the fields for wire compatibility.

--- a/crates/p2p/src/signing.rs
+++ b/crates/p2p/src/signing.rs
@@ -78,7 +78,8 @@ where
     msg.set_signature(None);
 
     // CBOR serialize the message
-    let bytes = serde_cbor::to_vec(&msg).map_err(|e| Error::CborSerialization(e.to_string()))?;
+    let bytes =
+        defra_core::cbor::to_vec(&msg).map_err(|e| Error::CborSerialization(e.to_string()))?;
 
     // Debug logging
     tracing::debug!(
@@ -151,8 +152,8 @@ where
     msg_for_verify.set_signature(None);
 
     // CBOR serialize
-    let bytes =
-        serde_cbor::to_vec(&msg_for_verify).map_err(|e| Error::CborSerialization(e.to_string()))?;
+    let bytes = defra_core::cbor::to_vec(&msg_for_verify)
+        .map_err(|e| Error::CborSerialization(e.to_string()))?;
 
     // Verify signature
     if !pubkey.verify(&bytes, signature) {
@@ -198,7 +199,8 @@ where
     msg.set_pubkey(transport.local_public_key_proto().to_vec());
     msg.set_signature(None);
 
-    let bytes = serde_cbor::to_vec(&msg).map_err(|e| Error::CborSerialization(e.to_string()))?;
+    let bytes =
+        defra_core::cbor::to_vec(&msg).map_err(|e| Error::CborSerialization(e.to_string()))?;
 
     let signature = transport.sign(&bytes)?;
     msg.set_signature(Some(signature));

--- a/crates/p2p/src/sync/car.rs
+++ b/crates/p2p/src/sync/car.rs
@@ -309,39 +309,51 @@ fn extract_links(block_data: &[u8]) -> Vec<Cid> {
 // is an internal Rust-to-Rust protocol.
 
 fn encode_car_header(roots: &[Cid]) -> Result<Vec<u8>> {
-    use serde_cbor::Value;
+    use ciborium::Value;
     let roots_val: Vec<Value> = roots
         .iter()
         .map(|cid| Value::Bytes(cid.to_bytes()))
         .collect();
 
-    let mut map = std::collections::BTreeMap::new();
-    map.insert(Value::Text("roots".into()), Value::Array(roots_val));
-    map.insert(Value::Text("version".into()), Value::Integer(1));
+    // ciborium's Value::Map is an ordered Vec, so key order is written out
+    // explicitly here. It previously came from a BTreeMap, which sorted the
+    // keys; "roots" < "version" alphabetically, so this order reproduces the
+    // existing bytes exactly. `car_header_bytes_unchanged_by_encoder` pins it.
+    let header = Value::Map(vec![
+        (Value::Text("roots".into()), Value::Array(roots_val)),
+        (Value::Text("version".into()), Value::Integer(1.into())),
+    ]);
 
-    serde_cbor::to_vec(&Value::Map(map))
-        .map_err(|e| Error::Codec(format!("failed to encode CAR header: {}", e)))
+    let mut out = Vec::new();
+    ciborium::into_writer(&header, &mut out)
+        .map_err(|e| Error::Codec(format!("failed to encode CAR header: {}", e)))?;
+    Ok(out)
 }
 
 fn decode_car_header(data: &[u8]) -> Result<Vec<Cid>> {
-    use serde_cbor::Value;
+    use ciborium::Value;
 
-    let value: Value = serde_cbor::from_slice(data)
+    let value: Value = defra_core::cbor::from_slice(data)
         .map_err(|e| Error::Codec(format!("invalid CAR header: {}", e)))?;
 
+    // ciborium models a CBOR map as an ordered Vec of pairs rather than a
+    // keyed map, so entries are looked up by scanning.
     let map = match value {
         Value::Map(m) => m,
         _ => return Err(Error::Codec("CAR header is not a CBOR map".into())),
     };
+    let field = |name: &str| {
+        map.iter()
+            .find(|(key, _)| matches!(key, Value::Text(text) if text == name))
+            .map(|(_, value)| value)
+    };
 
-    let version_key = Value::Text("version".into());
-    match map.get(&version_key) {
-        Some(Value::Integer(1)) => {}
+    match field("version") {
+        Some(Value::Integer(v)) if i128::from(*v) == 1 => {}
         _ => return Err(Error::Codec("CAR header version must be 1".into())),
     }
 
-    let roots_key = Value::Text("roots".into());
-    let roots_array = match map.get(&roots_key) {
+    let roots_array = match field("roots") {
         Some(Value::Array(a)) => a,
         _ => return Err(Error::Codec("CAR header 'roots' must be an array".into())),
     };

--- a/crates/p2p/src/sync/pending_store.rs
+++ b/crates/p2p/src/sync/pending_store.rs
@@ -81,11 +81,11 @@ pub struct PersistedPendingDag {
 
 impl PersistedPendingDag {
     pub fn to_bytes(&self) -> Result<Vec<u8>> {
-        serde_cbor::to_vec(self).map_err(|e| Error::Storage(e.to_string()))
+        defra_core::cbor::to_vec(self).map_err(|e| Error::Storage(e.to_string()))
     }
 
     pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
-        serde_cbor::from_slice(bytes).map_err(|e| Error::Storage(e.to_string()))
+        defra_core::cbor::from_slice(bytes).map_err(|e| Error::Storage(e.to_string()))
     }
 }
 
@@ -101,11 +101,11 @@ pub struct PersistedQuarantinedDag {
 
 impl PersistedQuarantinedDag {
     pub fn to_bytes(&self) -> Result<Vec<u8>> {
-        serde_cbor::to_vec(self).map_err(|e| Error::Storage(e.to_string()))
+        defra_core::cbor::to_vec(self).map_err(|e| Error::Storage(e.to_string()))
     }
 
     pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
-        serde_cbor::from_slice(bytes).map_err(|e| Error::Storage(e.to_string()))
+        defra_core::cbor::from_slice(bytes).map_err(|e| Error::Storage(e.to_string()))
     }
 
     /// Current wall-clock time as Unix seconds, for stamping `quarantined_at_unix_secs`.

--- a/crates/p2p/src/two_stream/handler/inbound.rs
+++ b/crates/p2p/src/two_stream/handler/inbound.rs
@@ -46,7 +46,7 @@ impl TwoStreamHandler {
         })?;
 
         // Try to deserialize as PushLogRequest first
-        if let Ok(request) = serde_cbor::from_slice::<PushLogRequest>(&buf) {
+        if let Ok(request) = defra_core::cbor::from_slice::<PushLogRequest>(&buf) {
             crate::verify_message(&request)?;
             ensure_transport_sender(&peer_id, &request)?;
             tracing::info!(
@@ -59,7 +59,7 @@ impl TwoStreamHandler {
         }
 
         // Try to deserialize as DocSyncRequest
-        if let Ok(request) = serde_cbor::from_slice::<DocSyncRequest>(&buf) {
+        if let Ok(request) = defra_core::cbor::from_slice::<DocSyncRequest>(&buf) {
             crate::verify_message(&request)?;
             ensure_transport_sender(&peer_id, &request)?;
             tracing::info!(
@@ -72,7 +72,7 @@ impl TwoStreamHandler {
         }
 
         // Try to deserialize as BranchableSyncRequest
-        if let Ok(request) = serde_cbor::from_slice::<BranchableSyncRequest>(&buf) {
+        if let Ok(request) = defra_core::cbor::from_slice::<BranchableSyncRequest>(&buf) {
             crate::verify_message(&request)?;
             ensure_transport_sender(&peer_id, &request)?;
             tracing::info!(
@@ -85,7 +85,7 @@ impl TwoStreamHandler {
         }
 
         // Try to deserialize as IdentityRequest
-        if let Ok(request) = serde_cbor::from_slice::<IdentityRequest>(&buf) {
+        if let Ok(request) = defra_core::cbor::from_slice::<IdentityRequest>(&buf) {
             crate::verify_message(&request)?;
             ensure_transport_sender(&peer_id, &request)?;
             tracing::info!(
@@ -144,8 +144,8 @@ impl TwoStreamHandler {
         );
 
         // Try BranchableSyncReply first (has CollectionID + Heads fields).
-        // Must come before DocSyncReply since serde_cbor ignores unknown fields.
-        match serde_cbor::from_slice::<BranchableSyncReply>(&buf) {
+        // Must come before DocSyncReply since CBOR decoding ignores unknown fields.
+        match defra_core::cbor::from_slice::<BranchableSyncReply>(&buf) {
             Ok(reply) if !reply.collection_id.is_empty() => {
                 crate::verify_message(&reply)?;
                 ensure_transport_sender(&peer_id, &reply)?;
@@ -189,7 +189,7 @@ impl TwoStreamHandler {
         // A PushLogReply will also deserialize as DocSyncReply (with default
         // empty Results), but verifying the signature against the DocSyncReply
         // shape changes the serialized bytes and fails validation.
-        if let Ok(response) = serde_cbor::from_slice::<PushLogReply>(&buf) {
+        if let Ok(response) = defra_core::cbor::from_slice::<PushLogReply>(&buf) {
             let message_id = response.message_id.clone();
             let pending_key = PendingResponseKey::new(peer_id, message_id.clone());
             let is_pending_pushlog = {
@@ -220,7 +220,7 @@ impl TwoStreamHandler {
             }
         }
 
-        if let Ok(reply) = serde_cbor::from_slice::<IdentityResponse>(&buf) {
+        if let Ok(reply) = defra_core::cbor::from_slice::<IdentityResponse>(&buf) {
             crate::verify_message(&reply)?;
             ensure_transport_sender(&peer_id, &reply)?;
             let message_id = reply.message_id.clone();
@@ -246,7 +246,7 @@ impl TwoStreamHandler {
         // Deserialize as DocSyncReply once we've ruled out a pending PushLogReply
         // and an IdentityResponse. IdentityResponse shares the same metadata
         // shape and DocSyncReply defaults Results to empty, so DocSync must come later.
-        if let Ok(reply) = serde_cbor::from_slice::<DocSyncReply>(&buf) {
+        if let Ok(reply) = defra_core::cbor::from_slice::<DocSyncReply>(&buf) {
             crate::verify_message(&reply)?;
             ensure_transport_sender(&peer_id, &reply)?;
             let message_id = reply.message_id.clone();
@@ -290,7 +290,7 @@ impl TwoStreamHandler {
         }
 
         // Fallback: try PushLogReply in case the message doesn't parse as DocSyncReply
-        if let Ok(response) = serde_cbor::from_slice::<PushLogReply>(&buf) {
+        if let Ok(response) = defra_core::cbor::from_slice::<PushLogReply>(&buf) {
             crate::verify_message(&response)?;
             ensure_transport_sender(&peer_id, &response)?;
             let message_id = response.message_id.clone();

--- a/crates/p2p/src/two_stream/handler/manage.rs
+++ b/crates/p2p/src/two_stream/handler/manage.rs
@@ -251,7 +251,7 @@ mod tests {
             b"t".to_vec(),
         );
         let back: ManageRequest =
-            serde_cbor::from_slice(&serde_cbor::to_vec(&req).unwrap()).unwrap();
+            defra_core::cbor::from_slice(&defra_core::cbor::to_vec(&req).unwrap()).unwrap();
         assert!(matches!(back.op, ManageMutateOp::CollectionAdd { .. }));
     }
 }

--- a/crates/p2p/src/two_stream/handler/mod.rs
+++ b/crates/p2p/src/two_stream/handler/mod.rs
@@ -282,7 +282,7 @@ where
     })?
     .map_err(|e| Error::CborDeserialization(format!("failed to read {label}: {e}")))?;
 
-    serde_cbor::from_slice(&buf)
+    defra_core::cbor::from_slice(&buf)
         .map_err(|e| Error::CborDeserialization(format!("failed to decode {label}: {e}")))
 }
 

--- a/crates/p2p/src/two_stream/runner.rs
+++ b/crates/p2p/src/two_stream/runner.rs
@@ -219,7 +219,7 @@ impl TwoStreamRunner {
                                 tracing::warn!(peer_id = %peer_id, error = %e, "Failed to read SE request stream");
                             }
                             Ok(Ok(_)) => {
-                                match serde_cbor::from_slice::<crate::message::PushSEArtifactsRequest>(&buf) {
+                                match defra_core::cbor::from_slice::<crate::message::PushSEArtifactsRequest>(&buf) {
                                     Ok(request) => {
                                         tracing::info!(
                                             peer_id = %peer_id,

--- a/crates/p2p/tests/message_tests.rs
+++ b/crates/p2p/tests/message_tests.rs
@@ -422,7 +422,7 @@ fn test_pushlog_broadcast_to_request() {
 
 // Regression guard for issue #827.
 //
-// `#[serde(flatten)]` on MetaData causes serde_cbor to emit an indefinite-
+// `#[serde(flatten)]` on MetaData causes the encoder to emit an indefinite-
 // length CBOR map (major type 5, additional info 31 = byte 0xbf) instead of
 // a definite-length map (0xa0–0xb7 for 0–23 entries). Go's fxamacker/cbor
 // emits definite maps. Since both sides re-serialize for signature
@@ -460,42 +460,42 @@ mod regression_827 {
             "creator".into(),
             Bytes::from(vec![2]),
         );
-        let bytes = serde_cbor::to_vec(&req).unwrap();
+        let bytes = defra_core::cbor::to_vec(&req).unwrap();
         assert_definite_cbor_map("PushLogRequest", &bytes);
     }
 
     #[test]
     fn docsync_request_definite_map() {
         let req = DocSyncRequest::new(vec!["doc1".into()]);
-        let bytes = serde_cbor::to_vec(&req).unwrap();
+        let bytes = defra_core::cbor::to_vec(&req).unwrap();
         assert_definite_cbor_map("DocSyncRequest", &bytes);
     }
 
     #[test]
     fn branchable_request_definite_map() {
         let req = BranchableSyncRequest::new("col1".into());
-        let bytes = serde_cbor::to_vec(&req).unwrap();
+        let bytes = defra_core::cbor::to_vec(&req).unwrap();
         assert_definite_cbor_map("BranchableSyncRequest", &bytes);
     }
 
     #[test]
     fn identity_request_definite_map() {
         let req = IdentityRequest::new("peer1".into());
-        let bytes = serde_cbor::to_vec(&req).unwrap();
+        let bytes = defra_core::cbor::to_vec(&req).unwrap();
         assert_definite_cbor_map("IdentityRequest", &bytes);
     }
 
     #[test]
     fn query_se_request_definite_map() {
         let req = QuerySEArtifactsRequest::new("col1", vec![]);
-        let bytes = serde_cbor::to_vec(&req).unwrap();
+        let bytes = defra_core::cbor::to_vec(&req).unwrap();
         assert_definite_cbor_map("QuerySEArtifactsRequest", &bytes);
     }
 
     #[test]
     fn push_se_request_definite_map() {
         let req = PushSEArtifactsRequest::new("col1", vec![]);
-        let bytes = serde_cbor::to_vec(&req).unwrap();
+        let bytes = defra_core::cbor::to_vec(&req).unwrap();
         assert_definite_cbor_map("PushSEArtifactsRequest", &bytes);
     }
 }

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -21,7 +21,6 @@ async-trait.workspace = true
 
 # Serialization
 serde.workspace = true
-serde_cbor.workspace = true
 serde_json.workspace = true
 
 # IPLD

--- a/crates/storage/src/corekv/errors.rs
+++ b/crates/storage/src/corekv/errors.rs
@@ -133,8 +133,8 @@ impl From<std::io::Error> for Error {
     }
 }
 
-impl From<serde_cbor::Error> for Error {
-    fn from(err: serde_cbor::Error) -> Self {
+impl From<defra_core::cbor::Error> for Error {
+    fn from(err: defra_core::cbor::Error) -> Self {
         Error::Serialization(err.to_string())
     }
 }

--- a/crates/storage/src/stores/retry_info.rs
+++ b/crates/storage/src/stores/retry_info.rs
@@ -103,12 +103,12 @@ impl PersistedPushRetry {
     }
 
     pub fn to_bytes(&self) -> Result<Vec<u8>, String> {
-        serde_cbor::to_vec(self)
+        defra_core::cbor::to_vec(self)
             .map_err(|error| format!("failed to serialize persisted push retry: {error}"))
     }
 
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, String> {
-        serde_cbor::from_slice(bytes)
+        defra_core::cbor::from_slice(bytes)
             .map_err(|error| format!("failed to deserialize persisted push retry: {error}"))
     }
 }
@@ -173,11 +173,12 @@ impl RetryInfo {
     }
 
     pub fn to_bytes(&self) -> Result<Vec<u8>, String> {
-        serde_cbor::to_vec(self).map_err(|e| format!("failed to serialize RetryInfo: {}", e))
+        defra_core::cbor::to_vec(self).map_err(|e| format!("failed to serialize RetryInfo: {}", e))
     }
 
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, String> {
-        serde_cbor::from_slice(bytes).map_err(|e| format!("failed to deserialize RetryInfo: {}", e))
+        defra_core::cbor::from_slice(bytes)
+            .map_err(|e| format!("failed to deserialize RetryInfo: {}", e))
     }
 }
 
@@ -228,7 +229,7 @@ mod tests {
             retry_info: RetryInfo,
         }
 
-        let bytes = serde_cbor::to_vec(&LegacyPersistedPushRetry {
+        let bytes = defra_core::cbor::to_vec(&LegacyPersistedPushRetry {
             doc_id: "doc",
             collection_id: "collection",
             cid: "cid",

--- a/deny.toml
+++ b/deny.toml
@@ -46,12 +46,6 @@ ignore = [
     # will disappear when iroh does.
     "RUSTSEC-2025-0134",
 
-    # serde_cbor — unmaintained. Used directly by db, storage, and p2p
-    # for wire-format CBOR. Replacing with ciborium is a workspace-wide
-    # refactor that touches P2P wire format — out of scope for #705 and
-    # deliberately tracked as future work.
-    "RUSTSEC-2021-0127",
-
     # wasmtime-related — belt-and-braces ignore after the wasmtime 41
     # upgrade (which remediated RUSTSEC-2025-0046 / 0118 / 2026-0006).
     # Retained until the upstream advisory is retracted for recent


### PR DESCRIPTION
Fixes #1347.

serde_cbor is unmaintained (RUSTSEC-2021-0127) and is now gone from the
workspace: no source references, no manifest entries, no lockfile entry.

## What changed

- New `defra_core::cbor` with `to_vec` / `from_slice` over ciborium — one
  helper, since all four consumers already depend on `defra-core`.
- 49 `to_vec` and 38 `from_slice` sites migrated. `Value` sites in `car.rs`,
  `pushlog.rs` and `kms/wire.rs` needed real porting: ciborium's `Value::Map`
  is an ordered `Vec`, not a `BTreeMap`, and its `Integer` is a wrapper.
- Both `From<serde_cbor::Error>` impls replaced. p2p's now discriminates
  serialize-vs-deserialize explicitly instead of guessing via `is_io()/is_eof()`.
- Dropped the now-stale `RUSTSEC-2021-0127` ignore from `deny.toml`, so
  cargo-deny fails if serde_cbor ever returns. `db` also declared it while
  using it zero times; removed.

## One behavioural difference, fixed

serde_cbor's `from_slice` rejects unconsumed input; ciborium's `from_reader`
decodes one item and stops. `b"hello from some other producer"` starts with
`0x68` ("text string, length 8"), so ciborium returned `Text("ello fro")`
having consumed 9 of 30 bytes. These bytes come from peers, so a padded or
truncated frame would have been silently accepted.

`defra_core::cbor::from_slice` now rejects trailing data, with a regression
test. All 38 decode sites inherit it.

## Size

Two sequential fat-LTO release builds, same machine:

| | bytes |
|---|---|
| before | 53,270,480 |
| after | 52,604,400 |
| **saved** | **666,080 (650.5 KiB, 1.25%)** |

`.text` down 478.4 KiB. Inside #1347's 500-800 KiB estimate. ciborium was
already in the lockfile, so this is a straight removal with no new dependency.

## Verification

Phase 1's byte-compare (21 cases, 15 frame types, all Go-facing frames
included) found **21/21 byte-identical** and 21/21 cross-decodable, which is
what justified migrating rather than versioning. That harness was scaffolding
and is not included here.

`just fmt-check`, `just lint`, `just lint-wasm` pass. `just test` has one
failing suite, `embedded::shutdown` — pre-existing on `main`, fixed by #1370.

dag-cbor (`serde_ipld_dagcbor`) is untouched.
