### PR TITLE
Run embedded queries with signed node provenance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3658,6 +3658,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
+ "base64 0.22.1",
  "cid",
  "criterion 0.6.0",
  "crypto",

--- a/crates/cli/src/block_adapter.rs
+++ b/crates/cli/src/block_adapter.rs
@@ -26,6 +26,25 @@ impl<S: Store + 'static> BlockAdapter<S> {
 
 #[async_trait]
 impl<S: Store + 'static> BlockOperations for BlockAdapter<S> {
+    async fn signed_block_bytes(
+        &self,
+        cid: &str,
+        caller_did: Option<&str>,
+    ) -> Result<(Vec<u8>, Vec<u8>), String> {
+        let caller_did = caller_did
+            .map(|did| identity::Did::try_from(did.to_string()))
+            .transpose()
+            .map_err(|error| format!("invalid caller DID: {error}"))?;
+        let caller_identity: acp::Identity = caller_did.into();
+        db::block_verify::authorized_signed_block_bytes(
+            &self.database,
+            self.document_acp.as_ref(),
+            cid,
+            &caller_identity,
+        )
+        .await
+    }
+
     async fn verify_signature(
         &self,
         cid: &str,
@@ -40,9 +59,11 @@ impl<S: Store + 'static> BlockOperations for BlockAdapter<S> {
             other => return Err(format!("unsupported key type: {}", other)),
         };
 
-        let caller_identity: acp::Identity = caller_did
-            .and_then(|d| identity::Did::try_from(d.to_string()).ok())
-            .into();
+        let caller_did = caller_did
+            .map(|did| identity::Did::try_from(did.to_string()))
+            .transpose()
+            .map_err(|error| format!("invalid caller DID: {error}"))?;
+        let caller_identity: acp::Identity = caller_did.into();
 
         db::block_verify::verify_block_signature(
             &self.database,

--- a/crates/db/src/block_verify.rs
+++ b/crates/db/src/block_verify.rs
@@ -6,6 +6,137 @@ use storage::corekv::Store;
 use crate::database::DB;
 use crate::txn::DbTxn;
 
+/// Verify a block's embedded signature and return the signer's DID.
+///
+/// The public key and algorithm are read from the signed block's signature
+/// header. The DID is returned only after the signature has been verified over
+/// the canonical DAG-CBOR block bytes.
+pub async fn verified_block_signer_did<S: Store>(
+    database: &Arc<DB<S>>,
+    document_acp: &dyn acp::DocumentACP,
+    cid_str: &str,
+    caller_identity: &acp::Identity,
+) -> Result<String, String> {
+    let txn = database
+        .new_txn(true)
+        .await
+        .map_err(|e| format!("failed to create transaction: {}", e))?;
+    let blockstore = txn
+        .blockstore()
+        .map_err(|e| format!("failed to get blockstore: {}", e))?;
+    let systemstore = txn
+        .systemstore()
+        .map_err(|e| format!("failed to get systemstore: {}", e))?;
+
+    verified_block_signer_did_with_blockstore(
+        database,
+        document_acp,
+        blockstore,
+        systemstore,
+        cid_str,
+        caller_identity,
+    )
+    .await
+}
+
+/// Load one authorized signed block and its detached signature block as
+/// canonical DAG-CBOR bytes. Remote clients use this to verify CID integrity
+/// and authorship locally instead of trusting a server-side yes/no verdict.
+pub async fn authorized_signed_block_bytes<S: Store>(
+    database: &Arc<DB<S>>,
+    document_acp: &dyn acp::DocumentACP,
+    cid_str: &str,
+    caller_identity: &acp::Identity,
+) -> Result<(Vec<u8>, Vec<u8>), String> {
+    let txn = database
+        .new_txn(true)
+        .await
+        .map_err(|e| format!("failed to create transaction: {}", e))?;
+    let blockstore = txn
+        .blockstore()
+        .map_err(|e| format!("failed to get blockstore: {}", e))?;
+    let systemstore = txn
+        .systemstore()
+        .map_err(|e| format!("failed to get systemstore: {}", e))?;
+    let (_, _, block_bytes, signature_bytes) = load_authorized_block_signature(
+        database,
+        document_acp,
+        blockstore,
+        systemstore,
+        cid_str,
+        caller_identity,
+    )
+    .await?;
+    Ok((block_bytes, signature_bytes))
+}
+
+/// Verify a block visible inside an active transaction and return its signer DID.
+pub async fn verified_block_signer_did_in_txn<S: Store>(
+    database: &Arc<DB<S>>,
+    document_acp: &dyn acp::DocumentACP,
+    txn: &DbTxn<S>,
+    cid_str: &str,
+    caller_identity: &acp::Identity,
+) -> Result<String, String> {
+    let blockstore = txn
+        .blockstore()
+        .map_err(|e| format!("failed to get blockstore: {}", e))?;
+    let systemstore = txn
+        .systemstore()
+        .map_err(|e| format!("failed to get systemstore: {}", e))?;
+
+    verified_block_signer_did_with_blockstore(
+        database,
+        document_acp,
+        blockstore,
+        systemstore,
+        cid_str,
+        caller_identity,
+    )
+    .await
+}
+
+pub(crate) async fn verified_block_signer_did_with_blockstore<S: Store>(
+    database: &Arc<DB<S>>,
+    document_acp: &dyn acp::DocumentACP,
+    blockstore: NamespaceView,
+    systemstore: NamespaceView,
+    cid_str: &str,
+    caller_identity: &acp::Identity,
+) -> Result<String, String> {
+    let (block, signature, _, _) = load_authorized_block_signature(
+        database,
+        document_acp,
+        blockstore,
+        systemstore,
+        cid_str,
+        caller_identity,
+    )
+    .await?;
+    verified_signature_signer_did(&block, &signature)
+}
+
+fn verified_signature_signer_did(
+    block: &defra_core::block::Block,
+    signature: &defra_core::block::Signature,
+) -> Result<String, String> {
+    let signature_identity = std::str::from_utf8(&signature.header.identity)
+        .map_err(|e| format!("signature identity is not valid UTF-8: {}", e))?;
+    let key_type = match signature.header.sig_type {
+        defra_core::block::SignatureType::ES256K => crypto::KeyType::Secp256k1,
+        defra_core::block::SignatureType::ES256 => crypto::KeyType::Secp256r1,
+        defra_core::block::SignatureType::EdDSA => crypto::KeyType::Ed25519,
+        defra_core::block::SignatureType::BLS => crypto::KeyType::Bls12381,
+    };
+    let public_key = crypto::public_key_from_string(key_type, signature_identity)
+        .map_err(|e| format!("invalid signature identity: {}", e))?;
+
+    verify_signature_bytes(block, signature, public_key.as_ref())?;
+    public_key
+        .did()
+        .map_err(|e| format!("failed to derive signer DID: {}", e))
+}
+
 /// Verify the signature of a block.
 ///
 /// Loads a block from the blockstore by CID, checks that it has a signature,
@@ -92,30 +223,62 @@ async fn verify_block_signature_with_blockstore<S: Store>(
     public_key_hex: &str,
     caller_identity: &acp::Identity,
 ) -> Result<(), String> {
+    let (block, signature, _, _) = load_authorized_block_signature(
+        database,
+        document_acp,
+        blockstore,
+        systemstore,
+        cid_str,
+        caller_identity,
+    )
+    .await?;
+
+    let sig_identity = std::str::from_utf8(&signature.header.identity)
+        .map_err(|e| format!("signature identity is not valid UTF-8: {}", e))?;
+    if sig_identity != public_key_hex {
+        return Err("signature was created by a different key".to_string());
+    }
+
+    verify_signature_bytes(&block, &signature, pub_key)
+}
+
+async fn load_authorized_block_signature<S: Store>(
+    database: &Arc<DB<S>>,
+    document_acp: &dyn acp::DocumentACP,
+    blockstore: NamespaceView,
+    systemstore: NamespaceView,
+    cid_str: &str,
+    caller_identity: &acp::Identity,
+) -> Result<
+    (
+        defra_core::block::Block,
+        defra_core::block::Signature,
+        Vec<u8>,
+        Vec<u8>,
+    ),
+    String,
+> {
     let parsed_cid: cid::Cid = cid_str.parse().map_err(|e| format!("invalid CID: {}", e))?;
-    let (block, signature) = {
-        let block_bytes = blockstore
-            .get(&parsed_cid.to_bytes())
-            .await
-            .map_err(|e| format!("failed to load block: {}", e))?
-            .ok_or_else(|| format!("could not find block: {}", cid_str))?;
+    let block_bytes = blockstore
+        .get(&parsed_cid.to_bytes())
+        .await
+        .map_err(|e| format!("failed to load block: {}", e))?
+        .ok_or_else(|| format!("could not find block: {}", cid_str))?;
+    blockstore::verify_block_cid(&parsed_cid, &block_bytes)
+        .map_err(|e| format!("block CID verification failed: {}", e))?;
 
-        let block = defra_core::block::Block::from_dag_cbor(&block_bytes)
-            .map_err(|e| format!("failed to decode block: {}", e))?;
-
-        let sig_cid = block.signature.ok_or("block has no signature")?;
-
-        let sig_bytes = blockstore
-            .get(&sig_cid.to_bytes())
-            .await
-            .map_err(|e| format!("failed to load signature block: {}", e))?
-            .ok_or_else(|| format!("signature block not found: {}", sig_cid))?;
-
-        let signature = defra_core::block::Signature::from_dag_cbor(&sig_bytes)
-            .map_err(|e| format!("failed to decode signature block: {}", e))?;
-
-        (block, signature)
-    };
+    let block = defra_core::block::Block::from_dag_cbor(&block_bytes)
+        .map_err(|e| format!("failed to decode block: {}", e))?;
+    let sig_cid = block.signature.ok_or("block has no signature")?;
+    let sig_bytes = blockstore
+        .get(&sig_cid.to_bytes())
+        .await
+        .map_err(|e| format!("failed to load signature block: {}", e))?
+        .ok_or_else(|| format!("signature block not found: {}", sig_cid))?;
+    blockstore::verify_block_cid(&sig_cid, &sig_bytes)
+        .map_err(|e| format!("signature block CID verification failed: {}", e))?;
+    let signature = defra_core::block::Signature::from_dag_cbor(&sig_bytes)
+        .map_err(|e| format!("failed to decode signature block: {}", e))?;
 
     // Check document/collection-level ACP permission (Read) if the block has
     // collection metadata.
@@ -173,20 +336,21 @@ async fn verify_block_signature_with_blockstore<S: Store>(
         }
     }
 
-    // Verify that the identity matches the signature's identity
-    let sig_identity = String::from_utf8_lossy(&signature.header.identity);
-    if sig_identity.as_ref() != public_key_hex {
-        return Err("signature was created by a different key".to_string());
-    }
+    Ok((block, signature, block_bytes.to_vec(), sig_bytes.to_vec()))
+}
 
-    // Get the bytes to verify (block serialized without signature)
+fn verify_signature_bytes(
+    block: &defra_core::block::Block,
+    signature: &defra_core::block::Signature,
+    public_key: &dyn crypto::PublicKey,
+) -> Result<(), String> {
     let mut block_to_verify = block.clone();
     block_to_verify.signature = None;
     let signed_bytes = block_to_verify
         .to_dag_cbor()
         .map_err(|e| format!("failed to serialize block for verification: {}", e))?;
 
-    let valid = pub_key
+    let valid = public_key
         .verify(&signed_bytes, &signature.value)
         .map_err(|e| format!("signature verification error: {}", e))?;
 
@@ -195,4 +359,81 @@ async fn verify_block_signature_with_blockstore<S: Store>(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crypto::PrivateKey;
+    use defra_core::block::{
+        Block, CrdtDelta, LwwDeltaPayload, Signature, SignatureHeader, SignatureType,
+    };
+
+    use super::verified_signature_signer_did;
+
+    fn test_block() -> Block {
+        Block {
+            delta: CrdtDelta::Lww(LwwDeltaPayload {
+                field_name: "name".to_string(),
+                schema_version_id: "v1".to_string(),
+                priority: 1,
+                data: b"original".to_vec(),
+            }),
+            heads: None,
+            links: None,
+            encryption: None,
+            signature: None,
+        }
+    }
+
+    fn sign_block(block: &Block) -> (Signature, String) {
+        let private_key = crypto::generate_ed25519().expect("generate Ed25519 key");
+        let public_key = private_key.public_key();
+        let signer_did = public_key.did().expect("derive signer DID");
+        let signature = Signature::new(
+            SignatureHeader::new(
+                SignatureType::EdDSA,
+                hex::encode(public_key.raw()).into_bytes(),
+            ),
+            private_key
+                .sign(&block.to_dag_cbor().expect("encode block"))
+                .expect("sign block"),
+        );
+        (signature, signer_did)
+    }
+
+    #[test]
+    fn verified_signer_returns_signer_did() {
+        let block = test_block();
+        let (signature, signer_did) = sign_block(&block);
+
+        let verified_did =
+            verified_signature_signer_did(&block, &signature).expect("valid signature must verify");
+        assert_eq!(verified_did, signer_did);
+    }
+
+    #[test]
+    fn verified_signer_rejects_tampered_block() {
+        let block = test_block();
+        let (signature, _) = sign_block(&block);
+        let mut tampered = block;
+        let CrdtDelta::Lww(payload) = &mut tampered.delta else {
+            panic!("expected LWW delta");
+        };
+        payload.data = b"tampered".to_vec();
+
+        let error = verified_signature_signer_did(&tampered, &signature)
+            .expect_err("tampered block must fail verification");
+        assert!(error.contains("signature verification"), "{error}");
+    }
+
+    #[test]
+    fn verified_signer_rejects_invalid_identity() {
+        let block = test_block();
+        let (mut signature, _) = sign_block(&block);
+        signature.header.identity = b"not hex".to_vec();
+
+        let error = verified_signature_signer_did(&block, &signature)
+            .expect_err("invalid identity must fail verification");
+        assert!(error.contains("invalid signature identity"), "{error}");
+    }
 }

--- a/crates/db/src/txn_registry.rs
+++ b/crates/db/src/txn_registry.rs
@@ -667,6 +667,40 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
         .map_err(Error::Other)
     }
 
+    /// Verify a block's embedded signature inside an active transaction and
+    /// return the signer DID.
+    pub async fn verified_block_signer_did_in_txn(
+        &self,
+        txn_id: &str,
+        document_acp: &dyn acp::DocumentACP,
+        cid_str: &str,
+        caller_identity: &acp::Identity,
+    ) -> Result<String> {
+        let ctx = self
+            .get_ctx(txn_id)?
+            .ok_or_else(|| Error::TransactionNotFound(txn_id.to_string()))?;
+        let action_lock = ctx.action_lock();
+        let _action_guard = action_lock.lock().await;
+
+        let (blockstore, systemstore) = {
+            let shared_txn = ctx.fetcher_shared_txn();
+            let txn_guard = shared_txn.lock().await;
+            let txn = txn_guard.as_ref().ok_or(Error::TxnNotActive)?;
+            (txn.blockstore()?, txn.systemstore()?)
+        };
+
+        crate::block_verify::verified_block_signer_did_with_blockstore(
+            &self.db,
+            document_acp,
+            blockstore,
+            systemstore,
+            cid_str,
+            caller_identity,
+        )
+        .await
+        .map_err(Error::Other)
+    }
+
     /// List all lenses visible within a transaction.
     pub async fn list_lenses_in_txn(
         &self,

--- a/crates/defra-node/src/db_impls.rs
+++ b/crates/defra-node/src/db_impls.rs
@@ -6,7 +6,80 @@ use identity::Did;
 use lens::{LensConfig, TransformId};
 use schema::CollectionVersion;
 
-use crate::SchemaOps;
+use crate::{BlockOps, SchemaOps};
+
+pub(crate) struct DbBlockOps<S: storage::corekv::Store + 'static> {
+    database: Arc<db::DB<S>>,
+    document_acp: Arc<dyn acp::DocumentACP>,
+    transaction_registry: Arc<db::DbTransactionRegistry<S>>,
+    caller_identity: acp::Identity,
+}
+
+impl<S: storage::corekv::Store + 'static> DbBlockOps<S> {
+    pub(crate) fn new(
+        database: Arc<db::DB<S>>,
+        document_acp: Arc<dyn acp::DocumentACP>,
+        transaction_registry: Arc<db::DbTransactionRegistry<S>>,
+        node_identity: Option<Did>,
+    ) -> Self {
+        let caller_identity = node_identity.into();
+        Self {
+            database,
+            document_acp,
+            transaction_registry,
+            caller_identity,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl<S: storage::corekv::Store + 'static> BlockOps for DbBlockOps<S> {
+    async fn signed_block_bytes(
+        &self,
+        cid: &str,
+        caller_did: Option<&str>,
+    ) -> anyhow::Result<(Vec<u8>, Vec<u8>)> {
+        let caller_did = caller_did
+            .map(|did| Did::try_from(did.to_string()))
+            .transpose()?;
+        let caller_identity: acp::Identity = caller_did.into();
+        db::block_verify::authorized_signed_block_bytes(
+            &self.database,
+            self.document_acp.as_ref(),
+            cid,
+            &caller_identity,
+        )
+        .await
+        .map_err(anyhow::Error::msg)
+    }
+
+    async fn verified_signer_did(&self, cid: &str) -> anyhow::Result<String> {
+        db::block_verify::verified_block_signer_did(
+            &self.database,
+            self.document_acp.as_ref(),
+            cid,
+            &self.caller_identity,
+        )
+        .await
+        .map_err(anyhow::Error::msg)
+    }
+
+    async fn verified_signer_did_in_txn(
+        &self,
+        cid: &str,
+        transaction: &query::TransactionHandle,
+    ) -> anyhow::Result<String> {
+        self.transaction_registry
+            .verified_block_signer_did_in_txn(
+                transaction.as_str(),
+                self.document_acp.as_ref(),
+                cid,
+                &self.caller_identity,
+            )
+            .await
+            .map_err(anyhow::Error::new)
+    }
+}
 
 pub(crate) struct DbSchemaOps<S: storage::corekv::Store + 'static> {
     database: Arc<db::DB<S>>,

--- a/crates/defra-node/src/embedded_query_identity_tests.rs
+++ b/crates/defra-node/src/embedded_query_identity_tests.rs
@@ -1,0 +1,244 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use defra_core::signing::{SigningConfig, SigningKeyType};
+use query::{QueryRequest, TransactionError, TransactionHandle};
+
+use super::tests::{TestRemoteSigner, SIGNING_STORE_GUARD};
+use super::{EmbeddedNode, ExecuteRetryPolicy, QueryExecutor};
+
+struct IdentityRecordingExecutor {
+    identities: std::sync::Mutex<Vec<Option<String>>>,
+    remaining_conflicts: AtomicUsize,
+}
+
+impl IdentityRecordingExecutor {
+    fn new(remaining_conflicts: usize) -> Self {
+        Self {
+            identities: std::sync::Mutex::new(Vec::new()),
+            remaining_conflicts: AtomicUsize::new(remaining_conflicts),
+        }
+    }
+
+    fn identities(&self) -> Vec<Option<String>> {
+        self.identities
+            .lock()
+            .expect("recorded identities poisoned")
+            .clone()
+    }
+
+    fn record(&self, request: &QueryRequest) {
+        self.identities
+            .lock()
+            .expect("recorded identities poisoned")
+            .push(request.identity.as_ref().map(ToString::to_string));
+    }
+}
+
+#[async_trait::async_trait]
+impl QueryExecutor for IdentityRecordingExecutor {
+    async fn execute(&self, request: QueryRequest) -> query::QueryResponse {
+        self.record(&request);
+        if self.remaining_conflicts.load(Ordering::SeqCst) > 0 {
+            self.remaining_conflicts.fetch_sub(1, Ordering::SeqCst);
+            query::QueryResponse::transaction_conflict("test transaction conflict")
+        } else {
+            query::QueryResponse::success(serde_json::json!({"ok": true}))
+        }
+    }
+
+    async fn execute_in_txn(
+        &self,
+        request: QueryRequest,
+        _handle: &TransactionHandle,
+    ) -> query::QueryResponse {
+        self.record(&request);
+        query::QueryResponse::success(serde_json::json!({"ok": true}))
+    }
+
+    async fn begin_txn(&self, _readonly: bool) -> Result<TransactionHandle, TransactionError> {
+        Ok(TransactionHandle::new("identity-test-txn".to_string()))
+    }
+
+    async fn commit_txn(&self, _handle: &TransactionHandle) -> Result<(), TransactionError> {
+        Ok(())
+    }
+
+    async fn rollback_txn(&self, _handle: &TransactionHandle) -> Result<(), TransactionError> {
+        Ok(())
+    }
+
+    async fn schema(&self) -> query::Result<String> {
+        Ok(String::new())
+    }
+}
+
+fn register_test_remote_node_identity(did: &str) {
+    defra_core::signing::store_identity(
+        did,
+        SigningConfig {
+            key_type: SigningKeyType::Secp256r1,
+            private_key_bytes: Vec::new(),
+            public_key_bytes: vec![2, 3, 4],
+            public_key_hex: "020304".to_string(),
+            remote_signer: Some(Arc::new(TestRemoteSigner)),
+            signing_authorization: None,
+        },
+    );
+}
+
+async fn signed_node_with_executor(
+    did: &str,
+    executor: Arc<IdentityRecordingExecutor>,
+) -> EmbeddedNode {
+    register_test_remote_node_identity(did);
+    let mut node = EmbeddedNode::builder()
+        .with_node_identity_did(did)
+        .build()
+        .await
+        .expect("build signed identity-observing node");
+    node.runner = executor;
+    node
+}
+
+fn no_retry() -> ExecuteRetryPolicy {
+    ExecuteRetryPolicy::new(0, std::time::Duration::ZERO, std::time::Duration::ZERO)
+}
+
+#[tokio::test]
+async fn builder_rejects_invalid_node_identity_did() {
+    let _serial = SIGNING_STORE_GUARD.lock().await;
+    defra_core::signing::clear_identity_store();
+    let invalid_did = "invalid:key:zNode";
+    register_test_remote_node_identity(invalid_did);
+
+    let result = EmbeddedNode::builder()
+        .with_node_identity_did(invalid_did)
+        .build()
+        .await;
+    let error = match result {
+        Ok(node) => {
+            node.shutdown().await;
+            panic!("invalid node identity DID must be rejected")
+        }
+        Err(error) => error,
+    };
+
+    assert!(
+        error.to_string().contains("invalid node identity DID"),
+        "{error:#}"
+    );
+    defra_core::signing::clear_identity_store();
+}
+
+#[tokio::test]
+async fn embedded_execute_defaults_node_identity_and_preserves_explicit_actor() {
+    let _serial = SIGNING_STORE_GUARD.lock().await;
+    defra_core::signing::clear_identity_store();
+    let node_did = "did:key:zEmbeddedNodeActor";
+    let explicit_did = identity::Did::new("did:key:zExplicitActor").unwrap();
+    let executor = Arc::new(IdentityRecordingExecutor::new(0));
+    let node = signed_node_with_executor(node_did, executor.clone()).await;
+
+    let defaulted = node.execute("query { defaulted }").await;
+    assert!(!defaulted.has_errors(), "defaulted query failed");
+    let explicit = node
+        .execute_request_with_retry(
+            QueryRequest::new("query { explicit }").with_identity(Some(explicit_did.clone())),
+            no_retry(),
+        )
+        .await;
+    assert!(!explicit.has_errors(), "explicit-actor query failed");
+    assert_eq!(
+        executor.identities(),
+        vec![Some(node_did.to_string()), Some(explicit_did.to_string())]
+    );
+
+    node.shutdown().await;
+    defra_core::signing::clear_identity_store();
+}
+
+#[tokio::test]
+async fn embedded_retry_keeps_node_identity_on_every_attempt() {
+    let _serial = SIGNING_STORE_GUARD.lock().await;
+    defra_core::signing::clear_identity_store();
+    let node_did = "did:key:zEmbeddedRetryActor";
+    let executor = Arc::new(IdentityRecordingExecutor::new(2));
+    let node = signed_node_with_executor(node_did, executor.clone()).await;
+
+    let response = node
+        .execute_with_retry(
+            "mutation { retry }",
+            ExecuteRetryPolicy::new(2, std::time::Duration::ZERO, std::time::Duration::ZERO),
+        )
+        .await;
+    assert!(!response.has_errors(), "retry query failed");
+    assert_eq!(
+        executor.identities(),
+        vec![
+            Some(node_did.to_string()),
+            Some(node_did.to_string()),
+            Some(node_did.to_string()),
+        ]
+    );
+
+    node.shutdown().await;
+    defra_core::signing::clear_identity_store();
+}
+
+#[tokio::test]
+async fn embedded_transaction_defaults_node_identity_and_preserves_explicit_actor() {
+    let _serial = SIGNING_STORE_GUARD.lock().await;
+    defra_core::signing::clear_identity_store();
+    let node_did = "did:key:zEmbeddedTransactionActor";
+    let explicit_did = identity::Did::new("did:key:zExplicitTransactionActor").unwrap();
+    let executor = Arc::new(IdentityRecordingExecutor::new(0));
+    let node = signed_node_with_executor(node_did, executor.clone()).await;
+    let handle = TransactionHandle::new("identity-test-txn".to_string());
+
+    let defaulted = node
+        .execute_request_in_txn(QueryRequest::new("query { defaulted }"), &handle)
+        .await;
+    assert!(
+        !defaulted.has_errors(),
+        "defaulted transaction query failed"
+    );
+    let explicit = node
+        .execute_request_in_txn(
+            QueryRequest::new("query { explicit }").with_identity(Some(explicit_did.clone())),
+            &handle,
+        )
+        .await;
+    assert!(!explicit.has_errors(), "explicit transaction query failed");
+    assert_eq!(
+        executor.identities(),
+        vec![Some(node_did.to_string()), Some(explicit_did.to_string())]
+    );
+
+    node.shutdown().await;
+    defra_core::signing::clear_identity_store();
+}
+
+#[tokio::test]
+async fn unsigned_embedded_execution_remains_anonymous() {
+    let executor = Arc::new(IdentityRecordingExecutor::new(0));
+    let mut node = EmbeddedNode::builder()
+        .build()
+        .await
+        .expect("build unsigned identity-observing node");
+    node.runner = executor.clone();
+    let handle = TransactionHandle::new("anonymous-test-txn".to_string());
+
+    let direct = node.execute("query { direct }").await;
+    let retry = node.execute_with_retry("query { retry }", no_retry()).await;
+    let transactional = node
+        .execute_request_in_txn(QueryRequest::new("query { transaction }"), &handle)
+        .await;
+
+    assert!(!direct.has_errors());
+    assert!(!retry.has_errors());
+    assert!(!transactional.has_errors());
+    assert_eq!(executor.identities(), vec![None, None, None]);
+
+    node.shutdown().await;
+}

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -15,10 +15,13 @@ pub mod coding_search;
 pub mod config;
 mod db_impls;
 pub mod dense_search;
+#[cfg(test)]
+mod embedded_query_identity_tests;
 mod node_acp;
 #[cfg(feature = "p2p")]
 mod p2p_runtime;
 pub mod search_chunks;
+mod signed_query_runtime;
 pub mod version;
 
 use std::path::PathBuf;
@@ -42,11 +45,17 @@ pub use dense_search::{DenseHybridSearchHit, DenseHybridSearchRequest, DenseHybr
 pub use events::EventName;
 pub use lens::{LensConfig, LensModule, TransformId};
 pub use query::QueryLimits;
-pub use query::{QueryExecutor, QueryRequest, QueryResponse};
+pub use query::{QueryExecutor, QueryRequest, QueryResponse, TransactionHandle};
 pub use schema::CollectionVersion;
 pub use telemetry::{ConflictMetricsSnapshot, RetryLayerSnapshot};
 #[cfg(feature = "otel")]
 pub use telemetry::{TelemetryConfig, TelemetryHandle};
+
+#[cfg(not(target_arch = "wasm32"))]
+use signed_query_runtime::{
+    execute_with_signing_context, unavailable_node_signer_response, SignedQueryRuntime,
+    SIGNED_QUERY_DRAIN_TIMEOUT,
+};
 
 /// Retry policy for [`EmbeddedNode::execute_with_retry`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -102,13 +111,32 @@ trait SchemaOps: Send + Sync {
     async fn get_all_collection_versions(&self) -> anyhow::Result<Vec<CollectionVersion>>;
 }
 
+#[async_trait::async_trait]
+trait BlockOps: Send + Sync {
+    async fn signed_block_bytes(
+        &self,
+        cid: &str,
+        caller_did: Option<&str>,
+    ) -> anyhow::Result<(Vec<u8>, Vec<u8>)>;
+    async fn verified_signer_did(&self, cid: &str) -> anyhow::Result<String>;
+    async fn verified_signer_did_in_txn(
+        &self,
+        cid: &str,
+        transaction: &TransactionHandle,
+    ) -> anyhow::Result<String>;
+}
+
 /// An embedded DefraDB node with query execution and event subscription.
 pub struct EmbeddedNode {
     runner: Arc<dyn QueryExecutor>,
     event_bus: Arc<dyn events::Bus>,
     schema_ops: Arc<dyn SchemaOps>,
+    block_ops: Arc<dyn BlockOps>,
     embedding_config: db::EmbeddingClientConfig,
     node_identity_did: Option<String>,
+    node_query_identity: Option<identity::Did>,
+    #[cfg(not(target_arch = "wasm32"))]
+    signed_query_runtime: Option<SignedQueryRuntime>,
     #[cfg(not(target_arch = "wasm32"))]
     transaction_stats: Option<storage::TransactionStatsHandle>,
     #[cfg(feature = "rocksdb")]
@@ -137,12 +165,18 @@ impl EmbeddedNode {
     }
 
     /// Execute a GraphQL query or mutation.
+    ///
+    /// A configured node identity is used as the document ACP actor. Prepared
+    /// requests with an explicit identity retain that actor instead.
     pub async fn execute(&self, query_str: &str) -> QueryResponse {
         self.execute_request_once(QueryRequest::new(query_str))
             .await
     }
 
     /// Execute a GraphQL query or mutation, retrying transient transaction conflicts.
+    ///
+    /// A configured node identity is used as the document ACP actor on every
+    /// attempt.
     pub async fn execute_with_retry(
         &self,
         query_str: &str,
@@ -153,6 +187,9 @@ impl EmbeddedNode {
     }
 
     /// Execute a prepared query request, retrying transient transaction conflicts.
+    ///
+    /// Requests without an identity use the configured node identity for
+    /// document ACP. An explicit request identity takes precedence.
     pub async fn execute_request_with_retry(
         &self,
         request: QueryRequest,
@@ -165,26 +202,79 @@ impl EmbeddedNode {
     }
 
     async fn execute_request_once(&self, request: QueryRequest) -> QueryResponse {
+        self.execute_prepared_request(request, None).await
+    }
+
+    async fn execute_prepared_request(
+        &self,
+        request: QueryRequest,
+        txn_handle: Option<TransactionHandle>,
+    ) -> QueryResponse {
+        let request = self.with_default_query_identity(request);
         let Some(node_identity_did) = self.node_identity_did.as_deref() else {
-            return self.runner.execute(request).await;
+            return match txn_handle {
+                Some(handle) => self.runner.execute_in_txn(request, &handle).await,
+                None => self.runner.execute(request).await,
+            };
         };
 
+        #[cfg(target_arch = "wasm32")]
+        return QueryResponse::error(format!(
+            "configured node signing identity {node_identity_did} cannot execute queries on wasm32"
+        ));
+
+        #[cfg(not(target_arch = "wasm32"))]
         let signing_config = defra_core::signing::resolve_signing_config_with_flag(
             None,
             Some(node_identity_did),
             true,
         );
-        let Some(signing_config) = signing_config else {
-            return self.runner.execute(request).await;
+        #[cfg(not(target_arch = "wasm32"))]
+        let Some(signing_config) = signing_config
+        else {
+            return unavailable_node_signer_response(node_identity_did);
+        };
+        #[cfg(not(target_arch = "wasm32"))]
+        let Some(signed_query_runtime) = self.signed_query_runtime.as_ref() else {
+            return unavailable_node_signer_response(node_identity_did);
+        };
+        #[cfg(not(target_arch = "wasm32"))]
+        let Some(signed_query_permit) = signed_query_runtime.admit() else {
+            return QueryResponse::error("signed query runtime is shutting down");
         };
 
+        #[cfg(not(target_arch = "wasm32"))]
         execute_with_signing_context(
             self.runner.clone(),
             request,
+            txn_handle,
             signing_config,
             node_identity_did.to_string(),
+            signed_query_runtime.handle(),
+            signed_query_permit,
         )
         .await
+    }
+
+    /// Execute a prepared query request within an existing transaction.
+    ///
+    /// When the node has a configured identity, the same signing and ambient
+    /// identity context used by [`Self::execute`] is applied to this request.
+    /// It is also the document ACP actor unless the request supplies one.
+    pub async fn execute_request_in_txn(
+        &self,
+        request: QueryRequest,
+        handle: &TransactionHandle,
+    ) -> QueryResponse {
+        self.execute_prepared_request(request, Some(handle.clone()))
+            .await
+    }
+
+    fn with_default_query_identity(&self, mut request: QueryRequest) -> QueryRequest {
+        if request.identity.is_none() {
+            request.identity.clone_from(&self.node_query_identity);
+        }
+        request
     }
 
     /// Run `op` with the node's own identity installed as the ambient acting
@@ -202,6 +292,40 @@ impl EmbeddedNode {
     /// DID used as the embedded node identity for signing, when configured.
     pub fn node_identity_did(&self) -> Option<&str> {
         self.node_identity_did.as_deref()
+    }
+
+    /// Cryptographically verify a committed block and return its signer DID.
+    ///
+    /// This reads the signature linked by `cid`, verifies it over the
+    /// canonical DAG-CBOR block bytes, and derives the DID from the verified
+    /// public key. Unsigned, malformed, missing, or invalid blocks fail closed.
+    pub async fn verified_block_signer_did(&self, cid: &str) -> anyhow::Result<String> {
+        self.block_ops.verified_signer_did(cid).await
+    }
+
+    /// Load canonical signed-block material after applying document ACP for
+    /// the supplied caller. The caller must independently verify both CIDs and
+    /// the detached signature before trusting the returned signer.
+    pub async fn authorized_signed_block_bytes(
+        &self,
+        cid: &str,
+        caller_did: Option<&str>,
+    ) -> anyhow::Result<(Vec<u8>, Vec<u8>)> {
+        self.block_ops.signed_block_bytes(cid, caller_did).await
+    }
+
+    /// Cryptographically verify a block visible inside an active transaction.
+    ///
+    /// This variant can verify uncommitted blocks before the caller commits or
+    /// rolls back the transaction.
+    pub async fn verified_block_signer_did_in_txn(
+        &self,
+        cid: &str,
+        transaction: &TransactionHandle,
+    ) -> anyhow::Result<String> {
+        self.block_ops
+            .verified_signer_did_in_txn(cid, transaction)
+            .await
     }
 
     /// Add a schema from a GraphQL SDL type definition.
@@ -304,7 +428,35 @@ impl EmbeddedNode {
         self.event_bus.subscribe(event_names)
     }
 
-    /// Access the underlying query executor for advanced use.
+    /// Begin a transaction owned by this embedded node.
+    pub async fn begin_transaction(
+        &self,
+        readonly: bool,
+    ) -> Result<TransactionHandle, query::TransactionError> {
+        self.runner.begin_txn(readonly).await
+    }
+
+    /// Commit a transaction owned by this embedded node.
+    pub async fn commit_transaction(
+        &self,
+        transaction: &TransactionHandle,
+    ) -> Result<(), query::TransactionError> {
+        self.runner.commit_txn(transaction).await
+    }
+
+    /// Roll back a transaction owned by this embedded node.
+    pub async fn rollback_transaction(
+        &self,
+        transaction: &TransactionHandle,
+    ) -> Result<(), query::TransactionError> {
+        self.runner.rollback_txn(transaction).await
+    }
+
+    /// Access the raw query executor for advanced use.
+    ///
+    /// Calling `execute` or `execute_in_txn` on this executor bypasses the
+    /// node's signing context and default ACP identity. Use [`Self::execute`]
+    /// or [`Self::execute_request_in_txn`] for document reads and writes.
     pub fn runner(&self) -> &Arc<dyn QueryExecutor> {
         &self.runner
     }
@@ -371,9 +523,28 @@ impl EmbeddedNode {
             let _ = tokio::time::timeout(Duration::from_secs(1), task).await;
         }
 
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Some(runtime) = &self.signed_query_runtime {
+            if !runtime
+                .close_admission_and_wait_for(SIGNED_QUERY_DRAIN_TIMEOUT)
+                .await
+            {
+                tracing::warn!(
+                    active_queries = runtime.active_queries(),
+                    timeout_secs = SIGNED_QUERY_DRAIN_TIMEOUT.as_secs(),
+                    "timed out draining signed queries during node shutdown"
+                );
+            }
+        }
+
         #[cfg(feature = "p2p")]
         if let Some(lifecycle) = &self.p2p_lifecycle {
             lifecycle.shutdown().await;
+        }
+
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Some(runtime) = &self.signed_query_runtime {
+            runtime.shutdown().await;
         }
 
         // Flush buffered spans / metrics. Done after P2P shutdown so trailing
@@ -435,33 +606,6 @@ where
             tokio::time::sleep(delay).await;
         }
         backoff = next_retry_backoff(backoff, policy.max_backoff);
-    }
-}
-
-async fn execute_with_signing_context(
-    executor: Arc<dyn QueryExecutor>,
-    request: QueryRequest,
-    signing_config: SigningConfig,
-    node_did: String,
-) -> QueryResponse {
-    let handle = tokio::runtime::Handle::current();
-    let batch_session_key = Some(signing_config.public_key_hex.clone());
-
-    match tokio::task::spawn_blocking(move || {
-        defra_core::signing::set_signing_config(Some(signing_config));
-        defra_core::batch_signing::set_batch_session_key(batch_session_key);
-        // Install the node identity as the ambient acting identity so DB-layer
-        // NAC checks resolve to the node itself. The pool thread is reused, so
-        // the guard clears it when the closure ends to prevent cross-request leak.
-        let _id_guard = defra_core::current_identity::scoped_current_identity(Some(node_did));
-        handle.block_on(async { executor.execute(request).await })
-    })
-    .await
-    {
-        Ok(response) => response,
-        Err(join_error) => {
-            QueryResponse::error(format!("query execution task failed: {join_error}"))
-        }
     }
 }
 
@@ -1118,6 +1262,12 @@ impl NodeBuilder {
             telemetry_handle,
         } = args;
 
+        let node_query_identity = node_identity_did
+            .as_ref()
+            .map(|did| identity::Did::new(did.clone()))
+            .transpose()
+            .map_err(|error| anyhow::anyhow!("invalid node identity DID: {error}"))?;
+
         let embedding_config = db_options.embedding_config();
         #[cfg(not(target_arch = "wasm32"))]
         let transaction_stats = store.transaction_stats_handle();
@@ -1161,6 +1311,16 @@ impl NodeBuilder {
                 .map_err(|e| anyhow::anyhow!("failed to enable node ACP: {e}"))?;
             database.set_nac_manager(nac_manager);
         }
+
+        // Build the node-owned signed-query runtime before starting P2P. If
+        // runtime construction fails, the builder can return without leaving
+        // already-started network tasks behind.
+        #[cfg(not(target_arch = "wasm32"))]
+        let signed_query_runtime = node_identity_did
+            .as_ref()
+            .map(|_| SignedQueryRuntime::new())
+            .transpose()
+            .map_err(anyhow::Error::msg)?;
 
         // P2P setup (affects mutator choice)
         #[cfg(feature = "p2p")]
@@ -1228,7 +1388,7 @@ impl NodeBuilder {
 
         // Assemble query runner
         let query_runner =
-            query::QueryRunner::with_arc_registry_and_provider(fetcher, provider, registry)
+            query::QueryRunner::with_arc_registry_and_provider(fetcher, provider, registry.clone())
                 .with_mutator(mutator)
                 .with_acp(document_acp.clone())
                 .with_node_did(database.node_did())
@@ -1244,7 +1404,13 @@ impl NodeBuilder {
         let schema_ops: Arc<dyn SchemaOps> = Arc::new(db_impls::DbSchemaOps::new(
             database.clone(),
             query_limits,
+            document_acp.clone(),
+        ));
+        let block_ops: Arc<dyn BlockOps> = Arc::new(db_impls::DbBlockOps::new(
+            database,
             document_acp,
+            registry,
+            node_query_identity.clone(),
         ));
 
         #[cfg(feature = "p2p")]
@@ -1257,8 +1423,12 @@ impl NodeBuilder {
             runner,
             event_bus,
             schema_ops,
+            block_ops,
             embedding_config,
             node_identity_did,
+            node_query_identity,
+            #[cfg(not(target_arch = "wasm32"))]
+            signed_query_runtime,
             #[cfg(not(target_arch = "wasm32"))]
             transaction_stats,
             #[cfg(feature = "rocksdb")]
@@ -1302,7 +1472,7 @@ mod tests {
     #[cfg(feature = "http")]
     use super::HttpConfig;
 
-    static SIGNING_STORE_GUARD: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+    pub(super) static SIGNING_STORE_GUARD: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
     #[cfg(feature = "rocksdb")]
     static ROCKS_ENV_GUARD: LazyLock<std::sync::Mutex<()>> =
         LazyLock::new(|| std::sync::Mutex::new(()));
@@ -1538,7 +1708,7 @@ mod tests {
         defra_core::signing::clear_identity_store();
     }
 
-    struct TestRemoteSigner;
+    pub(super) struct TestRemoteSigner;
 
     impl RemoteSigner for TestRemoteSigner {
         fn sign_sync(

--- a/crates/defra-node/src/signed_query_runtime/mod.rs
+++ b/crates/defra-node/src/signed_query_runtime/mod.rs
@@ -1,0 +1,334 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use defra_core::signing::SigningConfig;
+use query::{QueryExecutor, QueryRequest, QueryResponse, TransactionHandle};
+
+#[cfg(test)]
+mod tests;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(super) async fn execute_with_signing_context(
+    executor: Arc<dyn QueryExecutor>,
+    request: QueryRequest,
+    txn_handle: Option<TransactionHandle>,
+    signing_config: SigningConfig,
+    node_did: String,
+    runtime_handle: tokio::runtime::Handle,
+    signed_query_permit: SignedQueryPermit,
+) -> QueryResponse {
+    let spawn_handle = runtime_handle.clone();
+    let batch_session_key = Some(signing_config.public_key_hex.clone());
+
+    let run_query = move || {
+        let _signed_query_permit = signed_query_permit;
+        let _signing_guard = ThreadSigningContextGuard::install(signing_config, batch_session_key);
+        let _id_guard = defra_core::current_identity::scoped_current_identity(Some(node_did));
+        runtime_handle.block_on(async {
+            match txn_handle {
+                Some(txn_handle) => executor.execute_in_txn(request, &txn_handle).await,
+                None => executor.execute(request).await,
+            }
+        })
+    };
+    let result = spawn_handle.spawn_blocking(run_query).await;
+
+    match result {
+        Ok(response) => response,
+        Err(join_error) => {
+            QueryResponse::error(format!("query execution task failed: {join_error}"))
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(super) fn unavailable_node_signer_response(node_did: &str) -> QueryResponse {
+    QueryResponse::error(format!(
+        "configured node signing identity {node_did} is unavailable"
+    ))
+}
+
+struct ThreadSigningContextGuard {
+    previous_signing_config: Option<SigningConfig>,
+    previous_batch_session_key: Option<String>,
+}
+
+impl ThreadSigningContextGuard {
+    fn install(signing_config: SigningConfig, batch_session_key: Option<String>) -> Self {
+        let previous_signing_config = defra_core::signing::get_signing_config();
+        let previous_batch_session_key = defra_core::batch_signing::get_batch_session_key();
+        defra_core::signing::set_signing_config(Some(signing_config));
+        defra_core::batch_signing::set_batch_session_key(batch_session_key);
+        Self {
+            previous_signing_config,
+            previous_batch_session_key,
+        }
+    }
+}
+
+impl Drop for ThreadSigningContextGuard {
+    fn drop(&mut self) {
+        defra_core::signing::set_signing_config(self.previous_signing_config.take());
+        defra_core::batch_signing::set_batch_session_key(self.previous_batch_session_key.take());
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(super) struct SignedQueryRuntime {
+    handle: tokio::runtime::Handle,
+    state: Arc<SignedQueryRuntimeState>,
+    shutdown_tx: std::sync::Mutex<Option<std::sync::mpsc::Sender<()>>>,
+    owner_thread: std::sync::Mutex<Option<std::thread::JoinHandle<()>>>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+struct SignedQueryRuntimeState {
+    closing: std::sync::atomic::AtomicBool,
+    active_queries: std::sync::atomic::AtomicUsize,
+    active_queries_drained: tokio::sync::Notify,
+    active_queries_mutex: std::sync::Mutex<()>,
+    active_queries_changed: std::sync::Condvar,
+    closed: std::sync::atomic::AtomicBool,
+    closed_notify: tokio::sync::Notify,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(super) const SIGNED_QUERY_DRAIN_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[cfg(not(target_arch = "wasm32"))]
+const SIGNED_QUERY_DROP_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[cfg(not(target_arch = "wasm32"))]
+const SIGNED_QUERY_RUNTIME_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(super) struct SignedQueryPermit {
+    state: Arc<SignedQueryRuntimeState>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl Drop for SignedQueryPermit {
+    fn drop(&mut self) {
+        let _active_queries_guard = self
+            .state
+            .active_queries_mutex
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if self
+            .state
+            .active_queries
+            .fetch_sub(1, std::sync::atomic::Ordering::SeqCst)
+            == 1
+        {
+            self.state.active_queries_drained.notify_waiters();
+        }
+        self.state.active_queries_changed.notify_all();
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+struct SignedQueryRuntimeClosedGuard {
+    state: Arc<SignedQueryRuntimeState>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl Drop for SignedQueryRuntimeClosedGuard {
+    fn drop(&mut self) {
+        self.state
+            .closed
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        self.state.closed_notify.notify_waiters();
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl SignedQueryRuntime {
+    pub(super) fn new() -> Result<Self, String> {
+        let state = Arc::new(SignedQueryRuntimeState {
+            closing: std::sync::atomic::AtomicBool::new(false),
+            active_queries: std::sync::atomic::AtomicUsize::new(0),
+            active_queries_drained: tokio::sync::Notify::new(),
+            active_queries_mutex: std::sync::Mutex::new(()),
+            active_queries_changed: std::sync::Condvar::new(),
+            closed: std::sync::atomic::AtomicBool::new(false),
+            closed_notify: tokio::sync::Notify::new(),
+        });
+        let (shutdown_tx, shutdown_rx) = std::sync::mpsc::channel();
+        let (startup_tx, startup_rx) = std::sync::mpsc::sync_channel(1);
+        let owner_state = state.clone();
+        let owner_thread = std::thread::Builder::new()
+            .name("defra-signed-query-owner".to_string())
+            .spawn(move || {
+                let runtime = match tokio::runtime::Builder::new_multi_thread()
+                    .worker_threads(1)
+                    .thread_name("defra-signed-query")
+                    .enable_all()
+                    .build()
+                {
+                    Ok(runtime) => runtime,
+                    Err(error) => {
+                        let _ = startup_tx.send(Err(format!(
+                            "failed to create signed query runtime: {error}"
+                        )));
+                        return;
+                    }
+                };
+                if startup_tx.send(Ok(runtime.handle().clone())).is_err() {
+                    runtime.shutdown_background();
+                    return;
+                }
+                let _closed_guard = SignedQueryRuntimeClosedGuard {
+                    state: owner_state.clone(),
+                };
+                let _ = shutdown_rx.recv();
+                wait_for_active_signed_queries(&owner_state, SIGNED_QUERY_DROP_DRAIN_TIMEOUT);
+                runtime.shutdown_timeout(SIGNED_QUERY_RUNTIME_SHUTDOWN_TIMEOUT);
+            })
+            .map_err(|error| format!("failed to start signed query runtime owner: {error}"))?;
+        let handle = match startup_rx.recv() {
+            Ok(Ok(handle)) => handle,
+            Ok(Err(error)) => {
+                let _ = owner_thread.join();
+                return Err(error);
+            }
+            Err(error) => {
+                let _ = owner_thread.join();
+                return Err(format!(
+                    "signed query runtime owner exited during startup: {error}"
+                ));
+            }
+        };
+        Ok(Self {
+            handle,
+            state,
+            shutdown_tx: std::sync::Mutex::new(Some(shutdown_tx)),
+            owner_thread: std::sync::Mutex::new(Some(owner_thread)),
+        })
+    }
+
+    pub(super) fn handle(&self) -> tokio::runtime::Handle {
+        self.handle.clone()
+    }
+
+    pub(super) fn admit(&self) -> Option<SignedQueryPermit> {
+        if self.state.closing.load(std::sync::atomic::Ordering::SeqCst) {
+            return None;
+        }
+        self.state
+            .active_queries
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        if self.state.closing.load(std::sync::atomic::Ordering::SeqCst) {
+            drop(SignedQueryPermit {
+                state: self.state.clone(),
+            });
+            return None;
+        }
+        Some(SignedQueryPermit {
+            state: self.state.clone(),
+        })
+    }
+
+    pub(super) fn active_queries(&self) -> usize {
+        self.state
+            .active_queries
+            .load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    fn close_admission(&self) {
+        self.state
+            .closing
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    async fn wait_for_active_queries(&self) {
+        loop {
+            let notified = self.state.active_queries_drained.notified();
+            if self.active_queries() == 0 {
+                return;
+            }
+            notified.await;
+        }
+    }
+
+    pub(super) async fn close_admission_and_wait_for(&self, timeout: Duration) -> bool {
+        self.close_admission();
+        tokio::time::timeout(timeout, self.wait_for_active_queries())
+            .await
+            .is_ok()
+    }
+
+    pub(super) async fn shutdown(&self) {
+        self.signal_shutdown();
+        let owner_thread = self
+            .owner_thread
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
+        if let Some(owner_thread) = owner_thread {
+            let _ = tokio::task::spawn_blocking(move || owner_thread.join()).await;
+        } else {
+            loop {
+                let notified = self.state.closed_notify.notified();
+                if self.state.closed.load(std::sync::atomic::Ordering::SeqCst) {
+                    break;
+                }
+                notified.await;
+            }
+        }
+    }
+
+    fn signal_shutdown(&self) {
+        self.close_admission();
+        let shutdown_tx = self
+            .shutdown_tx
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
+        if let Some(shutdown_tx) = shutdown_tx {
+            let _ = shutdown_tx.send(());
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl Drop for SignedQueryRuntime {
+    fn drop(&mut self) {
+        self.signal_shutdown();
+        self.owner_thread
+            .get_mut()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn wait_for_active_signed_queries(state: &SignedQueryRuntimeState, timeout: Duration) -> bool {
+    let deadline = std::time::Instant::now() + timeout;
+    let mut guard = state
+        .active_queries_mutex
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    loop {
+        if state
+            .active_queries
+            .load(std::sync::atomic::Ordering::SeqCst)
+            == 0
+        {
+            return true;
+        }
+        let Some(remaining) = deadline.checked_duration_since(std::time::Instant::now()) else {
+            return false;
+        };
+        let (next_guard, wait_result) = state
+            .active_queries_changed
+            .wait_timeout(guard, remaining)
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        guard = next_guard;
+        if wait_result.timed_out() {
+            return state
+                .active_queries
+                .load(std::sync::atomic::Ordering::SeqCst)
+                == 0;
+        }
+    }
+}

--- a/crates/defra-node/src/signed_query_runtime/tests.rs
+++ b/crates/defra-node/src/signed_query_runtime/tests.rs
@@ -1,0 +1,230 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use query::QueryRequest;
+
+mod executors;
+
+use executors::{
+    context_observing_executor, slow_signing_executor, spawning_signing_executor,
+    test_signing_config,
+};
+
+#[test]
+fn cancelled_caller_runtime_does_not_own_signed_query_runtime() {
+    let started = Arc::new(AtomicBool::new(false));
+    let (completed_tx, completed_rx) = std::sync::mpsc::channel();
+    let executor = slow_signing_executor(started.clone(), completed_tx);
+    let caller_runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("caller runtime");
+    let signed_runtime = super::SignedQueryRuntime::new().expect("signed runtime");
+    let signed_runtime_handle = signed_runtime.handle();
+    let signed_query_permit = signed_runtime.admit().expect("query admission");
+
+    caller_runtime.block_on(async {
+        let task = tokio::spawn(async move {
+            super::execute_with_signing_context(
+                executor,
+                QueryRequest::new("{ delayed }"),
+                None,
+                test_signing_config(),
+                "did:key:zCancellationTest".to_string(),
+                signed_runtime_handle,
+                signed_query_permit,
+            )
+            .await
+        });
+        while !started.load(Ordering::SeqCst) {
+            tokio::task::yield_now().await;
+        }
+        task.abort();
+        let _ = task.await;
+    });
+    drop(caller_runtime);
+    drop(signed_runtime);
+
+    completed_rx
+        .recv_timeout(std::time::Duration::from_secs(2))
+        .expect("signed query must complete after its caller and node runtimes are dropped");
+}
+
+#[test]
+fn signed_query_runtime_keeps_spawned_work_alive_after_query_returns() {
+    let (completed_tx, completed_rx) = std::sync::mpsc::channel();
+    let executor = spawning_signing_executor(completed_tx);
+    let caller_runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("caller runtime");
+    let signed_runtime = super::SignedQueryRuntime::new().expect("signed runtime");
+
+    let response = caller_runtime.block_on(super::execute_with_signing_context(
+        executor,
+        QueryRequest::new("{ spawnBackgroundWork }"),
+        None,
+        test_signing_config(),
+        "did:key:zSpawnTest".to_string(),
+        signed_runtime.handle(),
+        signed_runtime.admit().expect("query admission"),
+    ));
+    assert!(
+        !response.has_errors(),
+        "query failed: {:?}",
+        response.errors
+    );
+    drop(caller_runtime);
+
+    completed_rx
+        .recv_timeout(std::time::Duration::from_secs(2))
+        .expect("work spawned by a signed query must outlive query completion");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn signed_query_context_survives_awaits_on_node_owned_runtime() {
+    let expected_did = "did:key:zContextTest".to_string();
+    let signing_config = test_signing_config();
+    let executor =
+        context_observing_executor(expected_did.clone(), signing_config.public_key_hex.clone());
+    let signed_runtime = super::SignedQueryRuntime::new().expect("signed runtime");
+
+    let response = super::execute_with_signing_context(
+        executor,
+        QueryRequest::new("{ observeContext }"),
+        None,
+        signing_config,
+        expected_did,
+        signed_runtime.handle(),
+        signed_runtime.admit().expect("query admission"),
+    )
+    .await;
+
+    assert!(
+        !response.has_errors(),
+        "signed query context failed: {:?}",
+        response.errors
+    );
+    assert!(
+        signed_runtime
+            .close_admission_and_wait_for(std::time::Duration::from_secs(2))
+            .await,
+        "signed query context permit did not drain"
+    );
+    signed_runtime.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn signed_query_runtime_closes_admission_and_drains_in_flight_queries() {
+    let runtime = Arc::new(super::SignedQueryRuntime::new().expect("signed runtime"));
+    let permit = runtime.admit().expect("initial query admission");
+    let closing_runtime = runtime.clone();
+    let mut close_task = tokio::spawn(async move {
+        closing_runtime
+            .close_admission_and_wait_for(std::time::Duration::from_secs(2))
+            .await
+    });
+
+    while !runtime.state.closing.load(Ordering::Acquire) {
+        tokio::task::yield_now().await;
+    }
+    assert!(
+        runtime.admit().is_none(),
+        "queries that race shutdown must fail admission"
+    );
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(25), &mut close_task)
+            .await
+            .is_err(),
+        "shutdown admission drain returned while a query permit was live"
+    );
+
+    drop(permit);
+    let drained = tokio::time::timeout(std::time::Duration::from_secs(2), close_task)
+        .await
+        .expect("admission drain timed out")
+        .expect("admission drain task panicked");
+    assert!(drained, "admission drain reported a timeout");
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn signed_query_runtime_admission_drain_has_a_deadline() {
+    let runtime = super::SignedQueryRuntime::new().expect("signed runtime");
+    let permit = runtime.admit().expect("query admission");
+
+    assert!(
+        !runtime
+            .close_admission_and_wait_for(std::time::Duration::from_millis(25))
+            .await,
+        "admission drain ignored its deadline"
+    );
+
+    drop(permit);
+    runtime.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn signed_query_runtime_shutdown_is_idempotent_and_node_scoped() {
+    let runtime_a = Arc::new(super::SignedQueryRuntime::new().expect("runtime A"));
+    let runtime_b = Arc::new(super::SignedQueryRuntime::new().expect("runtime B"));
+    assert!(
+        runtime_a
+            .close_admission_and_wait_for(std::time::Duration::from_secs(2))
+            .await
+    );
+
+    let first = {
+        let runtime = runtime_a.clone();
+        tokio::spawn(async move { runtime.shutdown().await })
+    };
+    let second = {
+        let runtime = runtime_a.clone();
+        tokio::spawn(async move { runtime.shutdown().await })
+    };
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        first.await.expect("first shutdown caller panicked");
+        second.await.expect("second shutdown caller panicked");
+    })
+    .await
+    .expect("concurrent shutdown callers did not converge");
+
+    let permit_b = runtime_b
+        .admit()
+        .expect("shutting down runtime A must not close runtime B");
+    drop(permit_b);
+    assert!(
+        runtime_b
+            .close_admission_and_wait_for(std::time::Duration::from_secs(2))
+            .await
+    );
+    runtime_b.shutdown().await;
+}
+
+#[tokio::test]
+async fn signed_query_runtime_drop_is_nonblocking_inside_async_context() {
+    let runtime = super::SignedQueryRuntime::new().expect("signed runtime");
+    let state = runtime.state.clone();
+    let permit = runtime.admit().expect("query admission");
+    drop(runtime);
+    assert!(
+        state.closing.load(Ordering::Acquire),
+        "drop must close query admission"
+    );
+    assert!(
+        !state.closed.load(Ordering::Acquire),
+        "runtime closed while an admitted query was still live"
+    );
+    drop(permit);
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            let notified = state.closed_notify.notified();
+            if state.closed.load(Ordering::Acquire) {
+                break;
+            }
+            notified.await;
+        }
+    })
+    .await
+    .expect("dropped signed runtime did not close after its query drained");
+}

--- a/crates/defra-node/src/signed_query_runtime/tests/executors.rs
+++ b/crates/defra-node/src/signed_query_runtime/tests/executors.rs
@@ -1,0 +1,144 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use defra_core::signing::{SigningConfig, SigningKeyType};
+use query::{QueryExecutor, QueryRequest, TransactionError, TransactionHandle};
+
+enum TestExecution {
+    Slow {
+        started: Arc<AtomicBool>,
+        completed: std::sync::Mutex<Option<std::sync::mpsc::Sender<()>>>,
+    },
+    Spawning {
+        completed: std::sync::Mutex<Option<std::sync::mpsc::Sender<()>>>,
+    },
+    ObserveContext {
+        expected_did: String,
+        expected_public_key_hex: String,
+    },
+}
+
+pub(super) fn slow_signing_executor(
+    started: Arc<AtomicBool>,
+    completed: std::sync::mpsc::Sender<()>,
+) -> Arc<dyn QueryExecutor> {
+    Arc::new(TestExecution::Slow {
+        started,
+        completed: std::sync::Mutex::new(Some(completed)),
+    })
+}
+
+pub(super) fn spawning_signing_executor(
+    completed: std::sync::mpsc::Sender<()>,
+) -> Arc<dyn QueryExecutor> {
+    Arc::new(TestExecution::Spawning {
+        completed: std::sync::Mutex::new(Some(completed)),
+    })
+}
+
+pub(super) fn context_observing_executor(
+    expected_did: String,
+    expected_public_key_hex: String,
+) -> Arc<dyn QueryExecutor> {
+    Arc::new(TestExecution::ObserveContext {
+        expected_did,
+        expected_public_key_hex,
+    })
+}
+
+pub(super) fn test_signing_config() -> SigningConfig {
+    SigningConfig {
+        key_type: SigningKeyType::Secp256r1,
+        private_key_bytes: vec![1],
+        public_key_bytes: vec![2],
+        public_key_hex: "02".to_string(),
+        remote_signer: None,
+        signing_authorization: None,
+    }
+}
+
+#[async_trait::async_trait]
+impl QueryExecutor for TestExecution {
+    async fn execute(&self, _request: QueryRequest) -> query::QueryResponse {
+        match self {
+            Self::Slow { started, completed } => {
+                started.store(true, Ordering::SeqCst);
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                completed
+                    .lock()
+                    .expect("completion sender poisoned")
+                    .take()
+                    .expect("completion sender missing")
+                    .send(())
+                    .expect("completion receiver dropped");
+            }
+            Self::Spawning { completed } => {
+                let completed = completed
+                    .lock()
+                    .expect("completion sender poisoned")
+                    .take()
+                    .expect("completion sender missing");
+                tokio::spawn(async move {
+                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                    completed.send(()).expect("completion receiver dropped");
+                });
+            }
+            Self::ObserveContext {
+                expected_did,
+                expected_public_key_hex,
+            } => {
+                for _ in 0..3 {
+                    let signing_config = defra_core::signing::get_signing_config();
+                    let current_identity = defra_core::current_identity::get_current_identity();
+                    let batch_session_key = defra_core::batch_signing::get_batch_session_key();
+                    if signing_config
+                        .as_ref()
+                        .map(|config| config.public_key_hex.as_str())
+                        != Some(expected_public_key_hex.as_str())
+                        || current_identity.as_deref() != Some(expected_did.as_str())
+                        || batch_session_key.as_deref() != Some(expected_public_key_hex.as_str())
+                    {
+                        return query::QueryResponse::error(
+                            "signed query context did not survive an await boundary",
+                        );
+                    }
+                    tokio::task::yield_now().await;
+                }
+            }
+        }
+        query::QueryResponse::success(serde_json::json!({"ok": true}))
+    }
+
+    async fn execute_in_txn(
+        &self,
+        request: QueryRequest,
+        _handle: &TransactionHandle,
+    ) -> query::QueryResponse {
+        self.execute(request).await
+    }
+
+    async fn begin_txn(
+        &self,
+        _readonly: bool,
+    ) -> std::result::Result<TransactionHandle, TransactionError> {
+        Err(TransactionError::not_supported("test executor"))
+    }
+
+    async fn commit_txn(
+        &self,
+        _handle: &TransactionHandle,
+    ) -> std::result::Result<(), TransactionError> {
+        Err(TransactionError::not_supported("test executor"))
+    }
+
+    async fn rollback_txn(
+        &self,
+        _handle: &TransactionHandle,
+    ) -> std::result::Result<(), TransactionError> {
+        Err(TransactionError::not_supported("test executor"))
+    }
+
+    async fn schema(&self) -> query::Result<String> {
+        Ok(String::new())
+    }
+}

--- a/crates/defra-node/tests/transaction_signing_test.rs
+++ b/crates/defra-node/tests/transaction_signing_test.rs
@@ -1,0 +1,248 @@
+use crypto::Key;
+use defra_core::signing::{SigningConfig, SigningKeyType};
+use defra_node::{EmbeddedNode, QueryRequest};
+use identity::{Identity as _, RawIdentity};
+
+fn register_local_node_identity() -> (String, String) {
+    let private_key = crypto::generate_ed25519().expect("generate ed25519 key");
+    let identity =
+        RawIdentity::from_ed25519(private_key.clone()).expect("build raw identity from key");
+    let did = identity.did().expect("derive DID").to_string();
+    let public_key_bytes = identity.public_key_bytes();
+    let public_key_hex = hex::encode(&public_key_bytes);
+
+    defra_core::signing::store_identity(
+        &did,
+        SigningConfig {
+            key_type: SigningKeyType::Ed25519,
+            private_key_bytes: private_key.raw().to_vec(),
+            public_key_bytes,
+            public_key_hex: public_key_hex.clone(),
+            remote_signer: None,
+            signing_authorization: None,
+        },
+    );
+
+    (did, public_key_hex)
+}
+
+#[tokio::test]
+async fn embedded_transaction_mutation_uses_node_signer() {
+    defra_core::signing::clear_identity_store();
+    let (did, expected_identity) = register_local_node_identity();
+
+    let node = EmbeddedNode::builder()
+        .with_node_identity_did(&did)
+        .build()
+        .await
+        .expect("build signed node");
+    node.add_schema("type Widget { name: String }")
+        .await
+        .expect("add schema");
+
+    let txn = node.begin_transaction(false).await.expect("begin txn");
+    let create = node
+        .execute_request_in_txn(
+            QueryRequest::new(r#"mutation { create_Widget(input: {name: "gadget"}) { _docID } }"#),
+            &txn,
+        )
+        .await;
+    assert!(
+        create.errors.is_empty(),
+        "create failed: {:?}",
+        create.errors
+    );
+    let create_data = create.data.as_ref().expect("create response data");
+    let doc_id = create_data
+        .pointer("/add_Widget/0/_docID")
+        .or_else(|| create_data.pointer("/create_Widget/0/_docID"))
+        .or_else(|| create_data.pointer("/create_Widget/_docID"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_else(|| panic!("created document id missing from {create_data}"))
+        .to_string();
+
+    let commits_in_txn = node
+        .execute_request_in_txn(
+            QueryRequest::new(format!(
+                r#"query {{ _commits(docID: "{doc_id}", filter: {{fieldName: {{_eq: "_C"}}}}) {{ cid }} }}"#
+            )),
+            &txn,
+        )
+        .await;
+    assert!(
+        commits_in_txn.errors.is_empty(),
+        "commit query in transaction failed: {:?}",
+        commits_in_txn.errors
+    );
+    let uncommitted_composite_cid = commits_in_txn
+        .data
+        .as_ref()
+        .and_then(|data| data.pointer("/_commits/0/cid"))
+        .and_then(serde_json::Value::as_str)
+        .expect("uncommitted composite CID");
+    let uncommitted_verified_did = node
+        .verified_block_signer_did_in_txn(uncommitted_composite_cid, &txn)
+        .await
+        .expect("verify uncommitted embedded block signature");
+    assert_eq!(uncommitted_verified_did, did);
+
+    node.commit_transaction(&txn).await.expect("commit txn");
+
+    let commits = node
+        .execute(&format!(
+            r#"query {{ _commits(docID: "{doc_id}", filter: {{fieldName: {{_eq: "_C"}}}}) {{ cid signature {{ type identity }} }} }}"#
+        ))
+        .await;
+    assert!(
+        commits.errors.is_empty(),
+        "commit query failed: {:?}",
+        commits.errors
+    );
+    let rows = commits
+        .data
+        .as_ref()
+        .and_then(|data| data.get("_commits"))
+        .and_then(serde_json::Value::as_array)
+        .expect("commit rows");
+    assert!(
+        rows.iter().any(|row| {
+            row.pointer("/signature/type")
+                .and_then(serde_json::Value::as_str)
+                == Some("EdDSA")
+                && row
+                    .pointer("/signature/identity")
+                    .and_then(serde_json::Value::as_str)
+                    == Some(expected_identity.as_str())
+        }),
+        "composite commit was not signed by the configured node: {rows:?}"
+    );
+
+    let composite_cid = rows
+        .iter()
+        .find_map(|row| row.get("cid").and_then(serde_json::Value::as_str))
+        .expect("composite commit CID");
+    let verified_did = node
+        .verified_block_signer_did(composite_cid)
+        .await
+        .expect("verify embedded block signature");
+    assert_eq!(verified_did, did);
+
+    let (block_bytes, signature_bytes) = node
+        .authorized_signed_block_bytes(composite_cid, Some(&did))
+        .await
+        .expect("load authorized signed block bytes");
+    let returned_block_cid = defra_core::block::generate_cid_from_bytes(&block_bytes)
+        .expect("derive returned block CID");
+    assert_eq!(returned_block_cid.to_string(), composite_cid);
+    let returned_block =
+        defra_core::block::Block::from_dag_cbor(&block_bytes).expect("decode returned block");
+    let signature_cid = returned_block.signature.expect("returned signature CID");
+    let returned_signature_cid = defra_core::block::generate_cid_from_bytes(&signature_bytes)
+        .expect("derive returned signature CID");
+    assert_eq!(returned_signature_cid, signature_cid);
+
+    defra_core::signing::clear_identity_store();
+    let create_without_signer = node
+        .execute(r#"mutation { create_Widget(input: {name: "must-fail"}) { _docID } }"#)
+        .await;
+    assert!(
+        create_without_signer.has_errors()
+            && create_without_signer.errors[0]
+                .message
+                .contains("configured node signing identity")
+            && create_without_signer.errors[0]
+                .message
+                .contains("is unavailable"),
+        "configured node must fail closed when its signer disappears: {:?}",
+        create_without_signer.errors
+    );
+
+    let txn_without_signer = node.begin_transaction(false).await.expect("begin txn");
+    let create_in_txn_without_signer = node
+        .execute_request_in_txn(
+            QueryRequest::new(
+                r#"mutation { create_Widget(input: {name: "must-also-fail"}) { _docID } }"#,
+            ),
+            &txn_without_signer,
+        )
+        .await;
+    assert!(
+        create_in_txn_without_signer.has_errors()
+            && create_in_txn_without_signer.errors[0]
+                .message
+                .contains("configured node signing identity")
+            && create_in_txn_without_signer.errors[0]
+                .message
+                .contains("is unavailable"),
+        "configured transactional execute must fail closed when its signer disappears: {:?}",
+        create_in_txn_without_signer.errors
+    );
+    node.rollback_transaction(&txn_without_signer)
+        .await
+        .expect("rollback txn");
+
+    node.shutdown().await;
+
+    let node = EmbeddedNode::builder()
+        .build()
+        .await
+        .expect("build unsigned node");
+    node.add_schema("type UnsignedWidget { name: String }")
+        .await
+        .expect("add schema");
+
+    let create = node
+        .execute(r#"mutation { create_UnsignedWidget(input: {name: "unsigned"}) { _docID } }"#)
+        .await;
+    assert!(
+        create.errors.is_empty(),
+        "create failed: {:?}",
+        create.errors
+    );
+    let doc_id = create
+        .data
+        .as_ref()
+        .and_then(|data| {
+            data.pointer("/add_UnsignedWidget/0/_docID")
+                .or_else(|| data.pointer("/create_UnsignedWidget/0/_docID"))
+                .or_else(|| data.pointer("/create_UnsignedWidget/_docID"))
+        })
+        .and_then(serde_json::Value::as_str)
+        .expect("created document ID");
+    let commits = node
+        .execute(&format!(
+            r#"query {{ _commits(docID: "{doc_id}", filter: {{fieldName: {{_eq: "_C"}}}}) {{ cid }} }}"#
+        ))
+        .await;
+    let composite_cid = commits
+        .data
+        .as_ref()
+        .and_then(|data| data.pointer("/_commits/0/cid"))
+        .and_then(serde_json::Value::as_str)
+        .expect("unsigned composite CID");
+
+    let unsigned_error = node
+        .verified_block_signer_did(composite_cid)
+        .await
+        .expect_err("unsigned block must fail verification");
+    assert!(
+        unsigned_error
+            .to_string()
+            .contains("block has no signature"),
+        "unexpected unsigned error: {unsigned_error:#}"
+    );
+
+    let missing_cid = defra_core::block::generate_cid_from_bytes(b"missing block")
+        .expect("generate missing CID")
+        .to_string();
+    let missing_error = node
+        .verified_block_signer_did(&missing_cid)
+        .await
+        .expect_err("missing block must fail verification");
+    assert!(
+        missing_error.to_string().contains("could not find block"),
+        "unexpected missing-block error: {missing_error:#}"
+    );
+
+    node.shutdown().await;
+}

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -29,6 +29,7 @@ db = { path = "../db", default-features = false, features = ["native"] }
 
 # Encoding
 hex = "0.4"
+base64.workspace = true
 cid.workspace = true
 
 # Async runtime

--- a/crates/http/src/handlers/block.rs
+++ b/crates/http/src/handlers/block.rs
@@ -1,6 +1,8 @@
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
-use serde::Deserialize;
+use axum::Json;
+use base64::Engine as _;
+use serde::{Deserialize, Serialize};
 
 use crate::error::{http_error_from_backend_message, HttpError};
 use crate::identity_extractor::ExtractIdentity;
@@ -15,6 +17,40 @@ pub struct VerifySignatureParams {
     pub public_key: String,
     #[serde(rename = "type")]
     pub key_type: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SignedBlockParams {
+    pub cid: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SignedBlockResponse {
+    pub cid: String,
+    pub block: String,
+    pub signature: String,
+}
+
+/// Return canonical signed-block material after document ACP authorization.
+/// The client must still verify both CIDs and the signature locally.
+pub async fn signed_block(
+    State(state): State<AppState>,
+    identity: ExtractIdentity,
+    Query(params): Query<SignedBlockParams>,
+) -> Result<Json<SignedBlockResponse>, HttpError> {
+    require_permission(&state, &identity, NodePermission::SignatureVerify).await?;
+    let block = state.require_block()?;
+    let caller_did = identity.did().map(|did| did.to_string());
+    let (block_bytes, signature_bytes) = block
+        .signed_block_bytes(&params.cid, caller_did.as_deref())
+        .await
+        .map_err(http_error_from_backend_message)?;
+    let encoder = base64::engine::general_purpose::STANDARD;
+    Ok(Json(SignedBlockResponse {
+        cid: params.cid,
+        block: encoder.encode(block_bytes),
+        signature: encoder.encode(signature_bytes),
+    }))
 }
 
 /// Verify the signature of a block.
@@ -42,3 +78,7 @@ pub async fn verify_signature(
         .map_err(http_error_from_backend_message)?;
     Ok(StatusCode::OK)
 }
+
+#[cfg(test)]
+#[path = "block_tests.rs"]
+mod tests;

--- a/crates/http/src/handlers/block_tests.rs
+++ b/crates/http/src/handlers/block_tests.rs
@@ -1,0 +1,82 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use axum::body::{to_bytes, Body};
+use axum::http::{Request, StatusCode};
+use query::executor::QueryExecutor;
+use serde_json::Value;
+use tower::ServiceExt;
+
+use crate::mock::MockQueryExecutor;
+use crate::router::{create_router_with_state, AppStateBuilder, BlockOperations};
+
+#[derive(Default)]
+struct RecordingBlock {
+    calls: Mutex<Vec<(String, Option<String>)>>,
+}
+
+#[async_trait]
+impl BlockOperations for RecordingBlock {
+    async fn signed_block_bytes(
+        &self,
+        cid: &str,
+        caller_did: Option<&str>,
+    ) -> Result<(Vec<u8>, Vec<u8>), String> {
+        self.calls
+            .lock()
+            .expect("recording block lock")
+            .push((cid.to_string(), caller_did.map(str::to_string)));
+        Ok((b"canonical block".to_vec(), b"detached signature".to_vec()))
+    }
+
+    async fn verify_signature(
+        &self,
+        _cid: &str,
+        _public_key: &str,
+        _key_type: Option<&str>,
+        _caller_did: Option<&str>,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn signed_block_route_returns_canonical_material() {
+    let executor = Arc::new(MockQueryExecutor::new()) as Arc<dyn QueryExecutor>;
+    let block = Arc::new(RecordingBlock::default());
+    let state = AppStateBuilder::new(executor)
+        .with_block(block.clone() as Arc<dyn BlockOperations>)
+        .build();
+
+    for path in [
+        "/api/v0/block/signed?cid=bafy-test",
+        "/api/v1/block/signed?cid=bafy-test",
+    ] {
+        let response = create_router_with_state(state.clone())
+            .oneshot(
+                Request::builder()
+                    .uri(path)
+                    .body(Body::empty())
+                    .expect("request should build"),
+            )
+            .await
+            .expect("router should respond");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("response body should be readable");
+        let value: Value = serde_json::from_slice(&body).expect("valid JSON response");
+        assert_eq!(value["cid"], "bafy-test");
+        assert_eq!(value["block"], "Y2Fub25pY2FsIGJsb2Nr");
+        assert_eq!(value["signature"], "ZGV0YWNoZWQgc2lnbmF0dXJl");
+    }
+
+    assert_eq!(
+        *block.calls.lock().expect("recording block lock"),
+        vec![
+            ("bafy-test".to_string(), None),
+            ("bafy-test".to_string(), None),
+        ]
+    );
+}

--- a/crates/http/src/handlers/utility.rs
+++ b/crates/http/src/handlers/utility.rs
@@ -22,6 +22,9 @@ pub struct NodeIdentityResponse {
     /// The node's peer ID (if P2P is enabled).
     #[serde(rename = "PeerID", skip_serializing_if = "Option::is_none")]
     pub peer_id: Option<String>,
+    /// DID used by the node to sign database mutations, when configured.
+    #[serde(rename = "DID", skip_serializing_if = "Option::is_none")]
+    pub did: Option<String>,
 }
 
 /// GET /api/v0/node/identity
@@ -41,7 +44,10 @@ pub async fn get_node_identity(
         None
     };
 
-    Ok(Json(NodeIdentityResponse { peer_id }))
+    Ok(Json(NodeIdentityResponse {
+        peer_id,
+        did: state.node_identity_did.clone(),
+    }))
 }
 
 /// GET /api/v0/debug/dump
@@ -105,17 +111,24 @@ mod tests {
     fn test_node_identity_response_serialize() {
         let response = NodeIdentityResponse {
             peer_id: Some("12D3KooWtest".to_string()),
+            did: Some("did:key:zNodeSigner".to_string()),
         };
         let json = serde_json::to_string(&response).unwrap();
         assert!(json.contains("\"PeerID\""));
         assert!(json.contains("12D3KooWtest"));
+        assert!(json.contains("\"DID\""));
+        assert!(json.contains("did:key:zNodeSigner"));
     }
 
     #[test]
     fn test_node_identity_response_empty() {
-        let response = NodeIdentityResponse { peer_id: None };
+        let response = NodeIdentityResponse {
+            peer_id: None,
+            did: None,
+        };
         let json = serde_json::to_string(&response).unwrap();
         // PeerID should be omitted when None
         assert!(!json.contains("PeerID"));
+        assert!(!json.contains("DID"));
     }
 }

--- a/crates/http/src/mock/block.rs
+++ b/crates/http/src/mock/block.rs
@@ -14,6 +14,14 @@ impl MockBlockOperations {
 
 #[async_trait]
 impl BlockOperations for MockBlockOperations {
+    async fn signed_block_bytes(
+        &self,
+        _cid: &str,
+        _caller_did: Option<&str>,
+    ) -> Result<(Vec<u8>, Vec<u8>), String> {
+        Err("mock signed block bytes unavailable".to_string())
+    }
+
     async fn verify_signature(
         &self,
         _cid: &str,

--- a/crates/http/src/route_permissions.rs
+++ b/crates/http/src/route_permissions.rs
@@ -244,7 +244,7 @@ pub fn route_permission(path: &str, method: &Method) -> RoutePermission {
         // =====================================================================
         // Block
         // =====================================================================
-        "/api/v0/block/verify-signature" => {
+        "/api/v0/block/verify-signature" | "/api/v0/block/signed" => {
             RoutePermission::Required(NodePermission::SignatureVerify)
         }
 
@@ -600,6 +600,17 @@ mod tests {
                 Method::POST,
                 RoutePermission::Required(NodePermission::DocumentUpdate),
             ),
+            // Block
+            (
+                "/api/v0/block/verify-signature",
+                Method::GET,
+                RoutePermission::Required(NodePermission::SignatureVerify),
+            ),
+            (
+                "/api/v0/block/signed",
+                Method::GET,
+                RoutePermission::Required(NodePermission::SignatureVerify),
+            ),
             // Views
             (
                 "/api/v0/views",
@@ -648,6 +659,7 @@ mod tests {
             ("/api/v0/p2p/replicators", Method::DELETE),
             ("/api/v0/acp/node/disable", Method::POST),
             ("/api/v0/backup/export", Method::POST),
+            ("/api/v0/block/signed", Method::GET),
         ] {
             let v1_path = v0_path.replacen("/api/v0", "/api/v1", 1);
             assert_eq!(

--- a/crates/http/src/router/routes.rs
+++ b/crates/http/src/router/routes.rs
@@ -193,8 +193,9 @@ pub(crate) fn create_router_with_state_and_sync_body_limit(
         .route("/import", post(handlers::backup::import));
 
     // Block routes
-    let block_routes =
-        Router::new().route("/verify-signature", get(handlers::block::verify_signature));
+    let block_routes = Router::new()
+        .route("/verify-signature", get(handlers::block::verify_signature))
+        .route("/signed", get(handlers::block::signed_block));
 
     // Lens migration routes
     let lens_routes = Router::new()

--- a/crates/http/src/router/traits.rs
+++ b/crates/http/src/router/traits.rs
@@ -561,6 +561,15 @@ pub struct EncryptedIndexInfo {
 /// DAG-CBOR blocks stored in the blockstore.
 #[async_trait::async_trait]
 pub trait BlockOperations: Send + Sync {
+    /// Return canonical bytes for an authorized signed block and its detached
+    /// signature so clients can verify content addressing and authorship
+    /// locally.
+    async fn signed_block_bytes(
+        &self,
+        cid: &str,
+        caller_did: Option<&str>,
+    ) -> Result<(Vec<u8>, Vec<u8>), String>;
+
     /// Verify the signature of a block.
     ///
     /// Loads a block by CID, checks its signature, and verifies using the


### PR DESCRIPTION
Supersedes #1325, #1352, and #1353.

## What changed

- run signed embedded queries and explicit-transaction statements on a node-owned Tokio runtime with admission, bounded draining, and shutdown ownership
- apply the configured node signer and ambient node identity to both auto-commit and explicit-transaction execution
- default embedded GraphQL requests to the configured node DID while preserving an explicitly supplied actor
- expose first-class transaction begin, commit, and rollback methods on `EmbeddedNode`
- expose cryptographically verified signer DIDs for committed and in-transaction blocks
- expose ACP-authorized canonical block and detached-signature bytes to embedded and HTTP clients
- split the signed execution runtime and its lifecycle tests into the descriptive `signed_query_runtime/` module

## Why

Embedded callers need one authoritative execution seam where the node identity is the default ACP actor and every mutation is signed consistently. Explicit transactions previously bypassed that seam, and caller cancellation could invalidate runtime work DefraDB still needed to finalize.

Provenance consumers also need the actual CID-verified DAG-CBOR material, not a server-side assertion or decoded/re-encoded approximation. The signed-block surface now returns the exact bytes loaded and verified from storage so clients can independently verify both CIDs, the detached signature, and the signer DID.

## Consolidation notes

- the iterative thirteen-commit stack from #1325 and #1353 is represented here as one current-`main` commit
- #1352's pending-DAG/store-release behavior is intentionally not duplicated: the broader lifecycle fix already landed on `main` through #1357 and #1370, including the immediate-reopen regression coverage
- the macOS integration cache failure from the old stack is also already fixed on `main` by #1360
- remote-signer-only nodes now use the configured node DID for embedded block authorization instead of falling back to an anonymous database identity
- the raw `runner()` API remains available for compatibility, but documents that direct execution bypasses node signing and default ACP identity

## Validation

- `cargo test -p defra-node`
- `cargo test -p defra-node --features p2p`
- `cargo test -p defra-node --test transaction_signing_test`
- `cargo test -p db block_verify`
- `cargo test -p defra-http block`
- `cargo clippy -p defra-node --features p2p --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`

The transaction signing regression now also verifies that returned block and signature bytes reproduce the persisted block CID and detached signature CID exactly.
