### PR TITLE
ci: simplify repository auth and restore fast macOS tests

### DIFF
--- a/.github/scripts/rustc-direct.sh
+++ b/.github/scripts/rustc-direct.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-# Cargo treats an empty RUSTC_WRAPPER as unset and falls back to the host's
-# build.rustc-wrapper setting (sccache on the studio/spark hosts, which
-# rejects incremental rustc invocations). Execute Cargo's rustc command
-# directly so incremental suites cannot accidentally re-enable sccache
-# through host config.
-exec "$@"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,11 @@ jobs:
           bash .github/scripts/apt-update-without-nodesource.sh
           sudo apt-get install -y protobuf-compiler clang
 
+      - name: Isolate the WASM dependency graph
+        # Cargo resolves every workspace member even for a package-specific build.
+        # These test-only members pin Git revisions that the WASM build does not use.
+        run: sed -i '/"tools\/integration-test"/d; /"tools\/ffi-test"/d; /"proofs"/d' Cargo.toml
+
       - name: Clippy (wasm32)
         run: cargo clippy -p defra-wasm --target wasm32-unknown-unknown --all-targets -- -D warnings
 
@@ -196,6 +201,10 @@ jobs:
       - name: Show sccache stats
         if: always()
         run: .github/scripts/show-sccache-stats.sh
+
+      - name: Cleanup
+        if: always()
+        run: git checkout -- Cargo.toml
 
   build:
     name: Build & Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,17 +210,14 @@ jobs:
     name: Build & Test
     runs-on: [self-hosted, macOS, ARM64, studio, studio-1]
     env:
-      # Warm-incremental beats sccache for the hot edit path (gents A/B on
-      # these hosts: 14.6s vs 5m54s for a representative source edit). The
-      # host-wide sccache rejects incremental invocations, and an empty
-      # RUSTC_WRAPPER falls back to host config, so route rustc through the
-      # pass-through wrapper. CARGO_BUILD_RUSTC_WRAPPER covers recursive
-      # Cargo invocations from build scripts. The rust/signed-docs suites on
-      # this runner use the same settings so the shared target tree never
-      # flip-flops flags.
-      CARGO_INCREMENTAL: "1"
-      RUSTC_WRAPPER: .github/scripts/rustc-direct.sh
-      CARGO_BUILD_RUSTC_WRAPPER: .github/scripts/rustc-direct.sh
+      # The full workspace test suite launches roughly 187 test executables.
+      # Incremental artifacts caused a ~25s startup delay per executable on
+      # this macOS host, turning this step from minutes into more than an hour.
+      # Prefer sccache here; the edit-only incremental benchmark does not
+      # represent this test workload.
+      CARGO_INCREMENTAL: "0"
+      RUSTC_WRAPPER: sccache
+      CARGO_BUILD_RUSTC_WRAPPER: sccache
     steps:
       - uses: actions/checkout@v4
         with:
@@ -386,15 +383,13 @@ jobs:
       # suites self-build on miss into their own host-local cache.
       matrix:
         include:
-          # studio-1 suites share the build job's incremental target tree, so
-          # they carry the same incremental + pass-through wrapper settings;
-          # studio-2 suites stay on the host sccache (incremental off) so the
-          # target tree they share with conformance keeps consistent flags.
+          # Each host uses sccache with incremental compilation disabled so
+          # jobs sharing its persistent target tree keep consistent flags.
           - suite: rust
             needs_go: false
             host: studio-1
-            cargo_incremental: "1"
-            rustc_wrapper: .github/scripts/rustc-direct.sh
+            cargo_incremental: "0"
+            rustc_wrapper: sccache
           - suite: go-compat
             needs_go: true
             host: studio-2
@@ -414,8 +409,8 @@ jobs:
             needs_go: false
             multipliers: signed-docs
             host: studio-1
-            cargo_incremental: "1"
-            rustc_wrapper: .github/scripts/rustc-direct.sh
+            cargo_incremental: "0"
+            rustc_wrapper: sccache
     env:
       DEFRA_RUST_BINARY: ${{ github.workspace }}/target/ci/defra
       DEFRA_IROH_BINARY: ${{ github.workspace }}/target/ci/defra-iroh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,15 +53,6 @@ jobs:
         with:
           clean: false
 
-      - name: Configure private repo access
-        run: |
-          # Org-wide PAT rewrite for private sourcenetwork deps.
-          git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
-          # backbone is public. Fine-grained PATs that omit it make GitHub
-          # treat authenticated fetches as "not our ref" for new commits;
-          # longest-prefix insteadOf wins, so this keeps backbone unauthenticated.
-          git config --global url."https://github.com/sourcenetwork/backbone".insteadOf "https://github.com/sourcenetwork/backbone"
-
       - uses: dtolnay/rust-toolchain@stable
 
       - run: cargo fmt --all -- --check
@@ -99,12 +90,6 @@ jobs:
         if: always()
         run: .github/scripts/show-sccache-stats.sh
 
-      - name: Cleanup
-        if: always()
-        run: |
-          git config --global --remove-section "url.https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/" 2>/dev/null || true
-          git config --global --remove-section "url.https://github.com/sourcenetwork/backbone" 2>/dev/null || true
-
   wasm-check:
     name: WASM Build Check
     # spark-1: the wasm32 target doesn't care about host arch, and pinning
@@ -118,15 +103,6 @@ jobs:
         with:
           clean: false
 
-      - name: Configure private repo access
-        run: |
-          # Org-wide PAT rewrite for private sourcenetwork deps.
-          git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
-          # backbone is public. Fine-grained PATs that omit it make GitHub
-          # treat authenticated fetches as "not our ref" for new commits;
-          # longest-prefix insteadOf wins, so this keeps backbone unauthenticated.
-          git config --global url."https://github.com/sourcenetwork/backbone".insteadOf "https://github.com/sourcenetwork/backbone"
-
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
@@ -139,11 +115,6 @@ jobs:
         run: |
           bash .github/scripts/apt-update-without-nodesource.sh
           sudo apt-get install -y protobuf-compiler clang
-
-      - name: Exclude packages that pull private/public git harness deps
-        # wasm doesn't need integration-test, ffi-test, or proofs (defra-harness).
-        # Stripping them keeps cargo from resolving backbone during wasm clippy.
-        run: sed -i '/"tools\/integration-test"/d; /"tools\/ffi-test"/d; /"proofs"/d' Cargo.toml
 
       - name: Clippy (wasm32)
         run: cargo clippy -p defra-wasm --target wasm32-unknown-unknown --all-targets -- -D warnings
@@ -226,13 +197,6 @@ jobs:
         if: always()
         run: .github/scripts/show-sccache-stats.sh
 
-      - name: Cleanup
-        if: always()
-        run: |
-          git config --global --remove-section "url.https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/" 2>/dev/null || true
-          git config --global --remove-section "url.https://github.com/sourcenetwork/backbone" 2>/dev/null || true
-          git checkout -- Cargo.toml
-
   build:
     name: Build & Test
     runs-on: [self-hosted, macOS, ARM64, studio, studio-1]
@@ -252,15 +216,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           clean: false
-
-      - name: Configure private repo access
-        run: |
-          # Org-wide PAT rewrite for private sourcenetwork deps.
-          git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
-          # backbone is public. Fine-grained PATs that omit it make GitHub
-          # treat authenticated fetches as "not our ref" for new commits;
-          # longest-prefix insteadOf wins, so this keeps backbone unauthenticated.
-          git config --global url."https://github.com/sourcenetwork/backbone".insteadOf "https://github.com/sourcenetwork/backbone"
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -308,8 +263,6 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          git config --global --remove-section "url.https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/" 2>/dev/null || true
-          git config --global --remove-section "url.https://github.com/sourcenetwork/backbone" 2>/dev/null || true
           git checkout -- .
           git clean -fd
           pkill -f "target/debug/defra" || true
@@ -320,13 +273,6 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
-
-      - name: Configure private repo access
-        run: |
-          git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
-          git config --global --add url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "ssh://git@github.com/sourcenetwork/"
-          # Public backbone: keep unauthenticated (see comment on other jobs).
-          git config --global url."https://github.com/sourcenetwork/backbone".insteadOf "https://github.com/sourcenetwork/backbone"
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -346,12 +292,6 @@ jobs:
 
       - name: Check Lean-to-Rust conformance
         run: cargo test -p conformance --lib --test lean_conformance
-
-      - name: Cleanup
-        if: always()
-        run: |
-          git config --global --remove-section "url.https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/" 2>/dev/null || true
-          git config --global --remove-section "url.https://github.com/sourcenetwork/backbone" 2>/dev/null || true
 
   conformance:
     name: Conformance
@@ -378,15 +318,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           clean: false
-
-      - name: Configure private repo access
-        run: |
-          # Org-wide PAT rewrite for private sourcenetwork deps.
-          git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
-          # backbone is public. Fine-grained PATs that omit it make GitHub
-          # treat authenticated fetches as "not our ref" for new commits;
-          # longest-prefix insteadOf wins, so this keeps backbone unauthenticated.
-          git config --global url."https://github.com/sourcenetwork/backbone".insteadOf "https://github.com/sourcenetwork/backbone"
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -423,8 +354,6 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          git config --global --remove-section "url.https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/" 2>/dev/null || true
-          git config --global --remove-section "url.https://github.com/sourcenetwork/backbone" 2>/dev/null || true
           git checkout -- .
           git clean -fd
           rm -rf target/e2e
@@ -489,15 +418,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           clean: false
-
-      - name: Configure private repo access
-        run: |
-          # Org-wide PAT rewrite for private sourcenetwork deps.
-          git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
-          # backbone is public. Fine-grained PATs that omit it make GitHub
-          # treat authenticated fetches as "not our ref" for new commits;
-          # longest-prefix insteadOf wins, so this keeps backbone unauthenticated.
-          git config --global url."https://github.com/sourcenetwork/backbone".insteadOf "https://github.com/sourcenetwork/backbone"
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -717,8 +637,6 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          git config --global --remove-section "url.https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/" 2>/dev/null || true
-          git config --global --remove-section "url.https://github.com/sourcenetwork/backbone" 2>/dev/null || true
           git checkout -- .
           git clean -fd
           pkill -f "target/(debug|ci)/defra" || true
@@ -755,15 +673,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           clean: false
-
-      - name: Configure private repo access
-        run: |
-          # Org-wide PAT rewrite for private sourcenetwork deps.
-          git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
-          # backbone is public. Fine-grained PATs that omit it make GitHub
-          # treat authenticated fetches as "not our ref" for new commits;
-          # longest-prefix insteadOf wins, so this keeps backbone unauthenticated.
-          git config --global url."https://github.com/sourcenetwork/backbone".insteadOf "https://github.com/sourcenetwork/backbone"
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -815,8 +724,6 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          git config --global --remove-section "url.https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/" 2>/dev/null || true
-          git config --global --remove-section "url.https://github.com/sourcenetwork/backbone" 2>/dev/null || true
           git checkout -- .
           git clean -fd
           rm -rf target/e2e
@@ -833,15 +740,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           clean: false
-
-      - name: Configure private repo access
-        run: |
-          # Org-wide PAT rewrite for private sourcenetwork deps.
-          git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
-          # backbone is public. Fine-grained PATs that omit it make GitHub
-          # treat authenticated fetches as "not our ref" for new commits;
-          # longest-prefix insteadOf wins, so this keeps backbone unauthenticated.
-          git config --global url."https://github.com/sourcenetwork/backbone".insteadOf "https://github.com/sourcenetwork/backbone"
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -870,7 +768,5 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          git config --global --remove-section "url.https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/" 2>/dev/null || true
-          git config --global --remove-section "url.https://github.com/sourcenetwork/backbone" 2>/dev/null || true
           git checkout -- .
           git clean -fd

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,9 +82,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Configure private repo access
-        run: git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
-
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -130,14 +127,6 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install protobuf
 
-      - name: Exclude workspace members with private deps
-        run: |
-          if [[ "$OSTYPE" == "darwin"* ]]; then
-            sed -i '' '/"tools\/integration-test"/d; /"tools\/ffi-test"/d; /"proofs"/d' Cargo.toml
-          else
-            sed -i '/"tools\/integration-test"/d; /"tools\/ffi-test"/d; /"proofs"/d' Cargo.toml
-          fi
-
       - name: Build
         run: cargo build --release -p cli --target ${{ matrix.target }} ${{ matrix.features }}
 
@@ -161,7 +150,6 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          git config --global --remove-section "url.https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/" 2>/dev/null || true
           git checkout -- .
           git clean -fd
 
@@ -170,9 +158,6 @@ jobs:
     runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v4
-
-      - name: Configure private repo access
-        run: git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -187,9 +172,6 @@ jobs:
         run: |
           bash .github/scripts/apt-update-without-nodesource.sh
           sudo apt-get install -y protobuf-compiler
-
-      - name: Exclude workspace members with private deps
-        run: sed -i '/"tools\/integration-test"/d; /"tools\/ffi-test"/d; /"proofs"/d' Cargo.toml
 
       - name: Install wasm-pack
         run: cargo install wasm-pack
@@ -212,7 +194,6 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          git config --global --remove-section "url.https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/" 2>/dev/null || true
           git checkout -- .
           git clean -fd
 
@@ -268,9 +249,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Configure private repo access
-        run: git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
-
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -316,14 +294,6 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install protobuf
 
-      - name: Exclude workspace members with private deps
-        run: |
-          if [[ "$OSTYPE" == "darwin"* ]]; then
-            sed -i '' '/"tools\/integration-test"/d; /"tools\/ffi-test"/d; /"proofs"/d' Cargo.toml
-          else
-            sed -i '/"tools\/integration-test"/d; /"tools\/ffi-test"/d; /"proofs"/d' Cargo.toml
-          fi
-
       - name: Install cbindgen
         run: cargo install cbindgen
 
@@ -361,7 +331,6 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          git config --global --remove-section "url.https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/" 2>/dev/null || true
           git checkout -- .
           git clean -fd
 
@@ -370,9 +339,6 @@ jobs:
     runs-on: ["self-hosted", "macOS", "ARM64", "studio"]
     steps:
       - uses: actions/checkout@v4
-
-      - name: Configure private repo access
-        run: git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -385,9 +351,6 @@ jobs:
 
       - name: Install system dependencies
         run: brew install protobuf
-
-      - name: Exclude workspace members with private deps
-        run: sed -i '' '/"tools\/integration-test"/d; /"tools\/ffi-test"/d; /"proofs"/d' Cargo.toml
 
       - name: Install cbindgen
         run: cargo install cbindgen
@@ -419,7 +382,6 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          git config --global --remove-section "url.https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/" 2>/dev/null || true
           git checkout -- .
           git clean -fd
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,16 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install protobuf
 
+      - name: Isolate the release dependency graph
+        # Cargo resolves every workspace member even for a package-specific build.
+        # These test-only members pin Git revisions that release builds do not use.
+        run: |
+          if [[ "$OSTYPE" == "darwin"* ]]; then
+            sed -i '' '/"tools\/integration-test"/d; /"tools\/ffi-test"/d; /"proofs"/d' Cargo.toml
+          else
+            sed -i '/"tools\/integration-test"/d; /"tools\/ffi-test"/d; /"proofs"/d' Cargo.toml
+          fi
+
       - name: Build
         run: cargo build --release -p cli --target ${{ matrix.target }} ${{ matrix.features }}
 
@@ -172,6 +182,10 @@ jobs:
         run: |
           bash .github/scripts/apt-update-without-nodesource.sh
           sudo apt-get install -y protobuf-compiler
+
+      - name: Isolate the WASM dependency graph
+        # Avoid resolving test-only Git dependencies that this build does not use.
+        run: sed -i '/"tools\/integration-test"/d; /"tools\/ffi-test"/d; /"proofs"/d' Cargo.toml
 
       - name: Install wasm-pack
         run: cargo install wasm-pack
@@ -294,6 +308,15 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install protobuf
 
+      - name: Isolate the FFI dependency graph
+        # Avoid resolving test-only Git dependencies that this build does not use.
+        run: |
+          if [[ "$OSTYPE" == "darwin"* ]]; then
+            sed -i '' '/"tools\/integration-test"/d; /"tools\/ffi-test"/d; /"proofs"/d' Cargo.toml
+          else
+            sed -i '/"tools\/integration-test"/d; /"tools\/ffi-test"/d; /"proofs"/d' Cargo.toml
+          fi
+
       - name: Install cbindgen
         run: cargo install cbindgen
 
@@ -351,6 +374,10 @@ jobs:
 
       - name: Install system dependencies
         run: brew install protobuf
+
+      - name: Isolate the Apple FFI dependency graph
+        # Avoid resolving test-only Git dependencies that this build does not use.
+        run: sed -i '' '/"tools\/integration-test"/d; /"tools\/ffi-test"/d; /"proofs"/d' Cargo.toml
 
       - name: Install cbindgen
         run: cargo install cbindgen

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ dependencies = [
 [[package]]
 name = "acp-light-client"
 version = "0.1.0"
-source = "git+ssh://git@github.com/sourcenetwork/backbone.git?rev=086ddadc98bc55183920aa0fe6bc4d3719e0e5e7#086ddadc98bc55183920aa0fe6bc4d3719e0e5e7"
+source = "git+https://github.com/sourcenetwork/backbone.git?rev=086ddadc98bc55183920aa0fe6bc4d3719e0e5e7#086ddadc98bc55183920aa0fe6bc4d3719e0e5e7"
 dependencies = [
  "alloy-primitives",
  "borsh",

--- a/crates/sourcehub/Cargo.toml
+++ b/crates/sourcehub/Cargo.toml
@@ -59,7 +59,7 @@ alloy-rlp.workspace = true
 bs58.workspace = true
 
 # ACP light client (proof-validated cache)
-acp-light-client = { git = "ssh://git@github.com/sourcenetwork/backbone.git", rev = "086ddadc98bc55183920aa0fe6bc4d3719e0e5e7" }
+acp-light-client = { git = "https://github.com/sourcenetwork/backbone.git", rev = "086ddadc98bc55183920aa0fe6bc4d3719e0e5e7" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 futures.workspace = true

--- a/tools/integration-test/src/lib.rs
+++ b/tools/integration-test/src/lib.rs
@@ -67,6 +67,13 @@ pub fn workspace_root() -> PathBuf {
         .expect("failed to canonicalize workspace root")
 }
 
+/// Return the configured Rust CLI binary, falling back to Cargo's debug output.
+pub fn rust_binary() -> PathBuf {
+    std::env::var_os("DEFRA_RUST_BINARY")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| workspace_root().join("target/debug/defra"))
+}
+
 /// Generate `rust_<name>` and `go_<name>` test wrappers for a single-node test.
 ///
 /// Usage: `for_each_runtime!(name, inner_fn);` (bare builder)

--- a/tools/integration-test/tests/basic/smoke.rs
+++ b/tools/integration-test/tests/basic/smoke.rs
@@ -3,12 +3,14 @@ use integration_test::TestCluster;
 #[tokio::test]
 async fn version_json_has_all_fields() {
     let root = integration_test::workspace_root();
-    let binary = root.join("target/debug/defra");
+    let binary = std::env::var_os("DEFRA_RUST_BINARY")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| root.join("target/debug/defra"));
 
     let output = std::process::Command::new(&binary)
         .args(["version", "--format", "json"])
         .output()
-        .expect("defra binary not found — run `cargo build -p cli` first");
+        .expect("defra binary not found — set DEFRA_RUST_BINARY or run `cargo build -p cli`");
 
     assert!(output.status.success(), "defra version failed");
 

--- a/tools/integration-test/tests/basic/smoke.rs
+++ b/tools/integration-test/tests/basic/smoke.rs
@@ -2,10 +2,7 @@ use integration_test::TestCluster;
 
 #[tokio::test]
 async fn version_json_has_all_fields() {
-    let root = integration_test::workspace_root();
-    let binary = std::env::var_os("DEFRA_RUST_BINARY")
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|| root.join("target/debug/defra"));
+    let binary = integration_test::rust_binary();
 
     let output = std::process::Command::new(&binary)
         .args(["version", "--format", "json"])

--- a/tools/integration-test/tests/identity/keyring_dev_mode.rs
+++ b/tools/integration-test/tests/identity/keyring_dev_mode.rs
@@ -1,15 +1,8 @@
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 
-fn workspace_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../..")
-        .canonicalize()
-        .expect("failed to canonicalize workspace root")
-}
-
 fn defra_binary() -> PathBuf {
-    workspace_root().join("target/debug/defra")
+    integration_test::rust_binary()
 }
 
 fn defra_keyring(binary: &Path, keyring_dir: &Path, args: &[&str]) -> Output {

--- a/tools/integration-test/tests/identity/keyring_lifecycle.rs
+++ b/tools/integration-test/tests/identity/keyring_lifecycle.rs
@@ -1,17 +1,8 @@
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 
-fn workspace_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../..")
-        .canonicalize()
-        .expect("failed to canonicalize workspace root")
-}
-
 fn defra_binary() -> PathBuf {
-    std::env::var_os("DEFRA_RUST_BINARY")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| workspace_root().join("target/debug/defra"))
+    integration_test::rust_binary()
 }
 
 fn is_rust_binary(binary: &Path) -> bool {

--- a/tools/integration-test/tests/identity/lifecycle.rs
+++ b/tools/integration-test/tests/identity/lifecycle.rs
@@ -1,15 +1,8 @@
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
-fn workspace_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../..")
-        .canonicalize()
-        .expect("failed to canonicalize workspace root")
-}
-
 fn defra_binary() -> PathBuf {
-    workspace_root().join("target/debug/defra")
+    integration_test::rust_binary()
 }
 
 /// Run a `defra identity` subcommand with the file keyring pointed at `keyring_dir`.

--- a/tools/integration-test/tests/p2p_iroh/acp/dac.rs
+++ b/tools/integration-test/tests/p2p_iroh/acp/dac.rs
@@ -73,7 +73,7 @@ async fn setup_sourcehub_cluster() -> Option<(TestCluster, String, String)> {
         return None;
     }
 
-    let binary = integration_test::workspace_root().join("target/debug/defra");
+    let binary = integration_test::rust_binary();
     let owner = generate_identity(&binary).expect("generate owner identity");
     let owner_key = owner.private_key_hex.clone();
 
@@ -451,7 +451,7 @@ async fn create_private_sync_after_relationship() {
     let node1 = cluster.client(1);
 
     // Generate a second identity (reader)
-    let binary = integration_test::workspace_root().join("target/debug/defra");
+    let binary = integration_test::rust_binary();
     let reader = generate_identity(&binary).expect("generate reader identity");
 
     // Create private doc as owner
@@ -706,7 +706,7 @@ async fn replicator_permissioned_sourcehub() {
     );
 
     // A different identity cannot read
-    let binary = integration_test::workspace_root().join("target/debug/defra");
+    let binary = integration_test::rust_binary();
     let stranger = generate_identity(&binary).expect("stranger identity");
     let stranger_result = node1
         .query_with_identity("query { User { name } }", &stranger.private_key_hex)
@@ -735,7 +735,7 @@ async fn subscribe_add_get_with_doc_actor_relationship() {
     let node0 = cluster.client(0);
     let node1 = cluster.client(1);
 
-    let binary = integration_test::workspace_root().join("target/debug/defra");
+    let binary = integration_test::rust_binary();
     let reader = generate_identity(&binary).expect("reader identity");
 
     // Create doc as owner
@@ -807,7 +807,7 @@ async fn replicator_with_doc_actor_relationship() {
     let node0 = cluster.client(0);
     let node1 = cluster.client(1);
 
-    let binary = integration_test::workspace_root().join("target/debug/defra");
+    let binary = integration_test::rust_binary();
     let reader = generate_identity(&binary).expect("reader identity");
 
     // Create doc

--- a/tools/integration-test/tests/p2p_iroh/connection/signature.rs
+++ b/tools/integration-test/tests/p2p_iroh/connection/signature.rs
@@ -61,8 +61,7 @@ fn require_public_key(identity: &integration_test::TestIdentity) -> String {
 #[serial]
 async fn peers_secp256k1_sync() {
     let identity =
-        generate_identity(&integration_test::workspace_root().join("target/debug/defra"))
-            .expect("generate secp256k1 identity");
+        generate_identity(&integration_test::rust_binary()).expect("generate secp256k1 identity");
 
     let cluster = TestCluster::builder()
         .rust_nodes(2)
@@ -126,9 +125,8 @@ async fn peers_secp256k1_sync() {
 #[tokio::test]
 #[serial]
 async fn peers_ed25519_sync() {
-    let identity =
-        generate_ed25519_identity(&integration_test::workspace_root().join("target/debug/defra"))
-            .expect("generate ed25519 identity");
+    let identity = generate_ed25519_identity(&integration_test::rust_binary())
+        .expect("generate ed25519 identity");
 
     let cluster = TestCluster::builder()
         .rust_nodes(2)
@@ -192,7 +190,7 @@ async fn peers_ed25519_sync() {
 #[tokio::test]
 #[serial]
 async fn peers_different_key_types_sync() {
-    let binary = &integration_test::workspace_root().join("target/debug/defra");
+    let binary = &integration_test::rust_binary();
     let id0 = generate_identity(binary).expect("generate secp256k1 identity");
     let id1 = generate_ed25519_identity(binary).expect("generate ed25519 identity");
 
@@ -279,7 +277,7 @@ async fn peers_different_key_types_sync() {
 #[tokio::test]
 #[serial]
 async fn peers_different_key_types_same_doc_sync() {
-    let binary = &integration_test::workspace_root().join("target/debug/defra");
+    let binary = &integration_test::rust_binary();
     let id0 = generate_identity(binary).expect("generate secp256k1 identity");
     let id1 = generate_ed25519_identity(binary).expect("generate ed25519 identity");
 
@@ -431,9 +429,7 @@ async fn peers_different_key_types_same_doc_sync() {
 #[tokio::test]
 #[serial]
 async fn branchable_collection_signed() {
-    let identity =
-        generate_identity(&integration_test::workspace_root().join("target/debug/defra"))
-            .expect("generate identity");
+    let identity = generate_identity(&integration_test::rust_binary()).expect("generate identity");
 
     let cluster = TestCluster::builder()
         .rust_nodes(1)
@@ -506,9 +502,7 @@ async fn branchable_collection_signed() {
 #[tokio::test]
 #[serial]
 async fn verify_valid_data() {
-    let identity =
-        generate_identity(&integration_test::workspace_root().join("target/debug/defra"))
-            .expect("generate identity");
+    let identity = generate_identity(&integration_test::rust_binary()).expect("generate identity");
 
     let cluster = TestCluster::builder()
         .rust_nodes(1)
@@ -543,9 +537,8 @@ async fn verify_valid_data() {
 #[tokio::test]
 #[serial]
 async fn verify_different_key_type() {
-    let identity =
-        generate_ed25519_identity(&integration_test::workspace_root().join("target/debug/defra"))
-            .expect("generate ed25519 identity");
+    let identity = generate_ed25519_identity(&integration_test::rust_binary())
+        .expect("generate ed25519 identity");
 
     let cluster = TestCluster::builder()
         .rust_nodes(1)
@@ -580,9 +573,7 @@ async fn verify_different_key_type() {
 #[tokio::test]
 #[serial]
 async fn verify_wrong_identity_error() {
-    let identity =
-        generate_identity(&integration_test::workspace_root().join("target/debug/defra"))
-            .expect("generate identity");
+    let identity = generate_identity(&integration_test::rust_binary()).expect("generate identity");
 
     let cluster = TestCluster::builder()
         .rust_nodes(1)
@@ -620,9 +611,7 @@ async fn verify_wrong_identity_error() {
 #[tokio::test]
 #[serial]
 async fn verify_wrong_cid_error() {
-    let identity =
-        generate_identity(&integration_test::workspace_root().join("target/debug/defra"))
-            .expect("generate identity");
+    let identity = generate_identity(&integration_test::rust_binary()).expect("generate identity");
 
     let cluster = TestCluster::builder()
         .rust_nodes(1)

--- a/tools/integration-test/tests/query/sdl_generate.rs
+++ b/tools/integration-test/tests/query/sdl_generate.rs
@@ -1,15 +1,8 @@
 use std::path::PathBuf;
 use std::process::Command;
 
-fn workspace_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../..")
-        .canonicalize()
-        .expect("failed to canonicalize workspace root")
-}
-
 fn defra_binary() -> PathBuf {
-    workspace_root().join("target/debug/defra")
+    integration_test::rust_binary()
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Remove `PRIVATE_REPO_PAT` URL rewrites and matching global Git cleanup from CI and release jobs.
- Keep package-specific WASM/release builds isolated from test-only workspace members, but document that isolation as Cargo dependency-graph scoping rather than private-repository access.
- Switch the remaining `acp-light-client` dependency from SSH to anonymous HTTPS.
- Restore non-incremental `sccache` builds for the macOS test chain and remove the now-unused pass-through rustc wrapper.

## Why

All pinned Git dependencies used by this workspace are publicly readable. The authentication setup is no longer necessary, and its `git config --global` writes make concurrent self-hosted jobs contend on the shared user-level `.gitconfig`. That race caused PR #1371's `Lint` job to fail before linting with `could not lock config file /Users/admin/.gitconfig: File exists`.

The recent incremental-compilation optimization also regressed the full workspace test workload. Before it, `cargo test --workspace` took about 2.5–5.5 minutes in representative successful jobs. Afterward it took 65–83 minutes. Compilation completed in roughly 10 minutes, but each of approximately 187 test executables then incurred a 25–26 second startup delay on the macOS runner—even binaries whose tests finished in 0.00 seconds. The original 14.6-second incremental A/B measured a representative source edit, not execution of the complete test suite.

Cargo still resolves every workspace member for package-specific builds. The existing manifest isolation remains necessary for WASM and release jobs because they do not use the test harnesses and should not resolve those pinned Git revisions.

## Impact

CI and release no longer require `PRIVATE_REPO_PAT` or mutate shared Git configuration. The workflows retain only target-specific workspace isolation. The runner-topology improvements remain intact, while macOS test jobs return to the pre-regression `sccache` configuration with consistent flags across their shared target trees.

## Validation

- Fetched every pinned `backbone`, `beetle`, and `lark` revision anonymously over HTTPS with global and system Git configuration disabled.
- `cargo metadata --locked --format-version 1 --no-deps`
- `cargo check -p sourcehub --locked`
- Parsed `.github/workflows/ci.yml` and `.github/workflows/release.yml` as YAML.
- `cargo fmt --all -- --check`
- `git diff --check`
- The replacement CI run passed WASM Clippy, build, and browser tests with dependency-graph isolation restored.
- A combined integration gate in #1376 exercises the corrected macOS test configuration against the complete `v0.18.0` content tree.
