### PR TITLE
perf(wasm): remove Tokio from dependency graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3614,6 +3614,7 @@ dependencies = [
  "bytes",
  "cid",
  "criterion 0.6.0",
+ "futures",
  "ipld-core",
  "multibase",
  "multicodec",
@@ -6576,12 +6577,14 @@ name = "kms"
 version = "0.5.0"
 dependencies = [
  "acp",
+ "async-channel 2.5.0",
  "async-lock",
  "async-trait",
  "base64 0.22.1",
  "cid",
  "crypto",
  "defra-core",
+ "futures",
  "identity",
  "orbis",
  "rand 0.8.5",

--- a/crates/defra-core/Cargo.toml
+++ b/crates/defra-core/Cargo.toml
@@ -44,6 +44,7 @@ tokio = { workspace = true, features = ["rt"] }
 
 [dev-dependencies]
 criterion.workspace = true
+futures.workspace = true
 multihash-codetable.workspace = true
 
 [[bench]]

--- a/crates/defra-core/src/lib.rs
+++ b/crates/defra-core/src/lib.rs
@@ -24,6 +24,8 @@ pub mod store;
 pub mod thread_bounds;
 pub mod transaction;
 pub mod types;
+#[cfg(any(target_arch = "wasm32", test))]
+pub mod wasm_task_local;
 
 pub use action::{Action, ActionExecution, ActionStatus};
 pub use block::{

--- a/crates/defra-core/src/wasm_task_local.rs
+++ b/crates/defra-core/src/wasm_task_local.rs
@@ -1,0 +1,93 @@
+//! Single-threaded task-local storage for WASM futures.
+
+use std::cell::RefCell;
+use std::future::{poll_fn, Future};
+use std::thread::LocalKey;
+
+fn with_value<T: 'static, R>(
+    local: &'static LocalKey<RefCell<Option<T>>>,
+    value: &mut Option<T>,
+    f: impl FnOnce() -> R,
+) -> R {
+    struct Reset<'a, T: 'static> {
+        local: &'static LocalKey<RefCell<Option<T>>>,
+        value: &'a mut Option<T>,
+    }
+
+    impl<T: 'static> Drop for Reset<'_, T> {
+        fn drop(&mut self) {
+            self.local
+                .with(|local| std::mem::swap(self.value, &mut *local.borrow_mut()));
+        }
+    }
+
+    local.with(|local| std::mem::swap(value, &mut *local.borrow_mut()));
+    let reset = Reset { local, value };
+    let result = f();
+    drop(reset);
+    result
+}
+
+/// Poll a future with `value` installed in its task-local slot.
+pub async fn scope<T: 'static, F>(
+    local: &'static LocalKey<RefCell<Option<T>>>,
+    value: T,
+    future: F,
+) -> F::Output
+where
+    F: Future,
+{
+    let mut value = Some(value);
+    let mut future = Box::pin(future);
+    poll_fn(move |cx| with_value(local, &mut value, || future.as_mut().poll(cx))).await
+}
+
+/// Access the current task-local value when a scope is active.
+pub fn try_with<T: 'static, R>(
+    local: &'static LocalKey<RefCell<Option<T>>>,
+    f: impl FnOnce(&T) -> R,
+) -> Option<R> {
+    local.with(|local| local.borrow().as_ref().map(f))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    thread_local! {
+        static VALUE: RefCell<Option<u8>> = const { RefCell::new(None) };
+    }
+
+    async fn yield_once() {
+        let mut yielded = false;
+        poll_fn(move |cx| {
+            if yielded {
+                std::task::Poll::Ready(())
+            } else {
+                yielded = true;
+                cx.waker().wake_by_ref();
+                std::task::Poll::Pending
+            }
+        })
+        .await;
+    }
+
+    #[test]
+    fn scopes_survive_interleaved_polls() {
+        futures::executor::block_on(async {
+            let first = scope(&VALUE, 1, async {
+                assert_eq!(try_with(&VALUE, |value| *value), Some(1));
+                yield_once().await;
+                assert_eq!(try_with(&VALUE, |value| *value), Some(1));
+            });
+            let second = scope(&VALUE, 2, async {
+                assert_eq!(try_with(&VALUE, |value| *value), Some(2));
+                yield_once().await;
+                assert_eq!(try_with(&VALUE, |value| *value), Some(2));
+            });
+
+            futures::join!(first, second);
+        });
+        assert_eq!(try_with(&VALUE, |value| *value), None);
+    }
+}

--- a/crates/kms/Cargo.toml
+++ b/crates/kms/Cargo.toml
@@ -43,11 +43,15 @@ zeroize = "1.8"
 rand = { workspace = true }
 uuid = { workspace = true }
 cid = { workspace = true }
-tokio = { version = "1.35", default-features = false, features = ["rt", "sync", "macros"] }
 x25519-dalek = { version = "2.0", features = ["static_secrets"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+async-channel = "2"
+futures.workspace = true
 wasm-bindgen-futures = "0.4"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { version = "1.35", default-features = false, features = ["rt", "sync", "macros"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }

--- a/crates/kms/src/channel.rs
+++ b/crates/kms/src/channel.rs
@@ -1,0 +1,81 @@
+//! Bounded channels backed by the native runtime or a WASM-compatible queue.
+
+/// Sending side of a bounded channel.
+pub struct Sender<T> {
+    #[cfg(not(target_arch = "wasm32"))]
+    inner: tokio::sync::mpsc::Sender<T>,
+    #[cfg(target_arch = "wasm32")]
+    inner: async_channel::Sender<T>,
+}
+
+impl<T> Clone for Sender<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl<T> Sender<T> {
+    /// Send a value, returning it when the receiver is closed.
+    pub async fn send(&self, value: T) -> Result<(), T> {
+        #[cfg(not(target_arch = "wasm32"))]
+        return self.inner.send(value).await.map_err(|error| error.0);
+
+        #[cfg(target_arch = "wasm32")]
+        self.inner.send(value).await.map_err(|error| error.0)
+    }
+
+    /// Wait until every receiver has been dropped.
+    pub async fn closed(&self) {
+        self.inner.closed().await;
+    }
+}
+
+/// Receiving side of a bounded channel.
+pub struct Receiver<T> {
+    #[cfg(not(target_arch = "wasm32"))]
+    inner: tokio::sync::mpsc::Receiver<T>,
+    #[cfg(target_arch = "wasm32")]
+    inner: async_channel::Receiver<T>,
+}
+
+impl<T> Receiver<T> {
+    /// Receive the next value, or `None` once every sender is closed.
+    pub async fn recv(&mut self) -> Option<T> {
+        #[cfg(not(target_arch = "wasm32"))]
+        return self.inner.recv().await;
+
+        #[cfg(target_arch = "wasm32")]
+        self.inner.recv().await.ok()
+    }
+}
+
+pub fn bounded<T>(capacity: usize) -> (Sender<T>, Receiver<T>) {
+    #[cfg(not(target_arch = "wasm32"))]
+    let (sender, receiver) = tokio::sync::mpsc::channel(capacity);
+    #[cfg(target_arch = "wasm32")]
+    let (sender, receiver) = async_channel::bounded(capacity);
+
+    (Sender { inner: sender }, Receiver { inner: receiver })
+}
+
+pub async fn recv_until_closed<T, U>(receiver: &mut Receiver<T>, sender: &Sender<U>) -> Option<T> {
+    #[cfg(not(target_arch = "wasm32"))]
+    return tokio::select! {
+        _ = sender.inner.closed() => None,
+        value = receiver.inner.recv() => value,
+    };
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        use futures::future::{select, Either};
+
+        let receive = Box::pin(receiver.inner.recv());
+        let closed = Box::pin(sender.inner.closed());
+        match select(receive, closed).await {
+            Either::Left((Ok(value), _)) => Some(value),
+            Either::Left((Err(_), _)) | Either::Right(_) => None,
+        }
+    }
+}

--- a/crates/kms/src/defra_kms.rs
+++ b/crates/kms/src/defra_kms.rs
@@ -276,7 +276,7 @@ impl KmsService for DefraKms {
                     remote.iter().copied().collect();
 
                 let (transport_tx, mut transport_rx) =
-                    tokio::sync::mpsc::channel(self.transports.len().max(1) * 16);
+                    crate::channel::bounded(self.transports.len().max(1) * 16);
                 for transport in &self.transports {
                     let mut rx = match transport.send_request(encoded.clone()).await {
                         Ok(rx) => rx,
@@ -287,17 +287,11 @@ impl KmsService for DefraKms {
                     };
                     let transport_tx = transport_tx.clone();
                     spawn_task(async move {
-                        loop {
-                            tokio::select! {
-                                _ = transport_tx.closed() => break,
-                                result = rx.recv() => {
-                                    let Some(result) = result else {
-                                        break;
-                                    };
-                                    if transport_tx.send(result).await.is_err() {
-                                        break;
-                                    }
-                                }
+                        while let Some(result) =
+                            crate::channel::recv_until_closed(&mut rx, &transport_tx).await
+                        {
+                            if transport_tx.send(result).await.is_err() {
+                                break;
                             }
                         }
                     });

--- a/crates/kms/src/defra_kms_tests.rs
+++ b/crates/kms/src/defra_kms_tests.rs
@@ -413,7 +413,7 @@ impl KeyTransport for FakeTransport {
         "fake"
     }
     async fn send_request(&self, _: EncodedFetchRequest) -> crate::Result<TransportReplyStream> {
-        let (tx, rx) = tokio::sync::mpsc::channel(1);
+        let (tx, rx) = crate::transport_reply_channel(1);
         if let Some(r) = self.reply.lock().await.take() {
             let _ = tx.send(r).await;
         }
@@ -437,7 +437,7 @@ impl KeyTransport for RecordingTransport {
         request: EncodedFetchRequest,
     ) -> crate::Result<TransportReplyStream> {
         *self.payload.lock().await = Some(request.payload);
-        let (_tx, rx) = tokio::sync::mpsc::channel(1);
+        let (_tx, rx) = crate::transport_reply_channel(1);
         Ok(rx)
     }
 

--- a/crates/kms/src/lib.rs
+++ b/crates/kms/src/lib.rs
@@ -20,6 +20,8 @@
 mod error;
 pub use error::{Error, Result};
 
+mod channel;
+
 mod types;
 pub use defra_kms::BlockDocIDResolver;
 pub use types::{EncryptionCid, KeyScope, PolicyDecision};
@@ -46,7 +48,10 @@ mod blockstore_store;
 pub use blockstore_store::{BlockstoreKeyStore, EncBlockStore};
 
 mod transport;
-pub use transport::{EncodedFetchRequest, IncomingHandler, KeyTransport, TransportReplyStream};
+pub use transport::{
+    transport_reply_channel, EncodedFetchRequest, IncomingHandler, KeyTransport,
+    TransportReplySender, TransportReplyStream,
+};
 
 mod ecies_envelope;
 pub use ecies_envelope::{unwrap_with_private, wrap_for_requester};

--- a/crates/kms/src/results.rs
+++ b/crates/kms/src/results.rs
@@ -6,8 +6,8 @@
 //! or `wait_all()` for a HashMap once the producer side closes.
 
 use std::collections::HashMap;
-use tokio::sync::mpsc;
 
+use crate::channel;
 use crate::error::Result;
 use crate::types::EncryptionCid;
 
@@ -15,10 +15,10 @@ use crate::types::EncryptionCid;
 pub type ResolvedKey = (EncryptionCid, [u8; 32]);
 
 /// Receiver half of the results channel.
-pub type ResultsReceiver = mpsc::Receiver<Result<ResolvedKey>>;
+pub type ResultsReceiver = channel::Receiver<Result<ResolvedKey>>;
 
 /// Sender half, given to the producer (DefraKms or transport adapter).
-pub type ResultsSender = mpsc::Sender<Result<ResolvedKey>>;
+pub type ResultsSender = channel::Sender<Result<ResolvedKey>>;
 
 /// Streaming aggregator over `(EncryptionCid, [u8;32])` resolutions.
 pub struct KeyResults {
@@ -29,7 +29,7 @@ impl KeyResults {
     /// Build a new pair (results consumer, sender). `buffer` is the channel
     /// capacity; clamped to ≥1.
     pub fn new(buffer: usize) -> (Self, ResultsSender) {
-        let (tx, rx) = mpsc::channel(buffer.max(1));
+        let (tx, rx) = channel::bounded(buffer.max(1));
         (Self { rx }, tx)
     }
 

--- a/crates/kms/src/transport.rs
+++ b/crates/kms/src/transport.rs
@@ -8,8 +8,8 @@
 use async_trait::async_trait;
 use defra_core::thread_bounds::MaybeSendSync;
 use std::sync::Arc;
-use tokio::sync::mpsc;
 
+use crate::channel;
 use crate::error::Result;
 use crate::service::PeerIdentity;
 use crate::wire::{FetchEncryptionKeyReply, FetchEncryptionKeyRequest};
@@ -37,7 +37,15 @@ pub struct EncodedFetchRequest {
 ///
 /// Closes when the transport stops listening for replies (timeout
 /// elapsed, peer set exhausted). Callers drain until close.
-pub type TransportReplyStream = mpsc::Receiver<Result<(FetchEncryptionKeyReply, String)>>;
+pub type TransportReplyStream = channel::Receiver<Result<(FetchEncryptionKeyReply, String)>>;
+
+/// Sender paired with a [`TransportReplyStream`].
+pub type TransportReplySender = channel::Sender<Result<(FetchEncryptionKeyReply, String)>>;
+
+/// Create a bounded transport reply stream.
+pub fn transport_reply_channel(buffer: usize) -> (TransportReplySender, TransportReplyStream) {
+    channel::bounded(buffer.max(1))
+}
 
 /// Handler invoked by a transport when an inbound request arrives.
 /// `DefraKms` installs itself as the handler at startup.

--- a/crates/p2p/src/kms/pubsub_transport.rs
+++ b/crates/p2p/src/kms/pubsub_transport.rs
@@ -29,7 +29,6 @@ use kms::{
 };
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
-use tokio::sync::mpsc;
 use tracing::{debug, warn};
 
 use crate::peer_identity::PeerIdentityResolver;
@@ -382,7 +381,7 @@ impl<T: P2PTransport> KeyTransport for PubsubKeyTransport<T> {
         // identical request every `REPUBLISH_INTERVAL` and give up after
         // `RESPONSE_TIMEOUT` — closing the stream so the caller's `wait_all`
         // resolves instead of hanging forever on a lost gossip message.
-        let (tx, rx) = mpsc::channel(16);
+        let (tx, rx) = kms::transport_reply_channel(16);
         let transport = self.transport.clone();
         let correlator = self.correlator.clone();
         tokio::spawn(async move {

--- a/crates/query-plan/Cargo.toml
+++ b/crates/query-plan/Cargo.toml
@@ -25,7 +25,6 @@ lens = { path = "../lens", default-features = false }
 async-trait.workspace = true
 async-lock.workspace = true
 futures.workspace = true
-tokio = { version = "1.35", default-features = false, features = ["rt"] }
 
 # Serialization
 serde_json.workspace = true
@@ -38,6 +37,9 @@ tracing.workspace = true
 
 # Time handling
 chrono = { version = "0.4", features = ["serde"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { version = "1.35", default-features = false, features = ["rt"] }
 
 [dev-dependencies]
 tokio.workspace = true

--- a/crates/query-plan/src/txn/context.rs
+++ b/crates/query-plan/src/txn/context.rs
@@ -17,8 +17,15 @@ use crate::fetcher::CollectionProvider;
 use crate::fetcher::DocFetcher;
 use crate::mutator::DocMutator;
 
+#[cfg(not(target_arch = "wasm32"))]
 tokio::task_local! {
     static TXN_DEFERRED_ACP_MUTATIONS: Arc<DeferredAcpMutations>;
+}
+
+#[cfg(target_arch = "wasm32")]
+thread_local! {
+    static TXN_DEFERRED_ACP_MUTATIONS: std::cell::RefCell<Option<Arc<DeferredAcpMutations>>> =
+        const { std::cell::RefCell::new(None) };
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -270,14 +277,20 @@ pub async fn scope_deferred_acp_mutations<Fut, T>(
 where
     Fut: Future<Output = T>,
 {
-    TXN_DEFERRED_ACP_MUTATIONS.scope(mutations, future).await
+    #[cfg(not(target_arch = "wasm32"))]
+    return TXN_DEFERRED_ACP_MUTATIONS.scope(mutations, future).await;
+
+    #[cfg(target_arch = "wasm32")]
+    defra_core::wasm_task_local::scope(&TXN_DEFERRED_ACP_MUTATIONS, mutations, future).await
 }
 
 /// Return the current transaction's deferred ACP projection, if any.
 pub fn current_deferred_acp_mutations() -> Option<Arc<DeferredAcpMutations>> {
-    TXN_DEFERRED_ACP_MUTATIONS
-        .try_with(|mutations| mutations.clone())
-        .ok()
+    #[cfg(not(target_arch = "wasm32"))]
+    return TXN_DEFERRED_ACP_MUTATIONS.try_with(Clone::clone).ok();
+
+    #[cfg(target_arch = "wasm32")]
+    defra_core::wasm_task_local::try_with(&TXN_DEFERRED_ACP_MUTATIONS, Clone::clone)
 }
 
 /// Check document registration while honoring any ACP mutations buffered in the current txn.

--- a/crates/query/Cargo.toml
+++ b/crates/query/Cargo.toml
@@ -23,7 +23,6 @@ lens = { path = "../lens", default-features = false }
 
 # Async runtime
 async-trait.workspace = true
-tokio = { version = "1.35", default-features = false, features = ["rt"] }
 
 # Serialization
 serde.workspace = true
@@ -49,7 +48,7 @@ chrono = { version = "0.4", features = ["serde"] }
 
 # Query timeouts are native-only.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version = "1.35", default-features = false, features = ["time"] }
+tokio = { version = "1.35", default-features = false, features = ["rt", "time"] }
 
 [dev-dependencies]
 async-lock.workspace = true

--- a/crates/query/src/runner/executor.rs
+++ b/crates/query/src/runner/executor.rs
@@ -452,19 +452,20 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
         // and ACP checks see uncommitted state.
         let result = if let Some(provider) = txn_provider {
             if let Some(deferred_acp_mutations) = deferred_acp_mutations {
-                super::TXN_COLLECTION_PROVIDER
-                    .scope(
-                        provider,
-                        crate::txn::scope_deferred_acp_mutations(
-                            deferred_acp_mutations,
-                            await_with_timeout(execution, self.query_timeout),
-                        ),
-                    )
-                    .await
+                super::scope_txn_collection_provider(
+                    provider,
+                    crate::txn::scope_deferred_acp_mutations(
+                        deferred_acp_mutations,
+                        await_with_timeout(execution, self.query_timeout),
+                    ),
+                )
+                .await
             } else {
-                super::TXN_COLLECTION_PROVIDER
-                    .scope(provider, await_with_timeout(execution, self.query_timeout))
-                    .await
+                super::scope_txn_collection_provider(
+                    provider,
+                    await_with_timeout(execution, self.query_timeout),
+                )
+                .await
             }
         } else if let Some(deferred_acp_mutations) = deferred_acp_mutations {
             crate::txn::scope_deferred_acp_mutations(

--- a/crates/query/src/runner/mod.rs
+++ b/crates/query/src/runner/mod.rs
@@ -57,12 +57,41 @@ use crate::mutator::DocMutator;
 use crate::planner::Doc;
 use crate::txn::{NoOpTransactionRegistry, TransactionRegistry};
 
+#[cfg(not(target_arch = "wasm32"))]
 tokio::task_local! {
     /// Per-request collection provider override for transaction-scoped schema resolution.
     ///
     /// When a query executes within a transaction that has uncommitted schema changes,
     /// this is set to a transaction-aware provider so `get_collection()` sees the new schemas.
     static TXN_COLLECTION_PROVIDER: Arc<dyn CollectionProvider>;
+}
+
+#[cfg(target_arch = "wasm32")]
+thread_local! {
+    static TXN_COLLECTION_PROVIDER: std::cell::RefCell<Option<Arc<dyn CollectionProvider>>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+async fn scope_txn_collection_provider<F>(
+    provider: Arc<dyn CollectionProvider>,
+    future: F,
+) -> F::Output
+where
+    F: std::future::Future,
+{
+    #[cfg(not(target_arch = "wasm32"))]
+    return TXN_COLLECTION_PROVIDER.scope(provider, future).await;
+
+    #[cfg(target_arch = "wasm32")]
+    defra_core::wasm_task_local::scope(&TXN_COLLECTION_PROVIDER, provider, future).await
+}
+
+fn current_txn_collection_provider() -> Option<Arc<dyn CollectionProvider>> {
+    #[cfg(not(target_arch = "wasm32"))]
+    return TXN_COLLECTION_PROVIDER.try_with(Clone::clone).ok();
+
+    #[cfg(target_arch = "wasm32")]
+    defra_core::wasm_task_local::try_with(&TXN_COLLECTION_PROVIDER, Clone::clone)
 }
 
 // Re-export for backwards compatibility
@@ -408,9 +437,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
     /// Returns the transaction-scoped provider if set (via task-local storage),
     /// otherwise returns the default process-wide provider.
     fn effective_provider(&self) -> Arc<dyn CollectionProvider> {
-        TXN_COLLECTION_PROVIDER
-            .try_with(|p| p.clone())
-            .unwrap_or_else(|_| self.collection_provider.clone())
+        current_txn_collection_provider().unwrap_or_else(|| self.collection_provider.clone())
     }
 
     /// Get the names of all collections.


### PR DESCRIPTION
Closes #1334.

## Problem

Tokio was declared unconditionally by query, query-plan, and KMS, pulling it into the browser WASM dependency graph. Removing the dependency also required runtime-neutral replacements for task-local query context and KMS reply channels.

## What changed

- Restrict Tokio dependencies in query, query-plan, and KMS to native targets.
- Add poll-scoped WASM task-local context that preserves the active value across nested and interleaved futures.
- Use async-channel for KMS reply streams on WASM while preserving the existing Tokio channel behavior on native targets.
- Route query, ACP, and P2P KMS call sites through the target-specific abstractions.
- Add regression coverage for interleaved WASM task-local scopes.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo clippy -p defra-wasm --target wasm32-unknown-unknown --all-targets -- -D warnings`
- [x] `cargo test -p defra-core -p kms -p query-plan -p query` (482 passed)
- [x] `cargo test -p p2p kms` (8 passed)
- [x] `cargo tree -p defra-wasm --target wasm32-unknown-unknown -i tokio` (no Tokio dependency)
- [x] Optimized WASM size: 7,096,189 -> 7,091,332 bytes (-4,857 bytes)
- [x] `git diff --check`
