### PR TITLE
release: validate v0.18.0 integration

### DIFF
--- a/.github/scripts/rustc-direct.sh
+++ b/.github/scripts/rustc-direct.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-# Cargo treats an empty RUSTC_WRAPPER as unset and falls back to the host's
-# build.rustc-wrapper setting (sccache on the studio/spark hosts, which
-# rejects incremental rustc invocations). Execute Cargo's rustc command
-# directly so incremental suites cannot accidentally re-enable sccache
-# through host config.
-exec "$@"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,11 @@ jobs:
           bash .github/scripts/apt-update-without-nodesource.sh
           sudo apt-get install -y protobuf-compiler clang
 
+      - name: Isolate the WASM dependency graph
+        # Cargo resolves every workspace member even for a package-specific build.
+        # These test-only members pin Git revisions that the WASM build does not use.
+        run: sed -i '/"tools\/integration-test"/d; /"tools\/ffi-test"/d; /"proofs"/d' Cargo.toml
+
       - name: Clippy (wasm32)
         run: cargo clippy -p defra-wasm --target wasm32-unknown-unknown --all-targets -- -D warnings
 
@@ -196,6 +201,10 @@ jobs:
       - name: Show sccache stats
         if: always()
         run: .github/scripts/show-sccache-stats.sh
+
+      - name: Cleanup
+        if: always()
+        run: git checkout -- Cargo.toml
 
   build:
     name: Build & Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,17 +210,14 @@ jobs:
     name: Build & Test
     runs-on: [self-hosted, macOS, ARM64, studio, studio-1]
     env:
-      # Warm-incremental beats sccache for the hot edit path (gents A/B on
-      # these hosts: 14.6s vs 5m54s for a representative source edit). The
-      # host-wide sccache rejects incremental invocations, and an empty
-      # RUSTC_WRAPPER falls back to host config, so route rustc through the
-      # pass-through wrapper. CARGO_BUILD_RUSTC_WRAPPER covers recursive
-      # Cargo invocations from build scripts. The rust/signed-docs suites on
-      # this runner use the same settings so the shared target tree never
-      # flip-flops flags.
-      CARGO_INCREMENTAL: "1"
-      RUSTC_WRAPPER: .github/scripts/rustc-direct.sh
-      CARGO_BUILD_RUSTC_WRAPPER: .github/scripts/rustc-direct.sh
+      # The full workspace test suite launches roughly 187 test executables.
+      # Incremental artifacts caused a ~25s startup delay per executable on
+      # this macOS host, turning this step from minutes into more than an hour.
+      # Prefer sccache here; the edit-only incremental benchmark does not
+      # represent this test workload.
+      CARGO_INCREMENTAL: "0"
+      RUSTC_WRAPPER: sccache
+      CARGO_BUILD_RUSTC_WRAPPER: sccache
     steps:
       - uses: actions/checkout@v4
         with:
@@ -386,15 +383,13 @@ jobs:
       # suites self-build on miss into their own host-local cache.
       matrix:
         include:
-          # studio-1 suites share the build job's incremental target tree, so
-          # they carry the same incremental + pass-through wrapper settings;
-          # studio-2 suites stay on the host sccache (incremental off) so the
-          # target tree they share with conformance keeps consistent flags.
+          # Each host uses sccache with incremental compilation disabled so
+          # jobs sharing its persistent target tree keep consistent flags.
           - suite: rust
             needs_go: false
             host: studio-1
-            cargo_incremental: "1"
-            rustc_wrapper: .github/scripts/rustc-direct.sh
+            cargo_incremental: "0"
+            rustc_wrapper: sccache
           - suite: go-compat
             needs_go: true
             host: studio-2
@@ -414,8 +409,8 @@ jobs:
             needs_go: false
             multipliers: signed-docs
             host: studio-1
-            cargo_incremental: "1"
-            rustc_wrapper: .github/scripts/rustc-direct.sh
+            cargo_incremental: "0"
+            rustc_wrapper: sccache
     env:
       DEFRA_RUST_BINARY: ${{ github.workspace }}/target/ci/defra
       DEFRA_IROH_BINARY: ${{ github.workspace }}/target/ci/defra-iroh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,15 +53,6 @@ jobs:
         with:
           clean: false
 
-      - name: Configure private repo access
-        run: |
-          # Org-wide PAT rewrite for private sourcenetwork deps.
-          git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
-          # backbone is public. Fine-grained PATs that omit it make GitHub
-          # treat authenticated fetches as "not our ref" for new commits;
-          # longest-prefix insteadOf wins, so this keeps backbone unauthenticated.
-          git config --global url."https://github.com/sourcenetwork/backbone".insteadOf "https://github.com/sourcenetwork/backbone"
-
       - uses: dtolnay/rust-toolchain@stable
 
       - run: cargo fmt --all -- --check
@@ -99,12 +90,6 @@ jobs:
         if: always()
         run: .github/scripts/show-sccache-stats.sh
 
-      - name: Cleanup
-        if: always()
-        run: |
-          git config --global --remove-section "url.https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/" 2>/dev/null || true
-          git config --global --remove-section "url.https://github.com/sourcenetwork/backbone" 2>/dev/null || true
-
   wasm-check:
     name: WASM Build Check
     # spark-1: the wasm32 target doesn't care about host arch, and pinning
@@ -118,15 +103,6 @@ jobs:
         with:
           clean: false
 
-      - name: Configure private repo access
-        run: |
-          # Org-wide PAT rewrite for private sourcenetwork deps.
-          git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
-          # backbone is public. Fine-grained PATs that omit it make GitHub
-          # treat authenticated fetches as "not our ref" for new commits;
-          # longest-prefix insteadOf wins, so this keeps backbone unauthenticated.
-          git config --global url."https://github.com/sourcenetwork/backbone".insteadOf "https://github.com/sourcenetwork/backbone"
-
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
@@ -139,11 +115,6 @@ jobs:
         run: |
           bash .github/scripts/apt-update-without-nodesource.sh
           sudo apt-get install -y protobuf-compiler clang
-
-      - name: Exclude packages that pull private/public git harness deps
-        # wasm doesn't need integration-test, ffi-test, or proofs (defra-harness).
-        # Stripping them keeps cargo from resolving backbone during wasm clippy.
-        run: sed -i '/"tools\/integration-test"/d; /"tools\/ffi-test"/d; /"proofs"/d' Cargo.toml
 
       - name: Clippy (wasm32)
         run: cargo clippy -p defra-wasm --target wasm32-unknown-unknown --all-targets -- -D warnings
@@ -226,13 +197,6 @@ jobs:
         if: always()
         run: .github/scripts/show-sccache-stats.sh
 
-      - name: Cleanup
-        if: always()
-        run: |
-          git config --global --remove-section "url.https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/" 2>/dev/null || true
-          git config --global --remove-section "url.https://github.com/sourcenetwork/backbone" 2>/dev/null || true
-          git checkout -- Cargo.toml
-
   build:
     name: Build & Test
     runs-on: [self-hosted, macOS, ARM64, studio, studio-1]
@@ -252,15 +216,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           clean: false
-
-      - name: Configure private repo access
-        run: |
-          # Org-wide PAT rewrite for private sourcenetwork deps.
-          git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
-          # backbone is public. Fine-grained PATs that omit it make GitHub
-          # treat authenticated fetches as "not our ref" for new commits;
-          # longest-prefix insteadOf wins, so this keeps backbone unauthenticated.
-          git config --global url."https://github.com/sourcenetwork/backbone".insteadOf "https://github.com/sourcenetwork/backbone"
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -308,8 +263,6 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          git config --global --remove-section "url.https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/" 2>/dev/null || true
-          git config --global --remove-section "url.https://github.com/sourcenetwork/backbone" 2>/dev/null || true
           git checkout -- .
           git clean -fd
           pkill -f "target/debug/defra" || true
@@ -320,13 +273,6 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
-
-      - name: Configure private repo access
-        run: |
-          git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
-          git config --global --add url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "ssh://git@github.com/sourcenetwork/"
-          # Public backbone: keep unauthenticated (see comment on other jobs).
-          git config --global url."https://github.com/sourcenetwork/backbone".insteadOf "https://github.com/sourcenetwork/backbone"
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -346,12 +292,6 @@ jobs:
 
       - name: Check Lean-to-Rust conformance
         run: cargo test -p conformance --lib --test lean_conformance
-
-      - name: Cleanup
-        if: always()
-        run: |
-          git config --global --remove-section "url.https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/" 2>/dev/null || true
-          git config --global --remove-section "url.https://github.com/sourcenetwork/backbone" 2>/dev/null || true
 
   conformance:
     name: Conformance
@@ -378,15 +318,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           clean: false
-
-      - name: Configure private repo access
-        run: |
-          # Org-wide PAT rewrite for private sourcenetwork deps.
-          git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
-          # backbone is public. Fine-grained PATs that omit it make GitHub
-          # treat authenticated fetches as "not our ref" for new commits;
-          # longest-prefix insteadOf wins, so this keeps backbone unauthenticated.
-          git config --global url."https://github.com/sourcenetwork/backbone".insteadOf "https://github.com/sourcenetwork/backbone"
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -423,8 +354,6 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          git config --global --remove-section "url.https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/" 2>/dev/null || true
-          git config --global --remove-section "url.https://github.com/sourcenetwork/backbone" 2>/dev/null || true
           git checkout -- .
           git clean -fd
           rm -rf target/e2e
@@ -489,15 +418,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           clean: false
-
-      - name: Configure private repo access
-        run: |
-          # Org-wide PAT rewrite for private sourcenetwork deps.
-          git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
-          # backbone is public. Fine-grained PATs that omit it make GitHub
-          # treat authenticated fetches as "not our ref" for new commits;
-          # longest-prefix insteadOf wins, so this keeps backbone unauthenticated.
-          git config --global url."https://github.com/sourcenetwork/backbone".insteadOf "https://github.com/sourcenetwork/backbone"
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -717,8 +637,6 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          git config --global --remove-section "url.https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/" 2>/dev/null || true
-          git config --global --remove-section "url.https://github.com/sourcenetwork/backbone" 2>/dev/null || true
           git checkout -- .
           git clean -fd
           pkill -f "target/(debug|ci)/defra" || true
@@ -755,15 +673,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           clean: false
-
-      - name: Configure private repo access
-        run: |
-          # Org-wide PAT rewrite for private sourcenetwork deps.
-          git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
-          # backbone is public. Fine-grained PATs that omit it make GitHub
-          # treat authenticated fetches as "not our ref" for new commits;
-          # longest-prefix insteadOf wins, so this keeps backbone unauthenticated.
-          git config --global url."https://github.com/sourcenetwork/backbone".insteadOf "https://github.com/sourcenetwork/backbone"
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -815,8 +724,6 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          git config --global --remove-section "url.https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/" 2>/dev/null || true
-          git config --global --remove-section "url.https://github.com/sourcenetwork/backbone" 2>/dev/null || true
           git checkout -- .
           git clean -fd
           rm -rf target/e2e
@@ -833,15 +740,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           clean: false
-
-      - name: Configure private repo access
-        run: |
-          # Org-wide PAT rewrite for private sourcenetwork deps.
-          git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
-          # backbone is public. Fine-grained PATs that omit it make GitHub
-          # treat authenticated fetches as "not our ref" for new commits;
-          # longest-prefix insteadOf wins, so this keeps backbone unauthenticated.
-          git config --global url."https://github.com/sourcenetwork/backbone".insteadOf "https://github.com/sourcenetwork/backbone"
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -870,7 +768,5 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          git config --global --remove-section "url.https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/" 2>/dev/null || true
-          git config --global --remove-section "url.https://github.com/sourcenetwork/backbone" 2>/dev/null || true
           git checkout -- .
           git clean -fd

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,9 +82,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Configure private repo access
-        run: git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
-
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -130,14 +127,6 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install protobuf
 
-      - name: Exclude workspace members with private deps
-        run: |
-          if [[ "$OSTYPE" == "darwin"* ]]; then
-            sed -i '' '/"tools\/integration-test"/d; /"tools\/ffi-test"/d; /"proofs"/d' Cargo.toml
-          else
-            sed -i '/"tools\/integration-test"/d; /"tools\/ffi-test"/d; /"proofs"/d' Cargo.toml
-          fi
-
       - name: Build
         run: cargo build --release -p cli --target ${{ matrix.target }} ${{ matrix.features }}
 
@@ -161,7 +150,6 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          git config --global --remove-section "url.https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/" 2>/dev/null || true
           git checkout -- .
           git clean -fd
 
@@ -170,9 +158,6 @@ jobs:
     runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v4
-
-      - name: Configure private repo access
-        run: git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -187,9 +172,6 @@ jobs:
         run: |
           bash .github/scripts/apt-update-without-nodesource.sh
           sudo apt-get install -y protobuf-compiler
-
-      - name: Exclude workspace members with private deps
-        run: sed -i '/"tools\/integration-test"/d; /"tools\/ffi-test"/d; /"proofs"/d' Cargo.toml
 
       - name: Install wasm-pack
         run: cargo install wasm-pack
@@ -212,7 +194,6 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          git config --global --remove-section "url.https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/" 2>/dev/null || true
           git checkout -- .
           git clean -fd
 
@@ -268,9 +249,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Configure private repo access
-        run: git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
-
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -316,14 +294,6 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install protobuf
 
-      - name: Exclude workspace members with private deps
-        run: |
-          if [[ "$OSTYPE" == "darwin"* ]]; then
-            sed -i '' '/"tools\/integration-test"/d; /"tools\/ffi-test"/d; /"proofs"/d' Cargo.toml
-          else
-            sed -i '/"tools\/integration-test"/d; /"tools\/ffi-test"/d; /"proofs"/d' Cargo.toml
-          fi
-
       - name: Install cbindgen
         run: cargo install cbindgen
 
@@ -361,7 +331,6 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          git config --global --remove-section "url.https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/" 2>/dev/null || true
           git checkout -- .
           git clean -fd
 
@@ -370,9 +339,6 @@ jobs:
     runs-on: ["self-hosted", "macOS", "ARM64", "studio"]
     steps:
       - uses: actions/checkout@v4
-
-      - name: Configure private repo access
-        run: git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -385,9 +351,6 @@ jobs:
 
       - name: Install system dependencies
         run: brew install protobuf
-
-      - name: Exclude workspace members with private deps
-        run: sed -i '' '/"tools\/integration-test"/d; /"tools\/ffi-test"/d; /"proofs"/d' Cargo.toml
 
       - name: Install cbindgen
         run: cargo install cbindgen
@@ -419,7 +382,6 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          git config --global --remove-section "url.https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/" 2>/dev/null || true
           git checkout -- .
           git clean -fd
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,16 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install protobuf
 
+      - name: Isolate the release dependency graph
+        # Cargo resolves every workspace member even for a package-specific build.
+        # These test-only members pin Git revisions that release builds do not use.
+        run: |
+          if [[ "$OSTYPE" == "darwin"* ]]; then
+            sed -i '' '/"tools\/integration-test"/d; /"tools\/ffi-test"/d; /"proofs"/d' Cargo.toml
+          else
+            sed -i '/"tools\/integration-test"/d; /"tools\/ffi-test"/d; /"proofs"/d' Cargo.toml
+          fi
+
       - name: Build
         run: cargo build --release -p cli --target ${{ matrix.target }} ${{ matrix.features }}
 
@@ -172,6 +182,10 @@ jobs:
         run: |
           bash .github/scripts/apt-update-without-nodesource.sh
           sudo apt-get install -y protobuf-compiler
+
+      - name: Isolate the WASM dependency graph
+        # Avoid resolving test-only Git dependencies that this build does not use.
+        run: sed -i '/"tools\/integration-test"/d; /"tools\/ffi-test"/d; /"proofs"/d' Cargo.toml
 
       - name: Install wasm-pack
         run: cargo install wasm-pack
@@ -294,6 +308,15 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install protobuf
 
+      - name: Isolate the FFI dependency graph
+        # Avoid resolving test-only Git dependencies that this build does not use.
+        run: |
+          if [[ "$OSTYPE" == "darwin"* ]]; then
+            sed -i '' '/"tools\/integration-test"/d; /"tools\/ffi-test"/d; /"proofs"/d' Cargo.toml
+          else
+            sed -i '/"tools\/integration-test"/d; /"tools\/ffi-test"/d; /"proofs"/d' Cargo.toml
+          fi
+
       - name: Install cbindgen
         run: cargo install cbindgen
 
@@ -351,6 +374,10 @@ jobs:
 
       - name: Install system dependencies
         run: brew install protobuf
+
+      - name: Isolate the Apple FFI dependency graph
+        # Avoid resolving test-only Git dependencies that this build does not use.
+        run: sed -i '' '/"tools\/integration-test"/d; /"tools\/ffi-test"/d; /"proofs"/d' Cargo.toml
 
       - name: Install cbindgen
         run: cargo install cbindgen

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3614,6 +3614,7 @@ dependencies = [
  "bytes",
  "cid",
  "criterion 0.6.0",
+ "futures",
  "ipld-core",
  "multibase",
  "multicodec",
@@ -6576,12 +6577,14 @@ name = "kms"
 version = "0.5.0"
 dependencies = [
  "acp",
+ "async-channel 2.5.0",
  "async-lock",
  "async-trait",
  "base64 0.22.1",
  "cid",
  "crypto",
  "defra-core",
+ "futures",
  "identity",
  "orbis",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ dependencies = [
 [[package]]
 name = "acp-light-client"
 version = "0.1.0"
-source = "git+ssh://git@github.com/sourcenetwork/backbone.git?rev=086ddadc98bc55183920aa0fe6bc4d3719e0e5e7#086ddadc98bc55183920aa0fe6bc4d3719e0e5e7"
+source = "git+https://github.com/sourcenetwork/backbone.git?rev=086ddadc98bc55183920aa0fe6bc4d3719e0e5e7#086ddadc98bc55183920aa0fe6bc4d3719e0e5e7"
 dependencies = [
  "alloy-primitives",
  "borsh",

--- a/crates/db/src/commit_priority_index.rs
+++ b/crates/db/src/commit_priority_index.rs
@@ -1,10 +1,9 @@
 use std::collections::HashSet;
-use std::str::FromStr;
 
 use cid::Cid;
 use defra_core::block::Block;
 use storage::corekv::{IterOptions, Key, Store};
-use storage::keys::HeadstorePriorityKey;
+use storage::keys::{HeadstoreDocKey, HeadstorePriorityKey};
 
 use crate::{Error, Result, DB};
 
@@ -53,20 +52,11 @@ impl<S: Store> DB<S> {
             let mut root_heads: Vec<(Cid, u64)> = Vec::new();
             let mut seen_root_heads = HashSet::new();
             while let Some(pair) = head_iter.next().await.map_err(Error::Storage)? {
-                let Ok((_, doc_short_id)) =
-                    storage::keys::doc_id_index::decode_doc_short_id_prefix(&pair.key[3..])
-                else {
+                let Some(head_key) = HeadstoreDocKey::parse(&pair.key) else {
                     continue;
                 };
-                let key_str = String::from_utf8_lossy(&pair.key);
-                let Some(cid_str) = key_str.rsplit('/').next() else {
-                    continue;
-                };
-                let Ok(cid) = Cid::from_str(cid_str) else {
-                    continue;
-                };
-                if seen_root_heads.insert((cid, doc_short_id)) {
-                    root_heads.push((cid, doc_short_id));
+                if seen_root_heads.insert((head_key.cid, head_key.doc_short_id)) {
+                    root_heads.push((head_key.cid, head_key.doc_short_id));
                 }
             }
             head_iter.close().await.map_err(Error::Storage)?;

--- a/crates/defra-core/Cargo.toml
+++ b/crates/defra-core/Cargo.toml
@@ -44,6 +44,7 @@ tokio = { workspace = true, features = ["rt"] }
 
 [dev-dependencies]
 criterion.workspace = true
+futures.workspace = true
 multihash-codetable.workspace = true
 
 [[bench]]

--- a/crates/defra-core/src/lib.rs
+++ b/crates/defra-core/src/lib.rs
@@ -24,6 +24,8 @@ pub mod store;
 pub mod thread_bounds;
 pub mod transaction;
 pub mod types;
+#[cfg(any(target_arch = "wasm32", test))]
+pub mod wasm_task_local;
 
 pub use action::{Action, ActionExecution, ActionStatus};
 pub use block::{

--- a/crates/defra-core/src/wasm_task_local.rs
+++ b/crates/defra-core/src/wasm_task_local.rs
@@ -1,0 +1,93 @@
+//! Single-threaded task-local storage for WASM futures.
+
+use std::cell::RefCell;
+use std::future::{poll_fn, Future};
+use std::thread::LocalKey;
+
+fn with_value<T: 'static, R>(
+    local: &'static LocalKey<RefCell<Option<T>>>,
+    value: &mut Option<T>,
+    f: impl FnOnce() -> R,
+) -> R {
+    struct Reset<'a, T: 'static> {
+        local: &'static LocalKey<RefCell<Option<T>>>,
+        value: &'a mut Option<T>,
+    }
+
+    impl<T: 'static> Drop for Reset<'_, T> {
+        fn drop(&mut self) {
+            self.local
+                .with(|local| std::mem::swap(self.value, &mut *local.borrow_mut()));
+        }
+    }
+
+    local.with(|local| std::mem::swap(value, &mut *local.borrow_mut()));
+    let reset = Reset { local, value };
+    let result = f();
+    drop(reset);
+    result
+}
+
+/// Poll a future with `value` installed in its task-local slot.
+pub async fn scope<T: 'static, F>(
+    local: &'static LocalKey<RefCell<Option<T>>>,
+    value: T,
+    future: F,
+) -> F::Output
+where
+    F: Future,
+{
+    let mut value = Some(value);
+    let mut future = Box::pin(future);
+    poll_fn(move |cx| with_value(local, &mut value, || future.as_mut().poll(cx))).await
+}
+
+/// Access the current task-local value when a scope is active.
+pub fn try_with<T: 'static, R>(
+    local: &'static LocalKey<RefCell<Option<T>>>,
+    f: impl FnOnce(&T) -> R,
+) -> Option<R> {
+    local.with(|local| local.borrow().as_ref().map(f))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    thread_local! {
+        static VALUE: RefCell<Option<u8>> = const { RefCell::new(None) };
+    }
+
+    async fn yield_once() {
+        let mut yielded = false;
+        poll_fn(move |cx| {
+            if yielded {
+                std::task::Poll::Ready(())
+            } else {
+                yielded = true;
+                cx.waker().wake_by_ref();
+                std::task::Poll::Pending
+            }
+        })
+        .await;
+    }
+
+    #[test]
+    fn scopes_survive_interleaved_polls() {
+        futures::executor::block_on(async {
+            let first = scope(&VALUE, 1, async {
+                assert_eq!(try_with(&VALUE, |value| *value), Some(1));
+                yield_once().await;
+                assert_eq!(try_with(&VALUE, |value| *value), Some(1));
+            });
+            let second = scope(&VALUE, 2, async {
+                assert_eq!(try_with(&VALUE, |value| *value), Some(2));
+                yield_once().await;
+                assert_eq!(try_with(&VALUE, |value| *value), Some(2));
+            });
+
+            futures::join!(first, second);
+        });
+        assert_eq!(try_with(&VALUE, |value| *value), None);
+    }
+}

--- a/crates/kms/Cargo.toml
+++ b/crates/kms/Cargo.toml
@@ -43,11 +43,15 @@ zeroize = "1.8"
 rand = { workspace = true }
 uuid = { workspace = true }
 cid = { workspace = true }
-tokio = { version = "1.35", default-features = false, features = ["rt", "sync", "macros"] }
 x25519-dalek = { version = "2.0", features = ["static_secrets"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+async-channel = "2"
+futures.workspace = true
 wasm-bindgen-futures = "0.4"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { version = "1.35", default-features = false, features = ["rt", "sync", "macros"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }

--- a/crates/kms/src/channel.rs
+++ b/crates/kms/src/channel.rs
@@ -1,0 +1,81 @@
+//! Bounded channels backed by the native runtime or a WASM-compatible queue.
+
+/// Sending side of a bounded channel.
+pub struct Sender<T> {
+    #[cfg(not(target_arch = "wasm32"))]
+    inner: tokio::sync::mpsc::Sender<T>,
+    #[cfg(target_arch = "wasm32")]
+    inner: async_channel::Sender<T>,
+}
+
+impl<T> Clone for Sender<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl<T> Sender<T> {
+    /// Send a value, returning it when the receiver is closed.
+    pub async fn send(&self, value: T) -> Result<(), T> {
+        #[cfg(not(target_arch = "wasm32"))]
+        return self.inner.send(value).await.map_err(|error| error.0);
+
+        #[cfg(target_arch = "wasm32")]
+        self.inner.send(value).await.map_err(|error| error.0)
+    }
+
+    /// Wait until every receiver has been dropped.
+    pub async fn closed(&self) {
+        self.inner.closed().await;
+    }
+}
+
+/// Receiving side of a bounded channel.
+pub struct Receiver<T> {
+    #[cfg(not(target_arch = "wasm32"))]
+    inner: tokio::sync::mpsc::Receiver<T>,
+    #[cfg(target_arch = "wasm32")]
+    inner: async_channel::Receiver<T>,
+}
+
+impl<T> Receiver<T> {
+    /// Receive the next value, or `None` once every sender is closed.
+    pub async fn recv(&mut self) -> Option<T> {
+        #[cfg(not(target_arch = "wasm32"))]
+        return self.inner.recv().await;
+
+        #[cfg(target_arch = "wasm32")]
+        self.inner.recv().await.ok()
+    }
+}
+
+pub fn bounded<T>(capacity: usize) -> (Sender<T>, Receiver<T>) {
+    #[cfg(not(target_arch = "wasm32"))]
+    let (sender, receiver) = tokio::sync::mpsc::channel(capacity);
+    #[cfg(target_arch = "wasm32")]
+    let (sender, receiver) = async_channel::bounded(capacity);
+
+    (Sender { inner: sender }, Receiver { inner: receiver })
+}
+
+pub async fn recv_until_closed<T, U>(receiver: &mut Receiver<T>, sender: &Sender<U>) -> Option<T> {
+    #[cfg(not(target_arch = "wasm32"))]
+    return tokio::select! {
+        _ = sender.inner.closed() => None,
+        value = receiver.inner.recv() => value,
+    };
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        use futures::future::{select, Either};
+
+        let receive = Box::pin(receiver.inner.recv());
+        let closed = Box::pin(sender.inner.closed());
+        match select(receive, closed).await {
+            Either::Left((Ok(value), _)) => Some(value),
+            Either::Left((Err(_), _)) | Either::Right(_) => None,
+        }
+    }
+}

--- a/crates/kms/src/defra_kms.rs
+++ b/crates/kms/src/defra_kms.rs
@@ -276,7 +276,7 @@ impl KmsService for DefraKms {
                     remote.iter().copied().collect();
 
                 let (transport_tx, mut transport_rx) =
-                    tokio::sync::mpsc::channel(self.transports.len().max(1) * 16);
+                    crate::channel::bounded(self.transports.len().max(1) * 16);
                 for transport in &self.transports {
                     let mut rx = match transport.send_request(encoded.clone()).await {
                         Ok(rx) => rx,
@@ -287,17 +287,11 @@ impl KmsService for DefraKms {
                     };
                     let transport_tx = transport_tx.clone();
                     spawn_task(async move {
-                        loop {
-                            tokio::select! {
-                                _ = transport_tx.closed() => break,
-                                result = rx.recv() => {
-                                    let Some(result) = result else {
-                                        break;
-                                    };
-                                    if transport_tx.send(result).await.is_err() {
-                                        break;
-                                    }
-                                }
+                        while let Some(result) =
+                            crate::channel::recv_until_closed(&mut rx, &transport_tx).await
+                        {
+                            if transport_tx.send(result).await.is_err() {
+                                break;
                             }
                         }
                     });

--- a/crates/kms/src/defra_kms_tests.rs
+++ b/crates/kms/src/defra_kms_tests.rs
@@ -413,7 +413,7 @@ impl KeyTransport for FakeTransport {
         "fake"
     }
     async fn send_request(&self, _: EncodedFetchRequest) -> crate::Result<TransportReplyStream> {
-        let (tx, rx) = tokio::sync::mpsc::channel(1);
+        let (tx, rx) = crate::transport_reply_channel(1);
         if let Some(r) = self.reply.lock().await.take() {
             let _ = tx.send(r).await;
         }
@@ -437,7 +437,7 @@ impl KeyTransport for RecordingTransport {
         request: EncodedFetchRequest,
     ) -> crate::Result<TransportReplyStream> {
         *self.payload.lock().await = Some(request.payload);
-        let (_tx, rx) = tokio::sync::mpsc::channel(1);
+        let (_tx, rx) = crate::transport_reply_channel(1);
         Ok(rx)
     }
 

--- a/crates/kms/src/lib.rs
+++ b/crates/kms/src/lib.rs
@@ -20,6 +20,8 @@
 mod error;
 pub use error::{Error, Result};
 
+mod channel;
+
 mod types;
 pub use defra_kms::BlockDocIDResolver;
 pub use types::{EncryptionCid, KeyScope, PolicyDecision};
@@ -46,7 +48,10 @@ mod blockstore_store;
 pub use blockstore_store::{BlockstoreKeyStore, EncBlockStore};
 
 mod transport;
-pub use transport::{EncodedFetchRequest, IncomingHandler, KeyTransport, TransportReplyStream};
+pub use transport::{
+    transport_reply_channel, EncodedFetchRequest, IncomingHandler, KeyTransport,
+    TransportReplySender, TransportReplyStream,
+};
 
 mod ecies_envelope;
 pub use ecies_envelope::{unwrap_with_private, wrap_for_requester};

--- a/crates/kms/src/results.rs
+++ b/crates/kms/src/results.rs
@@ -6,8 +6,8 @@
 //! or `wait_all()` for a HashMap once the producer side closes.
 
 use std::collections::HashMap;
-use tokio::sync::mpsc;
 
+use crate::channel;
 use crate::error::Result;
 use crate::types::EncryptionCid;
 
@@ -15,10 +15,10 @@ use crate::types::EncryptionCid;
 pub type ResolvedKey = (EncryptionCid, [u8; 32]);
 
 /// Receiver half of the results channel.
-pub type ResultsReceiver = mpsc::Receiver<Result<ResolvedKey>>;
+pub type ResultsReceiver = channel::Receiver<Result<ResolvedKey>>;
 
 /// Sender half, given to the producer (DefraKms or transport adapter).
-pub type ResultsSender = mpsc::Sender<Result<ResolvedKey>>;
+pub type ResultsSender = channel::Sender<Result<ResolvedKey>>;
 
 /// Streaming aggregator over `(EncryptionCid, [u8;32])` resolutions.
 pub struct KeyResults {
@@ -29,7 +29,7 @@ impl KeyResults {
     /// Build a new pair (results consumer, sender). `buffer` is the channel
     /// capacity; clamped to ≥1.
     pub fn new(buffer: usize) -> (Self, ResultsSender) {
-        let (tx, rx) = mpsc::channel(buffer.max(1));
+        let (tx, rx) = channel::bounded(buffer.max(1));
         (Self { rx }, tx)
     }
 

--- a/crates/kms/src/transport.rs
+++ b/crates/kms/src/transport.rs
@@ -8,8 +8,8 @@
 use async_trait::async_trait;
 use defra_core::thread_bounds::MaybeSendSync;
 use std::sync::Arc;
-use tokio::sync::mpsc;
 
+use crate::channel;
 use crate::error::Result;
 use crate::service::PeerIdentity;
 use crate::wire::{FetchEncryptionKeyReply, FetchEncryptionKeyRequest};
@@ -37,7 +37,15 @@ pub struct EncodedFetchRequest {
 ///
 /// Closes when the transport stops listening for replies (timeout
 /// elapsed, peer set exhausted). Callers drain until close.
-pub type TransportReplyStream = mpsc::Receiver<Result<(FetchEncryptionKeyReply, String)>>;
+pub type TransportReplyStream = channel::Receiver<Result<(FetchEncryptionKeyReply, String)>>;
+
+/// Sender paired with a [`TransportReplyStream`].
+pub type TransportReplySender = channel::Sender<Result<(FetchEncryptionKeyReply, String)>>;
+
+/// Create a bounded transport reply stream.
+pub fn transport_reply_channel(buffer: usize) -> (TransportReplySender, TransportReplyStream) {
+    channel::bounded(buffer.max(1))
+}
 
 /// Handler invoked by a transport when an inbound request arrives.
 /// `DefraKms` installs itself as the handler at startup.

--- a/crates/p2p/src/kms/pubsub_transport.rs
+++ b/crates/p2p/src/kms/pubsub_transport.rs
@@ -29,7 +29,6 @@ use kms::{
 };
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
-use tokio::sync::mpsc;
 use tracing::{debug, warn};
 
 use crate::peer_identity::PeerIdentityResolver;
@@ -382,7 +381,7 @@ impl<T: P2PTransport> KeyTransport for PubsubKeyTransport<T> {
         // identical request every `REPUBLISH_INTERVAL` and give up after
         // `RESPONSE_TIMEOUT` — closing the stream so the caller's `wait_all`
         // resolves instead of hanging forever on a lost gossip message.
-        let (tx, rx) = mpsc::channel(16);
+        let (tx, rx) = kms::transport_reply_channel(16);
         let transport = self.transport.clone();
         let correlator = self.correlator.clone();
         tokio::spawn(async move {

--- a/crates/query-plan/Cargo.toml
+++ b/crates/query-plan/Cargo.toml
@@ -25,7 +25,6 @@ lens = { path = "../lens", default-features = false }
 async-trait.workspace = true
 async-lock.workspace = true
 futures.workspace = true
-tokio = { version = "1.35", default-features = false, features = ["rt"] }
 
 # Serialization
 serde_json.workspace = true
@@ -38,6 +37,9 @@ tracing.workspace = true
 
 # Time handling
 chrono = { version = "0.4", features = ["serde"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { version = "1.35", default-features = false, features = ["rt"] }
 
 [dev-dependencies]
 tokio.workspace = true

--- a/crates/query-plan/src/txn/context.rs
+++ b/crates/query-plan/src/txn/context.rs
@@ -17,8 +17,15 @@ use crate::fetcher::CollectionProvider;
 use crate::fetcher::DocFetcher;
 use crate::mutator::DocMutator;
 
+#[cfg(not(target_arch = "wasm32"))]
 tokio::task_local! {
     static TXN_DEFERRED_ACP_MUTATIONS: Arc<DeferredAcpMutations>;
+}
+
+#[cfg(target_arch = "wasm32")]
+thread_local! {
+    static TXN_DEFERRED_ACP_MUTATIONS: std::cell::RefCell<Option<Arc<DeferredAcpMutations>>> =
+        const { std::cell::RefCell::new(None) };
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -270,14 +277,20 @@ pub async fn scope_deferred_acp_mutations<Fut, T>(
 where
     Fut: Future<Output = T>,
 {
-    TXN_DEFERRED_ACP_MUTATIONS.scope(mutations, future).await
+    #[cfg(not(target_arch = "wasm32"))]
+    return TXN_DEFERRED_ACP_MUTATIONS.scope(mutations, future).await;
+
+    #[cfg(target_arch = "wasm32")]
+    defra_core::wasm_task_local::scope(&TXN_DEFERRED_ACP_MUTATIONS, mutations, future).await
 }
 
 /// Return the current transaction's deferred ACP projection, if any.
 pub fn current_deferred_acp_mutations() -> Option<Arc<DeferredAcpMutations>> {
-    TXN_DEFERRED_ACP_MUTATIONS
-        .try_with(|mutations| mutations.clone())
-        .ok()
+    #[cfg(not(target_arch = "wasm32"))]
+    return TXN_DEFERRED_ACP_MUTATIONS.try_with(Clone::clone).ok();
+
+    #[cfg(target_arch = "wasm32")]
+    defra_core::wasm_task_local::try_with(&TXN_DEFERRED_ACP_MUTATIONS, Clone::clone)
 }
 
 /// Check document registration while honoring any ACP mutations buffered in the current txn.

--- a/crates/query/Cargo.toml
+++ b/crates/query/Cargo.toml
@@ -23,7 +23,6 @@ lens = { path = "../lens", default-features = false }
 
 # Async runtime
 async-trait.workspace = true
-tokio = { version = "1.35", default-features = false, features = ["rt"] }
 
 # Serialization
 serde.workspace = true
@@ -49,7 +48,7 @@ chrono = { version = "0.4", features = ["serde"] }
 
 # Query timeouts are native-only.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version = "1.35", default-features = false, features = ["time"] }
+tokio = { version = "1.35", default-features = false, features = ["rt", "time"] }
 
 [dev-dependencies]
 async-lock.workspace = true

--- a/crates/query/src/runner/executor.rs
+++ b/crates/query/src/runner/executor.rs
@@ -452,19 +452,20 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
         // and ACP checks see uncommitted state.
         let result = if let Some(provider) = txn_provider {
             if let Some(deferred_acp_mutations) = deferred_acp_mutations {
-                super::TXN_COLLECTION_PROVIDER
-                    .scope(
-                        provider,
-                        crate::txn::scope_deferred_acp_mutations(
-                            deferred_acp_mutations,
-                            await_with_timeout(execution, self.query_timeout),
-                        ),
-                    )
-                    .await
+                super::scope_txn_collection_provider(
+                    provider,
+                    crate::txn::scope_deferred_acp_mutations(
+                        deferred_acp_mutations,
+                        await_with_timeout(execution, self.query_timeout),
+                    ),
+                )
+                .await
             } else {
-                super::TXN_COLLECTION_PROVIDER
-                    .scope(provider, await_with_timeout(execution, self.query_timeout))
-                    .await
+                super::scope_txn_collection_provider(
+                    provider,
+                    await_with_timeout(execution, self.query_timeout),
+                )
+                .await
             }
         } else if let Some(deferred_acp_mutations) = deferred_acp_mutations {
             crate::txn::scope_deferred_acp_mutations(

--- a/crates/query/src/runner/mod.rs
+++ b/crates/query/src/runner/mod.rs
@@ -57,12 +57,41 @@ use crate::mutator::DocMutator;
 use crate::planner::Doc;
 use crate::txn::{NoOpTransactionRegistry, TransactionRegistry};
 
+#[cfg(not(target_arch = "wasm32"))]
 tokio::task_local! {
     /// Per-request collection provider override for transaction-scoped schema resolution.
     ///
     /// When a query executes within a transaction that has uncommitted schema changes,
     /// this is set to a transaction-aware provider so `get_collection()` sees the new schemas.
     static TXN_COLLECTION_PROVIDER: Arc<dyn CollectionProvider>;
+}
+
+#[cfg(target_arch = "wasm32")]
+thread_local! {
+    static TXN_COLLECTION_PROVIDER: std::cell::RefCell<Option<Arc<dyn CollectionProvider>>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+async fn scope_txn_collection_provider<F>(
+    provider: Arc<dyn CollectionProvider>,
+    future: F,
+) -> F::Output
+where
+    F: std::future::Future,
+{
+    #[cfg(not(target_arch = "wasm32"))]
+    return TXN_COLLECTION_PROVIDER.scope(provider, future).await;
+
+    #[cfg(target_arch = "wasm32")]
+    defra_core::wasm_task_local::scope(&TXN_COLLECTION_PROVIDER, provider, future).await
+}
+
+fn current_txn_collection_provider() -> Option<Arc<dyn CollectionProvider>> {
+    #[cfg(not(target_arch = "wasm32"))]
+    return TXN_COLLECTION_PROVIDER.try_with(Clone::clone).ok();
+
+    #[cfg(target_arch = "wasm32")]
+    defra_core::wasm_task_local::try_with(&TXN_COLLECTION_PROVIDER, Clone::clone)
 }
 
 // Re-export for backwards compatibility
@@ -408,9 +437,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
     /// Returns the transaction-scoped provider if set (via task-local storage),
     /// otherwise returns the default process-wide provider.
     fn effective_provider(&self) -> Arc<dyn CollectionProvider> {
-        TXN_COLLECTION_PROVIDER
-            .try_with(|p| p.clone())
-            .unwrap_or_else(|_| self.collection_provider.clone())
+        current_txn_collection_provider().unwrap_or_else(|| self.collection_provider.clone())
     }
 
     /// Get the names of all collections.

--- a/crates/sourcehub/Cargo.toml
+++ b/crates/sourcehub/Cargo.toml
@@ -59,7 +59,7 @@ alloy-rlp.workspace = true
 bs58.workspace = true
 
 # ACP light client (proof-validated cache)
-acp-light-client = { git = "ssh://git@github.com/sourcenetwork/backbone.git", rev = "086ddadc98bc55183920aa0fe6bc4d3719e0e5e7" }
+acp-light-client = { git = "https://github.com/sourcenetwork/backbone.git", rev = "086ddadc98bc55183920aa0fe6bc4d3719e0e5e7" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 futures.workspace = true

--- a/crates/storage/src/keys/headstore.rs
+++ b/crates/storage/src/keys/headstore.rs
@@ -56,7 +56,10 @@ impl HeadstoreDocKey {
         let rest = bytes.strip_prefix(b"/d/")?;
         let (rest, doc_short_id) = decode_doc_short_id_prefix(rest).ok()?;
         let rest = rest.strip_prefix(b"/")?;
-        let text = std::str::from_utf8(rest).ok()?;
+        // SAFETY: `Key::bytes` always writes `field_id` and the CID as UTF-8
+        // (ASCII field names + base32 CID). After the binary short-id segment,
+        // the remainder is only those text fields.
+        let text = unsafe { std::str::from_utf8_unchecked(rest) };
         let (field_id, cid_str) = text.rsplit_once('/')?;
         if field_id.is_empty() || cid_str.is_empty() {
             return None;

--- a/crates/storage/src/keys/headstore.rs
+++ b/crates/storage/src/keys/headstore.rs
@@ -1,6 +1,7 @@
-use super::doc_id_index::encode_doc_short_id;
+use super::doc_id_index::{decode_doc_short_id_prefix, encode_doc_short_id};
 use crate::corekv::Key;
 use cid::Cid;
+use std::str::FromStr;
 
 const PRIORITY_HEX_WIDTH: usize = 16;
 
@@ -43,6 +44,29 @@ impl HeadstoreDocKey {
         buf.extend_from_slice(field_id.as_bytes());
         buf.push(b'/');
         buf
+    }
+
+    /// Parse a serialized headstore document key from raw bytes.
+    ///
+    /// Decodes the binary `doc_short_id` uvarint without a lossy UTF-8 conversion,
+    /// so a short ID whose encoding is `0x2F` (`/`) cannot create a false separator.
+    /// Modelled on [`super::systemstore::ActionStatusKey::parse`]: fail-closed,
+    /// no trailing garbage.
+    pub fn parse(bytes: &[u8]) -> Option<Self> {
+        let rest = bytes.strip_prefix(b"/d/")?;
+        let (rest, doc_short_id) = decode_doc_short_id_prefix(rest).ok()?;
+        let rest = rest.strip_prefix(b"/")?;
+        let text = std::str::from_utf8(rest).ok()?;
+        let (field_id, cid_str) = text.rsplit_once('/')?;
+        if field_id.is_empty() || cid_str.is_empty() {
+            return None;
+        }
+        let cid = Cid::from_str(cid_str).ok()?;
+        Some(Self {
+            doc_short_id,
+            field_id: field_id.to_string(),
+            cid,
+        })
     }
 }
 
@@ -334,6 +358,59 @@ mod tests {
         expected.extend_from_slice(b"/fieldname/");
         expected.extend_from_slice(cid.to_string().as_bytes());
         assert_eq!(bytes, expected);
+    }
+
+    #[test]
+    fn test_headstore_doc_key_parse_roundtrip() {
+        let cid = test_cid();
+        for doc_short_id in [1u64, 46, 47, 48, 239, 240, 2287, 2288] {
+            let key = HeadstoreDocKey::new(doc_short_id, "fieldname", cid);
+            assert_eq!(HeadstoreDocKey::parse(&key.bytes()), Some(key));
+        }
+        let composite = HeadstoreDocKey::new(47, "C", cid);
+        assert_eq!(HeadstoreDocKey::parse(&composite.bytes()), Some(composite));
+    }
+
+    #[test]
+    fn test_headstore_doc_key_parse_rejects_malformed() {
+        assert_eq!(HeadstoreDocKey::parse(b""), None);
+        assert_eq!(HeadstoreDocKey::parse(b"/c/1/notacid"), None);
+        assert_eq!(HeadstoreDocKey::parse(b"/d/"), None);
+        // prefix only — no field or cid
+        assert_eq!(
+            HeadstoreDocKey::parse(&HeadstoreDocKey::document_prefix(1)),
+            None
+        );
+        // trailing garbage after a valid key
+        let mut bad = HeadstoreDocKey::new(1, "C", test_cid()).bytes();
+        bad.extend_from_slice(b"/extra");
+        assert_eq!(HeadstoreDocKey::parse(&bad), None);
+    }
+
+    /// Documents the encoding hazard: uvarint 47 is raw `0x2F` (`/`), so a naive
+    /// forward `split('/')` after lossy UTF-8 sees a different segment count than
+    /// neighbouring short IDs. Typed [`HeadstoreDocKey::parse`] is immune.
+    #[test]
+    fn test_headstore_doc_key_short_id_47_false_slash_separator() {
+        let cid = test_cid();
+        let segment_count = |doc_short_id: u64| -> usize {
+            let bytes = HeadstoreDocKey::new(doc_short_id, "C", cid).bytes();
+            String::from_utf8_lossy(&bytes).split('/').count()
+        };
+        let count_46 = segment_count(46);
+        let count_47 = segment_count(47);
+        let count_48 = segment_count(48);
+        assert_eq!(count_46, count_48);
+        assert_ne!(
+            count_47, count_46,
+            "doc_short_id=47 must insert a false '/' under naive split"
+        );
+        // And the typed decoder still recovers 47 correctly.
+        let key = HeadstoreDocKey::new(47, "C", cid);
+        let parsed = HeadstoreDocKey::parse(&key.bytes()).expect("parse 47");
+        assert_eq!(parsed.doc_short_id, 47);
+        assert_eq!(parsed.field_id, "C");
+        assert_eq!(parsed.cid, cid);
     }
 
     #[test]

--- a/tools/integration-test/src/lib.rs
+++ b/tools/integration-test/src/lib.rs
@@ -67,6 +67,13 @@ pub fn workspace_root() -> PathBuf {
         .expect("failed to canonicalize workspace root")
 }
 
+/// Return the configured Rust CLI binary, falling back to Cargo's debug output.
+pub fn rust_binary() -> PathBuf {
+    std::env::var_os("DEFRA_RUST_BINARY")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| workspace_root().join("target/debug/defra"))
+}
+
 /// Generate `rust_<name>` and `go_<name>` test wrappers for a single-node test.
 ///
 /// Usage: `for_each_runtime!(name, inner_fn);` (bare builder)

--- a/tools/integration-test/tests/basic/smoke.rs
+++ b/tools/integration-test/tests/basic/smoke.rs
@@ -3,12 +3,14 @@ use integration_test::TestCluster;
 #[tokio::test]
 async fn version_json_has_all_fields() {
     let root = integration_test::workspace_root();
-    let binary = root.join("target/debug/defra");
+    let binary = std::env::var_os("DEFRA_RUST_BINARY")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| root.join("target/debug/defra"));
 
     let output = std::process::Command::new(&binary)
         .args(["version", "--format", "json"])
         .output()
-        .expect("defra binary not found — run `cargo build -p cli` first");
+        .expect("defra binary not found — set DEFRA_RUST_BINARY or run `cargo build -p cli`");
 
     assert!(output.status.success(), "defra version failed");
 

--- a/tools/integration-test/tests/basic/smoke.rs
+++ b/tools/integration-test/tests/basic/smoke.rs
@@ -2,10 +2,7 @@ use integration_test::TestCluster;
 
 #[tokio::test]
 async fn version_json_has_all_fields() {
-    let root = integration_test::workspace_root();
-    let binary = std::env::var_os("DEFRA_RUST_BINARY")
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|| root.join("target/debug/defra"));
+    let binary = integration_test::rust_binary();
 
     let output = std::process::Command::new(&binary)
         .args(["version", "--format", "json"])

--- a/tools/integration-test/tests/identity/keyring_dev_mode.rs
+++ b/tools/integration-test/tests/identity/keyring_dev_mode.rs
@@ -1,15 +1,8 @@
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 
-fn workspace_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../..")
-        .canonicalize()
-        .expect("failed to canonicalize workspace root")
-}
-
 fn defra_binary() -> PathBuf {
-    workspace_root().join("target/debug/defra")
+    integration_test::rust_binary()
 }
 
 fn defra_keyring(binary: &Path, keyring_dir: &Path, args: &[&str]) -> Output {

--- a/tools/integration-test/tests/identity/keyring_lifecycle.rs
+++ b/tools/integration-test/tests/identity/keyring_lifecycle.rs
@@ -1,17 +1,8 @@
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 
-fn workspace_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../..")
-        .canonicalize()
-        .expect("failed to canonicalize workspace root")
-}
-
 fn defra_binary() -> PathBuf {
-    std::env::var_os("DEFRA_RUST_BINARY")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| workspace_root().join("target/debug/defra"))
+    integration_test::rust_binary()
 }
 
 fn is_rust_binary(binary: &Path) -> bool {

--- a/tools/integration-test/tests/identity/lifecycle.rs
+++ b/tools/integration-test/tests/identity/lifecycle.rs
@@ -1,15 +1,8 @@
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
-fn workspace_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../..")
-        .canonicalize()
-        .expect("failed to canonicalize workspace root")
-}
-
 fn defra_binary() -> PathBuf {
-    workspace_root().join("target/debug/defra")
+    integration_test::rust_binary()
 }
 
 /// Run a `defra identity` subcommand with the file keyring pointed at `keyring_dir`.

--- a/tools/integration-test/tests/p2p_iroh/acp/dac.rs
+++ b/tools/integration-test/tests/p2p_iroh/acp/dac.rs
@@ -73,7 +73,7 @@ async fn setup_sourcehub_cluster() -> Option<(TestCluster, String, String)> {
         return None;
     }
 
-    let binary = integration_test::workspace_root().join("target/debug/defra");
+    let binary = integration_test::rust_binary();
     let owner = generate_identity(&binary).expect("generate owner identity");
     let owner_key = owner.private_key_hex.clone();
 
@@ -451,7 +451,7 @@ async fn create_private_sync_after_relationship() {
     let node1 = cluster.client(1);
 
     // Generate a second identity (reader)
-    let binary = integration_test::workspace_root().join("target/debug/defra");
+    let binary = integration_test::rust_binary();
     let reader = generate_identity(&binary).expect("generate reader identity");
 
     // Create private doc as owner
@@ -706,7 +706,7 @@ async fn replicator_permissioned_sourcehub() {
     );
 
     // A different identity cannot read
-    let binary = integration_test::workspace_root().join("target/debug/defra");
+    let binary = integration_test::rust_binary();
     let stranger = generate_identity(&binary).expect("stranger identity");
     let stranger_result = node1
         .query_with_identity("query { User { name } }", &stranger.private_key_hex)
@@ -735,7 +735,7 @@ async fn subscribe_add_get_with_doc_actor_relationship() {
     let node0 = cluster.client(0);
     let node1 = cluster.client(1);
 
-    let binary = integration_test::workspace_root().join("target/debug/defra");
+    let binary = integration_test::rust_binary();
     let reader = generate_identity(&binary).expect("reader identity");
 
     // Create doc as owner
@@ -807,7 +807,7 @@ async fn replicator_with_doc_actor_relationship() {
     let node0 = cluster.client(0);
     let node1 = cluster.client(1);
 
-    let binary = integration_test::workspace_root().join("target/debug/defra");
+    let binary = integration_test::rust_binary();
     let reader = generate_identity(&binary).expect("reader identity");
 
     // Create doc

--- a/tools/integration-test/tests/p2p_iroh/connection/signature.rs
+++ b/tools/integration-test/tests/p2p_iroh/connection/signature.rs
@@ -61,8 +61,7 @@ fn require_public_key(identity: &integration_test::TestIdentity) -> String {
 #[serial]
 async fn peers_secp256k1_sync() {
     let identity =
-        generate_identity(&integration_test::workspace_root().join("target/debug/defra"))
-            .expect("generate secp256k1 identity");
+        generate_identity(&integration_test::rust_binary()).expect("generate secp256k1 identity");
 
     let cluster = TestCluster::builder()
         .rust_nodes(2)
@@ -126,9 +125,8 @@ async fn peers_secp256k1_sync() {
 #[tokio::test]
 #[serial]
 async fn peers_ed25519_sync() {
-    let identity =
-        generate_ed25519_identity(&integration_test::workspace_root().join("target/debug/defra"))
-            .expect("generate ed25519 identity");
+    let identity = generate_ed25519_identity(&integration_test::rust_binary())
+        .expect("generate ed25519 identity");
 
     let cluster = TestCluster::builder()
         .rust_nodes(2)
@@ -192,7 +190,7 @@ async fn peers_ed25519_sync() {
 #[tokio::test]
 #[serial]
 async fn peers_different_key_types_sync() {
-    let binary = &integration_test::workspace_root().join("target/debug/defra");
+    let binary = &integration_test::rust_binary();
     let id0 = generate_identity(binary).expect("generate secp256k1 identity");
     let id1 = generate_ed25519_identity(binary).expect("generate ed25519 identity");
 
@@ -279,7 +277,7 @@ async fn peers_different_key_types_sync() {
 #[tokio::test]
 #[serial]
 async fn peers_different_key_types_same_doc_sync() {
-    let binary = &integration_test::workspace_root().join("target/debug/defra");
+    let binary = &integration_test::rust_binary();
     let id0 = generate_identity(binary).expect("generate secp256k1 identity");
     let id1 = generate_ed25519_identity(binary).expect("generate ed25519 identity");
 
@@ -431,9 +429,7 @@ async fn peers_different_key_types_same_doc_sync() {
 #[tokio::test]
 #[serial]
 async fn branchable_collection_signed() {
-    let identity =
-        generate_identity(&integration_test::workspace_root().join("target/debug/defra"))
-            .expect("generate identity");
+    let identity = generate_identity(&integration_test::rust_binary()).expect("generate identity");
 
     let cluster = TestCluster::builder()
         .rust_nodes(1)
@@ -506,9 +502,7 @@ async fn branchable_collection_signed() {
 #[tokio::test]
 #[serial]
 async fn verify_valid_data() {
-    let identity =
-        generate_identity(&integration_test::workspace_root().join("target/debug/defra"))
-            .expect("generate identity");
+    let identity = generate_identity(&integration_test::rust_binary()).expect("generate identity");
 
     let cluster = TestCluster::builder()
         .rust_nodes(1)
@@ -543,9 +537,8 @@ async fn verify_valid_data() {
 #[tokio::test]
 #[serial]
 async fn verify_different_key_type() {
-    let identity =
-        generate_ed25519_identity(&integration_test::workspace_root().join("target/debug/defra"))
-            .expect("generate ed25519 identity");
+    let identity = generate_ed25519_identity(&integration_test::rust_binary())
+        .expect("generate ed25519 identity");
 
     let cluster = TestCluster::builder()
         .rust_nodes(1)
@@ -580,9 +573,7 @@ async fn verify_different_key_type() {
 #[tokio::test]
 #[serial]
 async fn verify_wrong_identity_error() {
-    let identity =
-        generate_identity(&integration_test::workspace_root().join("target/debug/defra"))
-            .expect("generate identity");
+    let identity = generate_identity(&integration_test::rust_binary()).expect("generate identity");
 
     let cluster = TestCluster::builder()
         .rust_nodes(1)
@@ -620,9 +611,7 @@ async fn verify_wrong_identity_error() {
 #[tokio::test]
 #[serial]
 async fn verify_wrong_cid_error() {
-    let identity =
-        generate_identity(&integration_test::workspace_root().join("target/debug/defra"))
-            .expect("generate identity");
+    let identity = generate_identity(&integration_test::rust_binary()).expect("generate identity");
 
     let cluster = TestCluster::builder()
         .rust_nodes(1)

--- a/tools/integration-test/tests/query/sdl_generate.rs
+++ b/tools/integration-test/tests/query/sdl_generate.rs
@@ -1,15 +1,8 @@
 use std::path::PathBuf;
 use std::process::Command;
 
-fn workspace_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../..")
-        .canonicalize()
-        .expect("failed to canonicalize workspace root")
-}
-
 fn defra_binary() -> PathBuf {
-    workspace_root().join("target/debug/defra")
+    integration_test::rust_binary()
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Integration gate for the changes scheduled for `v0.18.0`:

- #1371 — harden `HeadstoreDocKey` binary short-ID decoding
- #1374 — simplify CI/release authentication and restore fast macOS test settings
- #1375 — remove Tokio from the browser WASM dependency graph

The branch preserves each PR's commits and combines them in the intended merge order. Their shared `Cargo.lock` edits merge cleanly.

## Purpose

`Build & Test` is pinned to one self-hosted runner. Recent jobs exposed a regression from forcing incremental compilation: the full workspace test step grew from roughly 2.5–5.5 minutes to 65–83 minutes, principally from a 25–26 second startup delay across approximately 187 test executables. #1374 now restores the pre-regression non-incremental `sccache` configuration while retaining the successful runner-topology changes.

Running one combined gate avoids three serial repetitions and tests the exact content tree intended for `main` before the `v0.18.0` tag. After this gate is green, the original PRs will be merged with redundant push CI suppressed. The resulting `main` tree will be compared byte-for-byte (Git tree ID) with this tested branch before release.

## Local validation

- Parsed CI and release workflows as YAML
- `cargo metadata --locked --format-version 1 --no-deps`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
