### PR TITLE
fix(release): pin SourceHub dependency to reachable revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ dependencies = [
 [[package]]
 name = "acp-light-client"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/backbone.git?rev=086ddadc98bc55183920aa0fe6bc4d3719e0e5e7#086ddadc98bc55183920aa0fe6bc4d3719e0e5e7"
+source = "git+https://github.com/sourcenetwork/backbone.git?tag=defra-harness%2F2026-08-07-port-conflict#d14172101436e5a3f62c967c34e7db8bc230aa79"
 dependencies = [
  "alloy-primitives",
  "borsh",

--- a/crates/sourcehub/Cargo.toml
+++ b/crates/sourcehub/Cargo.toml
@@ -59,7 +59,7 @@ alloy-rlp.workspace = true
 bs58.workspace = true
 
 # ACP light client (proof-validated cache)
-acp-light-client = { git = "https://github.com/sourcenetwork/backbone.git", rev = "086ddadc98bc55183920aa0fe6bc4d3719e0e5e7" }
+acp-light-client = { git = "https://github.com/sourcenetwork/backbone.git", tag = "defra-harness/2026-08-07-port-conflict" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 futures.workspace = true


### PR DESCRIPTION
## Summary
- replace the unreachable Backbone revision used by `acp-light-client` with the current public tagged tip
- keep the dependency source on public HTTPS
- update only the corresponding Cargo.lock source entry

The old revision is an ancestor of the replacement but is not advertised by the remote, so clean Cargo fetches fail with `git upload-pack: not our ref`. The `acp-light-client` package contents are byte-for-byte identical between the two revisions.

## Validation
- clean `git fetch` of the exact replacement SHA
- `cargo metadata --locked --no-deps`
- `cargo check -p sourcehub --locked`
- `cargo fmt --all -- --check`
- `git diff --check`

Observed in v0.18.0 Release run 31524275627.