### PR TITLE
build(deps): declare the tokio features each crate uses

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -51,7 +51,7 @@ telemetry = { path = "../telemetry", default-features = false }
 clap = { version = "4.5", features = ["derive", "env"] }
 
 # Async runtime
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "fs", "signal", "sync", "time"] }
 futures = { workspace = true }
 async-trait = { workspace = true }
 

--- a/crates/crdt/Cargo.toml
+++ b/crates/crdt/Cargo.toml
@@ -28,7 +28,7 @@ tracing.workspace = true
 [dev-dependencies]
 criterion.workspace = true
 proptest.workspace = true
-tokio = { workspace = true, features = ["test-util"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }
 
 [[bench]]
 name = "merge"

--- a/crates/datastore/Cargo.toml
+++ b/crates/datastore/Cargo.toml
@@ -34,7 +34,7 @@ tokio = { workspace = true, features = ["rt"] }
 [dev-dependencies]
 # Testing
 futures.workspace = true
-tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time"] }
 
 [lints]
 workspace = true

--- a/crates/db-merge/Cargo.toml
+++ b/crates/db-merge/Cargo.toml
@@ -66,7 +66,7 @@ events = { path = "../events", default-features = false }
 kms = { path = "../kms" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { workspace = true, features = ["sync"] }
+tokio = { workspace = true, features = ["rt", "sync", "time"] }
 libp2p.workspace = true
 p2p = { path = "../p2p", features = ["libp2p-transport"] }
 
@@ -74,7 +74,7 @@ p2p = { path = "../p2p", features = ["libp2p-transport"] }
 wasm-bindgen-futures = "0.4"
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
 blst = "0.3"
 getrandom = "0.2"
 criterion.workspace = true

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -65,7 +65,7 @@ hex.workspace = true
 libp2p = { workspace = true, optional = true }
 
 # Native-only (optional)
-tokio = { workspace = true, features = ["sync"], optional = true }
+tokio = { workspace = true, features = ["rt", "fs", "sync", "time"], optional = true }
 parking_lot.workspace = true
 
 # Internal crates
@@ -92,7 +92,7 @@ lens = { path = "../lens", default-features = false }
 p2p = { path = "../p2p", optional = true }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time"] }
 proptest.workspace = true
 blst = "0.3"
 getrandom = "0.2"

--- a/crates/defra-core/Cargo.toml
+++ b/crates/defra-core/Cargo.toml
@@ -46,6 +46,9 @@ tracing.workspace = true
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true, features = ["rt"] }
 
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+tokio = { workspace = true, features = ["rt", "macros"] }
+
 [dev-dependencies]
 criterion.workspace = true
 futures.workspace = true

--- a/crates/defra-node/Cargo.toml
+++ b/crates/defra-node/Cargo.toml
@@ -39,7 +39,7 @@ identity = { path = "../identity" }
 defra-core = { path = "../defra-core" }
 schema = { path = "../schema" }
 lens = { path = "../lens" }
-tokio.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "fs", "net", "sync", "time"] }
 anyhow.workspace = true
 tracing.workspace = true
 async-trait = "0.1"

--- a/crates/embedded/Cargo.toml
+++ b/crates/embedded/Cargo.toml
@@ -43,7 +43,7 @@ serde_bytes.workspace = true
 serde_ipld_dagcbor.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["rt", "macros", "sync", "time"] }
+tokio = { workspace = true, features = ["rt", "macros", "fs", "sync", "time"] }
 tracing.workspace = true
 
 [features]

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -33,7 +33,7 @@ base64.workspace = true
 cid.workspace = true
 
 # Async runtime
-tokio.workspace = true
+tokio = { workspace = true, features = ["rt", "net", "time"] }
 tokio-stream.workspace = true
 async-trait.workspace = true
 futures.workspace = true
@@ -61,7 +61,7 @@ rand.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true
-tokio = { workspace = true, features = ["test-util"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "test-util"] }
 tower = { workspace = true, features = ["util"] }
 urlencoding = "2.1"
 crypto = { path = "../crypto" }

--- a/crates/kms/Cargo.toml
+++ b/crates/kms/Cargo.toml
@@ -57,7 +57,7 @@ wasm-bindgen-futures = "0.4"
 tokio = { version = "1.35", default-features = false, features = ["rt", "sync", "macros"] }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "test-util"] }
 
 [lints]
 workspace = true

--- a/crates/lens/Cargo.toml
+++ b/crates/lens/Cargo.toml
@@ -35,7 +35,7 @@ sha2.workspace = true
 hex.workspace = true
 
 # Wasmtime runtime dependencies (optional for wasm32)
-tokio = { workspace = true, optional = true }
+tokio = { workspace = true, features = ["rt"], optional = true }
 parking_lot = { workspace = true, optional = true }
 wasmtime = { version = "46.0.2", optional = true, default-features = false, features = [
     "runtime",

--- a/crates/orbis/Cargo.toml
+++ b/crates/orbis/Cargo.toml
@@ -21,7 +21,7 @@ tonic-prost = { workspace = true }
 prost = { workspace = true }
 
 # Async runtime (dedicated runtime for sync bridge)
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt"] }
 
 # Encoding
 hex.workspace = true
@@ -36,6 +36,7 @@ thiserror.workspace = true
 [dev-dependencies]
 base64.workspace = true
 serde_json.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "sync"] }
 tokio-stream.workspace = true
 blst = "0.3"
 

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -27,7 +27,7 @@ libp2p-stream = { workspace = true, optional = true }
 multiaddr = { workspace = true, optional = true }
 
 # Async
-tokio = { workspace = true, features = ["sync", "rt", "macros", "fs"] }
+tokio = { workspace = true, features = ["sync", "rt", "macros", "fs", "time"] }
 async-trait = { workspace = true }
 futures = { workspace = true }
 

--- a/crates/pg-compat/Cargo.toml
+++ b/crates/pg-compat/Cargo.toml
@@ -23,7 +23,7 @@ pgwire = "0.38"
 sqlparser = { version = "0.55", features = ["visitor"] }
 
 # Async runtime
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt", "net", "sync"] }
 async-trait = { workspace = true }
 
 # Serialization

--- a/crates/query-plan/Cargo.toml
+++ b/crates/query-plan/Cargo.toml
@@ -42,7 +42,7 @@ chrono = { version = "0.4", features = ["serde"] }
 tokio = { version = "1.35", default-features = false, features = ["rt"] }
 
 [dev-dependencies]
-tokio.workspace = true
+tokio = { workspace = true, features = ["rt", "macros", "time"] }
 
 [lints]
 workspace = true

--- a/crates/query/Cargo.toml
+++ b/crates/query/Cargo.toml
@@ -53,7 +53,7 @@ tokio = { version = "1.35", default-features = false, features = ["rt", "time"] 
 [dev-dependencies]
 async-lock.workspace = true
 criterion.workspace = true
-tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
 
 [[bench]]
 name = "parsing"

--- a/crates/sourcehub/Cargo.toml
+++ b/crates/sourcehub/Cargo.toml
@@ -23,7 +23,7 @@ serde.workspace = true
 serde_json.workspace = true
 
 # Async
-tokio.workspace = true
+tokio = { workspace = true, features = ["rt", "sync", "time", "io-util"] }
 async-trait.workspace = true
 
 # Error handling
@@ -65,6 +65,9 @@ acp-light-client = { git = "https://github.com/sourcenetwork/backbone.git", rev 
 futures.workspace = true
 prost.workspace = true
 tokio-tungstenite = { version = "0.26.2", features = ["rustls-tls-webpki-roots"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "net"] }
 
 [lints]
 workspace = true

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -70,7 +70,7 @@ js-sys = { version = "0.3", optional = true }
 
 # Tokio is only available on non-WASM targets
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio.workspace = true
+tokio = { workspace = true, features = ["rt", "sync", "time"] }
 
 # Native storage backends
 redb = { workspace = true, optional = true }
@@ -80,6 +80,7 @@ lark-kv = { workspace = true, optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 futures.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time"] }
 
 [dev-dependencies]
 proptest.workspace = true

--- a/tools/lens-host/Cargo.toml
+++ b/tools/lens-host/Cargo.toml
@@ -11,7 +11,7 @@ description = "Lens host CLI backed by the Rust WASM runtime"
 [dependencies]
 lens = { path = "../../crates/lens", features = ["wasmtime-runtime"] }
 serde_json.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "fs", "io-std", "io-util"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION

## Summary

Cargo workspace dependency inheritance is **additive** — a member's
`features = [...]` are unioned with the workspace entry's, never subtracted. The
workspace entry requests `full` (`Cargo.toml:79`), so every member writing
`tokio.workspace = true` silently receives `full`, including the ~20 that name a
narrow set and look correct. `cargo tree -p defra-core -e features -i tokio`
attributes `tokio feature "full"` to `defra-core`, which declares only `["rt"]`.

The result is that the manifests lie: crates compile only because a sibling
turns on a feature they use but never declare.

- Declare the real tokio feature set on all 21 inheriting lines across 19
  manifests; **the workspace entry is deliberately left at `full`**.
- Add the four missing tokio dev-dependencies: `defra-core`, `orbis`,
  `sourcehub` (which had no `[dev-dependencies]` section at all), and `storage`.
- 14 crates had a genuine declared-vs-used gap, each verified against source —
  e.g. `db` uses `tokio::fs` (`migration/mod.rs:66`) while declaring only
  `sync`; `p2p` uses `tokio::time::Instant`
  (`sync/push_fanout_coalescer.rs:70`) without declaring `time`;
  `defra-core`'s `#[tokio::test]` (`current_identity.rs:139`) compiled with no
  tokio dev-dependency at all.

**This is 1 of 3.** 1332-b drops `features = ["full"]` from `Cargo.toml:79`;
1332-c removes the four dev/test-only explicit `full`s. Splitting this way is
what makes the diff reviewable — see below.

### Why this is provably behaviour-neutral

Because inheritance is additive and the workspace entry still says `full`,
adding features to a member **cannot** change the resolved graph. The resolved
tokio feature set is byte-identical before and after for **all 45 workspace
packages**, under both default features and `--all-features`. Normalising the
full `cargo tree -e features` output shows no edge ever leaves any graph; every
difference is an added feature edge.

Reviewers can accept 19 files on that mechanical evidence rather than by reading
each line. In 1332-b, by contrast, any remaining gap surfaces as a compile error
against a baseline where the manifests are already believed correct.

### Out of scope

- `Cargo.toml:79` (1332-b) and the four explicit dev/test `full`s (1332-c).
- The already-narrow non-inherited lines owned by #1334 / #1375
  (`kms`, `query-plan`, `query` normal deps). This PR touches only their **dev**
  lines, which #1375 left inheriting.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo tree -e features` tokio feature set identical before/after for all
      45 packages, default and `--all-features` (empty diff)
- [x] normalised full `cargo tree -e features`: no edge removed from any graph
- [x] per-crate `cargo check -p <pkg> --all-targets` for all 45 packages (44 ok;
      `defra-wasm` fails identically on the base commit — see below)
- [x] `cargo clippy -p cli --no-default-features --features release-full --all-targets -- -D warnings`
- [x] `cargo hack check --each-feature -p db -p lens` (fails identically on the
      base commit — see below)

### Pre-existing failures, confirmed not introduced here

`cargo check -p defra-wasm` and `cargo hack --each-feature` on `db` / `lens`
fail on `--no-default-features`, **identically on the base commit**.

Root cause, unrelated to tokio *features*: `crates/db` and `crates/lens` declare
tokio `optional = true` while their source uses `tokio::` unconditionally, so
any build without `db/native` or `lens/wasmtime-runtime` fails with
`E0433: cannot find module or crate tokio`. Worth its own issue; it is a
dependency-optionality bug, not a feature bug.

Part of #1327. Refs #1332.
