### PR TITLE
chore(deps): unify sysinfo on 0.33 and document the duplicates we cannot unify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3165,7 +3165,7 @@ dependencies = [
  "base64 0.22.1",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4553,7 +4553,7 @@ dependencies = [
  "dirs",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -8632,7 +8632,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "storage",
- "sysinfo 0.29.11",
+ "sysinfo 0.33.1",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -11801,21 +11801,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "sysinfo"
-version = "0.29.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd727fc423c2060f6c92d9534cef765c65a6ed3f428a03d7def74a8c4348e666"
-dependencies = [
- "cfg-if",
- "core-foundation-sys",
- "libc",
- "ntapi",
- "once_cell",
- "rayon",
- "winapi",
 ]
 
 [[package]]

--- a/crates/cursor/Cargo.toml
+++ b/crates/cursor/Cargo.toml
@@ -9,4 +9,4 @@ license = "Apache-2.0 OR MIT"
 base64 = "0.22"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-thiserror = "1"
+thiserror = "2"

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -56,7 +56,7 @@ thiserror = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
 rlimit = { version = "0.9", optional = true }
-sysinfo = { version = "0.29", optional = true }
+sysinfo = { version = "0.33", optional = true }
 
 # Bytes
 bytes = { workspace = true }

--- a/crates/p2p/src/host/p2p_host/mod.rs
+++ b/crates/p2p/src/host/p2p_host/mod.rs
@@ -20,7 +20,7 @@ use libp2p::{
     swarm::{behaviour::toggle::Toggle, dial_opts::DialOpts},
     tcp, yamux, Multiaddr, PeerId, Swarm, SwarmBuilder,
 };
-use sysinfo::{RefreshKind, System, SystemExt};
+use sysinfo::{MemoryRefreshKind, RefreshKind, System};
 use tokio::{
     sync::mpsc,
     time::{self, Instant, MissedTickBehavior},
@@ -101,7 +101,9 @@ impl ResourceManagerRuntimeLimits {
 }
 
 fn total_system_memory_bytes() -> u64 {
-    let system = System::new_with_specifics(RefreshKind::new().with_memory());
+    let system = System::new_with_specifics(
+        RefreshKind::nothing().with_memory(MemoryRefreshKind::nothing().with_ram()),
+    );
     system.total_memory()
 }
 
@@ -793,6 +795,22 @@ mod tests {
             GO_RESOURCE_MANAGER_MIN_MEMORY_BYTES,
         )
         .expect("Go minimum FD and memory limits must be accepted");
+    }
+
+    /// `sysinfo::total_memory` reports bytes; a unit or refresh-kind regression
+    /// would be orders of magnitude off and skew the Go-parity memory divisor.
+    #[test]
+    fn total_system_memory_is_reported_in_bytes() {
+        let total = total_system_memory_bytes();
+
+        assert!(
+            total > 256 * 1024 * 1024,
+            "implausibly small system memory, expected bytes: {total}"
+        );
+        assert!(
+            total < 16 * 1024 * 1024 * 1024 * 1024,
+            "implausibly large system memory, expected bytes: {total}"
+        );
     }
 
     #[test]

--- a/deny.toml
+++ b/deny.toml
@@ -75,7 +75,99 @@ multiple-versions = "warn"
 allow = []
 deny = []
 highlight = "lowest-version"
-skip = []
+
+# ------------------------------------------------------------------
+# Accepted duplicate versions, from the #1333 inventory. Each entry
+# names the version we cannot remove, the path that pulls it, and the
+# condition under which it disappears. Versions absent from this list
+# are still reported as warnings.
+#
+# Measure duplicates per shipped artifact, not with `--workspace`:
+# `--workspace` unifies features across every member including
+# tools/integration-test. Count distinct names, because `cargo tree -d`
+# double-lists some same-version packages:
+#
+#   cargo tree -d -e normal -p cli | grep -E '^[a-zA-Z0-9_-]+ v' \
+#     | awk '{print $1}' | sort -u | wc -l
+#
+# `keyring v0.5.0` alongside `keyring v3.6.3` in that output is our own
+# crates/keyring colliding with the crates.io name. Not a duplicate.
+# ------------------------------------------------------------------
+skip = [
+    # prost 0.11 — iroh-bitswap 0.2 in the sourcenetwork/beetle fork.
+    # Needs a commit in beetle plus a rev bump here; we are already on
+    # the newest line (workspace prost = "0.14").
+    { crate = "prost@0.11.9", reason = "iroh-bitswap (beetle fork) pins prost 0.11; removable only by a beetle commit + rev bump" },
+
+    # prost 0.13 — cosmos-sdk-proto / tendermint / ics23 under cosmrs
+    # 0.22 (crates/sourcehub), and jmt under acp-light-client.
+    # Removable when that stack moves to prost 0.14.
+    { crate = "prost@0.13.5", reason = "hard-pinned by the cosmrs 0.22 / tendermint 0.40 stack; not ours to move" },
+
+    # sha2 0.9 — ed25519-consensus 2.1, via commonware-cryptography and
+    # tendermint. Only present in sourcehub/backbone builds.
+    { crate = "sha2@0.9.9", reason = "ed25519-consensus 2.1 under commonware-cryptography and tendermint" },
+
+    # sha2 0.11 — multihash-codetable 0.2.2 requires sha2 0.11 and sits
+    # in the CID path via crates/blockstore; ed25519-dalek 3.0.0-rc.0
+    # (iroh) pulls it too. The 0.10 floor is held by libp2p-identity
+    # 0.2.13 (requires 0.10.8), and libp2p stays, so the floor for sha2
+    # is 2 versions. Bumping our workspace sha2 to 0.11 would change
+    # hashing under docID/CID and still not remove 0.10.
+    { crate = "sha2@0.11.0", reason = "multihash-codetable 0.2.2 needs 0.11 in the CID path; libp2p-identity 0.2.13 pins 0.10.8 — floor is 2" },
+
+    # ed25519-dalek / curve25519-dalek — iroh-base 1.0.1 uses exact
+    # pins (=3.0.0-rc.0, =5.0.0-rc.0) leaving no semver room, while
+    # libp2p-identity 0.2.13 requires ed25519-dalek 2.1. Unification is
+    # impossible in both directions; moving crates/crypto to the rc
+    # line would put Go-interop signing on a prerelease and still leave
+    # 2.2.0 in the graph. Absent from the default cli and ffi graphs
+    # (iroh is opt-in); dies with #1341.
+    { crate = "ed25519-dalek@3.0.0-rc.0", reason = "exact-pinned by iroh-base 1.0.1; libp2p-identity floor-pins 2.x — dies with #1341" },
+    { crate = "curve25519-dalek@5.0.0-rc.0", reason = "exact-pinned by iroh-base 1.0.1 — dies with #1341" },
+
+    # reqwest 0.11 — one edge: tendermint-rpc 0.40.4 under cosmrs 0.22.
+    # It carries hyper 0.14, h2 0.3, rustls 0.21, tokio-rustls 0.24,
+    # hyper-rustls 0.24, rustls-webpki 0.101, system-configuration 0.5
+    # and untrusted 0.7 with it. cosmrs gates tendermint-rpc behind an
+    # optional `rpc` feature that is not in its defaults, so this may
+    # be removable — tracked separately under #1327.
+    { crate = "reqwest@0.11.27", reason = "tendermint-rpc 0.40.4 under cosmrs 0.22; cosmrs/rpc audit tracked under #1327" },
+
+    # reqwest 0.13 — iroh 1.0.1 / iroh-relay. Dies with #1341.
+    { crate = "reqwest@0.13.3", reason = "iroh 1.0.1 and iroh-relay — dies with #1341" },
+
+    # rand / getrandom — every major has third-party dependents that
+    # pin it: libp2p and ring on getrandom 0.2, hickory/quinn/yamux on
+    # rand 0.9, iroh and hickory 0.26 on rand 0.10. crates/crypto and
+    # defra-core use rand 0.8 for key generation, so our declaration
+    # does not move without a key-generation review.
+    { crate = "rand@0.9.2", reason = "hickory-proto 0.25, quinn-proto, yamux, governor; crates/p2p follows them" },
+    { crate = "rand@0.10.1", reason = "iroh 1.0.1, hickory 0.26, pgwire — largely dies with #1341" },
+    { crate = "getrandom@0.3.4", reason = "rand_core 0.9 under ahash, fastbloom, governor" },
+    { crate = "getrandom@0.4.2", reason = "rand 0.10, tempfile 3.26, uuid 1.23" },
+
+    # unsigned-varint 0.2 — reached only through multicodec 0.1 under
+    # defra-core. Removed for free by #1330.
+    { crate = "unsigned-varint@0.2.3", reason = "multicodec 0.1 under defra-core — removed by #1330" },
+
+    # unsigned-varint 0.7 — multistream-select 0.13 inside libp2p.
+    { crate = "unsigned-varint@0.7.2", reason = "multistream-select 0.13 inside libp2p" },
+
+    # sysinfo 0.37 — commonware-runtime, i.e. sourcehub/backbone builds
+    # only. crates/p2p was moved 0.29 -> 0.33 in #1333 to unify with
+    # libp2p-memory-connection-limits 0.5, which is present in every
+    # Go-interop variant; 0.37 would have unified with commonware
+    # instead and left the default CLI on two versions.
+    { crate = "sysinfo@0.37.2", reason = "commonware-runtime; sourcehub/backbone builds only" },
+
+    # thiserror 1 — graphql-parser 0.4, josekit 0.8, lark-kv,
+    # iroh-bitswap (beetle), cosmrs, jmt, tendermint-rpc,
+    # proc-macro-crate 1.1 and quick-protobuf-codec. No first-party
+    # crate declares v1 as of #1333; the duplicate is entirely
+    # third-party.
+    { crate = "thiserror@1.0.69", reason = "graphql-parser, josekit, lark-kv, iroh-bitswap, cosmrs, jmt — no first-party declaration remains" },
+]
 skip-tree = []
 
 [sources]

--- a/tools/ffi-test/Cargo.toml
+++ b/tools/ffi-test/Cargo.toml
@@ -15,7 +15,7 @@ clap = { version = "4.5", features = ["derive"] }
 tokio = { version = "1.35", features = ["process", "fs", "net", "rt-multi-thread", "macros", "io-util"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-thiserror = "1.0"
+thiserror = "2.0"
 chrono = { version = "0.4", features = ["serde"] }
 colored = "2.0"
 dirs = "5.0"


### PR DESCRIPTION
Refs #1333.

**Of the four duplicates the issue names, one is ours to fix.** `prost` 0.13 is pinned by the
cosmrs/tendermint stack and 0.11 by our beetle fork; `sha2` is at its floor of 2, held by
`libp2p-identity` and by `multihash-codetable` in the CID path; the dalek pair is exact-pinned
by `iroh-base` in one direction and floor-pinned by `libp2p-identity` in the other. Measured
detail: [comment on #1333](https://github.com/sourcenetwork/defradb.rs/issues/1333#issuecomment-5258604793).

### Changes

- **`sysinfo` 0.29 → 0.33 in `crates/p2p`**, the sole dependent of `0.29.11`. 0.33 unifies with
  `libp2p-memory-connection-limits`, present in every Go-interop variant; 0.37 would unify with
  `commonware-runtime` and leave the default CLI on two versions. `total_memory()` returns
  bytes in both versions, so the Go-parity memory divisor is unchanged; a unit test asserts the
  magnitude (it returns 0 and fails if the refresh kind is dropped — verified deliberately).
- **`thiserror` 1 → 2 in `crates/cursor` and `tools/ffi-test`**, matching the workspace.
  **Zero duplicate-count change** — `graphql-parser`, `josekit`, `lark-kv`, `iroh-bitswap` and
  others still pull v1. First-party consistency only.
- **`deny.toml [bans].skip`**: 17 accepted duplicates, each with the path that pulls it and the
  condition under which it goes away. This is the issue's AC 2, put where `cargo deny` reads it
  instead of in a comment that rots. `multiple-versions` stays `"warn"`.

### Effect, measured at `5e5c4990`

| Variant | duplicated names | duplicate nodes |
|---|---|---|
| `-p cli` (default `defra`) | 39 → **38** | 82 → **80** |
| `-p cli --features release-full` | 54 → 54 | 128 → **127** |
| `-p ffi` | 53 → 53 | 124 → **123** |
| `-p ffi --features iroh` | 75 → 75 | 170 → **169** |
| wasm32 | 15 → 15 | 33 → 33 |
| `--workspace` | 92 → 92 | 207 → **206** |

**Net: one duplicated name removed, default CLI only** — elsewhere `sysinfo` goes 3 versions →
2 via `sourcehub → commonware-runtime` and stays duplicated. Not a size fix, and not a
build-time fix either: `sysinfo 0.29.11` costs 0.35 CPU-seconds to compile and ~1.7 MB of
target artifacts. The value is supply-chain surface — one fewer crate version to audit — plus
the inventory.

### Verification

`cargo clippy --all -- -D warnings` ✅ · `cargo clippy -p p2p --features test-utils
--all-targets` ✅ (the pass that lints the changed code, since `crates/p2p` is `default = []`) ·
`cargo test --workspace` ✅ 194 suites · `cargo test -p integration-test --test p2p` ✅ 100
passed · `cargo deny check bans` ✅ 17 skips matched, none unused · `cargo fmt --all` ✅

Two pre-existing failures, unchanged by this PR: `cargo deny check` advisories (21 errors
before and after), and `cargo clippy --all --all-targets` (two `useless_borrows_in_formatting`
errors in `tools/integration-test`, which neither CI nor `just lint` runs).

⚠️ **Known expiry:** the `unsigned-varint@0.2.3` skip exists only for `multicodec 0.1`, which
#1330 removes. Delete that line when #1330 lands or `cargo deny` will warn about it.