### PR TITLE
refactor: replace multicodec crate with inline codec constants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,20 +56,11 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
-dependencies = [
- "gimli 0.32.3",
-]
-
-[[package]]
-name = "addr2line"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59317f77929f0e679d39364702289274de2f0f0b22cbf50b2b8cff2169a0b27a"
 dependencies = [
- "gimli 0.33.1",
+ "gimli",
 ]
 
 [[package]]
@@ -965,7 +956,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "synstructure 0.13.2",
+ "synstructure",
 ]
 
 [[package]]
@@ -1385,21 +1376,6 @@ dependencies = [
  "fastrand",
  "gloo-timers",
  "tokio",
-]
-
-[[package]]
-name = "backtrace"
-version = "0.3.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
-dependencies = [
- "addr2line 0.25.1",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object 0.37.3",
- "rustc-demangle",
- "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2776,7 +2752,7 @@ dependencies = [
  "cranelift-control",
  "cranelift-entity",
  "cranelift-isle",
- "gimli 0.33.1",
+ "gimli",
  "hashbrown 0.17.1",
  "libm",
  "log",
@@ -3615,7 +3591,6 @@ dependencies = [
  "futures",
  "ipld-core",
  "multibase",
- "multicodec",
  "multihash",
  "multihash-codetable",
  "rand 0.8.5",
@@ -4035,7 +4010,6 @@ dependencies = [
  "cid",
  "defra-core",
  "multibase",
- "multicodec",
  "multihash",
  "schema",
  "serde",
@@ -4397,28 +4371,6 @@ checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
 dependencies = [
  "indenter",
  "once_cell",
-]
-
-[[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "synstructure 0.12.6",
 ]
 
 [[package]]
@@ -4946,12 +4898,6 @@ dependencies = [
  "opaque-debug",
  "polyval",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "gimli"
@@ -7569,17 +7515,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "multicodec"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f287a558ce2cac6f63944876d2f76ae2254a17fbe174c82967e76e0aab3379ed"
-dependencies = [
- "failure",
- "serde",
- "unsigned-varint 0.2.3",
-]
-
-[[package]]
 name = "multihash"
 version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7626,7 +7561,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "synstructure 0.13.2",
+ "synstructure",
 ]
 
 [[package]]
@@ -11782,18 +11717,6 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "unicode-xid",
-]
-
-[[package]]
-name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
@@ -12830,12 +12753,6 @@ checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "unsigned-varint"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f0023a96687fe169081e8adce3f65e3874426b7886e9234d490af2dc077959"
-
-[[package]]
-name = "unsigned-varint"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
@@ -13238,7 +13155,7 @@ version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed27b4a4a5271d2608406a99c8d1cf8aea1e894fe4ec361d470063bcf342f1d7"
 dependencies = [
- "addr2line 0.26.1",
+ "addr2line",
  "async-trait",
  "bitflags 2.11.0",
  "bumpalo",
@@ -13281,7 +13198,7 @@ dependencies = [
  "cranelift-bforest",
  "cranelift-bitset",
  "cranelift-entity",
- "gimli 0.33.1",
+ "gimli",
  "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "log",
@@ -13330,7 +13247,7 @@ dependencies = [
  "cranelift-entity",
  "cranelift-frontend",
  "cranelift-native",
- "gimli 0.33.1",
+ "gimli",
  "itertools 0.14.0",
  "log",
  "object 0.39.1",
@@ -14357,7 +14274,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "synstructure 0.13.2",
+ "synstructure",
 ]
 
 [[package]]
@@ -14471,7 +14388,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "synstructure 0.13.2",
+ "synstructure",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,6 @@ bs58 = "0.5"
 cid = { version = "0.11.3", features = ["serde"] }
 multihash = "0.19"
 multihash-codetable = { version = "0.2.2", features = ["sha2"] }
-multicodec = "0.1"
 serde_ipld_dagcbor = "0.6"
 ipld-core = { version = "0.4", features = ["codec", "serde"] }
 

--- a/crates/crypto/src/batch.rs
+++ b/crates/crypto/src/batch.rs
@@ -143,7 +143,7 @@ mod tests {
 
     fn make_cid(data: &[u8]) -> Cid {
         let hash = Code::Sha2_256.digest(data);
-        Cid::new_v1(*DAG_CBOR_CODEC, hash)
+        Cid::new_v1(DAG_CBOR_CODEC, hash)
     }
 
     fn test_ed25519_config() -> SigningConfig {

--- a/crates/db-merge/src/browser_sync/validation.rs
+++ b/crates/db-merge/src/browser_sync/validation.rs
@@ -68,7 +68,7 @@ impl<S: Store + 'static> BrowserSyncEngine<S> {
             let cid = Cid::from_str(&block.cid).map_err(|error| {
                 BrowserSyncError::Invalid(format!("invalid block CID '{}': {error}", block.cid))
             })?;
-            if cid.codec() != *DAG_CBOR_CODEC {
+            if cid.codec() != DAG_CBOR_CODEC {
                 return Err(BrowserSyncError::Invalid(format!(
                     "block {cid} is not DAG-CBOR"
                 )));

--- a/crates/defra-core/Cargo.toml
+++ b/crates/defra-core/Cargo.toml
@@ -25,7 +25,6 @@ multibase = "0.9"
 # IPLD
 cid.workspace = true
 multihash.workspace = true
-multicodec.workspace = true
 serde_ipld_dagcbor.workspace = true
 ipld-core.workspace = true
 

--- a/crates/defra-core/src/batch_signing.rs
+++ b/crates/defra-core/src/batch_signing.rs
@@ -124,7 +124,7 @@ mod tests {
 
     fn make_cid(data: &[u8]) -> Cid {
         let hash = Code::Sha2_256.digest(data);
-        Cid::new_v1(*DAG_CBOR_CODEC, hash)
+        Cid::new_v1(DAG_CBOR_CODEC, hash)
     }
 
     #[test]

--- a/crates/defra-core/src/block.rs
+++ b/crates/defra-core/src/block.rs
@@ -4,11 +4,9 @@
 //! All types match the Go implementation in `internal/core/block/` for wire compatibility.
 
 use cid::Cid;
-use multicodec::Codec;
 use multihash::Multihash;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::sync::LazyLock;
 
 use crate::{Error, Result};
 
@@ -23,11 +21,13 @@ pub use crate::block_signature::{
     DocumentStatus, Encryption, Signature, SignatureHeader, SignatureType,
 };
 
-/// DAG-CBOR codec identifier (multicodec 0x71)
-pub static DAG_CBOR_CODEC: LazyLock<u64> = LazyLock::new(|| Codec::Dag_Cbor.code() as u64);
+// Multicodec table: https://github.com/multiformats/multicodec/blob/master/table.csv
 
-/// SHA2-256 multihash code
-pub static SHA2_256_CODE: LazyLock<u64> = LazyLock::new(|| Codec::Sha2_256.code() as u64);
+/// DAG-CBOR codec identifier (multicodec 0x71)
+pub const DAG_CBOR_CODEC: u64 = 0x71;
+
+/// SHA2-256 multihash code (multicodec 0x12)
+pub const SHA2_256_CODE: u64 = 0x12;
 
 // ============================================================================
 // Block - The fundamental unit of content-addressed storage
@@ -348,9 +348,9 @@ pub fn generate_cid_from_bytes(bytes: &[u8]) -> Result<Cid> {
     let digest = hasher.finalize();
 
     // Create multihash
-    let mh = Multihash::<64>::wrap(*SHA2_256_CODE, &digest)
+    let mh = Multihash::<64>::wrap(SHA2_256_CODE, &digest)
         .map_err(|e| Error::BlockError(format!("Failed to create multihash: {}", e)))?;
 
     // Create CIDv1 with DAG-CBOR codec
-    Ok(Cid::new_v1(*DAG_CBOR_CODEC, mh))
+    Ok(Cid::new_v1(DAG_CBOR_CODEC, mh))
 }

--- a/crates/defra-core/src/lens_block.rs
+++ b/crates/defra-core/src/lens_block.rs
@@ -115,9 +115,9 @@ pub fn build_lens_ipld_blocks(
         let mut hasher = Sha256::new();
         hasher.update(bytes);
         let digest = hasher.finalize();
-        let mh = Multihash::<64>::wrap(*SHA2_256_CODE, &digest)
+        let mh = Multihash::<64>::wrap(SHA2_256_CODE, &digest)
             .map_err(|e| format!("multihash: {}", e))?;
-        Ok(Cid::new_v1(*DAG_CBOR_CODEC, mh))
+        Ok(Cid::new_v1(DAG_CBOR_CODEC, mh))
     };
 
     let mut blocks = Vec::new();

--- a/crates/defra-core/src/types.rs
+++ b/crates/defra-core/src/types.rs
@@ -175,7 +175,7 @@ impl CID {
 
         // Validate hash function (only support SHA-256 for now)
         let hash = c.hash();
-        if hash.code() != *SHA2_256_CODE {
+        if hash.code() != SHA2_256_CODE {
             return Err(Error::InvalidCID(format!(
                 "unsupported hash function: {}",
                 hash.code()
@@ -196,7 +196,7 @@ impl CID {
 
         // Validate hash function
         let hash = c.hash();
-        if hash.code() != *SHA2_256_CODE {
+        if hash.code() != SHA2_256_CODE {
             return Err(Error::InvalidCID(format!(
                 "unsupported hash function: {}",
                 hash.code()

--- a/crates/defra-core/tests/block_tests.rs
+++ b/crates/defra-core/tests/block_tests.rs
@@ -8,6 +8,7 @@ use cid::Cid;
 use defra_core::{
     Block, CollectionDeltaPayload, CompositeDeltaPayload, CounterDeltaPayload, CrdtDelta, DAGLink,
     Encryption, LwwDeltaPayload, Signature, SignatureHeader, SignatureType, DAG_CBOR_CODEC,
+    SHA2_256_CODE,
 };
 
 fn test_cid() -> Cid {
@@ -289,7 +290,18 @@ fn test_block_cid_uses_dag_cbor_codec() {
     let block = Block::new(test_lww_delta(), vec![], vec![]);
     let cid = block.generate_cid().unwrap();
 
-    assert_eq!(cid.codec(), *DAG_CBOR_CODEC);
+    assert_eq!(cid.codec(), DAG_CBOR_CODEC);
+}
+
+/// Both codec values are encoded in the prefix of every CID Go produces, so
+/// decoding a Go test vector re-derives them independently of the literals in
+/// `block.rs`. A wrong constant there would silently rewrite every document ID.
+#[test]
+fn test_codec_constants_match_go_cid_prefix() {
+    let go_cid = Cid::from_str(GO_LWW_SIMPLE_CID).unwrap();
+
+    assert_eq!(go_cid.codec(), DAG_CBOR_CODEC);
+    assert_eq!(go_cid.hash().code(), SHA2_256_CODE);
 }
 
 #[test]

--- a/crates/document/Cargo.toml
+++ b/crates/document/Cargo.toml
@@ -37,7 +37,6 @@ base64 = "0.22"
 thiserror = { workspace = true }
 
 [dev-dependencies]
-multicodec = { workspace = true }
 multihash = { workspace = true }
 sha2 = { workspace = true }
 

--- a/crates/document/tests/doc_id_tests.rs
+++ b/crates/document/tests/doc_id_tests.rs
@@ -3,16 +3,18 @@
 use cid::Cid;
 use defra_core::SHA2_256_CODE;
 use document::{DocID, DOC_ID_V0, SDN_NAMESPACE_V0};
-use multicodec::Codec;
 use multihash::Multihash;
 use sha2::{Digest, Sha256};
+
+/// Raw binary codec identifier (multicodec 0x55)
+const RAW_CODEC: u64 = 0x55;
 
 fn test_cid() -> Cid {
     let mut hasher = Sha256::new();
     hasher.update(b"test document content");
     let hash_bytes = hasher.finalize();
-    let mh: Multihash<64> = Multihash::wrap(*SHA2_256_CODE, &hash_bytes).unwrap();
-    Cid::new_v1(Codec::Bin.code() as u64, mh)
+    let mh: Multihash<64> = Multihash::wrap(SHA2_256_CODE, &hash_bytes).unwrap();
+    Cid::new_v1(RAW_CODEC, mh)
 }
 
 #[test]
@@ -49,15 +51,15 @@ fn test_different_cids_produce_different_uuids() {
     let mut hasher1 = Sha256::new();
     hasher1.update(b"document 1");
     let hash1 = hasher1.finalize();
-    let mh1: Multihash<64> = Multihash::wrap(*SHA2_256_CODE, &hash1).unwrap();
+    let mh1: Multihash<64> = Multihash::wrap(SHA2_256_CODE, &hash1).unwrap();
 
     let mut hasher2 = Sha256::new();
     hasher2.update(b"document 2");
     let hash2 = hasher2.finalize();
-    let mh2: Multihash<64> = Multihash::wrap(*SHA2_256_CODE, &hash2).unwrap();
+    let mh2: Multihash<64> = Multihash::wrap(SHA2_256_CODE, &hash2).unwrap();
 
-    let cid1 = Cid::new_v1(Codec::Bin.code() as u64, mh1);
-    let cid2 = Cid::new_v1(Codec::Bin.code() as u64, mh2);
+    let cid1 = Cid::new_v1(RAW_CODEC, mh1);
+    let cid2 = Cid::new_v1(RAW_CODEC, mh2);
 
     let doc_id1 = DocID::new_v0(cid1);
     let doc_id2 = DocID::new_v0(cid2);

--- a/crates/schema/src/cid.rs
+++ b/crates/schema/src/cid.rs
@@ -186,11 +186,11 @@ fn generate_cid_from_bytes(cbor_bytes: &[u8]) -> crate::Result<Cid> {
     let hash_bytes = hasher.finalize();
 
     // Create multihash (CID crate uses Multihash<64>)
-    let mh: Multihash<64> = Multihash::wrap(*SHA2_256_CODE, &hash_bytes)
+    let mh: Multihash<64> = Multihash::wrap(SHA2_256_CODE, &hash_bytes)
         .map_err(|e| crate::SchemaError::CidGeneration(e.to_string()))?;
 
     // Create CIDv1 with DAG-CBOR codec
-    Ok(Cid::new_v1(*DAG_CBOR_CODEC, mh))
+    Ok(Cid::new_v1(DAG_CBOR_CODEC, mh))
 }
 
 /// Generate a field definition block with CID and bytes for storage.


### PR DESCRIPTION
Closes #1330. Child of #1327 (Tier 1).

## Problem

`multicodec 0.1` had exactly one import in the workspace and existed only to produce two integer constants.
It was the sole path pulling the unmaintained `failure 0.1.8` (last released 2020, deprecated upstream) and its `backtrace` chain into the graph.

## What Changed

`DAG_CBOR_CODEC` and `SHA2_256_CODE` become inline `const` values, mirroring `crates/crypto/src/did/mod.rs:26-32`, which already hand-rolls the same multicodec table.

```rust
// before
pub static DAG_CBOR_CODEC: LazyLock<u64> = LazyLock::new(|| Codec::Dag_Cbor.code() as u64);
pub static SHA2_256_CODE:  LazyLock<u64> = LazyLock::new(|| Codec::Sha2_256.code() as u64);

// after
// Multicodec table: https://github.com/multiformats/multicodec/blob/master/table.csv
pub const DAG_CBOR_CODEC: u64 = 0x71;
pub const SHA2_256_CODE:  u64 = 0x12;
```

`LazyLock<u64>` forced `*CONST` at every use, so this removes that deref at 14 sites across 8 files in 5 crates (`defra-core`, `crypto`, `schema`, `db-merge`, `document`). Entirely mechanical and compiler-caught: a stale `*` on a `u64` does not compile.

It also finishes #1329's unfinished half. `crates/document` still declared `multicodec` as a dev-dependency for one `Codec::Bin.code()` call in a test, replaced with an inline `0x55`. The root workspace declaration could not be deleted while that stood.

**Removed outright** — zero entries remain in the lock: `multicodec`, `failure`, `failure_derive`, `backtrace`.

**Duplicate versions dropped**, one copy of each survives under another dependent: `gimli 0.32.3`, `synstructure 0.12.6`, `addr2line 0.25.1`, `unsigned-varint 0.2.3`.

These crates **remain** under different dependents, and this PR does not claim them:

| Crate | Actually pulled by |
|---|---|
| `gimli 0.33.1` | `cranelift-codegen` ← `wasmtime` ← `lens` |
| `object 0.39.1`, `addr2line 0.26.1` | `wasmtime` ← `lens` |
| `rustc-demangle 0.1.27` | `wasmtime-environ` ← `lens` |
| `object 0.37.3` | `ar_archive_writer` ← `psm` ← `stacker` ← `recursive` ← `sqlparser` ← `pg-compat` |
| `miniz_oxide 0.8.9` | `flate2` ← `josekit` ← `keyring` |
| `synstructure 0.13.2` | `multihash-derive-impl`, `asn1-rs-derive`, `yoke-derive`, `zerofrom-derive` |
| `unsigned-varint 0.7.2` | `multistream-select` ← `libp2p-core` ← `libp2p` |
| `unsigned-varint 0.8.0` | `cid`, `multihash`, `multiaddr`, and `crypto`/`p2p` directly |

**Merge-order note for #1383:** it adds a `deny.toml [bans].skip` for `unsigned-varint@0.2.3` that exists solely because of `multicodec 0.1`. Whichever lands second must drop that line, or `cargo deny` warns about a skip matching nothing. Same applies to any skip covering `gimli 0.32.3` or `synstructure 0.12.6`.

Not touched: `serde_ipld_dagcbor` and the dag-cbor encoding path (epic red line) — only the *source* of two integer literals changed. Nor `crates/crypto`'s constants (the reference pattern), nor `audit/past/**`.

## Validation

```
cargo test --workspace --exclude integration-test --exclude ffi-test --exclude conformance
    194 binaries, 4701 passed, 0 failed

cargo test -p integration-test --test basic
    34 passed, 0 failed  (includes all 10 go_* cross-runtime tests)

cargo clippy --all -- -D warnings    clean
cargo fmt --all --check              clean
```

The `--test basic` run used a Go `defradb` binary built from the pinned `GO_COMPAT_COMMIT` (`13c46ec9`), confirming the inline literals produce CIDs the Go implementation agrees with. That run predates the final rebase; CI covers it on the current head.

**Graph assertions:**

```
$ awk '/^name = /{n=$3} /^ "failure"/{print n}' Cargo.lock     # (no output)
$ grep -c '^name = "multicodec"$' Cargo.lock
0
```

**Guarding the constants.** These values feed docID/CID generation and Go parity — a wrong hex literal would silently rewrite every document ID. `test_codec_constants_match_go_cid_prefix` decodes both values out of the multicodec prefix of an existing Go-generated CID vector rather than restating the literals:

```rust
let go_cid = Cid::from_str(GO_LWW_SIMPLE_CID).unwrap();
assert_eq!(go_cid.codec(), DAG_CBOR_CODEC);
assert_eq!(go_cid.hash().code(), SHA2_256_CODE);
```

Asserting `DAG_CBOR_CODEC == 0x71` would be a tautology: the reference value would live inside the same change surface the test polices. A Go vector cannot be edited consistently without regenerating Go's output. Mutation-checked — setting `DAG_CBOR_CODEC = 0x72` fails it with `left: 113, right: 114`. All three values were read from `multicodec-0.1.0/src/lib.rs` (`:202`, `:72`, `:52`), not recalled. The 12 existing `test_go_wire_compat_*` golden-CID assertions pass untouched.

**This is not a size fix.** The issue estimated 200-500 KiB of native savings; the measured release binary delta is **0 bytes**.

| | bytes |
|---|---|
| `target/release/defra` before | 35,890,192 |
| `target/release/defra` after | 35,890,192 |
| **delta** | **0** |

Both are fat-LTO builds of the same worktree on arm64 macOS differing only by reverse-applying this commit; the baseline recompiled 29 crates, so it is a genuine relink rather than a cache hit. The chain was already dead-stripped: under `lto = true`, `codegen-units = 1`, `strip = true`, `panic = "abort"`, and with the only call being `Codec::code()` (an integer match), `failure`'s error types were never constructed. #1328's CI size tooling is unmerged (PR #1355), so these are local numbers.

Where it does pay off is build artifacts — **≈16.35 MiB** of compile units no longer produced per fresh release build, attributed via `cargo build --message-format=json` so duplicate-version crates split correctly between the copy that survives and the one that does not:

| Package | Artifacts no longer produced |
|---|---|
| `gimli 0.32.3` (dup) | 9.99 MiB |
| `failure_derive` | 2.19 MiB |
| `synstructure 0.12.6` (dup) | 1.37 MiB |
| `backtrace` | 1.30 MiB |
| `addr2line 0.25.1` (dup) | 0.85 MiB |
| `failure` | 0.36 MiB |
| `multicodec` | 0.19 MiB |
| `unsigned-varint 0.2.3` (dup) | 0.10 MiB |
| **Total** | **≈16.35 MiB** |

In proportion: a full `target/` is ~35 GiB, so this is ~0.8% of the release directory. A real saving on every fresh build and in CI cache size, not a fix for local disk pressure.
