### PR TITLE
fix(wasm): make the debug feature actually control the panic hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,10 @@ jobs:
       - name: Clippy (wasm32)
         run: cargo clippy -p defra-wasm --target wasm32-unknown-unknown --all-targets -- -D warnings
 
+      # The panic hook is default-on; this keeps the opt-out path compiling.
+      - name: Clippy (wasm32, no default features)
+        run: cargo clippy -p defra-wasm --target wasm32-unknown-unknown --no-default-features --all-targets -- -D warnings
+
       - name: Install wasm-pack
         run: cargo install wasm-pack --locked
 

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -44,7 +44,7 @@ futures.workspace = true
 async-trait.workspace = true
 
 # Debugging
-console_error_panic_hook = "0.1"
+console_error_panic_hook = { version = "0.1", optional = true }
 
 # Cryptography (for hashing schema IDs)
 sha2.workspace = true
@@ -73,9 +73,12 @@ cid.workspace = true
 wasm-bindgen-test = "0.3"
 
 [features]
-default = []
+# The shipped browser artifact depends on this default. Building with
+# --no-default-features drops the panic hook, turning browser panics into
+# silent aborts.
+default = ["debug"]
 # Enable console_error_panic_hook for better error messages in debug builds
-debug = []
+debug = ["dep:console_error_panic_hook"]
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = ["-Oz", "--enable-mutable-globals", "--enable-bulk-memory", "--enable-nontrapping-float-to-int"]

--- a/crates/wasm/src/client.rs
+++ b/crates/wasm/src/client.rs
@@ -71,10 +71,6 @@ impl DefraClient {
     /// ```
     #[wasm_bindgen(js_name = create)]
     pub async fn create(config: JsValue) -> std::result::Result<DefraClient, JsValue> {
-        // Set up panic hook for better error messages
-        #[cfg(feature = "debug")]
-        console_error_panic_hook::set_once();
-
         Self::new_impl(config).await.map_err(|e| e.into())
     }
 

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -83,6 +83,7 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen(start)]
 pub fn wasm_init() {
     // Set panic hook for better error messages
+    #[cfg(feature = "debug")]
     console_error_panic_hook::set_once();
 }
 

--- a/justfile
+++ b/justfile
@@ -505,6 +505,7 @@ lint-all-targets:
 [group('check')]
 lint-wasm:
     cargo clippy -p defra-wasm --target wasm32-unknown-unknown --all-targets -- -D warnings
+    cargo clippy -p defra-wasm --target wasm32-unknown-unknown --no-default-features --all-targets -- -D warnings
 
 # Docs must build without warnings; a broken intra-doc link fails CI.
 [doc("Build docs with warnings denied (broken links fail CI).")]


### PR DESCRIPTION
Closes #1335

## Problem

`crates/wasm` advertised a `debug` feature for `console_error_panic_hook`, but `wasm_init` installed the hook unconditionally at module import and the dependency was not optional — so the `#[cfg(feature = "debug")]` call in `DefraClient::create` could never have an observable effect, and `cargo tree -i console_error_panic_hook` returned identical output with and without `--no-default-features`.

## Changes

- `console_error_panic_hook` is now `optional = true`, reachable only via `debug = ["dep:console_error_panic_hook"]`.
- `default = ["debug"]` keeps the hook in every shipped build; dropping it is now an explicit `--no-default-features`.
- Gated the `lib.rs` call, deleted the redundant `client.rs` one — exactly one call site remains.
- Added a `--no-default-features` clippy run to `just lint-wasm` and the WASM CI job so the opt-out path cannot rot untested.
- Truth-in-manifest fix, not a size win: the incidental delta is 1,651 B (0.03%), and the hook stays default-on.
- Issue nit: `debug` was referenced at `client.rs:75` rather than an "empty no-op", and only `lib.rs:86` was unconditional.

## Validation

| Check | Command | Result |
|---|---|---|
| Feature is really wired (on) | `cargo tree -p defra-wasm --target wasm32-unknown-unknown -i console_error_panic_hook` | present, exit 0 |
| Feature is really wired (off) | same, `--no-default-features` | exit 101, `did not match any packages`. Before this change: still present |
| One call site remains | `rg -c 'console_error_panic_hook::set_once' crates/wasm/src/` | `lib.rs:1` |
| Lint, default features | `cargo clippy -p defra-wasm --target wasm32-unknown-unknown --all-targets -- -D warnings` | exit 0 |
| Lint, no default features | same, `--no-default-features` | exit 0 |
| Workspace lint | `cargo clippy --all -- -D warnings` | exit 0 |
| Dead-dependency gate (#1329) | `cargo machete` | exit 0, no metadata change needed |
| Shipped artifact keeps the hook | `just build-wasm`, then `strings pkg/wasm/defra_wasm_bg.wasm \| rg -i console_error_panic_hook` | `console_error_panic_hook-0.1.7` present |
| Format | `cargo fmt --all` | applied, no diff |

Part of #1327 (Tier 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
