### PR TITLE
chore(telemetry): gate tracing-subscriber behind the otlp feature

### DIFF
--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -14,6 +14,7 @@ default = []
 # runtime behavior is default-on (Go parity); use `--no-telemetry` to disable
 # at runtime.
 otlp = [
+    "dep:tracing-subscriber",
     "dep:thiserror",
     "dep:opentelemetry",
     "dep:opentelemetry_sdk",
@@ -36,7 +37,7 @@ otlp = [
 ]
 [dependencies]
 tracing.workspace = true
-tracing-subscriber = { version = "0.3", features = ["registry", "std"] }
+tracing-subscriber = { version = "0.3", features = ["registry", "std"], optional = true }
 thiserror = { workspace = true, optional = true }
 
 opentelemetry = { version = "0.32", features = ["metrics"], optional = true }

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -1,23 +1,26 @@
 //! OpenTelemetry exporter setup for DefraDB.
 //!
 //! Mirrors Go DefraDB's `internal/telemetry/otel.go`. The `otlp` feature
-//! compiles in OTLP/HTTP trace and metric export; without it the crate provides a
-//! no-op [`TelemetryHandle`] and the [`OtelDedupFilter`] (always available,
-//! no-op when no `opentelemetry*` events exist).
+//! compiles in OTLP/HTTP trace and metric export together with
+//! `OtelDedupFilter`; without it the crate is the no-op [`TelemetryHandle`] and
+//! the conflict/retry counters alone, and carries no `tracing-subscriber`
+//! dependency.
 //!
 //! Connection-refused log spam from the OTEL SDK is deduped via
-//! [`OtelDedupFilter`] — the Rust equivalent of Go's `sync.Once`-guarded
+//! `OtelDedupFilter` — the Rust equivalent of Go's `sync.Once`-guarded
 //! `otel.SetErrorHandler`. The global error handler API was removed from
 //! `opentelemetry::global` in v0.27; SDK diagnostics now flow through
 //! `tracing` at `target = "opentelemetry"*`, so a `tracing_subscriber`
 //! filter is the natural hook.
 
 mod config;
+#[cfg(feature = "otlp")]
 mod dedup;
 mod handle;
 mod metrics;
 
 pub use config::TelemetryConfig;
+#[cfg(feature = "otlp")]
 pub use dedup::OtelDedupFilter;
 pub use handle::TelemetryHandle;
 pub use metrics::{


### PR DESCRIPTION
closes #1331

## Problem

`crates/telemetry` declared `tracing-subscriber` as a plain, non-optional
dependency, so every consumer paid for it, including the browser client that
never installs a subscriber. Only `dedup` and `init` need it, and both are
otel-specific.

This is dependency hygiene, not a size win. #1331 estimated 100-300 KiB of wasm;
the artifact measured 4,263 bytes *larger*, because fat LTO plus `wasm-opt -Oz`
had already stripped the crate entirely.

## What changed

- `tracing-subscriber` is now `optional = true`, pulled in by the existing `otlp` feature.
- `mod dedup` and the `OtelDedupFilter` re-export are `#[cfg(feature = "otlp")]`.
- Module doc corrected: the filter is no longer "always available".
- No call sites touched, and no `crates/cli` manifest change.

## Validation

- Wasm graph: `tracing-subscriber`, `nu-ansi-term`, `sharded-slab`, `thread_local`,
  `lazy_static`, `tracing-log` all absent; 299 -> 293 crates.
- Measured wasm size, 4 builds with a determinism control (both arms reproduce
  byte-identically, so the noise floor is 0):

  | Metric | Before | After | Delta |
  |---|---:|---:|---:|
  | raw | 5,246,360 | 5,250,623 | +4,263 B |
  | gzip-9 | 2,017,300 | 2,019,173 | +1,873 B |
  | brotli-11 | 1,485,107 | 1,486,488 | +1,381 B |

- `cli`, `ffi`, `defra-node` resolve an identical feature set, so no shipped binary
  changes. `embedded` and `defra-http` shed the 6 crates; neither references
  `tracing_subscriber`.
- `cargo test -p telemetry` and `--features otlp` (6 dedup tests) green.
- `cargo test -p cli --features otel --test telemetry_dedup` green.
- The `telemetry::metrics` conflict counters still work, unmodified:
  `query_context::tests::auto_commit_execution_retries_typed_conflicts` (defra-http,
  115 lib tests green) and `tests::execute_retry_loop_retries_conflicts_until_success`
  (defra-node, 39 lib tests green) both pass.
- `cargo clippy -p defra-wasm --target wasm32-unknown-unknown --all-targets -- -D warnings`,
  `cargo clippy -p telemetry --all-targets` (both feature states), and
  `cargo fmt --all --check` clean.

Note: the 6 `dedup.rs` tests now require `--features otlp`. They stay covered by
`just test-features`, which `just ci` runs.
