### PR TITLE
build(deps): drop tokio `full` from the workspace entry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ await_holding_refcell_ref = "warn"
 defra-p2p-adapter = { path = "crates/p2p-adapter", default-features = false }
 
 # Async runtime
-tokio = { version = "1.35", features = ["full"] }
+tokio = { version = "1.35" }
 async-trait = "0.1"
 async-lock = "3"
 futures = "0.3"

--- a/crates/embedded/Cargo.toml
+++ b/crates/embedded/Cargo.toml
@@ -64,7 +64,7 @@ iroh = ["p2p/iroh-transport", "defra-p2p-adapter/iroh"]
 [dev-dependencies]
 base64 = { workspace = true }
 tempfile = "3.17"
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 zeroize = "1"
 zstd = "0.13"
 

--- a/crates/lens/Cargo.toml
+++ b/crates/lens/Cargo.toml
@@ -43,5 +43,8 @@ wasmtime = { version = "46.0.2", optional = true, default-features = false, feat
     "std",
 ] }
 
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt", "macros"] }
+
 [lints]
 workspace = true

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -91,7 +91,7 @@ libp2p-transport = [
 iroh-transport = ["dep:iroh", "dep:iroh-gossip", "dep:iroh-tickets", "dep:noq", "dep:rand", "dep:blake3"]
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["full", "test-util"] }
+tokio = { workspace = true, features = ["test-util"] }
 p2p = { path = ".", features = ["test-utils"] }
 
 [package.metadata.cargo-machete]

--- a/proofs/Cargo.toml
+++ b/proofs/Cargo.toml
@@ -25,7 +25,7 @@ anyhow = "1.0"
 
 [dev-dependencies]
 defra-harness = { git = "https://github.com/sourcenetwork/backbone.git", rev = "defra-harness/2026-08-07-port-conflict" }
-tokio = { version = "1.35", features = ["full"] }
+tokio = { workspace = true, features = ["rt", "macros", "sync", "time"] }
 serial_test = "3"
 
 [lints]

--- a/tools/integration-test/Cargo.toml
+++ b/tools/integration-test/Cargo.toml
@@ -109,7 +109,7 @@ path = "tests/cursor.rs"
 hub-harness = { git = "https://github.com/sourcenetwork/backbone.git", rev = "defra-harness/2026-08-07-port-conflict" }
 defra-harness = { git = "https://github.com/sourcenetwork/backbone.git", rev = "defra-harness/2026-08-07-port-conflict" }
 document = { path = "../../crates/document" }
-tokio = { version = "1.35", features = ["full"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time"] }
 reqwest = { version = "0.12", features = ["json", "stream"] }
 serde_json = "1.0"
 anyhow = "1.0"


### PR DESCRIPTION
Closes #1332

## Problem

Cargo's workspace dependency inheritance is additive: a member's `features`
are unioned with the workspace entry's, never subtracted. The workspace entry
requested `full`, so every member received the whole tokio runtime no matter
what it declared.

The effect is that manifests lie. Crates use `tokio::fs` or `tokio::time`
without naming the feature and still compile, because a sibling turned it on,
leaving `cargo check -p <crate>` one unrelated change away from breaking.

## What changed

- `Cargo.toml`: workspace `tokio` drops `features = ["full"]`, becoming version-only.
- `crates/lens`: new tokio dev-dependency (`rt`, `macros`) for its `#[tokio::test]`s.
- `crates/p2p` dev: `["full", "test-util"]` → `["test-util"]`.
- `crates/embedded` dev: `["full"]` → `["rt-multi-thread"]`.
- `tools/integration-test`: own `version = "1.35"` + `full` → workspace inherit, narrow features.
- `proofs`: same, `["rt", "macros", "sync", "time"]`.

tokio's `default = []`, so no `default-features = false` is needed.

## Validation

- **Isolation gate — 44/45 packages pass `cargo check -p <pkg> --all-targets`.** This is the check a `--workspace` build cannot substitute for, since unification still masks omitted features inside it.
- `cargo clippy --all -- -D warnings` clean; `cargo fmt --all -- --check` clean.
- `cargo test --workspace` (excl. `integration-test`, `conformance`) green.
- `cargo test -p integration-test`: **794 passed, 21 failed** — 20 are missing external binaries (`sourcehubd`, `hubd`) or a hardcoded absolute path in test source; the 21st (`p2p_backlog`) is deterministic and reproduces identically at the base commit.
- `cargo hack check --each-feature --all-targets -p lens` went **FAIL → PASS**; the new dev-dependency also frees the test target from `wasmtime-runtime`.
- The one remaining isolated-check failure, `defra-wasm`, is **pre-existing and proven**: re-running at the base commit with `full` restored fails identically. Root cause is `crates/db` declaring tokio `optional = true` while its source uses `tokio::` unconditionally — a dependency-optionality bug, not a feature bug, and untouched here.

### On size

Measured on the default-feature `defra`: **35,890,192 → 35,890,176 bytes, −16.**

The two shipped artifacts are unchanged, and provably so: `acp-light-client`
and `commonware-runtime` both request tokio `full` directly, so `full` cannot
leave the `ffi` or `release-full` graphs. Under `lto = true` + `strip = true`
the unused runtime code was already dead-stripped, so this is a build-correctness
change, not a size change.


