### PR TITLE
ci: share the binary cache over Thunderbolt, then let Build & Test use either studio

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -433,16 +433,36 @@ jobs:
           CACHE_DIR="$HOME/.sourcenetwork/bin/defradb.rs/$HASH"
           mkdir -p target/ci "$CACHE_DIR"
 
+          # The two studio hosts share a Thunderbolt link, so a cache miss can
+          # be served by the sibling for the price of copying ~100MB rather
+          # than a full rebuild. Best-effort by design: any failure here falls
+          # through to the build path below, so an unreachable or rebooting
+          # peer costs time, never a red run.
+          case "${RUNNER_NAME:-}" in
+            studio-1*) PEER=studio-2 ;;
+            studio-2*) PEER=studio-1 ;;
+            *)         PEER="" ;;
+          esac
+
           if [ -f "$CACHE_DIR/defra" ] && [ -f "$CACHE_DIR/defra-iroh" ]; then
-            echo "Cache hit — restoring from $CACHE_DIR"
+            echo "Cache hit (local) — restoring from $CACHE_DIR"
+            cp "$CACHE_DIR/defra" target/ci/defra
+            cp "$CACHE_DIR/defra-iroh" target/ci/defra-iroh
+          elif [ -n "$PEER" ] \
+            && scp -q -o BatchMode=yes -o ConnectTimeout=5 \
+                 "$PEER:$CACHE_DIR/defra" "$CACHE_DIR/defra.tmp" 2>/dev/null \
+            && scp -q -o BatchMode=yes -o ConnectTimeout=5 \
+                 "$PEER:$CACHE_DIR/defra-iroh" "$CACHE_DIR/defra-iroh.tmp" 2>/dev/null; then
+            # Staged via .tmp so an interrupted copy cannot leave a truncated
+            # binary that later runs would treat as a valid cache hit.
+            mv "$CACHE_DIR/defra.tmp" "$CACHE_DIR/defra"
+            mv "$CACHE_DIR/defra-iroh.tmp" "$CACHE_DIR/defra-iroh"
+            echo "Cache hit (peer $PEER over Thunderbolt)"
             cp "$CACHE_DIR/defra" target/ci/defra
             cp "$CACHE_DIR/defra-iroh" target/ci/defra-iroh
           else
-            # The build job populates this cache on studio-1 only; suites
-            # pinned to the other host self-build once per commit and
-            # populate their own host-local cache so the sibling suite and
-            # any re-run hit it.
-            echo "Cache miss — building binaries"
+            rm -f "$CACHE_DIR/defra.tmp" "$CACHE_DIR/defra-iroh.tmp"
+            echo "Cache miss (local and peer) — building binaries"
             cargo build -p cli
             cp target/debug/defra target/ci/defra
             cp target/debug/defra "$CACHE_DIR/defra"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,12 @@ jobs:
 
   build:
     name: Build & Test
-    runs-on: [self-hosted, macOS, ARM64, studio, studio-1]
+    # Either studio host. Port isolation comes from there being exactly one
+    # `studio`-labelled runner process per box, not from naming a host, so
+    # floating this job still permits only one node-spawning job per box.
+    # Cache warmth is preserved by the peer pull in "Restore or build
+    # binaries" rather than by pinning the producer.
+    runs-on: [self-hosted, macOS, ARM64, studio]
     env:
       # The full workspace test suite launches roughly 187 test executables.
       # Incremental artifacts caused a ~25s startup delay per executable on


### PR DESCRIPTION
Closes #1423.

## Problem

`Build & Test` gates every integration suite and was pinned to `studio-1`, giving the critical path a capacity of one. Measured today: **8 `Build & Test` jobs queued against studio-1 while studio-2 sat idle**, one waiting ~20h, and `main` went 2.5h without post-merge validation.

Separately, `ci.yml` already documented a standing waste: suites on studio-2 "self-build once per commit" because the binary cache is host-local. studio-2 currently holds **23 self-built commits** — full compiles duplicated purely because it cannot see studio-1's cache.

## Two separable commits

**1. Serve cache misses from the sibling over Thunderbolt.** On a miss, `scp` the two binaries from the peer before falling back to building. Valuable on its own even without the unpin, because it removes the duplicate compile.

**2. Unpin `Build & Test`** to `[self-hosted, macOS, ARM64, studio]`.

Split deliberately so the effect of each is measurable, and so the unpin can be reverted independently if it turns out to contend with the integration matrix.

## Why unpinning is safe

`a1cc7991` introduced the pin and cites two properties. Only one depends on it:

- **Port isolation does not.** There is exactly one `studio`-labelled runner process per box; the `-b` runners are `defra-light` and carry only Lint and Release Artifacts, neither of which spawns nodes. One node-spawning job per box follows from the runner topology, not from naming a host.
- **Cache warmth did**, and commit 1 replaces that mechanism.

The integration matrix keeps its per-suite pinning unchanged.

## Validation

Run against the live hosts before opening this:

| Check | Result |
|---|---|
| `ssh studio-1 → ssh studio-2` | works, BatchMode, key-based |
| Runner user / $HOME on both | `admin` / `/Users/admin` — identical, so the absolute cache path resolves on both |
| Real peer pull, studio-2 ← studio-1 | **352MB (161M + 191M) in 1s** |
| Pulled binary executes | yes — `defra version` reports the expected commit |
| YAML + embedded shell parse | both clean |

## Failure behavior

Best-effort by construction: `BatchMode=yes`, `ConnectTimeout=5`, and any failure falls through to the existing build path. An unreachable or rebooting peer costs the time it always cost, never a red run.

Copies stage through `.tmp` before being moved into place, so an interrupted transfer cannot leave a truncated binary that a later run treats as a valid cache hit — the one way this could have introduced a genuinely confusing failure.

## Loose end

`Cache pre-built binaries` also writes `~/.sourcenetwork/bin/defra-iroh` as a symlink "for backbone CI consumption". With `Build & Test` floating, that symlink is refreshed on whichever host ran it. If an external consumer expects it on studio-1 specifically, that assumption now needs to tolerate either host — flagging rather than changing it, since I cannot see the consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)