### PR TITLE
ci: accept merge_group events so a merge queue can be enabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,11 @@ on:
     # limiting it to main means a stacked PR (one targeting the branch below it)
     # runs no jobs at all and shows an empty, green-looking check list.
     branches: ['**']
+  # Merge-queue entries. Inert until a ruleset on main requires a merge queue —
+  # nothing emits merge_group events before then. Present first so that
+  # enabling the queue does not strand entries waiting on checks that never run.
+  merge_group:
+    branches: [main]
 
 # Only the tip of each ref keeps a run. Superseded PR pushes and main merge
 # trains cancel prior work so intermediate SHAs cannot stack the self-hosted
@@ -15,7 +20,10 @@ on:
 # this concurrency group once the merge ref is gone).
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Merge-queue runs are never cancelled: cancelling one ejects that PR from
+  # the queue, so the queue stalls instead of merging. Every other ref keeps
+  # tip-only behaviour.
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Step 1 of enabling a merge queue for stacked PRs. Refs #1423.

## What this does

Adds the `merge_group` trigger to `ci.yml` and exempts queue runs from `cancel-in-progress`.

**Both are inert today.** Nothing emits `merge_group` events until a ruleset on `main` requires a queue, so merging this changes no current behaviour.

## Why it goes first

If the queue is enabled before CI answers `merge_group`, every entry sits waiting on required checks that never fire. The queue looks broken when it is simply never being asked to run anything. Landing the trigger first makes enabling the ruleset a safe, reversible switch.

## Why queue runs must not be cancelled

Cancelling a merge-queue run **ejects that PR from the queue**. With `cancel-in-progress: true` applying to queue refs, the queue would stall rather than merge. Hence:

```yaml
cancel-in-progress: ${{ github.event_name != 'merge_group' }}
```

Every other ref keeps existing tip-only behaviour. This deliberately does not touch the separate question of whether `main` pushes should be cancelled — see #1426, now draft.

## Why no job changes were needed

`ci.yml` contains **no** `github.event.pull_request`, `github.head_ref`, or `github.base_ref` references, so every job is already context-agnostic and runs unchanged under a merge group. The single event guard — `artifacts: if: github.event_name == 'push'` — correctly keeps release artifacts to main pushes and is left alone.

## Remaining steps, not in this PR

1. **Decide which checks are required.** This is the real design question, not a formality. Requiring the full integration matrix is most correct and would make every merge wait on the slowest suite; `Lint` + `Build & Test` required with integration advisory is the honest starting point on a two-host fleet.
2. **Create the ruleset** on `main` with `Require merge queue` plus those checks.
3. **Tune queue batching** — grouping several PRs per run is what makes this a throughput *win* rather than added load.

## Why this is worth doing

Two of today's costs come from exactly what a queue removes:

- **#1382 conflicted** because #1381's branch moved beneath it — a stacked PR tested against a base that no longer existed.
- **Four PRs were stale against main** and were failing on fixture flakes already fixed there.

A queue tests each entry against the *result* of merging everything ahead of it, which is that whole class. And batching means N PRs can share one run instead of consuming N.

🤖 Generated with [Claude Code](https://claude.com/claude-code)