### PR TITLE
fix(db): preserve concurrent first counter increments

### DIFF
--- a/crates/db-blocks/src/write.rs
+++ b/crates/db-blocks/src/write.rs
@@ -339,7 +339,7 @@ pub async fn write_document_blocks(
                 .unwrap_or(false)
                 || doc.get_counter_delta(field_name).is_some();
 
-            let nonce: i64 = if is_counter && !heads.is_empty() {
+            let nonce: i64 = if is_counter && !is_create {
                 rand::random()
             } else {
                 0
@@ -645,3 +645,7 @@ mod encryption_derivation_tests;
 #[cfg(test)]
 #[path = "write_kms_tests.rs"]
 mod kms_write_tests;
+
+#[cfg(test)]
+#[path = "write_counter_tests.rs"]
+mod counter_write_tests;

--- a/crates/db-blocks/src/write_counter_tests.rs
+++ b/crates/db-blocks/src/write_counter_tests.rs
@@ -1,0 +1,60 @@
+use super::*;
+use datastore::{NamespaceView, SharedTxn};
+use document::CType;
+use std::collections::HashSet;
+use storage::backends::MemoryStore;
+use storage::corekv::Store;
+use storage::namespace::Namespace;
+
+async fn first_counter_update() -> Cid {
+    let store = MemoryStore::new();
+    let txn = store.new_txn(false).await.unwrap();
+    let shared = SharedTxn::new(txn);
+    let blockstore = NamespaceView::new(shared.clone(), Namespace::Blockstore);
+    let headstore = NamespaceView::new(shared, Namespace::Headstore);
+    let identity = DocStorageIdentity::new(1, 1);
+
+    let mut doc = Document::new();
+    doc.set("name", NormalValue::String("Alice".to_string()));
+    let created = write_document_blocks(
+        &blockstore,
+        &headstore,
+        &doc,
+        "schema-v1",
+        identity,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    doc.set_id(document::DocID::from_string(&created.doc_id).unwrap());
+    doc.set_with_crdt("count", CType::PnCounter, NormalValue::Int(1))
+        .unwrap();
+    doc.set_counter_delta("count".to_string(), NormalValue::Int(1));
+    let modified = HashSet::from(["count".to_string()]);
+
+    write_document_blocks(
+        &blockstore,
+        &headstore,
+        &doc,
+        "schema-v1",
+        identity,
+        Some(&modified),
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap()
+    .field_cids[0]
+}
+
+#[tokio::test]
+async fn first_counter_updates_on_existing_document_have_distinct_cids() {
+    let (left, right) = tokio::join!(first_counter_update(), first_counter_update());
+
+    assert_ne!(left, right);
+}


### PR DESCRIPTION
Closes #1401.

## Problem

Rust selected a random counter nonce only when the counter field already had DAG heads. The first counter update on an existing document therefore used nonce zero, allowing equal concurrent increments from separate replicas to produce identical CIDs and collapse into one block. Go instead selects the nonce based on whether the document already exists.

## What changed

- Generate random counter nonces for every document update, including the first write of a counter field.
- Preserve nonce zero for document creation so genesis blocks remain deterministic.
- Add a regression that applies the same first counter increment on two replicas and verifies their blocks have distinct CIDs.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p db-blocks` (24 passed)
- [x] `cargo clippy -p db-blocks --all-targets -- -D warnings`
- [x] `git diff --check origin/main...HEAD`