### PR TITLE
Add defra-node feature-graph harness to just and CI

### DIFF
--- a/.github/scripts/assert-defra-node-graph.sh
+++ b/.github/scripts/assert-defra-node-graph.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Feature-graph contracts for defra-node (#1398–#1400). Not a size check.
+#
+# Inspect `cargo tree -p <crate> -e normal --locked [features] -i <pkg>` stdout.
+# Present iff a line matches ^<pkg> v (e.g. ^sourcehub v). Absent iff exit 101
+# or exit 0 with empty stdout (cargo prints `warning: nothing to print.` on
+# stderr for unused optional deps). Never treat the -i exit code as the
+# predicate. Never pass --workspace: workspace feature unification would pull
+# CLI's libp2p into every tree.
+set -euo pipefail
+
+# Always `-p defra-node` or `-p cli`. Workspace trees are forbidden.
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+assert_present() {
+  local crate=$1
+  local pkg=$2
+  shift 2
+  local stdout rc
+  set +e
+  stdout="$(cargo tree -p "$crate" -e normal --locked "$@" -i "$pkg")"
+  rc=$?
+  set -e
+  if printf '%s\n' "$stdout" | grep -q "^${pkg} v"; then
+    echo "ok: ${crate}${*:+ $*} contains ^${pkg} v"
+    return 0
+  fi
+  echo "error: expected ^${pkg} v in ${crate}${*:+ $*} tree (cargo tree -i exit ${rc})" >&2
+  if [ -n "$stdout" ]; then
+    printf '%s\n' "$stdout" >&2
+  fi
+  exit 1
+}
+
+unique_crate_names() {
+  cargo tree -p defra-node -e normal --locked --prefix none "$@" \
+    | awk '{print $1}' | grep -v '^(*)' | sort -u | wc -l
+}
+
+assert_present defra-node sourcehub
+assert_present defra-node wasmtime
+assert_present defra-node libp2p
+assert_present cli libp2p
+
+# Unique crate names. Log only — not a gate and not binary size. Main may move.
+echo "defra-node default unique crate names: $(unique_crate_names)"
+echo "defra-node --no-default-features --features lark,redb unique crate names: $(unique_crate_names --no-default-features --features lark,redb)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,10 @@ on:
   push:
     branches: [main]
   pull_request:
-    # Every base branch, not just main. The filter matches the PR's *base*, so
-    # limiting it to main means a stacked PR (one targeting the branch below it)
-    # runs no jobs at all and shows an empty, green-looking check list.
+    # Every base branch, not just main. GitHub stacks evaluate each layer as
+    # if it targeted the stack base, but a `main`-only filter still misses
+    # layers whose literal base is the branch below. `ci-scope` then drops
+    # the expensive jobs on middle layers.
     branches: ['**']
 
 # Only the tip of each ref keeps a run. Superseded PR pushes and main merge
@@ -28,6 +29,36 @@ env:
   PROTOC: /opt/homebrew/bin/protoc
 
 jobs:
+  # GitHub stacks fire a full `pull_request` workflow per layer. Lint and
+  # Lean stay on every layer (cheap; the graph harness lives in Lint). The
+  # self-hosted node suites run only on standalone PRs, the stack tip
+  # (whole change), and the lowest unmerged layer (what would land on
+  # main next). Middle layers skip them.
+  ci-scope:
+    name: CI scope
+    runs-on: ubuntu-latest
+    outputs:
+      full: ${{ steps.decide.outputs.full }}
+    steps:
+      - id: decide
+        uses: actions/github-script@v7
+        with:
+          script: |
+            if (context.eventName !== 'pull_request') {
+              core.setOutput('full', 'true');
+              return;
+            }
+            const stack = context.payload.pull_request && context.payload.pull_request.stack;
+            if (!stack) {
+              core.setOutput('full', 'true');
+              return;
+            }
+            const isTip = stack.position === stack.size;
+            const isLowest = stack.base && stack.base.ref === context.payload.pull_request.base.ref;
+            const full = isTip || isLowest;
+            core.setOutput('full', full ? 'true' : 'false');
+            core.info(`stack #${stack.number} pos ${stack.position}/${stack.size} full=${full}`);
+
   # Studio jobs are pinned to a runner slot so each job's incremental target
   # state stays warm on one machine (a suite that bounces between hosts turns
   # a small rebuild into a full one) and so same-host exclusivity is
@@ -97,6 +128,8 @@ jobs:
 
   wasm-check:
     name: WASM Build Check
+    needs: ci-scope
+    if: needs.ci-scope.outputs.full == 'true'
     # spark-1: the wasm32 target doesn't care about host arch, and pinning
     # here takes this job off the vps (which now serves release.yml's x86_64
     # builds only) and out of p2p-linux's way. No GitHub-hosted rust-cache:
@@ -217,6 +250,8 @@ jobs:
 
   build:
     name: Build & Test
+    needs: ci-scope
+    if: needs.ci-scope.outputs.full == 'true'
     # Either studio host. Port isolation comes from there being exactly one
     # `studio`-labelled runner process per box, not from naming a host, so
     # floating this job still permits only one node-spawning job per box.
@@ -315,6 +350,8 @@ jobs:
 
   conformance:
     name: Conformance
+    needs: ci-scope
+    if: needs.ci-scope.outputs.full == 'true'
     # Spawns real `defra` nodes, so it must never co-run with another
     # node-spawning job on the SAME host (harness port allocator TOCTOU bind
     # race — "failed to start rust-0"). Host pinning provides that: this job
@@ -383,7 +420,8 @@ jobs:
 
   integration:
     name: Integration (${{ matrix.suite }})
-    needs: build
+    needs: [ci-scope, build]
+    if: needs.ci-scope.outputs.full == 'true'
     runs-on: [self-hosted, macOS, ARM64, studio, "${{ matrix.host }}"]
     strategy:
       fail-fast: false
@@ -692,6 +730,8 @@ jobs:
     # now serves release.yml's x86_64 builds only. Still Linux/epoll — the
     # scheduling-race coverage is arch-independent.
     name: P2P Integration (Linux)
+    needs: ci-scope
+    if: needs.ci-scope.outputs.full == 'true'
     runs-on: [self-hosted, Linux, ARM64, spark, spark-2]
     timeout-minutes: 45
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,11 @@ jobs:
           command -v cargo-machete >/dev/null 2>&1 || cargo install cargo-machete --locked
           cargo machete
 
+      # Feature-graph contracts for defra-node (#1398–#1400). Not a size check.
+      # Stdout-based; never `--workspace`. Lint does not install `just`.
+      - name: Feature-graph contracts (defra-node)
+        run: bash .github/scripts/assert-defra-node-graph.sh
+
       - name: Show sccache stats
         if: always()
         run: .github/scripts/show-sccache-stats.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,7 @@ Single-purpose binaries, each its own `[[test]]` with no submodules:
 cargo test                         # Run all unit tests
 cargo test -p crdt                 # Test specific crate
 cargo clippy --all -- -D warnings  # Lint
+just check-node-graph              # Feature-graph contracts for defra-node
 cargo fmt --all                    # Format
 cargo build --release              # Build release
 ```

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ just build             # Build all crates
 just build-release     # Release binary
 just test              # Unit tests
 just lint              # Lint (every clippy invocation CI runs)
+just check-node-graph  # Feature-graph contracts for defra-node
 just fmt               # Format
 just gate              # fmt + lint + docs + tests, before asking for a review
 just ci                # Reproduce the CI pipeline locally

--- a/justfile
+++ b/justfile
@@ -493,6 +493,17 @@ lint:
     cargo clippy -p defra-node --features otel --all-targets -- -D warnings
     cargo clippy -p defra-node --features p2p --all-targets -- -D warnings
     cargo clippy -p db --features p2p --all-targets -- -D warnings
+    just check-node-graph
+
+# Feature-graph contracts for defra-node (#1398–#1400). Not a size check.
+[group('check')]
+check-node-graph:
+    bash .github/scripts/assert-defra-node-graph.sh
+
+# Lean combo check (grows as later PRs make the combo legal).
+[group('check')]
+check-node-lean *features:
+    cargo check -p defra-node --no-default-features --features {{ features }}
 
 # Lint the test and bench targets too. CI does NOT do this for the workspace, so
 # this catches lints that would otherwise sit in the tree unnoticed.


### PR DESCRIPTION
## Stack

1. **This PR** — graph harness
2. #1432 — SourceHub optional (#1398)
3. #1433 — Wasmtime boundary (#1400)
4. #1434 — db-merge libp2p gate (part of #1399)
5. #1435 — Iroh-only proof (#1399)

## Summary

No production behavior change. Adds a stdout-based `cargo tree` harness (`just check-node-graph`) that asserts today's true facts: default `defra-node` still resolves `sourcehub`, `wasmtime`, and `libp2p`; default `cli` still resolves `libp2p`. Unique crate-name counts are logged, not gated, and are not binary size.

Present iff stdout matches `^<pkg> v`. Never treat `cargo tree -i` exit codes as the predicate. Never `--workspace`.

## Test plan

- [x] `bash .github/scripts/assert-defra-node-graph.sh`
- [x] `just check-node-graph`