### PR TITLE
Make defra-node SourceHub ACP a default-on optional feature

### DIFF
--- a/.github/scripts/assert-defra-node-graph.sh
+++ b/.github/scripts/assert-defra-node-graph.sh
@@ -32,6 +32,26 @@ assert_present() {
   exit 1
 }
 
+# Present iff stdout matches ^<pkg> v. Absent iff no such line: exit 101 or
+# exit 0 + empty stdout both count as absent. Never treat the -i exit code
+# as present.
+assert_absent() {
+  local crate=$1
+  local pkg=$2
+  shift 2
+  local stdout rc
+  set +e
+  stdout="$(cargo tree -p "$crate" -e normal --locked "$@" -i "$pkg")"
+  rc=$?
+  set -e
+  if printf '%s\n' "$stdout" | grep -q "^${pkg} v"; then
+    echo "error: unexpected ^${pkg} v in ${crate}${*:+ $*} tree (cargo tree -i exit ${rc})" >&2
+    printf '%s\n' "$stdout" >&2
+    exit 1
+  fi
+  echo "ok: ${crate}${*:+ $*} has no ^${pkg} v"
+}
+
 unique_crate_names() {
   cargo tree -p defra-node -e normal --locked --prefix none "$@" \
     | awk '{print $1}' | grep -v '^(*)' | sort -u | wc -l
@@ -41,6 +61,13 @@ assert_present defra-node sourcehub
 assert_present defra-node wasmtime
 assert_present defra-node libp2p
 assert_present cli libp2p
+
+# Lean local-ACP combo. `native` is not a defra-node feature yet.
+assert_absent defra-node sourcehub --no-default-features --features lark,redb
+assert_absent defra-node acp-light-client --no-default-features --features lark,redb
+assert_absent defra-node commonware-cryptography --no-default-features --features lark,redb
+assert_absent defra-node aws-lc-rs --no-default-features --features lark,redb
+assert_absent defra-node cosmrs --no-default-features --features lark,redb
 
 # Unique crate names. Log only — not a gate and not binary size. Main may move.
 echo "defra-node default unique crate names: $(unique_crate_names)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
       # defra-node reached a release).
       - run: cargo clippy -p defra-node --features p2p --all-targets -- -D warnings
       - run: cargo clippy -p db --features p2p --all-targets -- -D warnings
+      - run: cargo clippy -p defra-node --no-default-features --features lark,redb --all-targets -- -D warnings
 
       # Dead-dependency gate (#1329). Matches `just machete`; ignores live in
       # each crate's [package.metadata.cargo-machete] for known false positives.

--- a/crates/defra-node/Cargo.toml
+++ b/crates/defra-node/Cargo.toml
@@ -14,12 +14,14 @@ path = "src/bin/coding-session-bench.rs"
 test = false
 
 [features]
-default = ["lark", "redb"]
+default = ["lark", "redb", "sourcehub"]
 lark = ["storage/lark"]
 http = ["dep:defra-http", "dep:axum"]
 p2p = ["dep:p2p", "dep:blockstore", "dep:cid", "dep:defra-http", "dep:defra-p2p-adapter"]
 redb = ["storage/redb"]
 rocksdb = ["storage/rocksdb"]
+# SourceHub / hub.rs on-chain document ACP. Default-on; omit for local-only ACP.
+sourcehub = ["dep:sourcehub"]
 # Compile in OpenTelemetry exporter support. Mirrors the CLI's `otel` feature
 # and the underlying `telemetry/otlp` gate. Off by default — embedded users
 # who want OTel must opt in.
@@ -34,7 +36,7 @@ query = { path = "../query" }
 events = { path = "../events" }
 rand.workspace = true
 acp = { path = "../acp" }
-sourcehub = { path = "../sourcehub" }
+sourcehub = { path = "../sourcehub", optional = true }
 identity = { path = "../identity" }
 defra-core = { path = "../defra-core" }
 schema = { path = "../schema" }

--- a/crates/defra-node/src/config.rs
+++ b/crates/defra-node/src/config.rs
@@ -12,10 +12,17 @@ use db::{DEFAULT_TRANSACTION_CLEANUP_INTERVAL, DEFAULT_TRANSACTION_IDLE_TIMEOUT}
 pub enum DocumentAcpConfig {
     #[default]
     Local,
+    /// On-chain document ACP via SourceHub.
+    ///
+    /// Requires the `sourcehub` feature (on by default).
+    #[cfg(feature = "sourcehub")]
     SourceHub(SourceHubConfig),
 }
 
 /// SourceHub document ACP configuration.
+///
+/// Requires the `sourcehub` feature (on by default).
+#[cfg(feature = "sourcehub")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SourceHubConfig {
     pub grpc_address: String,

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -5,6 +5,14 @@
 //! wiring code.
 //!
 //! P2P uses IROH (QUIC-native) transport for peer-to-peer replication.
+//!
+//! ## Cargo features
+//!
+//! - `lark` / `redb` / `rocksdb` — storage backends. Default: `lark`, `redb`.
+//! - `sourcehub` — on-chain document ACP. Default-on. Omit for local-only ACP.
+//! - `p2p` — Iroh/QUIC replication.
+//! - `http` — GraphQL HTTP server.
+//! - `otel` — OpenTelemetry exporter.
 
 mod benchmark_data_gen;
 mod benchmark_queries;
@@ -36,11 +44,13 @@ pub use coding_search::{
     CodingHybridSearchHit, CodingHybridSearchRequest, CodingHybridSearchResponse,
     CodingSearchTarget,
 };
+pub use config::DocumentAcpConfig;
 #[cfg(feature = "http")]
 pub use config::HttpConfig;
 #[cfg(feature = "p2p")]
 pub use config::P2PConfig;
-pub use config::{DocumentAcpConfig, SourceHubConfig};
+#[cfg(feature = "sourcehub")]
+pub use config::SourceHubConfig;
 pub use dense_search::{DenseHybridSearchHit, DenseHybridSearchRequest, DenseHybridSearchResponse};
 pub use events::EventName;
 pub use lens::{LensConfig, LensModule, TransformId};
@@ -833,6 +843,9 @@ impl NodeBuilder {
     }
 
     /// Configure the node to use SourceHub-backed document ACP.
+    ///
+    /// Requires the `sourcehub` feature (on by default).
+    #[cfg(feature = "sourcehub")]
     pub fn with_sourcehub(mut self, config: SourceHubConfig) -> Self {
         self.document_acp = DocumentAcpConfig::SourceHub(config);
         self

--- a/crates/defra-node/src/node_acp.rs
+++ b/crates/defra-node/src/node_acp.rs
@@ -1,12 +1,15 @@
 use std::sync::Arc;
 
-use anyhow::{anyhow, Result};
+#[cfg(feature = "sourcehub")]
+use anyhow::anyhow;
+use anyhow::Result;
 
 pub(crate) async fn create_document_acp(
     acp_store: Arc<dyn acp::AcpStore>,
     config: &crate::DocumentAcpConfig,
 ) -> Result<(Arc<dyn acp::DocumentACP>, bool)> {
     match config {
+        #[cfg(feature = "sourcehub")]
         crate::DocumentAcpConfig::SourceHub(sourcehub_config) => {
             let tuning = sourcehub::AcpTuning::default();
             let provider = Arc::new(

--- a/justfile
+++ b/justfile
@@ -493,6 +493,7 @@ lint:
     cargo clippy -p defra-node --features otel --all-targets -- -D warnings
     cargo clippy -p defra-node --features p2p --all-targets -- -D warnings
     cargo clippy -p db --features p2p --all-targets -- -D warnings
+    cargo clippy -p defra-node --no-default-features --features lark,redb --all-targets -- -D warnings
     just check-node-graph
 
 # Feature-graph contracts for defra-node (#1398–#1400). Not a size check.


### PR DESCRIPTION
## Stack

1. #1431 — graph harness
2. **This PR** — SourceHub optional
3. #1433 — Wasmtime boundary (#1400)
4. #1434 — db-merge libp2p gate (part of #1399)
5. #1435 — Iroh-only proof (#1399)

## Summary

Make `sourcehub` a default-on optional feature on `defra-node`, using the same `#[cfg(feature = "sourcehub")]` style as `crates/embedded`. `DocumentAcpConfig` stays in `config.rs` with the existing `(Arc<dyn DocumentACP>, bool)` return type.

`--no-default-features --features lark,redb` must not resolve `sourcehub`, `acp-light-client`, `commonware-cryptography`, `aws-lc-rs`, or `cosmrs`. Default node behavior is unchanged.

Closes #1398.

## Test plan

- [x] `cargo test -p defra-node`
- [x] `cargo test -p defra-node --features p2p`
- [x] lean clippy `lark,redb`
- [x] `just check-node-graph`