### PR TITLE
Plumb defra-node wasmtime-runtime and fail Lens without a runtime

### DIFF
--- a/.github/scripts/assert-defra-node-graph.sh
+++ b/.github/scripts/assert-defra-node-graph.sh
@@ -62,13 +62,16 @@ assert_present defra-node wasmtime
 assert_present defra-node libp2p
 assert_present cli libp2p
 
-# Lean local-ACP combo. `native` is not a defra-node feature yet.
-assert_absent defra-node sourcehub --no-default-features --features lark,redb
-assert_absent defra-node acp-light-client --no-default-features --features lark,redb
-assert_absent defra-node commonware-cryptography --no-default-features --features lark,redb
-assert_absent defra-node aws-lc-rs --no-default-features --features lark,redb
-assert_absent defra-node cosmrs --no-default-features --features lark,redb
+# Lean local-ACP + native host. No SourceHub, no Wasmtime. Still has libp2p
+# (db-merge native deps); that boundary is a later PR.
+assert_absent defra-node sourcehub --no-default-features --features lark,redb,native
+assert_absent defra-node acp-light-client --no-default-features --features lark,redb,native
+assert_absent defra-node commonware-cryptography --no-default-features --features lark,redb,native
+assert_absent defra-node aws-lc-rs --no-default-features --features lark,redb,native
+assert_absent defra-node cosmrs --no-default-features --features lark,redb,native
+assert_absent defra-node wasmtime --no-default-features --features lark,redb,native
+assert_absent defra-node cranelift-codegen --no-default-features --features lark,redb,native
 
 # Unique crate names. Log only — not a gate and not binary size. Main may move.
 echo "defra-node default unique crate names: $(unique_crate_names)"
-echo "defra-node --no-default-features --features lark,redb unique crate names: $(unique_crate_names --no-default-features --features lark,redb)"
+echo "defra-node --no-default-features --features lark,redb,native unique crate names: $(unique_crate_names --no-default-features --features lark,redb,native)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
       # defra-node reached a release).
       - run: cargo clippy -p defra-node --features p2p --all-targets -- -D warnings
       - run: cargo clippy -p db --features p2p --all-targets -- -D warnings
-      - run: cargo clippy -p defra-node --no-default-features --features lark,redb --all-targets -- -D warnings
+      - run: cargo clippy -p defra-node --no-default-features --features lark,redb,native --all-targets -- -D warnings
 
       # Dead-dependency gate (#1329). Matches `just machete`; ignores live in
       # each crate's [package.metadata.cargo-machete] for known false positives.

--- a/crates/db/src/database.rs
+++ b/crates/db/src/database.rs
@@ -13,9 +13,9 @@ use datastore::BasicTxn;
 pub use db_search::EmbeddingClientConfig;
 use events::Bus;
 use identity::{Identity, RawIdentity};
-#[cfg(not(feature = "wasmtime-runtime"))]
-use lens::MemoryTransformStore;
 use lens::TransformStore;
+#[cfg(not(feature = "wasmtime-runtime"))]
+use lens::UnsupportedTransformStore;
 #[cfg(feature = "wasmtime-runtime")]
 use lens::WasmTransformStore;
 use std::collections::{HashMap, HashSet};
@@ -572,7 +572,7 @@ impl<S: Store> DB<S> {
     /// Create the appropriate lens transform store for the current platform.
     #[cfg(not(feature = "wasmtime-runtime"))]
     fn create_lens_store() -> Result<Arc<dyn TransformStore>> {
-        Ok(Arc::new(MemoryTransformStore::new()))
+        Ok(Arc::new(UnsupportedTransformStore))
     }
 
     /// Get the current transaction ID counter value.

--- a/crates/db/src/txn_lens_store.rs
+++ b/crates/db/src/txn_lens_store.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 #[cfg(not(feature = "wasmtime-runtime"))]
-use lens::MemoryTransformStore;
+use lens::UnsupportedTransformStore;
 #[cfg(feature = "wasmtime-runtime")]
 use lens::WasmTransformStore;
 use lens::{LensConfig, LensDocResultStream, LensDocStream, TransformId, TransformStore};
@@ -38,7 +38,7 @@ impl TxnLensStore {
 
     #[cfg(not(feature = "wasmtime-runtime"))]
     fn create_local_store() -> Result<Arc<dyn TransformStore>> {
-        Ok(Arc::new(MemoryTransformStore::new()))
+        Ok(Arc::new(UnsupportedTransformStore))
     }
 }
 

--- a/crates/defra-node/Cargo.toml
+++ b/crates/defra-node/Cargo.toml
@@ -14,22 +14,32 @@ path = "src/bin/coding-session-bench.rs"
 test = false
 
 [features]
-default = ["lark", "redb", "sourcehub"]
+default = ["lark", "redb", "native", "sourcehub", "wasmtime-runtime"]
 lark = ["storage/lark"]
 http = ["dep:defra-http", "dep:axum"]
 p2p = ["dep:p2p", "dep:blockstore", "dep:cid", "dep:defra-http", "dep:defra-p2p-adapter"]
 redb = ["storage/redb"]
 rocksdb = ["storage/rocksdb"]
+# Native host (tokio, event channel). Default-on.
+native = ["db/native", "db-merge/native"]
 # SourceHub / hub.rs on-chain document ACP. Default-on; omit for local-only ACP.
 sourcehub = ["dep:sourcehub"]
+# Lens WASM execution. Default-on; without it set_migration fails explicitly.
+# Weak-dep `?` forwards onto the optional adapter only when `p2p` enabled it.
+wasmtime-runtime = [
+    "db/wasmtime-runtime",
+    "db-merge/wasmtime-runtime",
+    "lens/wasmtime-runtime",
+    "defra-p2p-adapter?/wasmtime-runtime",
+]
 # Compile in OpenTelemetry exporter support. Mirrors the CLI's `otel` feature
 # and the underlying `telemetry/otlp` gate. Off by default — embedded users
 # who want OTel must opt in.
 otel = ["telemetry/otlp"]
 
 [dependencies]
-db = { path = "../db" }
-db-merge = { path = "../db-merge" }
+db = { path = "../db", default-features = false }
+db-merge = { path = "../db-merge", default-features = false }
 replication-filter = { path = "../replication-filter" }
 storage = { path = "../storage" }
 query = { path = "../query" }
@@ -40,7 +50,7 @@ sourcehub = { path = "../sourcehub", optional = true }
 identity = { path = "../identity" }
 defra-core = { path = "../defra-core" }
 schema = { path = "../schema" }
-lens = { path = "../lens" }
+lens = { path = "../lens", default-features = false }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "fs", "net", "sync", "time"] }
 anyhow.workspace = true
 tracing.workspace = true

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -9,7 +9,10 @@
 //! ## Cargo features
 //!
 //! - `lark` / `redb` / `rocksdb` — storage backends. Default: `lark`, `redb`.
+//! - `native` — native host (tokio, event channel). Default-on.
 //! - `sourcehub` — on-chain document ACP. Default-on. Omit for local-only ACP.
+//! - `wasmtime-runtime` — Lens WASM execution. Default-on. Without it,
+//!   [`EmbeddedNode::set_migration`] returns an explicit error.
 //! - `p2p` — Iroh/QUIC replication.
 //! - `http` — GraphQL HTTP server.
 //! - `otel` — OpenTelemetry exporter.
@@ -385,6 +388,9 @@ impl EmbeddedNode {
     /// Returns the content-addressed [`TransformId`] of the stored transform.
     /// Placeholder versions are created if the source or destination are not
     /// yet materialized, allowing migrations to be registered ahead of patches.
+    ///
+    /// Requires the `wasmtime-runtime` feature (on by default). Without it this
+    /// returns an explicit error instead of registering a no-op transform.
     pub async fn set_migration(&self, config: LensConfig) -> anyhow::Result<TransformId> {
         self.as_node_identity(self.schema_ops.set_migration(config))
             .await

--- a/crates/defra-node/tests/issue_859_schema_migration.rs
+++ b/crates/defra-node/tests/issue_859_schema_migration.rs
@@ -2,7 +2,9 @@
 //! introspection exposed through [`EmbeddedNode`].
 
 use anyhow::{Context, Result};
-use defra_node::{EmbeddedNode, LensConfig, LensModule};
+use defra_node::EmbeddedNode;
+#[cfg(feature = "wasmtime-runtime")]
+use defra_node::{LensConfig, LensModule};
 
 const USER_SDL: &str = r#"
 type User {
@@ -15,6 +17,7 @@ type User {
 // 4-byte version (`1`). Wasmtime accepts this as an empty module, which is
 // all we need to prove [`EmbeddedNode::set_migration`] wires through to the
 // underlying lens store.
+#[cfg(feature = "wasmtime-runtime")]
 const EMPTY_WASM: &[u8] = &[0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00];
 
 #[tokio::test(flavor = "current_thread")]
@@ -191,6 +194,7 @@ async fn set_active_collection_version_round_trips_to_original() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "wasmtime-runtime")]
 #[tokio::test(flavor = "current_thread")]
 async fn set_migration_registers_lens_between_versions() -> Result<()> {
     let node = EmbeddedNode::builder().build().await?;

--- a/crates/lens/src/error.rs
+++ b/crates/lens/src/error.rs
@@ -44,4 +44,8 @@ pub enum Error {
     /// File path not allowed (path traversal or HTTP restriction).
     #[error("file path not allowed: {0}")]
     PathNotAllowed(String),
+
+    /// Lens WASM runtime is not compiled in.
+    #[error("lens runtime unavailable: rebuild with the wasmtime-runtime feature")]
+    RuntimeUnavailable,
 }

--- a/crates/lens/src/lib.rs
+++ b/crates/lens/src/lib.rs
@@ -9,6 +9,7 @@ mod error;
 mod history;
 mod pipeline;
 mod store;
+mod unsupported_store;
 #[cfg(feature = "wasmtime-runtime")]
 mod wasm;
 #[cfg(feature = "wasmtime-runtime")]
@@ -22,5 +23,6 @@ pub use pipeline::{Lens, LensInput};
 pub use store::{
     LensDocResultStream, LensDocStream, MemoryTransformStore, TransformId, TransformStore,
 };
+pub use unsupported_store::UnsupportedTransformStore;
 #[cfg(feature = "wasmtime-runtime")]
 pub use wasm::{WasmSandboxConfig, WasmTransformStore};

--- a/crates/lens/src/unsupported_store.rs
+++ b/crates/lens/src/unsupported_store.rs
@@ -1,0 +1,60 @@
+//! Transform store used when the `wasmtime-runtime` feature is off.
+
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+
+use crate::{
+    Error, LensConfig, LensDocResultStream, LensDocStream, LensModule, Result, TransformId,
+    TransformStore,
+};
+
+/// Transform store used when the `wasmtime-runtime` feature is off.
+///
+/// Registration and execution fail immediately so `set_migration` cannot
+/// register a silent identity transform.
+pub struct UnsupportedTransformStore;
+
+#[async_trait]
+impl TransformStore for UnsupportedTransformStore {
+    async fn add(&self, _config: LensConfig) -> Result<TransformId> {
+        Err(Error::RuntimeUnavailable)
+    }
+
+    async fn add_with_id(&self, _id: TransformId, _config: LensConfig) -> Result<()> {
+        Err(Error::RuntimeUnavailable)
+    }
+
+    async fn list(&self) -> Result<HashMap<String, LensModule>> {
+        Ok(HashMap::new())
+    }
+
+    fn transform(&self, _id: &TransformId, _docs: LensDocStream) -> Result<LensDocResultStream> {
+        Err(Error::RuntimeUnavailable)
+    }
+
+    fn inverse(&self, _id: &TransformId, _docs: LensDocStream) -> Result<LensDocResultStream> {
+        Err(Error::RuntimeUnavailable)
+    }
+
+    fn has_transform(&self, _id: &TransformId) -> bool {
+        false
+    }
+
+    async fn remove(&self, _id: &TransformId) -> Result<()> {
+        Err(Error::RuntimeUnavailable)
+    }
+}
+
+#[cfg(all(test, not(feature = "wasmtime-runtime")))]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn add_returns_runtime_unavailable() {
+        let store = UnsupportedTransformStore;
+        let config = LensConfig::new("v1", "v2", LensModule::from_path("/path/to/transform.wasm"));
+        let result = store.add(config).await;
+        assert!(matches!(result, Err(Error::RuntimeUnavailable)));
+    }
+}

--- a/justfile
+++ b/justfile
@@ -493,7 +493,7 @@ lint:
     cargo clippy -p defra-node --features otel --all-targets -- -D warnings
     cargo clippy -p defra-node --features p2p --all-targets -- -D warnings
     cargo clippy -p db --features p2p --all-targets -- -D warnings
-    cargo clippy -p defra-node --no-default-features --features lark,redb --all-targets -- -D warnings
+    cargo clippy -p defra-node --no-default-features --features lark,redb,native --all-targets -- -D warnings
     just check-node-graph
 
 # Feature-graph contracts for defra-node (#1398–#1400). Not a size check.


### PR DESCRIPTION
## Stack

1. #1431 — graph harness
2. #1432 — SourceHub optional (#1398)
3. **This PR** — Wasmtime boundary
4. #1434 — db-merge libp2p gate (part of #1399)
5. #1435 — Iroh-only proof (#1399)

## Summary

`defra-node` takes `db` / `db-merge` / `lens` with `default-features = false` and re-enables `native` + `wasmtime-runtime` via named default features. Production no-runtime Lens uses `UnsupportedTransformStore` so `set_migration` fails with `RuntimeUnavailable` instead of identity-mapping documents.

Does **not** claim a libp2p-free graph (`db-merge` still unconditionally enables libp2p). Prerequisite for #1399.

Closes #1400.

## Test plan

- [x] `cargo test -p defra-node`
- [x] `cargo test -p lens` and `cargo test -p lens --no-default-features`
- [x] `cargo test -p db --features native,wasmtime-runtime`
- [x] lean clippy `lark,redb,native`
- [x] `just check-node-graph`