### PR TITLE
Prove defra-node Iroh-only p2p is libp2p-free

### DIFF
--- a/.github/scripts/assert-defra-node-graph.sh
+++ b/.github/scripts/assert-defra-node-graph.sh
@@ -98,28 +98,35 @@ LEAN_IROH=(--no-default-features --features lark,redb,native,p2p)
 assert_no_libp2p defra-node "${LEAN_IROH[@]}"
 assert_present defra-node iroh "${LEAN_IROH[@]}"
 
-# p2p crate feature line (the ^p2p v package, not p2p-*) must omit libp2p-transport.
-assert_p2p_crate_no_libp2p_transport() {
-  local stdout rc
+# p2p crate feature line (the ^p2p v package, not p2p-*). Default cargo tree
+# omits features; --format '{p} {f}' prints them so this can fail.
+assert_p2p_crate_iroh_only() {
+  local stdout rc line
   set +e
-  stdout="$(cargo tree -p defra-node -e normal --locked "${LEAN_IROH[@]}" -i p2p)"
+  stdout="$(cargo tree -p defra-node -e normal --locked "${LEAN_IROH[@]}" -i p2p --format '{p} {f}')"
   rc=$?
   set -e
-  if ! printf '%s\n' "$stdout" | grep -q '^p2p v'; then
+  line="$(printf '%s\n' "$stdout" | grep '^p2p v' || true)"
+  if [ -z "$line" ]; then
     echo "error: expected ^p2p v in lean Iroh tree (cargo tree -i exit ${rc})" >&2
     if [ -n "$stdout" ]; then
       printf '%s\n' "$stdout" >&2
     fi
     exit 1
   fi
-  if printf '%s\n' "$stdout" | grep '^p2p v' | grep -q 'libp2p-transport'; then
-    echo "error: p2p crate line enables libp2p-transport" >&2
-    printf '%s\n' "$stdout" | grep '^p2p v' >&2
+  if ! printf '%s\n' "$line" | grep -q 'iroh-transport'; then
+    echo "error: p2p crate line missing iroh-transport" >&2
+    printf '%s\n' "$line" >&2
     exit 1
   fi
-  echo "ok: lean Iroh p2p crate line has no libp2p-transport"
+  if printf '%s\n' "$line" | grep -q 'libp2p-transport'; then
+    echo "error: p2p crate line enables libp2p-transport" >&2
+    printf '%s\n' "$line" >&2
+    exit 1
+  fi
+  echo "ok: lean Iroh p2p crate line has iroh-transport and no libp2p-transport"
 }
-assert_p2p_crate_no_libp2p_transport
+assert_p2p_crate_iroh_only
 
 # Unique crate names. Log only — not a gate and not binary size. Main may move.
 echo "defra-node default unique crate names: $(unique_crate_names)"

--- a/.github/scripts/assert-defra-node-graph.sh
+++ b/.github/scripts/assert-defra-node-graph.sh
@@ -91,6 +91,37 @@ assert_absent defra-node cosmrs --no-default-features --features lark,redb,nativ
 assert_absent defra-node wasmtime --no-default-features --features lark,redb,native
 assert_absent defra-node cranelift-codegen --no-default-features --features lark,redb,native
 
+# Lean Iroh P2P: Iroh present, no libp2p / libp2p-*, p2p crate not enabling
+# libp2p-transport. `p2p` implies native, so listing native is redundant but
+# matches the advertised combo.
+LEAN_IROH=(--no-default-features --features lark,redb,native,p2p)
+assert_no_libp2p defra-node "${LEAN_IROH[@]}"
+assert_present defra-node iroh "${LEAN_IROH[@]}"
+
+# p2p crate feature line (the ^p2p v package, not p2p-*) must omit libp2p-transport.
+assert_p2p_crate_no_libp2p_transport() {
+  local stdout rc
+  set +e
+  stdout="$(cargo tree -p defra-node -e normal --locked "${LEAN_IROH[@]}" -i p2p)"
+  rc=$?
+  set -e
+  if ! printf '%s\n' "$stdout" | grep -q '^p2p v'; then
+    echo "error: expected ^p2p v in lean Iroh tree (cargo tree -i exit ${rc})" >&2
+    if [ -n "$stdout" ]; then
+      printf '%s\n' "$stdout" >&2
+    fi
+    exit 1
+  fi
+  if printf '%s\n' "$stdout" | grep '^p2p v' | grep -q 'libp2p-transport'; then
+    echo "error: p2p crate line enables libp2p-transport" >&2
+    printf '%s\n' "$stdout" | grep '^p2p v' >&2
+    exit 1
+  fi
+  echo "ok: lean Iroh p2p crate line has no libp2p-transport"
+}
+assert_p2p_crate_no_libp2p_transport
+
 # Unique crate names. Log only — not a gate and not binary size. Main may move.
 echo "defra-node default unique crate names: $(unique_crate_names)"
 echo "defra-node --no-default-features --features lark,redb,native unique crate names: $(unique_crate_names --no-default-features --features lark,redb,native)"
+echo "defra-node --no-default-features --features lark,redb,native,p2p unique crate names: $(unique_crate_names --no-default-features --features lark,redb,native,p2p)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,8 @@ jobs:
       - run: cargo clippy -p defra-node --features p2p --all-targets -- -D warnings
       - run: cargo clippy -p db --features p2p --all-targets -- -D warnings
       - run: cargo clippy -p defra-node --no-default-features --features lark,redb,native --all-targets -- -D warnings
+      - run: cargo clippy -p defra-node --no-default-features --features lark,redb,native,p2p --all-targets -- -D warnings
+      - run: cargo check -p p2p --no-default-features --features iroh-transport
       - run: cargo check -p db-merge --no-default-features --features native
 
       # Dead-dependency gate (#1329). Matches `just machete`; ignores live in

--- a/crates/defra-node/Cargo.toml
+++ b/crates/defra-node/Cargo.toml
@@ -17,7 +17,18 @@ test = false
 default = ["lark", "redb", "native", "sourcehub", "wasmtime-runtime"]
 lark = ["storage/lark"]
 http = ["dep:defra-http", "dep:axum"]
-p2p = ["dep:p2p", "dep:blockstore", "dep:cid", "dep:defra-http", "dep:defra-p2p-adapter"]
+# Iroh/QUIC only. Implies native. Does not enable libp2p.
+p2p = [
+    "native",
+    "dep:p2p",
+    "dep:blockstore",
+    "dep:cid",
+    "dep:defra-http",
+    "dep:defra-p2p-adapter",
+    "p2p/iroh-transport",
+    "defra-p2p-adapter/iroh",
+    "defra-p2p-adapter/native",
+]
 redb = ["storage/redb"]
 rocksdb = ["storage/rocksdb"]
 # Native host (tokio, event channel). Default-on.

--- a/crates/defra-node/src/config.rs
+++ b/crates/defra-node/src/config.rs
@@ -89,7 +89,10 @@ impl HttpConfig {
     }
 }
 
-/// Configuration for the optional P2P networking layer (IROH/QUIC).
+/// Configuration for the optional P2P networking layer.
+///
+/// Iroh/QUIC only. Requires the `p2p` feature, which implies `native`.
+/// libp2p lives on CLI, FFI, and `embedded` — not this crate.
 #[cfg(feature = "p2p")]
 pub struct P2PConfig {
     /// UDP port for QUIC listener.

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -4,7 +4,7 @@
 //! downstream binaries can embed a DefraDB instance without duplicating
 //! wiring code.
 //!
-//! P2P uses IROH (QUIC-native) transport for peer-to-peer replication.
+//! P2P uses Iroh/QUIC only. libp2p lives on CLI, FFI, and `embedded`.
 //!
 //! ## Cargo features
 //!
@@ -13,7 +13,7 @@
 //! - `sourcehub` — on-chain document ACP. Default-on. Omit for local-only ACP.
 //! - `wasmtime-runtime` — Lens WASM execution. Default-on. Without it,
 //!   [`EmbeddedNode::set_migration`] returns an explicit error.
-//! - `p2p` — Iroh/QUIC replication.
+//! - `p2p` — Iroh/QUIC replication. Implies `native`. Does **not** compile libp2p.
 //! - `http` — GraphQL HTTP server.
 //! - `otel` — OpenTelemetry exporter.
 
@@ -900,7 +900,10 @@ impl NodeBuilder {
         self
     }
 
-    /// Enable P2P networking for replication.
+    /// Enable Iroh/QUIC P2P replication.
+    ///
+    /// Requires the `p2p` feature, which implies `native`. Does not compile
+    /// libp2p; that stack lives on CLI, FFI, and `embedded`.
     #[cfg(feature = "p2p")]
     pub fn with_p2p(mut self, config: P2PConfig) -> Self {
         self.p2p_config = Some(config);

--- a/justfile
+++ b/justfile
@@ -494,6 +494,8 @@ lint:
     cargo clippy -p defra-node --features p2p --all-targets -- -D warnings
     cargo clippy -p db --features p2p --all-targets -- -D warnings
     cargo clippy -p defra-node --no-default-features --features lark,redb,native --all-targets -- -D warnings
+    cargo clippy -p defra-node --no-default-features --features lark,redb,native,p2p --all-targets -- -D warnings
+    cargo check -p p2p --no-default-features --features iroh-transport
     cargo check -p db-merge --no-default-features --features native
     just check-node-graph
 
@@ -502,7 +504,7 @@ lint:
 check-node-graph:
     bash .github/scripts/assert-defra-node-graph.sh
 
-# Lean combo check (grows as later PRs make the combo legal).
+# Lean combo check. Examples: lark,redb,native  |  lark,redb,native,p2p
 [group('check')]
 check-node-lean *features:
     cargo check -p defra-node --no-default-features --features {{ features }}


### PR DESCRIPTION
## Stack

1. #1431 — graph harness
2. #1432 — SourceHub optional (#1398)
3. #1433 — Wasmtime boundary (#1400)
4. #1434 — db-merge libp2p gate
5. **This PR** — Iroh-only proof

## Summary

Final #1399 proof. `defra-node`'s `p2p` feature implies `native` and stays Iroh-only (`p2p/iroh-transport`, `defra-p2p-adapter/{iroh,native}`). It does not enable `db/p2p`, `db-merge/libp2p-transport`, or `defra-p2p-adapter/libp2p`.

Gents lean combo:

```toml
defra-node = { default-features = false, features = ["lark", "redb", "p2p"] }
```

Does **not** implement #1345 (mobile-lean FFI).

Closes #1399.

## Test plan

- [x] `just check-node-graph` (lean Iroh: no `^libp2p`, has `^iroh v`, p2p crate features are iroh-only)
- [x] clippy `lark,redb,native,p2p`
- [x] `cargo check -p p2p --no-default-features --features iroh-transport`
- [x] `cargo test -p defra-node --features p2p`
- [x] default `cli` still has `^libp2p v`