### PR TITLE
fix(db): apply collection patch migrations atomically

### DIFF
--- a/crates/cli/src/collection_mgmt_adapter.rs
+++ b/crates/cli/src/collection_mgmt_adapter.rs
@@ -38,10 +38,11 @@ impl<S: Store + 'static> CollectionManagementOperations for CollectionManagement
         &self,
         collection_name: &str,
         patch: &str,
+        migration: Option<lens::LensConfig>,
     ) -> Result<serde_json::Value, String> {
         let version = self
             .database
-            .patch_collection(collection_name, patch, None)
+            .patch_collection_with_migration(collection_name, patch, migration, None)
             .await
             .map_err(|e| format!("{}", e))?;
 

--- a/crates/cli/src/commands/client/collection/document.rs
+++ b/crates/cli/src/commands/client/collection/document.rs
@@ -9,12 +9,19 @@ use crate::error::{Error, Result};
 impl CollectionPatchArgs {
     pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
         let patch = get_data_from_args(&self.patch, &self.patch_file)?;
+        let migration = if self.migration.is_some() || self.lens_file.is_some() {
+            Some(get_data_from_args(&self.migration, &self.lens_file)?)
+        } else {
+            None
+        };
 
         let client = HttpClient::new(&ctx.url)?
             .with_auth_token(ctx.auth_token.clone())
             .with_verbose(ctx.verbose);
 
-        client.collection_patch(&patch).await?;
+        client
+            .collection_patch(&patch, migration.as_deref())
+            .await?;
         Ok(())
     }
 }

--- a/crates/cli/src/commands/client/http_client/collection.rs
+++ b/crates/cli/src/commands/client/http_client/collection.rs
@@ -5,6 +5,14 @@ use urlencoding::encode;
 use super::HttpClient;
 use crate::error::Result;
 
+fn collection_patch_body(patch: &str, migration: Option<&str>) -> Result<String> {
+    let mut body = serde_json::json!({ "Patch": patch });
+    if let Some(migration) = migration {
+        body["Migration"] = serde_json::from_str(migration)?;
+    }
+    Ok(serde_json::to_string(&body)?)
+}
+
 impl HttpClient {
     pub async fn collection_update_doc(&self, name: &str, doc_id: &str, patch: &str) -> Result<()> {
         let url = format!(
@@ -26,10 +34,9 @@ impl HttpClient {
         self.request_void("DELETE", &url, None).await
     }
 
-    pub async fn collection_patch(&self, patch: &str) -> Result<()> {
+    pub async fn collection_patch(&self, patch: &str, migration: Option<&str>) -> Result<()> {
         let url = format!("{}/api/v0/collections", self.base_url);
-        let body = serde_json::json!({ "Patch": patch });
-        let body_str = serde_json::to_string(&body)?;
+        let body_str = collection_patch_body(patch, migration)?;
         self.request_void("PATCH", &url, Some(&body_str)).await
     }
 
@@ -67,5 +74,23 @@ impl HttpClient {
             active_only
         );
         self.request_void("DELETE", &url, None).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collection_patch_body_embeds_migration_json() {
+        let body = collection_patch_body("[]", Some(r#"{"Lenses":[]}"#)).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&body).unwrap();
+
+        assert!(value["Migration"].is_object());
+        assert_eq!(value["Migration"]["Lenses"], serde_json::json!([]));
+
+        let patch_only: serde_json::Value =
+            serde_json::from_str(&collection_patch_body("[]", None).unwrap()).unwrap();
+        assert!(patch_only.get("Migration").is_none());
     }
 }

--- a/crates/db/src/patch/mod.rs
+++ b/crates/db/src/patch/mod.rs
@@ -51,11 +51,23 @@ impl<S: Store> crate::database::DB<S> {
     /// - `CollectionNotFound` if the collection doesn't exist
     /// - `InvalidPatch` if the patch is invalid or cannot be applied
     /// - `Schema` if the resulting schema is invalid
-    #[instrument(skip(self, patch), fields(collection = %collection_name), name = "db.patch_collection")]
     pub async fn patch_collection(
         &self,
         collection_name: &str,
         patch: &str,
+        identity: Option<&identity::Did>,
+    ) -> Result<CollectionVersion> {
+        self.patch_collection_with_migration(collection_name, patch, None, identity)
+            .await
+    }
+
+    /// Apply a JSON Patch and its migration as one operation.
+    #[instrument(skip(self, patch, migration), fields(collection = %collection_name), name = "db.patch_collection")]
+    pub async fn patch_collection_with_migration(
+        &self,
+        collection_name: &str,
+        patch: &str,
+        migration: Option<lens::LensConfig>,
         identity: Option<&identity::Did>,
     ) -> Result<CollectionVersion> {
         self.check_node_access(identity, acp::nac::NodePermission::CollectionPatch)
@@ -293,6 +305,7 @@ impl<S: Store> crate::database::DB<S> {
             &collection_id,
             collection_name,
             is_active_explicitly_set,
+            migration,
         )
         .await
     }

--- a/crates/db/src/patch/store.rs
+++ b/crates/db/src/patch/store.rs
@@ -1,4 +1,6 @@
 use super::*;
+use lens::TransformStore;
+use storage::keys::systemstore::LensConfigKey;
 
 impl<S: Store> crate::database::DB<S> {
     /// Create and store a new schema version from a validated patched schema.
@@ -16,6 +18,7 @@ impl<S: Store> crate::database::DB<S> {
         collection_id: &str,
         collection_name: &str,
         is_active_explicitly_set: bool,
+        migration: Option<lens::LensConfig>,
     ) -> Result<CollectionVersion> {
         // Go compatibility: default new fields with CType::None to CType::LwwRegister.
         // Go's patchCollection does this in collection_define.go for new fields that
@@ -180,16 +183,6 @@ impl<S: Store> crate::database::DB<S> {
         // Update new schema with version info
         new_schema.version_id = new_version_id.clone();
 
-        // Update schema_heads with new version CID and priority
-        if let Ok(new_cid) = cid::Cid::try_from(new_version_id.as_str()) {
-            if let Ok(mut heads) = self.schema_heads.write() {
-                heads.insert(
-                    actual_name.to_string(),
-                    (vec![new_cid], collection_priority),
-                );
-            }
-        }
-
         // Check if a placeholder version exists with this ID (from pre-registered migration).
         // When set_migration is called before patch_collection, it creates a placeholder
         // with previous_version.transform set. We need to copy that transform to preserve
@@ -273,6 +266,21 @@ impl<S: Store> crate::database::DB<S> {
             new_schema.is_active = true;
         }
 
+        let committed_migration = if let Some(mut config) = migration {
+            config.source_schema_version_id = old_version_id.to_string();
+            config.destination_schema_version_id = new_version_id.clone();
+
+            let txn_lens_store = crate::txn_lens_store::TxnLensStore::new(self.lens_store.clone())?;
+            let transform_id = txn_lens_store.add(config.clone()).await?;
+            new_schema.previous_version = Some(CollectionSource {
+                source_collection_id: old_version_id.to_string(),
+                transform: Some(transform_id.to_string()),
+            });
+            Some((transform_id, config))
+        } else {
+            None
+        };
+
         // Create old schema copy for storage. If new schema is active, mark old as inactive.
         // If new schema is inactive (explicit IsActive=false), old version stays active.
         let mut old_schema_inactive = old_schema.clone();
@@ -352,6 +360,16 @@ impl<S: Store> crate::database::DB<S> {
                 .set(&old_version_index_key.bytes(), b"1")
                 .await
                 .map_err(Error::Storage)?;
+
+            if let Some((transform_id, config)) = &committed_migration {
+                let lens_key = LensConfigKey::new(transform_id.to_string());
+                let lens_data = serde_json::to_vec(config)
+                    .map_err(|e| Error::lens_config_json("failed to serialize lens config", e))?;
+                systemstore
+                    .set(&lens_key.bytes(), &lens_data)
+                    .await
+                    .map_err(Error::Storage)?;
+            }
         } // systemstore reference dropped here
 
         // Store field and collection definition blocks in blockstore for Bitswap sync.
@@ -445,6 +463,31 @@ impl<S: Store> crate::database::DB<S> {
         }
 
         txn.commit().await?;
+
+        if let Some((transform_id, config)) = committed_migration {
+            self.bump_migration_generation();
+            if let Err(error) = self
+                .lens_store()
+                .add_with_id(transform_id.clone(), config)
+                .await
+            {
+                tracing::warn!(
+                    transform_id = %transform_id,
+                    error = %error,
+                    "failed to promote collection patch migration lens"
+                );
+            }
+        }
+
+        // Publish the new head only after all durable patch writes succeed.
+        if let Ok(new_cid) = cid::Cid::try_from(new_version_id.as_str()) {
+            if let Ok(mut heads) = self.schema_heads.write() {
+                heads.insert(
+                    actual_name.to_string(),
+                    (vec![new_cid], collection_priority),
+                );
+            }
+        }
 
         // Clean up any pending migration that was linked to this version
         {

--- a/crates/db/tests/patch_collection_tests.rs
+++ b/crates/db/tests/patch_collection_tests.rs
@@ -1,6 +1,9 @@
 use db::database::DB;
+use lens::{LensConfig, LensModule, TransformId};
 use schema::{FieldKind, ScalarArrayKind};
 use storage::backends::MemoryStore;
+use storage::corekv::Key;
+use storage::keys::systemstore::LensConfigKey;
 
 async fn agent_response_db() -> DB<MemoryStore> {
     let store = MemoryStore::new();
@@ -15,6 +18,90 @@ async fn agent_response_db() -> DB<MemoryStore> {
     .unwrap();
     db.create_collections_atomic(collections).await.unwrap();
     db
+}
+
+async fn users_db() -> DB<MemoryStore> {
+    let db = DB::new(MemoryStore::new()).unwrap();
+    let collections = query::parse_sdl("type Users { name: String }").unwrap();
+    db.create_collections_atomic(collections).await.unwrap();
+    db
+}
+
+const ADD_AGE_PATCH: &str = r#"
+    [{
+        "op": "add",
+        "path": "/Users/Fields/-",
+        "value": {"Name": "age", "Kind": "Int"}
+    }]
+"#;
+
+#[tokio::test]
+async fn patch_collection_registers_migration_atomically() {
+    let db = users_db().await;
+    let original = db.get_collection("Users").unwrap().unwrap();
+    let migration = LensConfig::new(
+        "ignored-source",
+        "ignored-destination",
+        LensModule::from_bytes(b"\0asm\x01\0\0\0".to_vec()),
+    );
+
+    let patched = db
+        .patch_collection_with_migration("Users", ADD_AGE_PATCH, Some(migration), None)
+        .await
+        .unwrap();
+    let previous = patched.previous_version.as_ref().unwrap();
+    let transform_id = previous.transform.as_ref().unwrap();
+
+    assert_eq!(previous.source_collection_id, original.version_id());
+    assert!(db.has_migration(&TransformId::new(transform_id)));
+
+    let txn = db.new_txn(true).await.unwrap();
+    let persisted = txn
+        .systemstore()
+        .unwrap()
+        .get(&LensConfigKey::new(transform_id).bytes())
+        .await
+        .unwrap()
+        .unwrap();
+    let persisted: LensConfig = serde_json::from_slice(&persisted).unwrap();
+    assert_eq!(persisted.source_schema_version_id, original.version_id());
+    assert_eq!(persisted.destination_schema_version_id, patched.version_id);
+    assert!(db
+        .get_all_collection_versions()
+        .await
+        .unwrap()
+        .iter()
+        .any(|version| version.version_id == patched.version_id
+            && version.previous_version == patched.previous_version));
+}
+
+#[tokio::test]
+async fn patch_collection_rolls_back_when_migration_is_invalid() {
+    let expected_db = users_db().await;
+    let expected = expected_db
+        .patch_collection("Users", ADD_AGE_PATCH, None)
+        .await
+        .unwrap();
+
+    let db = users_db().await;
+    let original = db.get_collection("Users").unwrap().unwrap();
+    let invalid_migration = LensConfig::new("", "", LensModule::from_bytes(vec![0]));
+
+    db.patch_collection_with_migration("Users", ADD_AGE_PATCH, Some(invalid_migration), None)
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        db.get_collection("Users").unwrap().unwrap().version_id(),
+        original.version_id()
+    );
+    assert_eq!(db.get_all_collection_versions().await.unwrap().len(), 1);
+
+    let retried = db
+        .patch_collection("Users", ADD_AGE_PATCH, None)
+        .await
+        .unwrap();
+    assert_eq!(retried.version_id, expected.version_id);
 }
 
 #[tokio::test]

--- a/crates/http/src/handlers/collections.rs
+++ b/crates/http/src/handlers/collections.rs
@@ -146,8 +146,8 @@ pub async fn get_collection_doc_ids(
 pub struct PatchCollectionRequest {
     #[serde(rename = "Patch", alias = "patch")]
     pub patch: serde_json::Value,
-    #[serde(rename = "Migration", default)]
-    pub migration: Option<serde_json::Value>,
+    #[serde(rename = "Migration", alias = "migration", default)]
+    pub migration: Option<lens::LensConfig>,
     #[serde(
         rename = "SetAsDefaultVersion",
         alias = "set_as_default_version",
@@ -187,8 +187,16 @@ pub async fn patch_collection(
 
     let name = extract_collection_name_from_patch(&patch_ops)?;
 
+    if !state.dev_mode {
+        if let Some(migration) = &body.migration {
+            migration
+                .validate_for_http()
+                .map_err(|e| HttpError::BadRequest(e.to_string()))?;
+        }
+    }
+
     collection_mgmt
-        .patch_collection(&name, &patch_str)
+        .patch_collection(&name, &patch_str, body.migration)
         .await
         .map_err(http_error_from_backend_message)?;
 

--- a/crates/http/src/handlers/collections_tests.rs
+++ b/crates/http/src/handlers/collections_tests.rs
@@ -57,9 +57,14 @@ async fn test_list_collections_error() {
 }
 
 fn router_with_collection_mgmt() -> axum::Router {
+    router_with_collection_mgmt_operations(Arc::new(MockCollectionManagementOperations::new()))
+}
+
+fn router_with_collection_mgmt_operations(
+    operations: Arc<dyn CollectionManagementOperations>,
+) -> axum::Router {
     let state = AppStateBuilder::new(Arc::new(MockQueryExecutor::new()) as Arc<dyn QueryExecutor>)
-        .with_collection_mgmt(Arc::new(MockCollectionManagementOperations::new())
-            as Arc<dyn CollectionManagementOperations>)
+        .with_collection_mgmt(operations)
         .build();
     crate::router::create_router_with_state(state)
 }
@@ -205,4 +210,64 @@ async fn delete_collections_by_query_rejects_invalid_active_only() {
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn patch_collection_forwards_migration() {
+    let operations = Arc::new(MockCollectionManagementOperations::new());
+    let router = router_with_collection_mgmt_operations(operations.clone());
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method(Method::PATCH)
+                .uri("/api/v0/collections")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "Patch": [{
+                            "op": "add",
+                            "path": "/Users/Fields/-",
+                            "value": {"Name": "age", "Kind": "Int"}
+                        }],
+                        "Migration": {"Lenses": []}
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(operations.last_migration().unwrap().lenses, Vec::new());
+}
+
+#[tokio::test]
+async fn patch_collection_rejects_migration_file_paths() {
+    let operations = Arc::new(MockCollectionManagementOperations::new());
+    let router = router_with_collection_mgmt_operations(operations.clone());
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method(Method::PATCH)
+                .uri("/api/v0/collections")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "Patch": [{
+                            "op": "add",
+                            "path": "/Users/Fields/-",
+                            "value": {"Name": "age", "Kind": "Int"}
+                        }],
+                        "Migration": {"Lenses": [{"Path": "/tmp/migration.wasm"}]}
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert!(operations.last_migration().is_none());
 }

--- a/crates/http/src/mock/collections.rs
+++ b/crates/http/src/mock/collections.rs
@@ -2,6 +2,7 @@
 
 use async_trait::async_trait;
 use serde_json::json;
+use std::sync::{Arc, Mutex};
 
 use crate::router::CollectionManagementOperations;
 
@@ -16,11 +17,17 @@ fn mock_collection_version(name: &str) -> schema::CollectionVersion {
 
 /// Mock collection management operations for testing.
 #[derive(Debug, Clone, Default)]
-pub struct MockCollectionManagementOperations;
+pub struct MockCollectionManagementOperations {
+    last_migration: Arc<Mutex<Option<lens::LensConfig>>>,
+}
 
 impl MockCollectionManagementOperations {
     pub fn new() -> Self {
-        Self
+        Self::default()
+    }
+
+    pub fn last_migration(&self) -> Option<lens::LensConfig> {
+        self.last_migration.lock().unwrap().clone()
     }
 }
 
@@ -34,7 +41,9 @@ impl CollectionManagementOperations for MockCollectionManagementOperations {
         &self,
         collection_name: &str,
         _patch: &str,
+        migration: Option<lens::LensConfig>,
     ) -> Result<serde_json::Value, String> {
+        *self.last_migration.lock().unwrap() = migration;
         Ok(json!({"name": collection_name, "version": "v2"}))
     }
 

--- a/crates/http/src/router/traits.rs
+++ b/crates/http/src/router/traits.rs
@@ -722,10 +722,12 @@ pub trait CollectionManagementOperations: Send + Sync {
     ///
     /// Creates a new schema version with the patched fields.
     /// The `patch` should be a JSON array of patch operations.
+    /// The optional migration is registered atomically with the new version.
     async fn patch_collection(
         &self,
         collection_name: &str,
         patch: &str,
+        migration: Option<lens::LensConfig>,
     ) -> Result<serde_json::Value, String>;
 
     /// Set the active collection version.


### PR DESCRIPTION
Closes #1415.

## Problem

Rust exposed a migration argument in the collection patch CLI and HTTP request, but dropped it before the database call. The endpoint returned success after applying the schema patch without registering the lens, leaving documents on the previous version untransformed and diverging from Go atomic patch-and-migration behavior.

## What changed

- Forward optional migration configurations through the CLI client, HTTP handler, and collection management adapter while preserving the existing patch-only request shape.
- Derive the source and destination version IDs from the actual patch, validate the lens before opening the transaction, and persist the migration configuration with the schema version in the same commit.
- Publish the runtime transform and schema head only after commit, so invalid migrations leave both durable and in-memory schema state unchanged.
- Reject file-backed lens modules over HTTP outside development mode and add regression coverage for forwarding, persistence, runtime registration, and rollback.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p db -p defra-http -p cli --all-targets -- -D warnings`
- [x] `cargo test -p db -p defra-http -p cli` (616 passed)
- [x] `git diff --check origin/main...HEAD`