### PR TITLE
fix(document): preserve Blob values through lens migrations

### DIFF
--- a/crates/db/src/migration/helpers.rs
+++ b/crates/db/src/migration/helpers.rs
@@ -318,6 +318,30 @@ mod tests {
     }
 
     #[test]
+    fn blob_field_remains_hex_text_after_lens_materialization() {
+        let collection = Collection::new(CollectionVersion::new(
+            "Files",
+            "v2",
+            "files",
+            vec![FieldDescription::new("1", "data", FieldKind::blob())],
+        ));
+        let mut lens_doc = LensDoc::new();
+        lens_doc.insert("data".to_string(), serde_json::json!("00ff"));
+
+        let migrated = lens_doc_to_document(lens_doc, &Document::new(), &collection);
+        assert_eq!(
+            migrated.get("data"),
+            Some(&document::NormalValue::String("00ff".to_string()))
+        );
+
+        let persisted = Document::from_cbor(&migrated.to_cbor().unwrap()).unwrap();
+        assert_eq!(
+            persisted.get("data"),
+            Some(&document::NormalValue::String("00ff".to_string()))
+        );
+    }
+
+    #[test]
     fn lens_removed_field_is_returned_as_explicit_null() {
         let collection = Collection::new(CollectionVersion::new(
             "Users",

--- a/crates/document/src/encoding.rs
+++ b/crates/document/src/encoding.rs
@@ -165,12 +165,9 @@ pub fn json_to_normal_value_for_kind(
         ScalarKind::Float64 => value.as_f64().map(NormalValue::Float64),
         ScalarKind::Float32 => value.as_f64().map(|f| NormalValue::Float32(f as f32)),
         ScalarKind::Bool => value.as_bool().map(NormalValue::Bool),
-        ScalarKind::String | ScalarKind::DocID => {
+        ScalarKind::String | ScalarKind::DocID | ScalarKind::Blob => {
             value.as_str().map(|s| NormalValue::String(s.to_string()))
         }
-        ScalarKind::Blob => value
-            .as_str()
-            .map(|s| NormalValue::Bytes(s.as_bytes().to_vec())),
         ScalarKind::DateTime => match value {
             JsonValue::String(s) => DateTime::parse_from_rfc3339(s).ok().map(NormalValue::Time),
             JsonValue::Number(n) => n.as_i64().and_then(|ts| {


### PR DESCRIPTION
Closes #1406.

## Problem

Lens migrations converted Blob hex text into `NormalValue::Bytes` containing the literal ASCII characters. After CBOR persistence and JSON conversion, values were hex-encoded a second time, so a value such as `00ff` became `30306666`. This silently changed stored document behavior and diverged from Go, which keeps Blob values as strings.

## What changed

- Treat Blob values as strings in the shared schema-aware JSON conversion path, matching fresh writes and Go behavior.
- Add regression coverage for lens materialization and the subsequent CBOR round trip.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p document -p query-plan -p db --all-targets -- -D warnings`
- [x] `cargo test -p db blob_field_remains_hex_text_after_lens_materialization`
- [x] `cargo test -p document -p query-plan -p db`
- [x] `git diff --check origin/main...HEAD`