### PR TITLE
fix(index): deduplicate typed array index values

### DIFF
--- a/crates/db-index/src/index_manager/value_extraction.rs
+++ b/crates/db-index/src/index_manager/value_extraction.rs
@@ -80,8 +80,9 @@ impl IndexManager {
                 if $arr.is_empty() {
                     vec![NormalValue::Null]
                 } else {
-                    $arr.iter()
-                        .map(|v| NormalValue::$variant(v.clone()))
+                    Self::deduplicate_array_values($arr.iter().cloned())
+                        .into_iter()
+                        .map(NormalValue::$variant)
                         .collect()
                 }
             };
@@ -94,8 +95,9 @@ impl IndexManager {
                         if arr.is_empty() {
                             vec![NormalValue::Null]
                         } else {
-                            arr.iter()
-                                .map(|v| NormalValue::$variant(v.clone()))
+                            Self::deduplicate_array_values(arr.iter().cloned())
+                                .into_iter()
+                                .map(NormalValue::$variant)
                                 .collect()
                         }
                     }
@@ -109,9 +111,10 @@ impl IndexManager {
                 if $arr.is_empty() {
                     vec![NormalValue::Null]
                 } else {
-                    $arr.iter()
+                    Self::deduplicate_array_values($arr.iter().cloned())
+                        .into_iter()
                         .map(|v| match v {
-                            Some(val) => NormalValue::$variant(val.clone()),
+                            Some(val) => NormalValue::$variant(val),
                             None => NormalValue::Null,
                         })
                         .collect()
@@ -164,7 +167,14 @@ impl IndexManager {
                         .collect()
                 }
             }
-            NormalValue::JsonArray(ref arr) => expand_array!(arr, Json),
+            // JSON array positions are part of their index paths, so repeated values stay distinct.
+            NormalValue::JsonArray(ref arr) => {
+                if arr.is_empty() {
+                    vec![NormalValue::Null]
+                } else {
+                    arr.iter().cloned().map(NormalValue::Json).collect()
+                }
+            }
 
             NormalValue::NillableBoolArray(ref opt) => expand_nillable_array!(opt, Bool),
             NormalValue::NillableIntArray(ref opt) => expand_nillable_array!(opt, Int),
@@ -221,6 +231,16 @@ impl IndexManager {
             }
             _ => unreachable!(),
         }
+    }
+
+    fn deduplicate_array_values<T: PartialEq>(values: impl IntoIterator<Item = T>) -> Vec<T> {
+        let mut unique = Vec::new();
+        for value in values {
+            if !unique.contains(&value) {
+                unique.push(value);
+            }
+        }
+        unique
     }
 
     /// Compute Cartesian product of field value sets.

--- a/crates/db/tests/index_manager_tests.rs
+++ b/crates/db/tests/index_manager_tests.rs
@@ -164,6 +164,7 @@ async fn unique_typed_array_index_deduplicates_repeated_values() {
             descending: false,
         }],
         unique: true,
+        kind: None,
         auto_generated: false,
     }];
     let manager = IndexManager::from_collection(1, &schema).unwrap();

--- a/crates/db/tests/index_manager_tests.rs
+++ b/crates/db/tests/index_manager_tests.rs
@@ -139,6 +139,46 @@ async fn unique_json_index_rejects_duplicate_array_values() {
 }
 
 #[tokio::test]
+async fn unique_typed_array_index_deduplicates_repeated_values() {
+    let store = MemoryStore::new();
+    let db = DB::new(store).unwrap();
+    let txn = db.new_txn(false).await.unwrap();
+    let datastore = txn.datastore().unwrap();
+
+    let mut schema = CollectionVersion::new(
+        "users",
+        "v1",
+        "col-users",
+        vec![FieldDescription::new(
+            "1",
+            "tags",
+            FieldKind::string_array(),
+        )],
+    );
+    schema.indexes = vec![IndexDescription {
+        name: "idx_tags".to_string(),
+        id: 1,
+        fields: vec![IndexedFieldDescription {
+            name: "tags".to_string(),
+            descending: false,
+        }],
+        unique: true,
+        auto_generated: false,
+    }];
+    let manager = IndexManager::from_collection(1, &schema).unwrap();
+    let mut first = Document::new();
+    first.set(
+        "tags",
+        NormalValue::StringArray(vec!["a".to_string(), "a".to_string(), "b".to_string()]),
+    );
+
+    manager
+        .on_document_create(&datastore, &first, next_test_doc_short_id(), &schema)
+        .await
+        .expect("repeated values in one typed array must share one index entry");
+}
+
+#[tokio::test]
 async fn test_create_duplicate_index_fails() {
     let store = MemoryStore::new();
     let db = DB::new(store).unwrap();


### PR DESCRIPTION
Closes #1409.

## Problem

Typed array fields generated one index entry for every element, including repeated values within the same document. A unique index therefore treated a self-duplicate such as `["a", "a", "b"]` as a uniqueness violation, while Go deduplicates typed-array values before indexing. JSON arrays intentionally use different semantics and must continue rejecting duplicate indexed values.

## What changed

- Deduplicate typed-array values before generating index Cartesian products, including nillable array forms.
- Keep JSON-array expansion unchanged so positional entries and duplicate validation retain their existing behavior.
- Add regression coverage proving repeated typed-array values no longer reject an otherwise valid document.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p db-index -p db --all-targets -- -D warnings`
- [x] `cargo test -p db --test index_manager_tests unique_`
- [x] `cargo test -p db-index -p db`
- [x] `git diff --check origin/main...HEAD`