### PR TITLE
Vector indexes: IVF-PQ

### DIFF
--- a/crates/db-index/src/vector/engine/ann/clusterer.rs
+++ b/crates/db-index/src/vector/engine/ann/clusterer.rs
@@ -1,0 +1,46 @@
+//! Fitting centroids over a resident sample.
+
+use crate::vector::core::squared_euclidean;
+
+/// Trained centroids, flat: `k * dimensions`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Centroids {
+    pub k: usize,
+    pub dimensions: usize,
+    pub values: Vec<f32>,
+}
+
+impl Centroids {
+    pub fn get(&self, index: usize) -> &[f32] {
+        let at = index * self.dimensions;
+        &self.values[at..at + self.dimensions]
+    }
+
+    /// The nearest centroid to `vector`, and its squared distance.
+    pub fn nearest(&self, vector: &[f32]) -> (usize, f64) {
+        let mut best = (0usize, f64::INFINITY);
+        for index in 0..self.k {
+            let distance = squared_euclidean(vector, self.get(index));
+            if distance < best.1 {
+                best = (index, distance);
+            }
+        }
+        best
+    }
+}
+
+/// How the fit went. Reported rather than assumed, because a sample smaller
+/// than `k` cannot produce `k` meaningful centroids and the caller has to know.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Fit {
+    /// Centroids actually produced, never more than the distinct sample size.
+    pub k: usize,
+    /// Iterations run before assignments stopped changing.
+    pub iterations: usize,
+    /// Mean squared distance from a sample point to its centroid.
+    pub inertia: f64,
+}
+
+pub trait Clusterer {
+    fn fit(&self, sample: &[f32], dimensions: usize, k: usize) -> (Centroids, Fit);
+}

--- a/crates/db-index/src/vector/engine/ann/engine_kind.rs
+++ b/crates/db-index/src/vector/engine/ann/engine_kind.rs
@@ -12,6 +12,8 @@ pub enum EngineKind {
     Hnsw,
     /// Exhaustive scan. Exact, and linear in the corpus.
     Flat,
+    /// Coarse lists of product-quantized codes.
+    IvfPq,
 }
 
 impl EngineKind {
@@ -19,6 +21,7 @@ impl EngineKind {
         match self {
             EngineKind::Hnsw => "HNSW",
             EngineKind::Flat => "FLAT",
+            EngineKind::IvfPq => "IVF_PQ",
         }
     }
 }

--- a/crates/db-index/src/vector/engine/ann/mod.rs
+++ b/crates/db-index/src/vector/engine/ann/mod.rs
@@ -9,10 +9,16 @@
 //! This mirrors pulsejetdb's `index/core` sitting beside `index/hnsw`,
 //! `index/flat`, `index/ivfpq`, `index/ssg` and `index/pq`.
 
+mod clusterer;
 mod engine;
 mod engine_kind;
 mod neighbor;
+mod quantizer;
+mod sampler;
 
+pub use clusterer::{Centroids, Clusterer, Fit};
 pub use engine::{Admit, AdmitAll, VectorIndexEngine};
 pub use engine_kind::EngineKind;
 pub use neighbor::Neighbor;
+pub use quantizer::Quantizer;
+pub use sampler::Sampler;

--- a/crates/db-index/src/vector/engine/ann/quantizer.rs
+++ b/crates/db-index/src/vector/engine/ann/quantizer.rs
@@ -1,0 +1,21 @@
+//! Turning a vector into a compact code, and ranking from codes.
+
+/// [`distance_table`](Quantizer::distance_table) is computed once per query and
+/// [`distance`](Quantizer::distance) is then a handful of lookups per
+/// candidate, which is what makes a list scan cheap.
+pub trait Quantizer {
+    /// Bytes in one code.
+    fn code_len(&self) -> usize;
+
+    /// Vectors this quantizer was trained for.
+    fn dimensions(&self) -> usize;
+
+    fn encode(&self, vector: &[f32], code: &mut [u8]);
+
+    /// Reconstructs approximately. Lossy by construction.
+    fn decode(&self, code: &[u8], out: &mut [f32]);
+
+    fn distance_table(&self, query: &[f32]) -> Vec<f32>;
+
+    fn distance(&self, table: &[f32], code: &[u8]) -> f64;
+}

--- a/crates/db-index/src/vector/engine/ann/sampler.rs
+++ b/crates/db-index/src/vector/engine/ann/sampler.rs
@@ -1,0 +1,24 @@
+//! Drawing a bounded training set from a stream of vectors.
+
+/// A batch-built kind trains on a sample, never the corpus, so the resident
+/// cost of a build is configured rather than proportional to the collection.
+///
+/// Bounded in **bytes**: the same 100,000 vectors are 6 MB at 16 dimensions and
+/// 300 MB at 768, so a count does not bound what actually fails.
+pub trait Sampler {
+    fn offer(&mut self, vector: &[f32]);
+
+    /// The sample as one flat `len() * dimensions` buffer.
+    fn as_flat(&self) -> &[f32];
+
+    fn len(&self) -> usize;
+
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Vectors offered, which exceeds `len` once the budget is reached.
+    fn seen(&self) -> u64;
+
+    fn resident_bytes(&self) -> usize;
+}

--- a/crates/db-index/src/vector/engine/dispatch.rs
+++ b/crates/db-index/src/vector/engine/dispatch.rs
@@ -7,6 +7,7 @@
 use super::ann::{Admit, EngineKind, Neighbor, VectorIndexEngine};
 use super::flat::Flat;
 use super::hnsw::Hnsw;
+use super::ivfpq::IvfPq;
 use crate::error::Result;
 use crate::vector::core::Element;
 use crate::vector::store::{NodeId, VectorNodeStore};
@@ -15,6 +16,7 @@ use crate::vector::store::{NodeId, VectorNodeStore};
 pub enum Engine<S> {
     Hnsw(Hnsw<S>),
     Flat(Flat<S>),
+    IvfPq(IvfPq<S>),
 }
 
 macro_rules! dispatch {
@@ -22,6 +24,7 @@ macro_rules! dispatch {
         match $self {
             Engine::Hnsw($engine) => $call,
             Engine::Flat($engine) => $call,
+            Engine::IvfPq($engine) => $call,
         }
     };
 }

--- a/crates/db-index/src/vector/engine/ivfpq/build.rs
+++ b/crates/db-index/src/vector/engine/ivfpq/build.rs
@@ -1,0 +1,203 @@
+//! Training and the build that follows it.
+
+use super::codec::{self, TrainedState};
+use super::IvfPq;
+use crate::error::{Error, Result};
+use crate::vector::engine::ann::{Centroids, Clusterer, Quantizer, Sampler};
+use crate::vector::quantize::{KMeans, ProductQuantizer, Reservoir};
+use crate::vector::store::{NodeId, VectorNodeStore};
+
+/// What a build did, so a caller can report it rather than guess.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BuildReport {
+    pub sampled: usize,
+    pub sample_bytes: usize,
+    pub indexed: u64,
+    pub state: TrainedState,
+}
+
+impl<S: VectorNodeStore> IvfPq<S> {
+    /// Vectors held, tombstones excluded.
+    pub async fn live_count(&self) -> Result<u64> {
+        let mut count = 0u64;
+        self.store()
+            .iterate_nodes(|_| {
+                count += 1;
+                Ok(())
+            })
+            .await?;
+        Ok(count)
+    }
+
+    /// Whether there are enough vectors to fit the configured lists.
+    pub async fn should_build(&self) -> Result<bool> {
+        if self.is_trained().await? {
+            return Ok(false);
+        }
+        let live = self.live_count().await?;
+        Ok(live >= self.params().train_threshold(live).max(1))
+    }
+
+    /// Trains from a byte-bounded sample and writes centroids, codebooks and
+    /// inverted lists.
+    ///
+    /// Two streaming passes over the nodes and nothing else resident: the
+    /// sample, the centroids and the codebooks, each bounded by configuration
+    /// rather than by the corpus.
+    pub async fn build(&mut self) -> Result<BuildReport> {
+        let live = self.live_count().await?;
+        if live == 0 {
+            return Err(Error::Other(
+                "vector index: nothing to train an IVF-PQ build on".into(),
+            ));
+        }
+
+        let dimensions = self.first_width().await?;
+        let nlist = self.params().resolved_nlist(live);
+        let m = self.params().resolved_m(dimensions);
+
+        let mut reservoir =
+            Reservoir::new(dimensions, self.params().sample_bytes as usize, self.seed());
+        self.store()
+            .iterate_nodes(|node| {
+                reservoir.offer(&node.vector);
+                Ok(())
+            })
+            .await?;
+
+        let sampled = reservoir.len();
+        let sample_bytes = reservoir.resident_bytes();
+        let clusterer = KMeans::new(self.seed());
+        let (coarse, _) = clusterer.fit(reservoir.as_flat(), dimensions, nlist as usize);
+        if coarse.k == 0 {
+            return Err(Error::Other(
+                "vector index: the training sample produced no centroids".into(),
+            ));
+        }
+
+        let residuals = residuals_of(reservoir.as_flat(), dimensions, &coarse);
+        let quantizer = ProductQuantizer::train(&clusterer, &residuals, dimensions, m)?;
+        drop(residuals);
+
+        for index in 0..coarse.k {
+            let bytes = codec::encode_vector(coarse.get(index));
+            self.store_mut()
+                .put_aux(codec::CENTROID, &(index as u32).to_be_bytes(), &bytes)
+                .await?;
+        }
+        for (sub, book) in quantizer.books().iter().enumerate() {
+            let bytes = codec::encode_centroids(book);
+            self.store_mut()
+                .put_aux(codec::CODEBOOK, &(sub as u32).to_be_bytes(), &bytes)
+                .await?;
+        }
+
+        let state = TrainedState {
+            nlist: coarse.k as u32,
+            m: quantizer.m() as u32,
+            dimensions: dimensions as u32,
+        };
+
+        let mut assignments: Vec<(u32, NodeId, Vec<u8>)> = Vec::new();
+        let mut code = vec![0u8; quantizer.code_len()];
+        let mut residual = vec![0.0f32; dimensions];
+        self.store()
+            .iterate_nodes(|node| {
+                let (list, _) = coarse.nearest(&node.vector);
+                subtract_into(&node.vector, coarse.get(list), &mut residual);
+                quantizer.encode(&residual, &mut code);
+                assignments.push((list as u32, node.id, code.clone()));
+                Ok(())
+            })
+            .await?;
+
+        let indexed = assignments.len() as u64;
+        for (list, id, code) in assignments {
+            self.store_mut()
+                .put_aux(codec::LIST, &codec::list_key(list, id), &code)
+                .await?;
+        }
+
+        self.store_mut()
+            .put_aux(codec::STATE, b"", &codec::encode_state(&state))
+            .await?;
+
+        Ok(BuildReport {
+            sampled,
+            sample_bytes,
+            indexed,
+            state,
+        })
+    }
+
+    /// The list a vector belongs to, and its code.
+    pub(super) async fn assign(
+        &self,
+        quantizer: &ProductQuantizer,
+        state: &TrainedState,
+        vector: &[f32],
+    ) -> Result<(u32, Vec<u8>)> {
+        let coarse = self.coarse_centroids(state).await?;
+        let (list, _) = coarse.nearest(vector);
+        let mut residual = vec![0.0f32; state.dimensions as usize];
+        subtract_into(vector, coarse.get(list), &mut residual);
+        let mut code = vec![0u8; quantizer.code_len()];
+        quantizer.encode(&residual, &mut code);
+        Ok((list as u32, code))
+    }
+
+    pub(super) async fn coarse_centroids(&self, state: &TrainedState) -> Result<Centroids> {
+        let mut values = Vec::with_capacity(state.nlist as usize * state.dimensions as usize);
+        for index in 0..state.nlist {
+            let bytes = self
+                .store()
+                .get_aux(codec::CENTROID, &index.to_be_bytes())
+                .await?
+                .ok_or_else(|| {
+                    Error::Other(format!("vector index: centroid {index} is missing"))
+                })?;
+            values.extend_from_slice(&codec::decode_vector(&bytes)?);
+        }
+        Ok(Centroids {
+            k: state.nlist as usize,
+            dimensions: state.dimensions as usize,
+            values,
+        })
+    }
+
+    async fn first_width(&self) -> Result<usize> {
+        let mut width = 0usize;
+        self.store()
+            .iterate_nodes(|node| {
+                if width == 0 {
+                    width = node.vector.len();
+                }
+                Ok(())
+            })
+            .await?;
+        if width == 0 {
+            return Err(Error::Other(
+                "vector index: no stored vector to take a width from".into(),
+            ));
+        }
+        Ok(width)
+    }
+}
+
+fn subtract_into(vector: &[f32], centroid: &[f32], out: &mut [f32]) {
+    for (slot, (v, c)) in out.iter_mut().zip(vector.iter().zip(centroid)) {
+        *slot = v - c;
+    }
+}
+
+fn residuals_of(sample: &[f32], dimensions: usize, coarse: &Centroids) -> Vec<f32> {
+    let mut residuals = vec![0.0f32; sample.len()];
+    for (point, slot) in sample
+        .chunks_exact(dimensions)
+        .zip(residuals.chunks_exact_mut(dimensions))
+    {
+        let (nearest, _) = coarse.nearest(point);
+        subtract_into(point, coarse.get(nearest), slot);
+    }
+    residuals
+}

--- a/crates/db-index/src/vector/engine/ivfpq/codec.rs
+++ b/crates/db-index/src/vector/engine/ivfpq/codec.rs
@@ -1,0 +1,113 @@
+//! Encoding for the entries IVF-PQ keeps beside its nodes.
+
+use crate::error::{Error, Result};
+use crate::vector::engine::ann::Centroids;
+use crate::vector::store::NodeId;
+
+pub const CENTROID: u8 = b'c';
+pub const CODEBOOK: u8 = b'b';
+pub const LIST: u8 = b'l';
+pub const STATE: u8 = b's';
+
+const STATE_VERSION: u8 = 1;
+
+pub fn encode_vector(values: &[f32]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(values.len() * 4);
+    for value in values {
+        out.extend_from_slice(&value.to_le_bytes());
+    }
+    out
+}
+
+pub fn decode_vector(bytes: &[u8]) -> Result<Vec<f32>> {
+    if !bytes.len().is_multiple_of(4) {
+        return Err(Error::Other(
+            "vector index: a stored vector is ragged".into(),
+        ));
+    }
+    Ok(bytes
+        .chunks_exact(4)
+        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect())
+}
+
+pub fn encode_centroids(centroids: &Centroids) -> Vec<u8> {
+    let mut out = Vec::with_capacity(8 + centroids.values.len() * 4);
+    out.extend_from_slice(&(centroids.k as u32).to_le_bytes());
+    out.extend_from_slice(&(centroids.dimensions as u32).to_le_bytes());
+    out.extend_from_slice(&encode_vector(&centroids.values));
+    out
+}
+
+pub fn decode_centroids(bytes: &[u8]) -> Result<Centroids> {
+    if bytes.len() < 8 {
+        return Err(Error::Other("vector index: a codebook is truncated".into()));
+    }
+    let k = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as usize;
+    let dimensions = u32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]) as usize;
+    let values = decode_vector(&bytes[8..])?;
+    if k * dimensions != values.len() {
+        return Err(Error::Other(
+            "vector index: a codebook's shape disagrees with its payload".into(),
+        ));
+    }
+    Ok(Centroids {
+        k,
+        dimensions,
+        values,
+    })
+}
+
+/// `listID || nodeID`, both big-endian so a prefix scan of a list is contiguous
+/// and ordered.
+pub fn list_key(list: u32, node: NodeId) -> Vec<u8> {
+    let mut key = Vec::with_capacity(12);
+    key.extend_from_slice(&list.to_be_bytes());
+    key.extend_from_slice(&node.0.to_be_bytes());
+    key
+}
+
+pub fn list_prefix(list: u32) -> Vec<u8> {
+    list.to_be_bytes().to_vec()
+}
+
+pub fn node_from_list_key(key: &[u8]) -> Result<NodeId> {
+    if key.len() < 12 {
+        return Err(Error::Other("vector index: a list key is truncated".into()));
+    }
+    let mut id = [0u8; 8];
+    id.copy_from_slice(&key[4..12]);
+    Ok(NodeId(u64::from_be_bytes(id)))
+}
+
+/// What a trained index needs to answer before it reads anything else.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TrainedState {
+    pub nlist: u32,
+    pub m: u32,
+    pub dimensions: u32,
+}
+
+pub fn encode_state(state: &TrainedState) -> Vec<u8> {
+    let mut out = Vec::with_capacity(13);
+    out.push(STATE_VERSION);
+    out.extend_from_slice(&state.nlist.to_le_bytes());
+    out.extend_from_slice(&state.m.to_le_bytes());
+    out.extend_from_slice(&state.dimensions.to_le_bytes());
+    out
+}
+
+pub fn decode_state(bytes: &[u8]) -> Result<TrainedState> {
+    if bytes.len() != 13 || bytes[0] != STATE_VERSION {
+        return Err(Error::Other(
+            "vector index: unsupported trained-state encoding".into(),
+        ));
+    }
+    let read =
+        |at: usize| u32::from_le_bytes([bytes[at], bytes[at + 1], bytes[at + 2], bytes[at + 3]]);
+    Ok(TrainedState {
+        nlist: read(1),
+        m: read(5),
+        dimensions: read(9),
+    })
+}

--- a/crates/db-index/src/vector/engine/ivfpq/mod.rs
+++ b/crates/db-index/src/vector/engine/ivfpq/mod.rs
@@ -1,0 +1,149 @@
+//! IVF-PQ: coarse lists of product-quantized codes.
+//!
+//! An index accepts writes from the first document and answers them exactly by
+//! exhaustive scan, exactly as [`Flat`](super::flat::Flat) does, because that is
+//! what it is until it has enough vectors to fit centroids. Once the threshold
+//! is reached it trains from a byte-bounded sample, writes centroids, codebooks
+//! and inverted lists, and answers from those instead.
+//!
+//! ADC is squared-L2. Under cosine that ranks identically to the metric, since
+//! vectors are normalized on insert and `|a-b|^2 = 2 - 2a.b`; under a
+//! magnitude-sensitive metric it does not, so those are refused at
+//! construction.
+
+mod build;
+mod codec;
+mod params;
+mod search;
+
+pub use codec::TrainedState;
+pub use params::{
+    IvfPqParams, DEFAULT_NBITS, DEFAULT_NPROBE, DEFAULT_SAMPLE_BYTES, MAX_M, MAX_NLIST,
+    TRAIN_PER_LIST,
+};
+
+use crate::error::{Error, Result};
+use crate::vector::core::{Element, Metric};
+use crate::vector::engine::ann::{Admit, EngineKind, Neighbor, VectorIndexEngine};
+use crate::vector::engine::flat::Flat;
+use crate::vector::quantize::ProductQuantizer;
+use crate::vector::store::{NodeId, VectorNodeStore};
+
+/// A coarse-quantized, product-compressed index.
+#[derive(Debug)]
+pub struct IvfPq<S> {
+    staging: Flat<S>,
+    metric: Metric,
+    params: IvfPqParams,
+    seed: u64,
+}
+
+impl<S: VectorNodeStore> IvfPq<S> {
+    /// Fails for a metric ADC cannot rank, rather than quietly ranking on
+    /// squared-L2 when the caller asked for something else.
+    pub fn try_new(store: S, metric: Metric, params: IvfPqParams, seed: u64) -> Result<Self> {
+        params.validate()?;
+        if metric != Metric::Cosine && metric != Metric::Euclidean {
+            return Err(Error::Other(format!(
+                "IVF-PQ ranks by squared distance, which does not order {metric:?}"
+            )));
+        }
+        Ok(Self {
+            staging: Flat::new(store, metric),
+            metric,
+            params,
+            seed,
+        })
+    }
+
+    pub fn store(&self) -> &S {
+        self.staging.store()
+    }
+
+    pub fn store_mut(&mut self) -> &mut S {
+        self.staging.store_mut()
+    }
+
+    pub fn params(&self) -> IvfPqParams {
+        self.params
+    }
+
+    pub fn metric(&self) -> Metric {
+        self.metric
+    }
+
+    pub fn seed(&self) -> u64 {
+        self.seed
+    }
+
+    /// The trained state, or `None` while the index is still exact.
+    pub async fn trained(&self) -> Result<Option<TrainedState>> {
+        match self.store().get_aux(codec::STATE, b"").await? {
+            Some(bytes) => codec::decode_state(&bytes).map(Some),
+            None => Ok(None),
+        }
+    }
+
+    pub async fn is_trained(&self) -> Result<bool> {
+        Ok(self.trained().await?.is_some())
+    }
+
+    async fn quantizer(&self, state: &TrainedState) -> Result<ProductQuantizer> {
+        let mut books = Vec::with_capacity(state.m as usize);
+        for sub in 0..state.m {
+            let bytes = self
+                .store()
+                .get_aux(codec::CODEBOOK, &sub.to_be_bytes())
+                .await?
+                .ok_or_else(|| Error::Other(format!("vector index: codebook {sub} is missing")))?;
+            books.push(codec::decode_centroids(&bytes)?);
+        }
+        ProductQuantizer::from_books(state.dimensions as usize, books)
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl<S: VectorNodeStore> VectorIndexEngine for IvfPq<S> {
+    fn kind(&self) -> EngineKind {
+        EngineKind::IvfPq
+    }
+
+    /// The vector is always stored, trained or not: it is what a rebuild reads
+    /// and what keeps the index exact until one happens.
+    async fn insert<E: Element>(&mut self, id: NodeId, vector: &[E]) -> Result<()> {
+        self.staging.insert(id, vector).await?;
+
+        if let Some(state) = self.trained().await? {
+            let quantizer = self.quantizer(&state).await?;
+            let stored =
+                self.store().get_node(id).await?.ok_or_else(|| {
+                    Error::Other("vector index: a just-stored node is gone".into())
+                })?;
+            let (list, code) = self.assign(&quantizer, &state, &stored.vector).await?;
+            self.store_mut()
+                .put_aux(codec::LIST, &codec::list_key(list, id), &code)
+                .await?;
+        }
+        Ok(())
+    }
+
+    /// Tombstones the node. Its code stays in its list and is skipped on the
+    /// scan, the same way the graph kinds skip a tombstone.
+    async fn delete(&mut self, id: NodeId) -> Result<bool> {
+        self.staging.delete(id).await
+    }
+
+    async fn search_where<E: Element, A: Admit>(
+        &self,
+        query: &[E],
+        k: usize,
+        effort: Option<usize>,
+        admit: &A,
+    ) -> Result<Vec<Neighbor>> {
+        match self.trained().await? {
+            None => self.staging.search_where(query, k, effort, admit).await,
+            Some(state) => self.search_lists(&state, query, k, effort, admit).await,
+        }
+    }
+}

--- a/crates/db-index/src/vector/engine/ivfpq/params.rs
+++ b/crates/db-index/src/vector/engine/ivfpq/params.rs
@@ -1,0 +1,83 @@
+//! IVF-PQ build and search parameters.
+
+use crate::error::{Error, Result};
+
+pub const DEFAULT_NPROBE: u32 = 8;
+pub const DEFAULT_NBITS: u32 = 8;
+/// FAISS's stated minimum for a usable k-means fit. Below `TRAIN_PER_LIST *
+/// nlist` vectors the index stays exact rather than training on too little.
+pub const TRAIN_PER_LIST: u32 = 39;
+pub const DEFAULT_SAMPLE_BYTES: u64 = 128 << 20;
+
+pub const MAX_NLIST: u32 = 65_536;
+pub const MAX_M: u32 = 4_096;
+
+/// `0` means derive from the corpus: `nlist` from its size, `m` from the width.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IvfPqParams {
+    pub nlist: u32,
+    pub nprobe: u32,
+    pub m: u32,
+    pub sample_bytes: u64,
+}
+
+impl Default for IvfPqParams {
+    fn default() -> Self {
+        Self {
+            nlist: 0,
+            nprobe: DEFAULT_NPROBE,
+            m: 0,
+            sample_bytes: DEFAULT_SAMPLE_BYTES,
+        }
+    }
+}
+
+impl IvfPqParams {
+    pub fn validate(&self) -> Result<()> {
+        for (name, value, max) in [
+            ("nlist", self.nlist, MAX_NLIST),
+            ("m", self.m, MAX_M),
+            ("nprobe", self.nprobe, MAX_NLIST),
+        ] {
+            if value > max {
+                return Err(Error::Other(format!(
+                    "vector index {name} is {value}, above the maximum {max}"
+                )));
+            }
+        }
+        if self.sample_bytes == 0 {
+            return Err(Error::Other(
+                "vector index sampleBytes must leave room for a training sample".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// `4*sqrt(n)` is the usual starting point: lists stay large enough to
+    /// train and small enough that probing a few is much cheaper than a scan.
+    pub fn resolved_nlist(&self, corpus: u64) -> u32 {
+        if self.nlist > 0 {
+            return self.nlist.min(MAX_NLIST);
+        }
+        let derived = 4.0 * (corpus as f64).sqrt();
+        (derived as u32).clamp(1, MAX_NLIST)
+    }
+
+    /// The largest `m` that divides the width and keeps subvectors at least 2
+    /// wide, capped so a code stays small against the vector it replaces.
+    pub fn resolved_m(&self, dimensions: usize) -> usize {
+        if self.m > 0 {
+            return (self.m as usize).min(dimensions.max(1));
+        }
+        let target = (dimensions / 8).clamp(1, MAX_M as usize);
+        (1..=target)
+            .rev()
+            .find(|m| dimensions.is_multiple_of(*m))
+            .unwrap_or(1)
+    }
+
+    /// Vectors needed before training fires.
+    pub fn train_threshold(&self, corpus: u64) -> u64 {
+        u64::from(self.resolved_nlist(corpus)) * u64::from(TRAIN_PER_LIST)
+    }
+}

--- a/crates/db-index/src/vector/engine/ivfpq/search.rs
+++ b/crates/db-index/src/vector/engine/ivfpq/search.rs
@@ -1,0 +1,125 @@
+//! Probing lists and scanning codes.
+
+use std::collections::BinaryHeap;
+
+use super::codec::{self, TrainedState};
+use super::IvfPq;
+use crate::error::Result;
+use crate::vector::core::{normalize, Element, Metric};
+use crate::vector::engine::ann::{Admit, Neighbor, Quantizer};
+use crate::vector::store::{NodeId, VectorNodeStore};
+
+impl<S: VectorNodeStore> IvfPq<S> {
+    pub(super) async fn search_lists<E: Element, A: Admit>(
+        &self,
+        state: &TrainedState,
+        query: &[E],
+        k: usize,
+        effort: Option<usize>,
+        admit: &A,
+    ) -> Result<Vec<Neighbor>> {
+        if k == 0 {
+            return Ok(Vec::new());
+        }
+
+        let mut query: Vec<f32> = query.iter().map(|x| f32::narrow(x.widen())).collect();
+        if self.metric() == Metric::Cosine {
+            normalize(&mut query);
+        }
+
+        let coarse = self.coarse_centroids(state).await?;
+        let quantizer = self.quantizer(state).await?;
+
+        // `effort` overrides nprobe the way ef_search does for a graph.
+        let nprobe = effort
+            .map(|e| e.max(1))
+            .unwrap_or(self.params().nprobe as usize)
+            .min(coarse.k)
+            .max(1);
+
+        let mut lists: Vec<(usize, f64)> = (0..coarse.k)
+            .map(|index| {
+                (
+                    index,
+                    Metric::Euclidean.distance(query.as_slice(), coarse.get(index)),
+                )
+            })
+            .collect();
+        lists.sort_by(|a, b| a.1.total_cmp(&b.1));
+        lists.truncate(nprobe);
+
+        let mut best: BinaryHeap<Ranked> = BinaryHeap::with_capacity(k + 1);
+        let mut residual = vec![0.0f32; state.dimensions as usize];
+
+        for (list, _) in lists {
+            for (slot, (q, c)) in residual.iter_mut().zip(query.iter().zip(coarse.get(list))) {
+                *slot = q - c;
+            }
+            let table = quantizer.distance_table(&residual);
+
+            let mut hits: Vec<(NodeId, f64)> = Vec::new();
+            self.store()
+                .iterate_aux(
+                    codec::LIST,
+                    &codec::list_prefix(list as u32),
+                    |key, code| {
+                        let id = codec::node_from_list_key(key)?;
+                        if admit.admits(id) {
+                            hits.push((id, quantizer.distance(&table, code)));
+                        }
+                        Ok(())
+                    },
+                )
+                .await?;
+
+            for (id, distance) in hits {
+                best.push(Ranked { id, distance });
+                if best.len() > k {
+                    best.pop();
+                }
+            }
+        }
+
+        // A tombstoned document keeps its code, so liveness is checked once on
+        // the survivors rather than on every candidate.
+        let mut ranked: Vec<Ranked> = best.into_sorted_vec();
+        let mut out = Vec::with_capacity(ranked.len());
+        for candidate in ranked.drain(..) {
+            let live = self
+                .store()
+                .get_node(candidate.id)
+                .await?
+                .is_some_and(|node| !node.deleted);
+            if live {
+                out.push(Neighbor {
+                    id: candidate.id,
+                    distance: candidate.distance,
+                });
+            }
+        }
+        Ok(out)
+    }
+}
+
+/// Farthest on top, so the heap drops its worst.
+#[derive(Debug, PartialEq)]
+struct Ranked {
+    id: NodeId,
+    distance: f64,
+}
+
+impl Eq for Ranked {}
+
+impl Ord for Ranked {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.distance
+            .total_cmp(&other.distance)
+            .then_with(|| other.id.cmp(&self.id))
+    }
+}
+
+impl PartialOrd for Ranked {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}

--- a/crates/db-index/src/vector/engine/mod.rs
+++ b/crates/db-index/src/vector/engine/mod.rs
@@ -10,3 +10,4 @@ pub mod ann;
 pub mod dispatch;
 pub mod flat;
 pub mod hnsw;
+pub mod ivfpq;

--- a/crates/db-index/src/vector/index.rs
+++ b/crates/db-index/src/vector/index.rs
@@ -16,6 +16,7 @@ use super::engine::ann::{Admit, Neighbor, VectorIndexEngine};
 use super::engine::dispatch::Engine;
 use super::engine::flat::Flat;
 use super::engine::hnsw::Hnsw;
+use super::engine::ivfpq::{IvfPq, IvfPqParams};
 use super::kv_store::KvNodeStore;
 use super::params::Params;
 use super::store::NodeId;
@@ -32,6 +33,7 @@ pub struct VectorIndex {
     desc: IndexDescription,
     vector: VectorIndexDescription,
     params: Params,
+    ivfpq: IvfPqParams,
     metric: Metric,
     seed: u64,
 }
@@ -48,16 +50,30 @@ impl VectorIndex {
         let mut params = Params::new(hnsw.m as usize);
         params.ef_construction = hnsw.ef_construction as usize;
         params.ef_search = hnsw.ef_search as usize;
-        // Flat has no build parameters, so an HNSW block alongside it is
-        // inert rather than a reason to refuse the index.
+        // Each algorithm validates only its own block, so parameters belonging
+        // to another are inert rather than a reason to refuse the index.
         if vector.algorithm == VectorAlgorithm::Hnsw {
             params.validate()?;
         }
+
+        let configured = vector.ivfpq.unwrap_or_default();
+        let ivfpq = IvfPqParams {
+            nlist: configured.nlist,
+            nprobe: configured.nprobe,
+            m: configured.m,
+            sample_bytes: configured.sample_bytes,
+        };
 
         let metric = match vector.metric {
             DistanceMetric::Cosine => Metric::Cosine,
             DistanceMetric::Dot => Metric::NegativeDot,
         };
+
+        // Refused here rather than at query time, so a description that can
+        // never answer is rejected where it is created.
+        if vector.algorithm == VectorAlgorithm::IvfPq {
+            IvfPq::try_new(super::store::MemoryNodeStore::new(), metric, ivfpq, 0)?;
+        }
 
         Ok(Self {
             collection_short_id,
@@ -67,6 +83,7 @@ impl VectorIndex {
             desc,
             vector,
             params,
+            ivfpq,
             metric,
         })
     }
@@ -83,7 +100,7 @@ impl VectorIndex {
         k: usize,
         effort: Option<usize>,
     ) -> Result<Vec<Neighbor>> {
-        self.engine(txn).search(query, k, effort).await
+        self.engine(txn)?.search(query, k, effort).await
     }
 
     /// [`search`](Self::search) restricted to the documents `admit` accepts.
@@ -95,7 +112,9 @@ impl VectorIndex {
         effort: Option<usize>,
         admit: &A,
     ) -> Result<Vec<Neighbor>> {
-        self.engine(txn).search_where(query, k, effort, admit).await
+        self.engine(txn)?
+            .search_where(query, k, effort, admit)
+            .await
     }
 
     /// Returns the configured algorithm behind [`VectorIndexEngine`] rather
@@ -104,14 +123,17 @@ impl VectorIndex {
     fn engine<'txn, T: Reader + Writer + MaybeSend>(
         &self,
         txn: &'txn mut T,
-    ) -> impl VectorIndexEngine + 'txn {
+    ) -> Result<impl VectorIndexEngine + 'txn> {
         let store = KvNodeStore::new(txn, self.collection_short_id, self.desc.id, LIVE_EPOCH);
-        match self.vector.algorithm {
+        Ok(match self.vector.algorithm {
             VectorAlgorithm::Hnsw => {
                 Engine::Hnsw(Hnsw::new(store, self.metric, self.params, self.seed))
             }
             VectorAlgorithm::Flat => Engine::Flat(Flat::new(store, self.metric)),
-        }
+            VectorAlgorithm::IvfPq => {
+                Engine::IvfPq(IvfPq::try_new(store, self.metric, self.ivfpq, self.seed)?)
+            }
+        })
     }
 
     /// The vector a document contributes, if any.
@@ -218,7 +240,7 @@ impl CollectionIndex for VectorIndex {
             return Ok(());
         };
         let id = NodeId(doc_short_id);
-        let mut engine = self.engine(txn);
+        let mut engine = self.engine(txn).map_err(into_storage)?;
         match indexable {
             Indexable::Narrow(v) => engine.insert(id, v).await,
             Indexable::Wide(v) => engine.insert(id, v).await,
@@ -252,6 +274,7 @@ impl CollectionIndex for VectorIndex {
         _values: &[NormalValue],
     ) -> storage::corekv::Result<()> {
         self.engine(txn)
+            .map_err(into_storage)?
             .delete(NodeId(doc_short_id))
             .await
             .map(|_| ())

--- a/crates/db-index/src/vector/kv_store.rs
+++ b/crates/db-index/src/vector/kv_store.rs
@@ -6,7 +6,7 @@
 
 use defra_core::thread_bounds::MaybeSend;
 use storage::corekv::{IterOptions, Key, Reader, Writer};
-use storage::keys::datastore::VectorIndexKey;
+use storage::keys::datastore::{VectorAuxKey, VectorIndexKey};
 
 use super::codec::{decode_meta, decode_node, encode_meta, encode_node};
 use super::store::{Meta, Node, NodeId, VectorNodeStore};
@@ -34,6 +34,17 @@ impl<'txn, T> KvNodeStore<'txn, T> {
     /// Which build of the index this reads and writes.
     pub fn epoch(&self) -> u32 {
         self.epoch
+    }
+
+    fn aux_key(&self, kind: u8, key: &[u8]) -> Vec<u8> {
+        VectorAuxKey::new(
+            self.collection_short_id,
+            self.index_id,
+            self.epoch,
+            kind,
+            key,
+        )
+        .bytes()
     }
 
     fn node_key(&self, id: NodeId) -> Vec<u8> {
@@ -128,6 +139,38 @@ impl<T: Reader + Writer + MaybeSend> VectorNodeStore for KvNodeStore<'_, T> {
                 continue;
             }
             visit(node)?;
+        }
+        Ok(())
+    }
+
+    async fn get_aux(&self, kind: u8, key: &[u8]) -> Result<Option<Vec<u8>>> {
+        Ok(self.txn.get(&self.aux_key(kind, key)).await?)
+    }
+
+    async fn put_aux(&mut self, kind: u8, key: &[u8], value: &[u8]) -> Result<()> {
+        let full = self.aux_key(kind, key);
+        self.txn.set(&full, value).await?;
+        Ok(())
+    }
+
+    /// Streams one kind's entries, holding one at a time. The prefix stops at
+    /// this epoch's discriminator, so a scan cannot reach the graph or another
+    /// kind.
+    async fn iterate_aux<F>(&self, kind: u8, key_prefix: &[u8], mut visit: F) -> Result<()>
+    where
+        F: FnMut(&[u8], &[u8]) -> Result<()> + MaybeSend,
+    {
+        let prefix = self.aux_key(kind, key_prefix);
+        // Every stored entry has a separator after the discriminator, whether
+        // or not the scan narrowed by a prefix.
+        let strip = self.aux_key(kind, &[]).len() + 1;
+        let mut iter = self
+            .txn
+            .iterator(IterOptions::default().with_prefix(prefix))
+            .await?;
+        while let Some(pair) = iter.next().await? {
+            let key = pair.key.get(strip..).unwrap_or_default();
+            visit(key, &pair.value)?;
         }
         Ok(())
     }

--- a/crates/db-index/src/vector/mod.rs
+++ b/crates/db-index/src/vector/mod.rs
@@ -9,4 +9,5 @@ pub mod engine;
 pub mod index;
 pub mod kv_store;
 pub mod params;
+pub mod quantize;
 pub mod store;

--- a/crates/db-index/src/vector/quantize/kmeans.rs
+++ b/crates/db-index/src/vector/quantize/kmeans.rs
@@ -1,0 +1,198 @@
+//! Lloyd's k-means with k-means++ seeding, over a resident sample.
+
+use crate::vector::core::squared_euclidean;
+use crate::vector::engine::ann::{Centroids, Clusterer, Fit};
+
+/// Lloyd's algorithm with k-means++ seeding.
+#[derive(Debug, Clone, Copy)]
+pub struct KMeans {
+    pub max_iterations: usize,
+    pub seed: u64,
+}
+
+impl KMeans {
+    pub fn new(seed: u64) -> Self {
+        Self {
+            max_iterations: 25,
+            seed,
+        }
+    }
+}
+
+impl Clusterer for KMeans {
+    fn fit(&self, sample: &[f32], dimensions: usize, k: usize) -> (Centroids, Fit) {
+        train(sample, dimensions, k, self.max_iterations, self.seed)
+    }
+}
+
+/// Trains `k` centroids over `sample`, a flat `n * dimensions` buffer.
+///
+/// `k` is clamped to the sample size: asking for more centroids than points
+/// would leave empty clusters whose contents are arbitrary.
+pub fn train(
+    sample: &[f32],
+    dimensions: usize,
+    k: usize,
+    max_iterations: usize,
+    seed: u64,
+) -> (Centroids, Fit) {
+    let n = sample.len().checked_div(dimensions).unwrap_or(0);
+    let k = k.min(n).max(1);
+
+    if n == 0 {
+        return (
+            Centroids {
+                k: 0,
+                dimensions,
+                values: Vec::new(),
+            },
+            Fit {
+                k: 0,
+                iterations: 0,
+                inertia: 0.0,
+            },
+        );
+    }
+
+    let point = |i: usize| &sample[i * dimensions..(i + 1) * dimensions];
+    let mut rng = Rng(seed);
+    let mut centroids = seed_plus_plus(sample, dimensions, n, k, &mut rng);
+
+    let mut assignment = vec![usize::MAX; n];
+    let mut iterations = 0;
+    for _ in 0..max_iterations {
+        iterations += 1;
+        let mut moved = false;
+
+        for (i, slot) in assignment.iter_mut().enumerate() {
+            let (nearest, _) = centroids.nearest(point(i));
+            if *slot != nearest {
+                *slot = nearest;
+                moved = true;
+            }
+        }
+
+        let mut sums = vec![0.0f64; k * dimensions];
+        let mut counts = vec![0usize; k];
+        for (i, &c) in assignment.iter().enumerate() {
+            counts[c] += 1;
+            let at = c * dimensions;
+            for (d, value) in point(i).iter().enumerate() {
+                sums[at + d] += *value as f64;
+            }
+        }
+
+        for (c, count) in counts.iter().enumerate() {
+            if *count == 0 {
+                // An empty cluster contributes nothing and would stay empty.
+                // Reseed it on the point furthest from its own centroid.
+                let mut worst = (0usize, -1.0f64);
+                for (i, &owner) in assignment.iter().enumerate() {
+                    let d = squared_euclidean(point(i), centroids.get(owner));
+                    if d > worst.1 {
+                        worst = (i, d);
+                    }
+                }
+                let at = c * dimensions;
+                centroids.values[at..at + dimensions].copy_from_slice(point(worst.0));
+                assignment[worst.0] = c;
+                moved = true;
+                continue;
+            }
+            let at = c * dimensions;
+            let divisor = *count as f64;
+            for d in 0..dimensions {
+                centroids.values[at + d] = (sums[at + d] / divisor) as f32;
+            }
+        }
+
+        if !moved {
+            break;
+        }
+    }
+
+    let inertia = (0..n)
+        .map(|i| squared_euclidean(point(i), centroids.get(centroids.nearest(point(i)).0)))
+        .sum::<f64>()
+        / n as f64;
+
+    (
+        centroids,
+        Fit {
+            k,
+            iterations,
+            inertia,
+        },
+    )
+}
+
+/// k-means++: each seed after the first is drawn with probability proportional
+/// to its squared distance from the nearest seed already chosen. Uniform
+/// seeding routinely puts two seeds in one cluster and leaves another empty.
+fn seed_plus_plus(
+    sample: &[f32],
+    dimensions: usize,
+    n: usize,
+    k: usize,
+    rng: &mut Rng,
+) -> Centroids {
+    let point = |i: usize| &sample[i * dimensions..(i + 1) * dimensions];
+    let mut values = Vec::with_capacity(k * dimensions);
+
+    let first = (rng.next_u64() % n as u64) as usize;
+    values.extend_from_slice(point(first));
+
+    let mut closest: Vec<f64> = (0..n)
+        .map(|i| squared_euclidean(point(i), point(first)))
+        .collect();
+
+    for chosen in 1..k {
+        let total: f64 = closest.iter().sum();
+        let picked = if total <= 0.0 || !total.is_finite() {
+            // Every remaining point coincides with a seed; any index will do.
+            (rng.next_u64() % n as u64) as usize
+        } else {
+            let mut target = rng.next_unit() * total;
+            let mut picked = n - 1;
+            for (i, weight) in closest.iter().enumerate() {
+                target -= weight;
+                if target <= 0.0 {
+                    picked = i;
+                    break;
+                }
+            }
+            picked
+        };
+
+        values.extend_from_slice(point(picked));
+        let at = chosen * dimensions;
+        for (i, nearest) in closest.iter_mut().enumerate() {
+            let d = squared_euclidean(point(i), &values[at..at + dimensions]);
+            if d < *nearest {
+                *nearest = d;
+            }
+        }
+    }
+
+    Centroids {
+        k,
+        dimensions,
+        values,
+    }
+}
+
+struct Rng(u64);
+
+impl Rng {
+    fn next_u64(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+
+    fn next_unit(&mut self) -> f64 {
+        (self.next_u64() >> 11) as f64 / (1u64 << 53) as f64
+    }
+}

--- a/crates/db-index/src/vector/quantize/mod.rs
+++ b/crates/db-index/src/vector/quantize/mod.rs
@@ -1,0 +1,13 @@
+//! Implementations of the sampling, clustering and quantization traits.
+//!
+//! The traits themselves live in [`engine::ann`](crate::vector::engine::ann),
+//! beside every other abstraction a kind implements. Nothing here imports
+//! storage.
+
+mod kmeans;
+mod pq;
+mod sample;
+
+pub use kmeans::KMeans;
+pub use pq::{ProductQuantizer, CODEBOOK_SIZE};
+pub use sample::Reservoir;

--- a/crates/db-index/src/vector/quantize/pq.rs
+++ b/crates/db-index/src/vector/quantize/pq.rs
@@ -1,0 +1,166 @@
+//! Product quantization: a vector as `m` bytes.
+
+use crate::error::{Error, Result};
+use crate::vector::core::squared_euclidean;
+use crate::vector::engine::ann::{Centroids, Clusterer, Quantizer};
+
+/// Codebook entries per subquantizer. `nbits = 8`, so a code component is a
+/// `u8` and a list scan is a byte lookup; that is the whole reason the scan is
+/// cheap, and why other widths are out of scope.
+pub const CODEBOOK_SIZE: usize = 256;
+
+/// Splits a vector into `m` subvectors and quantizes each against its own
+/// codebook, so `m` bytes stand in for `dimensions` floats.
+///
+/// At 768 dimensions and `m = 96` that is 96 bytes against 3,072: **32x**.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProductQuantizer {
+    dimensions: usize,
+    m: usize,
+    dsub: usize,
+    /// `m` codebooks, each `CODEBOOK_SIZE * dsub` values.
+    books: Vec<Centroids>,
+}
+
+impl ProductQuantizer {
+    /// Trains one codebook per subspace over `sample`, a flat
+    /// `n * dimensions` buffer.
+    ///
+    /// `m` must divide `dimensions`: a ragged split would leave one subspace a
+    /// different width and its codebook incomparable with the others.
+    pub fn train<C: Clusterer>(
+        clusterer: &C,
+        sample: &[f32],
+        dimensions: usize,
+        m: usize,
+    ) -> Result<Self> {
+        if dimensions == 0 || m == 0 {
+            return Err(Error::Other(
+                "product quantizer needs a non-zero width and subquantizer count".into(),
+            ));
+        }
+        if !dimensions.is_multiple_of(m) {
+            return Err(Error::Other(format!(
+                "product quantizer needs m to divide the width: {m} does not divide {dimensions}"
+            )));
+        }
+
+        let dsub = dimensions / m;
+        let n = sample.len() / dimensions;
+        let mut books = Vec::with_capacity(m);
+
+        let mut subspace = vec![0.0f32; n * dsub];
+        for j in 0..m {
+            for i in 0..n {
+                let from = i * dimensions + j * dsub;
+                subspace[i * dsub..(i + 1) * dsub].copy_from_slice(&sample[from..from + dsub]);
+            }
+            let (centroids, _) = clusterer.fit(&subspace, dsub, CODEBOOK_SIZE);
+            books.push(centroids);
+        }
+
+        Ok(Self {
+            dimensions,
+            m,
+            dsub,
+            books,
+        })
+    }
+
+    /// Rebuilds from stored codebooks.
+    pub fn from_books(dimensions: usize, books: Vec<Centroids>) -> Result<Self> {
+        let m = books.len();
+        if m == 0 || !dimensions.is_multiple_of(m) {
+            return Err(Error::Other(
+                "product quantizer codebooks do not divide the width".into(),
+            ));
+        }
+        let dsub = dimensions / m;
+        if books.iter().any(|book| book.dimensions != dsub) {
+            return Err(Error::Other(
+                "a product quantizer codebook has the wrong subspace width".into(),
+            ));
+        }
+        Ok(Self {
+            dimensions,
+            m,
+            dsub,
+            books,
+        })
+    }
+
+    pub fn books(&self) -> &[Centroids] {
+        &self.books
+    }
+
+    pub fn m(&self) -> usize {
+        self.m
+    }
+
+    fn subspace<'v>(&self, vector: &'v [f32], j: usize) -> &'v [f32] {
+        &vector[j * self.dsub..(j + 1) * self.dsub]
+    }
+}
+
+impl Quantizer for ProductQuantizer {
+    fn code_len(&self) -> usize {
+        self.m
+    }
+
+    fn dimensions(&self) -> usize {
+        self.dimensions
+    }
+
+    fn encode(&self, vector: &[f32], code: &mut [u8]) {
+        for j in 0..self.m {
+            let book = &self.books[j];
+            if book.k == 0 || vector.len() < (j + 1) * self.dsub || code.len() <= j {
+                continue;
+            }
+            let (nearest, _) = book.nearest(self.subspace(vector, j));
+            code[j] = nearest as u8;
+        }
+    }
+
+    fn decode(&self, code: &[u8], out: &mut [f32]) {
+        for j in 0..self.m {
+            let book = &self.books[j];
+            if book.k == 0 || code.len() <= j || out.len() < (j + 1) * self.dsub {
+                continue;
+            }
+            let index = (code[j] as usize).min(book.k - 1);
+            out[j * self.dsub..(j + 1) * self.dsub].copy_from_slice(book.get(index));
+        }
+    }
+
+    /// `m * CODEBOOK_SIZE` partial squared distances, computed once per query.
+    fn distance_table(&self, query: &[f32]) -> Vec<f32> {
+        let mut table = vec![0.0f32; self.m * CODEBOOK_SIZE];
+        for j in 0..self.m {
+            let book = &self.books[j];
+            if query.len() < (j + 1) * self.dsub {
+                continue;
+            }
+            let part = self.subspace(query, j);
+            for c in 0..CODEBOOK_SIZE {
+                table[j * CODEBOOK_SIZE + c] = if c < book.k {
+                    squared_euclidean(part, book.get(c)) as f32
+                } else {
+                    f32::INFINITY
+                };
+            }
+        }
+        table
+    }
+
+    fn distance(&self, table: &[f32], code: &[u8]) -> f64 {
+        let mut total = 0.0f64;
+        for (j, part) in code.iter().enumerate().take(self.m) {
+            let at = j * CODEBOOK_SIZE + *part as usize;
+            if at < table.len() {
+                total += table[at] as f64;
+            }
+        }
+        total
+    }
+}

--- a/crates/db-index/src/vector/quantize/sample.rs
+++ b/crates/db-index/src/vector/quantize/sample.rs
@@ -1,0 +1,90 @@
+//! A bounded training sample drawn from a stream.
+
+use crate::vector::engine::ann::Sampler;
+
+/// Reservoir sampling: every vector in the stream has the same chance of ending
+/// up in the sample, whatever the stream's length, and the stream is read once.
+pub struct Reservoir {
+    dimensions: usize,
+    capacity: usize,
+    vectors: Vec<f32>,
+    seen: u64,
+    state: u64,
+}
+
+impl Reservoir {
+    /// `budget_bytes` caps the resident sample. A budget too small for even one
+    /// vector still holds one, so training never sees an empty reservoir on a
+    /// non-empty stream.
+    pub fn new(dimensions: usize, budget_bytes: usize, seed: u64) -> Self {
+        let per_vector = dimensions.max(1) * size_of::<f32>();
+        let capacity = (budget_bytes / per_vector).max(1);
+        Self {
+            dimensions,
+            capacity,
+            vectors: Vec::with_capacity(capacity.min(1024) * dimensions),
+            seen: 0,
+            state: seed,
+        }
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.state = self.state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+
+    fn push(&mut self, vector: &[f32]) {
+        if vector.len() != self.dimensions {
+            return;
+        }
+        self.seen += 1;
+
+        if self.vectors.len() < self.capacity * self.dimensions {
+            self.vectors.extend_from_slice(vector);
+            return;
+        }
+
+        let slot = (self.next_u64() % self.seen) as usize;
+        if slot < self.capacity {
+            let at = slot * self.dimensions;
+            self.vectors[at..at + self.dimensions].copy_from_slice(vector);
+        }
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    pub fn into_flat(self) -> Vec<f32> {
+        self.vectors
+    }
+}
+
+impl Sampler for Reservoir {
+    /// Wrong-width vectors are ignored rather than corrupting the flat buffer.
+    fn offer(&mut self, vector: &[f32]) {
+        self.push(vector)
+    }
+
+    fn as_flat(&self) -> &[f32] {
+        &self.vectors
+    }
+
+    fn len(&self) -> usize {
+        if self.dimensions == 0 {
+            return 0;
+        }
+        self.vectors.len() / self.dimensions
+    }
+
+    fn seen(&self) -> u64 {
+        self.seen
+    }
+
+    fn resident_bytes(&self) -> usize {
+        self.vectors.len() * size_of::<f32>()
+    }
+}

--- a/crates/db-index/src/vector/store/memory.rs
+++ b/crates/db-index/src/vector/store/memory.rs
@@ -17,6 +17,7 @@ use crate::error::Result;
 pub struct MemoryNodeStore {
     nodes: BTreeMap<NodeId, Node>,
     meta: Option<Meta>,
+    aux: BTreeMap<(u8, Vec<u8>), Vec<u8>>,
 }
 
 impl MemoryNodeStore {
@@ -64,6 +65,27 @@ impl VectorNodeStore for MemoryNodeStore {
                 continue;
             }
             visit(node.clone())?;
+        }
+        Ok(())
+    }
+
+    async fn get_aux(&self, kind: u8, key: &[u8]) -> Result<Option<Vec<u8>>> {
+        Ok(self.aux.get(&(kind, key.to_vec())).cloned())
+    }
+
+    async fn put_aux(&mut self, kind: u8, key: &[u8], value: &[u8]) -> Result<()> {
+        self.aux.insert((kind, key.to_vec()), value.to_vec());
+        Ok(())
+    }
+
+    async fn iterate_aux<F>(&self, kind: u8, key_prefix: &[u8], mut visit: F) -> Result<()>
+    where
+        F: FnMut(&[u8], &[u8]) -> Result<()> + MaybeSend,
+    {
+        for ((entry_kind, key), value) in &self.aux {
+            if *entry_kind == kind && key.starts_with(key_prefix) {
+                visit(key, value)?;
+            }
         }
         Ok(())
     }

--- a/crates/db-index/src/vector/store/mod.rs
+++ b/crates/db-index/src/vector/store/mod.rs
@@ -86,4 +86,20 @@ pub trait VectorNodeStore: MaybeSendSync {
     async fn iterate_nodes<F>(&self, visit: F) -> Result<()>
     where
         F: FnMut(Node) -> Result<()> + MaybeSend;
+
+    /// A namespaced blob space private to this index and epoch, for whatever a
+    /// kind needs beyond nodes: coarse centroids, codebooks, inverted lists.
+    ///
+    /// `kind` separates concepts and `key` is the kind's own encoding, so a
+    /// kind adds a concept without a port change. Graph-only kinds never call
+    /// these.
+    async fn get_aux(&self, kind: u8, key: &[u8]) -> Result<Option<Vec<u8>>>;
+
+    async fn put_aux(&mut self, kind: u8, key: &[u8], value: &[u8]) -> Result<()>;
+
+    /// Visits every entry of `kind` whose key starts with `key_prefix`, in key
+    /// order, one at a time.
+    async fn iterate_aux<F>(&self, kind: u8, key_prefix: &[u8], visit: F) -> Result<()>
+    where
+        F: FnMut(&[u8], &[u8]) -> Result<()> + MaybeSend;
 }

--- a/crates/db-index/tests/ivfpq_engine.rs
+++ b/crates/db-index/tests/ivfpq_engine.rs
@@ -1,0 +1,283 @@
+//! The IVF-PQ engine and its train-on-threshold lifecycle.
+
+use db_index::vector::core::Metric;
+use db_index::vector::engine::ann::{EngineKind, VectorIndexEngine};
+use db_index::vector::engine::flat::Flat;
+use db_index::vector::engine::ivfpq::{IvfPq, IvfPqParams};
+use db_index::vector::store::{MemoryNodeStore, NodeId};
+
+mod common;
+
+const SEED: u64 = 0x1F4_9C0D;
+const DIMENSIONS: usize = 16;
+
+fn params(nlist: u32, nprobe: u32) -> IvfPqParams {
+    IvfPqParams {
+        nlist,
+        nprobe,
+        m: 4,
+        ..IvfPqParams::default()
+    }
+}
+
+fn index(nlist: u32, nprobe: u32) -> IvfPq<MemoryNodeStore> {
+    IvfPq::try_new(
+        MemoryNodeStore::new(),
+        Metric::Cosine,
+        params(nlist, nprobe),
+        SEED,
+    )
+    .expect("cosine is rankable by squared distance")
+}
+
+async fn filled(nlist: u32, nprobe: u32, vectors: &[Vec<f32>]) -> IvfPq<MemoryNodeStore> {
+    let mut index = index(nlist, nprobe);
+    for (i, vector) in vectors.iter().enumerate() {
+        index.insert(NodeId(i as u64 + 1), vector).await.unwrap();
+    }
+    index
+}
+
+async fn exact(vectors: &[Vec<f32>], query: &[f32], k: usize) -> Vec<u64> {
+    let mut flat = Flat::new(MemoryNodeStore::new(), Metric::Cosine);
+    for (i, vector) in vectors.iter().enumerate() {
+        flat.insert(NodeId(i as u64 + 1), vector).await.unwrap();
+    }
+    flat.search(query, k, None)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|n| n.id.0)
+        .collect()
+}
+
+#[tokio::test]
+async fn the_kind_is_reported() {
+    assert_eq!(index(4, 2).kind(), EngineKind::IvfPq);
+}
+
+/// A magnitude-sensitive metric is not ordered by squared distance, so it is
+/// refused rather than silently ranked on the wrong quantity.
+#[test]
+fn a_metric_adc_cannot_rank_is_refused() {
+    assert!(IvfPq::try_new(
+        MemoryNodeStore::new(),
+        Metric::NegativeDot,
+        IvfPqParams::default(),
+        SEED
+    )
+    .is_err());
+    assert!(IvfPq::try_new(
+        MemoryNodeStore::new(),
+        Metric::Cosine,
+        IvfPqParams::default(),
+        SEED
+    )
+    .is_ok());
+    assert!(IvfPq::try_new(
+        MemoryNodeStore::new(),
+        Metric::Euclidean,
+        IvfPqParams::default(),
+        SEED
+    )
+    .is_ok());
+}
+
+/// Before training the index is exact, because it is a flat scan.
+#[tokio::test]
+async fn an_untrained_index_answers_exactly() {
+    let mut corpus = common::Corpus::new(SEED);
+    let vectors = corpus.vectors(120, DIMENSIONS);
+    let index = filled(8, 4, &vectors).await;
+
+    assert!(!index.is_trained().await.unwrap());
+
+    let query = &vectors[5];
+    let got: Vec<u64> = index
+        .search(query.as_slice(), 10, None)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|n| n.id.0)
+        .collect();
+    assert_eq!(got, exact(&vectors, query, 10).await);
+}
+
+#[tokio::test]
+async fn building_marks_the_index_trained() {
+    let mut corpus = common::Corpus::new(SEED);
+    let vectors = corpus.vectors(400, DIMENSIONS);
+    let mut index = filled(8, 8, &vectors).await;
+
+    let report = index.build().await.unwrap();
+    assert_eq!(report.indexed, 400);
+    assert_eq!(report.state.dimensions, DIMENSIONS as u32);
+    assert_eq!(report.state.nlist, 8);
+    assert!(report.sampled > 0);
+    assert!(index.is_trained().await.unwrap());
+}
+
+/// Probing every list makes the coarse step exhaustive, so the only remaining
+/// error is quantization. The answers must be close to exact, not arbitrary.
+#[tokio::test]
+async fn a_trained_index_agrees_closely_with_an_exact_scan() {
+    let mut corpus = common::Corpus::new(SEED ^ 0xABC);
+    let vectors = corpus.clustered(600, DIMENSIONS, 12, 0.12);
+    let mut index = filled(12, 12, &vectors).await;
+    index.build().await.unwrap();
+
+    let mut matched = 0usize;
+    let queries = 20;
+    for i in 0..queries {
+        let query = &vectors[i * 7];
+        let got: Vec<u64> = index
+            .search(query.as_slice(), 10, None)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|n| n.id.0)
+            .collect();
+        let want = exact(&vectors, query, 10).await;
+        matched += got.iter().filter(|id| want.contains(id)).count();
+    }
+
+    let recall = matched as f64 / (queries * 10) as f64;
+    assert!(
+        recall >= 0.80,
+        "recall against an exact scan was {recall:.3}, too low to be quantization alone"
+    );
+}
+
+/// A vector's own document must come back first: quantization is lossy but not
+/// that lossy.
+#[tokio::test]
+async fn a_corpus_vector_finds_itself() {
+    let mut corpus = common::Corpus::new(SEED ^ 0xDEF);
+    let vectors = corpus.clustered(500, DIMENSIONS, 10, 0.1);
+    let mut index = filled(10, 10, &vectors).await;
+    index.build().await.unwrap();
+
+    let mut found = 0usize;
+    for i in [0usize, 37, 111, 250, 400] {
+        let hits = index.search(vectors[i].as_slice(), 5, None).await.unwrap();
+        if hits.iter().any(|n| n.id == NodeId(i as u64 + 1)) {
+            found += 1;
+        }
+    }
+    assert!(found >= 4, "only {found}/5 vectors found themselves");
+}
+
+/// Writes after a build must be searchable, or the index silently stops
+/// covering new documents.
+#[tokio::test]
+async fn a_document_written_after_the_build_is_searchable() {
+    let mut corpus = common::Corpus::new(SEED ^ 0x111);
+    let vectors = corpus.clustered(400, DIMENSIONS, 8, 0.1);
+    let mut index = filled(8, 8, &vectors).await;
+    index.build().await.unwrap();
+
+    let late = vectors[3].clone();
+    index.insert(NodeId(9_999), &late).await.unwrap();
+
+    let hits = index.search(late.as_slice(), 10, None).await.unwrap();
+    assert!(
+        hits.iter().any(|n| n.id == NodeId(9_999)),
+        "the late document was not found: {hits:?}"
+    );
+}
+
+#[tokio::test]
+async fn a_deleted_document_stops_ranking() {
+    let mut corpus = common::Corpus::new(SEED ^ 0x222);
+    let vectors = corpus.clustered(400, DIMENSIONS, 8, 0.1);
+    let mut index = filled(8, 8, &vectors).await;
+    index.build().await.unwrap();
+
+    assert!(index.delete(NodeId(1)).await.unwrap());
+    let hits = index.search(vectors[0].as_slice(), 10, None).await.unwrap();
+    assert!(
+        !hits.iter().any(|n| n.id == NodeId(1)),
+        "a deleted document ranked: {hits:?}"
+    );
+}
+
+/// `Admit` is trait-level, so it must work here exactly as it does for a graph.
+#[tokio::test]
+async fn a_filter_excludes_without_shortening_the_answer() {
+    let mut corpus = common::Corpus::new(SEED ^ 0x333);
+    let vectors = corpus.clustered(500, DIMENSIONS, 10, 0.1);
+    let mut index = filled(10, 10, &vectors).await;
+    index.build().await.unwrap();
+
+    let admit = |id: NodeId| id.0.is_multiple_of(2);
+    let hits = index
+        .search_where(vectors[9].as_slice(), 8, None, &admit)
+        .await
+        .unwrap();
+
+    assert!(
+        hits.iter().all(|n| n.id.0.is_multiple_of(2)),
+        "a filter leaked"
+    );
+    assert_eq!(hits.len(), 8, "the filter shortened the answer");
+}
+
+#[tokio::test]
+async fn results_are_ordered_nearest_first() {
+    let mut corpus = common::Corpus::new(SEED ^ 0x444);
+    let vectors = corpus.clustered(400, DIMENSIONS, 8, 0.1);
+    let mut index = filled(8, 8, &vectors).await;
+    index.build().await.unwrap();
+
+    let hits = index.search(vectors[2].as_slice(), 10, None).await.unwrap();
+    assert!(hits.windows(2).all(|w| w[0].distance <= w[1].distance));
+}
+
+/// Probing more lists can only look at more candidates, so recall must not
+/// fall as nprobe rises.
+#[tokio::test]
+async fn recall_does_not_fall_as_nprobe_rises() {
+    let mut corpus = common::Corpus::new(SEED ^ 0x555);
+    let vectors = corpus.clustered(600, DIMENSIONS, 16, 0.1);
+    let query = vectors[13].clone();
+    let want = exact(&vectors, &query, 10).await;
+
+    let mut previous = 0usize;
+    for nprobe in [1usize, 2, 4, 8, 16] {
+        let mut index = filled(16, nprobe as u32, &vectors).await;
+        index.build().await.unwrap();
+        let got: Vec<u64> = index
+            .search(query.as_slice(), 10, None)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|n| n.id.0)
+            .collect();
+        let hit = got.iter().filter(|id| want.contains(id)).count();
+        assert!(
+            hit + 1 >= previous,
+            "recall fell at nprobe={nprobe}: {hit} after {previous}"
+        );
+        previous = hit;
+    }
+}
+
+#[tokio::test]
+async fn an_empty_index_builds_no_state() {
+    let mut index = index(4, 2);
+    assert!(index.build().await.is_err());
+    assert!(!index.is_trained().await.unwrap());
+}
+
+#[tokio::test]
+async fn k_zero_returns_nothing() {
+    let mut corpus = common::Corpus::new(SEED ^ 0x666);
+    let vectors = corpus.vectors(200, DIMENSIONS);
+    let mut index = filled(4, 4, &vectors).await;
+    index.build().await.unwrap();
+    assert!(index
+        .search(vectors[0].as_slice(), 0, None)
+        .await
+        .unwrap()
+        .is_empty());
+}

--- a/crates/db-index/tests/ivfpq_engine.rs
+++ b/crates/db-index/tests/ivfpq_engine.rs
@@ -8,7 +8,7 @@ use db_index::vector::store::{MemoryNodeStore, NodeId};
 
 mod common;
 
-const SEED: u64 = 0x1F4_9C0D;
+const SEED: u64 = 0x01F4_9C0D;
 const DIMENSIONS: usize = 16;
 
 fn params(nlist: u32, nprobe: u32) -> IvfPqParams {

--- a/crates/db-index/tests/ivfpq_recall_baseline.rs
+++ b/crates/db-index/tests/ivfpq_recall_baseline.rs
@@ -1,0 +1,196 @@
+//! IVF-PQ recall and cost against `Flat`, the exact oracle.
+//!
+//! `#[ignore]` because it takes minutes. Its output is what the plan records,
+//! so the numbers there stay reproducible:
+//!
+//! ```text
+//! cargo test --release -p db-index --test ivfpq_recall_baseline -- --ignored --nocapture
+//! ```
+//!
+//! Two errors compound here and the table separates them. Probing fewer than
+//! every list can miss a neighbour whose code was never scanned; quantization
+//! can rank a scanned code wrongly. At `nprobe = nlist` only the second remains,
+//! which is the row that isolates the codec.
+
+use db_index::vector::core::Metric;
+use db_index::vector::engine::ann::VectorIndexEngine;
+use db_index::vector::engine::flat::Flat;
+use db_index::vector::engine::ivfpq::{IvfPq, IvfPqParams};
+use db_index::vector::store::{MemoryNodeStore, NodeId};
+
+mod common;
+
+const SEED: u64 = 0x01F4_9C0D;
+const K: usize = 10;
+const QUERIES: usize = 30;
+
+async fn exact(vectors: &[Vec<f32>], query: &[f32], k: usize) -> Vec<u64> {
+    let mut flat = Flat::new(MemoryNodeStore::new(), Metric::Cosine);
+    for (i, vector) in vectors.iter().enumerate() {
+        flat.insert(NodeId(i as u64 + 1), vector).await.unwrap();
+    }
+    flat.search(query, k, None)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|n| n.id.0)
+        .collect()
+}
+
+struct Row {
+    recall: f64,
+    ratio: f64,
+    code_bytes: usize,
+    vector_bytes: usize,
+}
+
+async fn measure(
+    vectors: &[Vec<f32>],
+    queries: &[Vec<f32>],
+    dimensions: usize,
+    nlist: u32,
+    nprobe: u32,
+    m: u32,
+) -> Row {
+    let mut index = IvfPq::try_new(
+        MemoryNodeStore::new(),
+        Metric::Cosine,
+        IvfPqParams {
+            nlist,
+            nprobe,
+            m,
+            ..IvfPqParams::default()
+        },
+        SEED,
+    )
+    .unwrap();
+    for (i, vector) in vectors.iter().enumerate() {
+        index.insert(NodeId(i as u64 + 1), vector).await.unwrap();
+    }
+    let report = index.build().await.unwrap();
+
+    let (mut hit, mut total, mut ratio_sum) = (0usize, 0usize, 0.0f64);
+    for query in queries {
+        let want = exact(vectors, query, K).await;
+        let got = index.search(query.as_slice(), K, None).await.unwrap();
+
+        hit += got.iter().filter(|n| want.contains(&n.id.0)).count();
+        total += want.len();
+
+        let ideal: f64 = want
+            .iter()
+            .map(|id| Metric::Cosine.distance(query.as_slice(), &vectors[*id as usize - 1]))
+            .sum();
+        let actual: f64 = got
+            .iter()
+            .map(|n| Metric::Cosine.distance(query.as_slice(), &vectors[n.id.0 as usize - 1]))
+            .sum();
+        ratio_sum += if ideal.abs() > f64::EPSILON {
+            actual / ideal
+        } else {
+            1.0
+        };
+    }
+
+    Row {
+        recall: hit as f64 / total as f64,
+        ratio: ratio_sum / QUERIES as f64,
+        code_bytes: report.state.m as usize,
+        vector_bytes: dimensions * size_of::<f32>(),
+    }
+}
+
+fn header() {
+    println!(
+        "{:>22} {:>7} {:>6} {:>7} {:>4} {:>10} {:>9} {:>12}",
+        "corpus", "N", "nlist", "nprobe", "m", "recall@10", "dist/best", "bytes/vector"
+    );
+}
+
+fn report(label: &str, n: usize, nlist: u32, nprobe: u32, m: u32, row: &Row) {
+    println!(
+        "{label:>22} {n:>7} {nlist:>6} {nprobe:>7} {m:>4} {:>10.4} {:>9.4} {:>5} -> {:<4}",
+        row.recall, row.ratio, row.vector_bytes, row.code_bytes
+    );
+}
+
+/// The full curve: how recall trades against how many lists are probed.
+///
+/// Queries are **held out**, not corpus members, and the clusters overlap. With
+/// tight clusters and a query drawn from the corpus, its true top-10 all sit in
+/// its own list and `nprobe` cannot matter, which measures nothing.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "measurement; run with --ignored --nocapture"]
+async fn recall_vs_nprobe() {
+    header();
+    for dimensions in [32usize, 128] {
+        let mut corpus = common::Corpus::new(SEED);
+        let vectors = corpus.clustered(5_000, dimensions, 64, 0.45);
+        let queries = corpus.vectors(QUERIES, dimensions);
+        for nprobe in [1u32, 2, 4, 8, 16, 32, 64] {
+            let row = measure(&vectors, &queries, dimensions, 64, nprobe, 32).await;
+            report(
+                &format!("clustered d={dimensions}"),
+                vectors.len(),
+                64,
+                nprobe,
+                32,
+                &row,
+            );
+        }
+    }
+}
+
+/// Compression against accuracy, with the coarse step exhaustive so the only
+/// error left is the codec's.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "measurement; run with --ignored --nocapture"]
+async fn recall_vs_compression() {
+    header();
+    let dimensions = 128;
+    let mut corpus = common::Corpus::new(SEED ^ 0xC0DE);
+    let vectors = corpus.clustered(5_000, dimensions, 32, 0.12);
+
+    let queries = corpus.vectors(QUERIES, dimensions);
+    for m in [4u32, 8, 16, 32, 64] {
+        let row = measure(&vectors, &queries, dimensions, 32, 32, m).await;
+        report("clustered d=128", vectors.len(), 32, 32, m, &row);
+    }
+}
+
+/// What the untrained state costs: exact, and linear.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "measurement; run with --ignored --nocapture"]
+async fn the_untrained_state_is_exact() {
+    let dimensions = 64;
+    let mut corpus = common::Corpus::new(SEED ^ 0xFEED);
+    let vectors = corpus.clustered(2_000, dimensions, 16, 0.12);
+
+    let mut index = IvfPq::try_new(
+        MemoryNodeStore::new(),
+        Metric::Cosine,
+        IvfPqParams::default(),
+        SEED,
+    )
+    .unwrap();
+    for (i, vector) in vectors.iter().enumerate() {
+        index.insert(NodeId(i as u64 + 1), vector).await.unwrap();
+    }
+
+    let mut agreed = 0usize;
+    for q in 0..QUERIES {
+        let query = &vectors[q * 7 % vectors.len()];
+        let got: Vec<u64> = index
+            .search(query.as_slice(), K, None)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|n| n.id.0)
+            .collect();
+        if got == exact(&vectors, query, K).await {
+            agreed += 1;
+        }
+    }
+    println!("untrained: {agreed}/{QUERIES} queries identical to an exact scan");
+    assert_eq!(agreed, QUERIES, "the untrained state must be exact");
+}

--- a/crates/db-index/tests/ivfpq_recall_gate.rs
+++ b/crates/db-index/tests/ivfpq_recall_gate.rs
@@ -1,0 +1,150 @@
+//! The IVF-PQ recall target: a regression gate on a named distribution.
+//!
+//! Scoped deliberately. These thresholds hold for the synthetic clustered
+//! corpus below and say nothing about a real embedding corpus, which has never
+//! been measured here. What they catch is the index getting worse than it is
+//! today.
+//!
+//! Sized to run in the ordinary suite; the full curves live in
+//! `ivfpq_recall_baseline.rs`, which is `#[ignore]`d.
+
+use db_index::vector::core::Metric;
+use db_index::vector::engine::ann::VectorIndexEngine;
+use db_index::vector::engine::flat::Flat;
+use db_index::vector::engine::ivfpq::{IvfPq, IvfPqParams};
+use db_index::vector::store::{MemoryNodeStore, NodeId};
+
+mod common;
+
+const SEED: u64 = 0x09C0_D1F4;
+const K: usize = 10;
+const QUERIES: usize = 12;
+const DIMENSIONS: usize = 16;
+
+struct Measured {
+    recall: f64,
+    ratio: f64,
+}
+
+async fn oracle(vectors: &[Vec<f32>]) -> Flat<MemoryNodeStore> {
+    let mut flat = Flat::new(MemoryNodeStore::new(), Metric::Cosine);
+    for (i, vector) in vectors.iter().enumerate() {
+        flat.insert(NodeId(i as u64 + 1), vector).await.unwrap();
+    }
+    flat
+}
+
+async fn exact(flat: &Flat<MemoryNodeStore>, query: &[f32]) -> Vec<u64> {
+    flat.search(query, K, None)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|n| n.id.0)
+        .collect()
+}
+
+async fn measure(nprobe: u32, m: u32) -> Measured {
+    let mut corpus = common::Corpus::new(SEED);
+    let vectors = corpus.clustered(600, DIMENSIONS, 8, 0.4);
+    let queries = corpus.vectors(QUERIES, DIMENSIONS);
+
+    let mut index = IvfPq::try_new(
+        MemoryNodeStore::new(),
+        Metric::Cosine,
+        IvfPqParams {
+            nlist: 8,
+            nprobe,
+            m,
+            ..IvfPqParams::default()
+        },
+        SEED,
+    )
+    .unwrap();
+    for (i, vector) in vectors.iter().enumerate() {
+        index.insert(NodeId(i as u64 + 1), vector).await.unwrap();
+    }
+    index.build().await.unwrap();
+
+    // Built once, not per query: the oracle is the same for every one of them.
+    let flat = oracle(&vectors).await;
+    let (mut hit, mut total, mut ratio_sum) = (0usize, 0usize, 0.0f64);
+    for query in &queries {
+        let want = exact(&flat, query).await;
+        let got = index.search(query.as_slice(), K, None).await.unwrap();
+        hit += got.iter().filter(|n| want.contains(&n.id.0)).count();
+        total += want.len();
+
+        let ideal: f64 = want
+            .iter()
+            .map(|id| Metric::Cosine.distance(query.as_slice(), &vectors[*id as usize - 1]))
+            .sum();
+        let actual: f64 = got
+            .iter()
+            .map(|n| Metric::Cosine.distance(query.as_slice(), &vectors[n.id.0 as usize - 1]))
+            .sum();
+        ratio_sum += if ideal.abs() > f64::EPSILON {
+            actual / ideal
+        } else {
+            1.0
+        };
+    }
+
+    Measured {
+        recall: hit as f64 / total as f64,
+        ratio: ratio_sum / QUERIES as f64,
+    }
+}
+
+/// Every list probed, so the coarse step is exhaustive and the only error left
+/// is the codec's. This is the row that gates the quantizer.
+#[tokio::test]
+async fn quantization_error_alone_stays_bounded() {
+    let m = measure(8, 8).await;
+    println!(
+        "nprobe=8 m=8: recall@10={:.4} dist/best={:.4}",
+        m.recall, m.ratio
+    );
+    assert!(m.recall >= 0.90, "recall@10 fell to {:.4}", m.recall);
+    assert!(
+        m.ratio <= 1.02,
+        "returned neighbours are {:.4}x ideal",
+        m.ratio
+    );
+}
+
+/// One list probed: most of the loss is the coarse step missing a neighbour it
+/// never scanned. A floor, so a broken probe ordering is caught.
+#[tokio::test]
+async fn a_single_probe_still_finds_most_neighbours() {
+    let m = measure(1, 8).await;
+    println!(
+        "nprobe=1 m=8: recall@10={:.4} dist/best={:.4}",
+        m.recall, m.ratio
+    );
+    assert!(m.recall >= 0.55, "recall@10 fell to {:.4}", m.recall);
+}
+
+/// Probing more lists can only see more candidates.
+#[tokio::test]
+async fn recall_rises_with_nprobe() {
+    let one = measure(1, 8).await.recall;
+    let all = measure(8, 8).await.recall;
+    assert!(
+        all > one,
+        "probing every list ({all:.4}) was no better than one ({one:.4})"
+    );
+}
+
+/// Finer codes can only rank better.
+#[tokio::test]
+async fn recall_rises_with_finer_codes() {
+    let coarse = measure(8, 2).await;
+    let fine = measure(8, 8).await;
+    assert!(
+        fine.recall >= coarse.recall,
+        "m=8 ({:.4}) was worse than m=2 ({:.4})",
+        fine.recall,
+        coarse.recall
+    );
+    assert!(fine.ratio <= coarse.ratio);
+}

--- a/crates/db-index/tests/quantize_kmeans.rs
+++ b/crates/db-index/tests/quantize_kmeans.rs
@@ -1,0 +1,133 @@
+//! Fitting centroids.
+
+use db_index::vector::core::squared_euclidean;
+use db_index::vector::engine::ann::Clusterer;
+use db_index::vector::quantize::KMeans;
+
+mod common;
+
+/// Four corners of a square, well separated, repeated. The right answer is
+/// known without computing anything.
+fn four_clusters(per_cluster: usize) -> (Vec<f32>, Vec<[f32; 2]>) {
+    let centers = vec![[0.0, 0.0], [10.0, 0.0], [0.0, 10.0], [10.0, 10.0]];
+    let mut flat = Vec::new();
+    let mut corpus = common::Corpus::new(0xC1057);
+    for _ in 0..per_cluster {
+        for center in &centers {
+            let jitter = corpus.vector(2);
+            flat.push(center[0] + jitter[0] * 0.3);
+            flat.push(center[1] + jitter[1] * 0.3);
+        }
+    }
+    (flat, centers)
+}
+
+#[test]
+fn separable_clusters_are_recovered() {
+    let (sample, centers) = four_clusters(60);
+    let (centroids, fit) = KMeans::new(1).fit(&sample, 2, 4);
+
+    assert_eq!(fit.k, 4);
+    for center in &centers {
+        let (_, distance) = centroids.nearest(center);
+        assert!(
+            distance < 1.0,
+            "no centroid landed near {center:?}, nearest was {distance} away"
+        );
+    }
+}
+
+/// Every centroid must own points. An empty cluster means the fit wasted a
+/// centroid and the index would have a list nothing routes to.
+#[test]
+fn no_cluster_is_left_empty() {
+    let (sample, _) = four_clusters(40);
+    let (centroids, _) = KMeans::new(7).fit(&sample, 2, 4);
+
+    let mut owned = vec![0usize; 4];
+    for point in sample.chunks(2) {
+        owned[centroids.nearest(point).0] += 1;
+    }
+    assert!(
+        owned.iter().all(|count| *count > 0),
+        "some centroid owns nothing: {owned:?}"
+    );
+}
+
+/// More centroids than points cannot be meaningful, so `k` is clamped and the
+/// fit reports what it actually produced.
+#[test]
+fn k_is_clamped_to_the_sample_size() {
+    let sample = vec![1.0f32, 1.0, 2.0, 2.0, 3.0, 3.0];
+    let (centroids, fit) = KMeans::new(3).fit(&sample, 2, 50);
+    assert_eq!(fit.k, 3);
+    assert_eq!(centroids.k, 3);
+    assert_eq!(centroids.values.len(), 3 * 2);
+}
+
+#[test]
+fn an_empty_sample_fits_nothing() {
+    let (centroids, fit) = KMeans::new(1).fit(&[], 4, 8);
+    assert_eq!(fit.k, 0);
+    assert_eq!(centroids.k, 0);
+    assert!(centroids.values.is_empty());
+}
+
+/// A rebuild must produce the same index, so the fit is a function of the seed.
+#[test]
+fn the_same_seed_fits_the_same_centroids() {
+    let (sample, _) = four_clusters(30);
+    let a = KMeans::new(99).fit(&sample, 2, 4).0;
+    let b = KMeans::new(99).fit(&sample, 2, 4).0;
+    assert_eq!(a, b);
+}
+
+/// More centroids can only fit the sample more tightly. A rise would mean the
+/// iteration is diverging.
+#[test]
+fn inertia_falls_as_k_rises() {
+    let mut corpus = common::Corpus::new(0x1E27);
+    let sample: Vec<f32> = corpus.vectors(400, 8).into_iter().flatten().collect();
+
+    let mut previous = f64::INFINITY;
+    for k in [2usize, 4, 8, 16, 32] {
+        let (_, fit) = KMeans::new(5).fit(&sample, 8, k);
+        assert!(
+            fit.inertia <= previous + 1e-6,
+            "inertia rose at k={k}: {} after {previous}",
+            fit.inertia
+        );
+        previous = fit.inertia;
+    }
+}
+
+/// Identical points give k-means++ nothing to spread over; it must not divide
+/// by a zero total or loop forever.
+#[test]
+fn a_degenerate_sample_still_fits() {
+    let sample = vec![2.0f32; 40 * 4];
+    let (centroids, fit) = KMeans::new(13).fit(&sample, 4, 8);
+    assert_eq!(fit.k, 8);
+    assert!(fit.inertia.abs() < 1e-9, "inertia was {}", fit.inertia);
+    for index in 0..centroids.k {
+        assert!(centroids.get(index).iter().all(|v| (*v - 2.0).abs() < 1e-6));
+    }
+}
+
+/// The centroid a point is assigned to must really be its nearest.
+#[test]
+fn nearest_agrees_with_an_exhaustive_scan() {
+    let mut corpus = common::Corpus::new(0x9A17);
+    let sample: Vec<f32> = corpus.vectors(200, 6).into_iter().flatten().collect();
+    let (centroids, _) = KMeans::new(2).fit(&sample, 6, 12);
+
+    for point in sample.chunks(6) {
+        let (got, distance) = centroids.nearest(point);
+        let want = (0..centroids.k)
+            .map(|i| (i, squared_euclidean(point, centroids.get(i))))
+            .min_by(|a, b| a.1.total_cmp(&b.1))
+            .unwrap();
+        assert_eq!(got, want.0);
+        assert!((distance - want.1).abs() < 1e-9);
+    }
+}

--- a/crates/db-index/tests/quantize_pq.rs
+++ b/crates/db-index/tests/quantize_pq.rs
@@ -1,0 +1,208 @@
+//! Product quantization: codes, reconstruction, and distances from codes.
+
+use db_index::vector::core::squared_euclidean;
+use db_index::vector::engine::ann::Quantizer;
+use db_index::vector::quantize::{KMeans, ProductQuantizer};
+
+mod common;
+
+const DIMENSIONS: usize = 16;
+const M: usize = 4;
+
+fn sample(count: usize, dimensions: usize, seed: u64) -> Vec<f32> {
+    common::Corpus::new(seed)
+        .vectors(count, dimensions)
+        .into_iter()
+        .flatten()
+        .collect()
+}
+
+fn trained(seed: u64) -> (ProductQuantizer, Vec<f32>) {
+    let flat = sample(600, DIMENSIONS, seed);
+    let pq = ProductQuantizer::train(&KMeans::new(seed), &flat, DIMENSIONS, M)
+        .expect("a divisible width trains");
+    (pq, flat)
+}
+
+#[test]
+fn a_code_is_one_byte_per_subquantizer() {
+    let (pq, _) = trained(1);
+    assert_eq!(pq.code_len(), M);
+    assert_eq!(pq.dimensions(), DIMENSIONS);
+    assert_eq!(pq.books().len(), M);
+    for book in pq.books() {
+        assert_eq!(book.dimensions, DIMENSIONS / M);
+    }
+}
+
+/// `m` must divide the width, or one subspace would be a different shape and
+/// its codebook incomparable with the others.
+#[test]
+fn an_indivisible_width_is_refused() {
+    let flat = sample(100, 10, 2);
+    let err = ProductQuantizer::train(&KMeans::new(2), &flat, 10, 4).unwrap_err();
+    assert!(
+        err.to_string().contains("divide"),
+        "the error must say why, got: {err}"
+    );
+    assert!(ProductQuantizer::train(&KMeans::new(2), &flat, 0, 4).is_err());
+    assert!(ProductQuantizer::train(&KMeans::new(2), &flat, 10, 0).is_err());
+}
+
+/// Reconstruction is lossy, but it must be much closer to the original than a
+/// competing vector is. Otherwise the codes carry no usable signal.
+#[test]
+fn reconstruction_is_closer_than_a_stranger() {
+    let (pq, flat) = trained(3);
+    let mut code = vec![0u8; pq.code_len()];
+    let mut decoded = vec![0.0f32; DIMENSIONS];
+
+    let mut better = 0usize;
+    let total = 200;
+    for i in 0..total {
+        let vector = &flat[i * DIMENSIONS..(i + 1) * DIMENSIONS];
+        let stranger = &flat[(i + 300) * DIMENSIONS..(i + 301) * DIMENSIONS];
+        pq.encode(vector, &mut code);
+        pq.decode(&code, &mut decoded);
+
+        if squared_euclidean(vector, &decoded) < squared_euclidean(vector, stranger) {
+            better += 1;
+        }
+    }
+    assert_eq!(
+        better,
+        total,
+        "reconstruction was worse than an unrelated vector for {} of {total}",
+        total - better
+    );
+}
+
+/// The whole point of the lookup table: the distance it yields must equal the
+/// distance to the reconstruction, or the scan is ranking on something else.
+#[test]
+fn the_lookup_table_agrees_with_the_reconstruction() {
+    let (pq, flat) = trained(4);
+    let mut code = vec![0u8; pq.code_len()];
+    let mut decoded = vec![0.0f32; DIMENSIONS];
+
+    let query = &flat[7 * DIMENSIONS..8 * DIMENSIONS];
+    let table = pq.distance_table(query);
+    assert_eq!(table.len(), M * 256);
+
+    for i in 0..100 {
+        let vector = &flat[i * DIMENSIONS..(i + 1) * DIMENSIONS];
+        pq.encode(vector, &mut code);
+        pq.decode(&code, &mut decoded);
+
+        let from_table = pq.distance(&table, &code);
+        let exact = squared_euclidean(query, &decoded);
+        assert!(
+            (from_table - exact).abs() <= 1e-4 * exact.max(1.0),
+            "table said {from_table}, reconstruction says {exact}"
+        );
+    }
+}
+
+/// Ranking is what the index uses. Against its own codes, the quantizer must
+/// put a vector nearest itself.
+#[test]
+fn a_vector_ranks_nearest_its_own_code() {
+    let (pq, flat) = trained(5);
+    let mut codes = Vec::new();
+    let mut code = vec![0u8; pq.code_len()];
+    for i in 0..200 {
+        pq.encode(&flat[i * DIMENSIONS..(i + 1) * DIMENSIONS], &mut code);
+        codes.push(code.clone());
+    }
+
+    let mut correct = 0usize;
+    for i in 0..200 {
+        let query = &flat[i * DIMENSIONS..(i + 1) * DIMENSIONS];
+        let table = pq.distance_table(query);
+        let nearest = codes
+            .iter()
+            .enumerate()
+            .min_by(|a, b| {
+                pq.distance(&table, a.1)
+                    .total_cmp(&pq.distance(&table, b.1))
+            })
+            .unwrap()
+            .0;
+        if nearest == i {
+            correct += 1;
+        }
+    }
+    // Two vectors can share a code, so this is not required to be perfect; it
+    // must be overwhelming or the codebooks are not separating anything.
+    assert!(
+        correct >= 190,
+        "only {correct}/200 vectors ranked nearest their own code"
+    );
+}
+
+/// More subquantizers means finer codes, so error must fall as `m` rises.
+#[test]
+fn error_falls_as_subquantizers_rise() {
+    let flat = sample(600, DIMENSIONS, 6);
+    let mut previous = f64::INFINITY;
+
+    for m in [1usize, 2, 4, 8, 16] {
+        let pq = ProductQuantizer::train(&KMeans::new(6), &flat, DIMENSIONS, m).unwrap();
+        let mut code = vec![0u8; pq.code_len()];
+        let mut decoded = vec![0.0f32; DIMENSIONS];
+
+        let error: f64 = (0..200)
+            .map(|i| {
+                let vector = &flat[i * DIMENSIONS..(i + 1) * DIMENSIONS];
+                pq.encode(vector, &mut code);
+                pq.decode(&code, &mut decoded);
+                squared_euclidean(vector, &decoded)
+            })
+            .sum::<f64>()
+            / 200.0;
+
+        assert!(
+            error <= previous + 1e-6,
+            "error rose at m={m}: {error} after {previous}"
+        );
+        previous = error;
+    }
+}
+
+/// A quantizer rebuilt from stored codebooks must encode identically, or a
+/// reopened index would disagree with the one that wrote it.
+#[test]
+fn a_quantizer_rebuilt_from_its_codebooks_is_identical() {
+    let (pq, flat) = trained(8);
+    let rebuilt = ProductQuantizer::from_books(DIMENSIONS, pq.books().to_vec()).unwrap();
+    assert_eq!(pq, rebuilt);
+
+    let mut a = vec![0u8; pq.code_len()];
+    let mut b = vec![0u8; rebuilt.code_len()];
+    for i in 0..100 {
+        let vector = &flat[i * DIMENSIONS..(i + 1) * DIMENSIONS];
+        pq.encode(vector, &mut a);
+        rebuilt.encode(vector, &mut b);
+        assert_eq!(a, b);
+    }
+}
+
+#[test]
+fn mismatched_codebooks_are_refused() {
+    let (pq, _) = trained(9);
+    assert!(ProductQuantizer::from_books(DIMENSIONS, Vec::new()).is_err());
+    assert!(ProductQuantizer::from_books(DIMENSIONS + 1, pq.books().to_vec()).is_err());
+}
+
+/// Compression is the reason this kind exists, so it is asserted rather than
+/// assumed.
+#[test]
+fn a_code_is_far_smaller_than_the_vector() {
+    let flat = sample(400, 768, 10);
+    let pq = ProductQuantizer::train(&KMeans::new(10), &flat, 768, 96).unwrap();
+
+    let vector_bytes = 768 * size_of::<f32>();
+    let code_bytes = pq.code_len();
+    assert_eq!(code_bytes, 96);
+    assert_eq!(vector_bytes / code_bytes, 32);
+}

--- a/crates/db-index/tests/quantize_sample.rs
+++ b/crates/db-index/tests/quantize_sample.rs
@@ -1,0 +1,142 @@
+//! The bounded training sample.
+
+use db_index::vector::engine::ann::Sampler;
+use db_index::vector::quantize::Reservoir;
+
+mod common;
+
+const DIMENSIONS: usize = 8;
+
+fn budget_for(vectors: usize) -> usize {
+    vectors * DIMENSIONS * size_of::<f32>()
+}
+
+#[test]
+fn the_sample_never_exceeds_its_byte_budget() {
+    let budget = budget_for(100);
+    let mut reservoir = Reservoir::new(DIMENSIONS, budget, 0x5EED);
+    let mut corpus = common::Corpus::new(0x5EED);
+
+    for vector in corpus.vectors(50_000, DIMENSIONS) {
+        reservoir.offer(&vector);
+        assert!(
+            reservoir.resident_bytes() <= budget,
+            "resident {} exceeded budget {budget}",
+            reservoir.resident_bytes()
+        );
+    }
+
+    assert_eq!(reservoir.len(), 100);
+    assert_eq!(reservoir.seen(), 50_000);
+}
+
+/// The budget bounds bytes, so the vector count it allows must fall as the
+/// width rises. A count-based cap would not.
+#[test]
+fn the_capacity_falls_as_the_width_rises() {
+    let budget = 64 * 1024;
+    let narrow = Reservoir::new(16, budget, 1);
+    let wide = Reservoir::new(768, budget, 1);
+
+    assert_eq!(narrow.capacity(), budget / (16 * 4));
+    assert_eq!(wide.capacity(), budget / (768 * 4));
+    assert!(wide.capacity() < narrow.capacity());
+}
+
+/// A budget too small for one vector still holds one, or training would see an
+/// empty sample on a non-empty stream.
+#[test]
+fn a_budget_below_one_vector_still_holds_one() {
+    let mut reservoir = Reservoir::new(DIMENSIONS, 1, 7);
+    assert_eq!(reservoir.capacity(), 1);
+    reservoir.offer(&[1.0; DIMENSIONS]);
+    assert_eq!(reservoir.len(), 1);
+}
+
+/// Below the budget the sample is the stream, exactly.
+#[test]
+fn a_short_stream_is_kept_whole() {
+    let mut reservoir = Reservoir::new(DIMENSIONS, budget_for(1000), 3);
+    let mut corpus = common::Corpus::new(11);
+    let vectors = corpus.vectors(40, DIMENSIONS);
+    for vector in &vectors {
+        reservoir.offer(vector);
+    }
+
+    assert_eq!(reservoir.len(), 40);
+    let flat: Vec<f32> = vectors.iter().flatten().copied().collect();
+    assert_eq!(reservoir.as_flat(), flat.as_slice());
+}
+
+#[test]
+fn an_empty_stream_samples_nothing() {
+    let reservoir = Reservoir::new(DIMENSIONS, budget_for(10), 5);
+    assert!(reservoir.is_empty());
+    assert_eq!(reservoir.seen(), 0);
+    assert!(reservoir.as_flat().is_empty());
+}
+
+/// A wrong-width vector would corrupt the flat buffer, so it is refused rather
+/// than truncated or padded.
+#[test]
+fn a_wrong_width_vector_is_ignored() {
+    let mut reservoir = Reservoir::new(DIMENSIONS, budget_for(10), 9);
+    reservoir.offer(&[1.0; DIMENSIONS - 1]);
+    reservoir.offer(&[1.0; DIMENSIONS + 1]);
+    assert!(reservoir.is_empty());
+    assert_eq!(reservoir.seen(), 0);
+
+    reservoir.offer(&[1.0; DIMENSIONS]);
+    assert_eq!(reservoir.len(), 1);
+}
+
+#[test]
+fn the_same_seed_draws_the_same_sample() {
+    let draw = |seed: u64| {
+        let mut reservoir = Reservoir::new(DIMENSIONS, budget_for(50), seed);
+        let mut corpus = common::Corpus::new(21);
+        for vector in corpus.vectors(5_000, DIMENSIONS) {
+            reservoir.offer(&vector);
+        }
+        reservoir.into_flat()
+    };
+
+    assert_eq!(draw(42), draw(42));
+    assert_ne!(draw(42), draw(43));
+}
+
+/// Reservoir sampling is uniform over the stream, so sampled positions must
+/// spread across it rather than clustering at whichever end the algorithm
+/// favours. Asserting on two *specific* vectors would be a coin flip: each
+/// survives with probability `capacity / stream`, here 1%.
+#[test]
+fn the_sample_is_drawn_from_the_whole_stream() {
+    const STREAM: usize = 2_000;
+    const CAPACITY: usize = 20;
+    const DRAWS: u64 = 40;
+
+    let mut corpus = common::Corpus::new(33);
+    let vectors = corpus.vectors(STREAM, DIMENSIONS);
+    let position = |chunk: &[f32]| vectors.iter().position(|v| v.as_slice() == chunk);
+
+    let mut positions = Vec::new();
+    for seed in 0..DRAWS {
+        let mut reservoir = Reservoir::new(DIMENSIONS, budget_for(CAPACITY), seed);
+        for vector in &vectors {
+            reservoir.offer(vector);
+        }
+        positions.extend(reservoir.as_flat().chunks(DIMENSIONS).filter_map(position));
+    }
+
+    assert_eq!(positions.len(), CAPACITY * DRAWS as usize);
+    let first_decile = positions.iter().filter(|p| **p < STREAM / 10).count();
+    let last_decile = positions
+        .iter()
+        .filter(|p| **p >= STREAM - STREAM / 10)
+        .count();
+
+    // ~80 expected in each decile across 800 samples; zero would mean the
+    // sampler cannot reach that end of the stream at all.
+    assert!(first_decile > 0, "nothing sampled from the head");
+    assert!(last_decile > 0, "nothing sampled from the tail");
+}

--- a/crates/db-index/tests/vector_aux_store.rs
+++ b/crates/db-index/tests/vector_aux_store.rs
@@ -1,0 +1,223 @@
+//! The index's private blob space, over both store implementations.
+
+use db_index::vector::kv_store::KvNodeStore;
+use db_index::vector::store::{MemoryNodeStore, Node, NodeId, VectorNodeStore};
+use storage::backends::MemoryStore;
+use storage::corekv::{Store, Txn};
+
+const COLLECTION: u32 = 41;
+const INDEX: u32 = 9;
+const CENTROID: u8 = b'c';
+const CODEBOOK: u8 = b'b';
+const LIST: u8 = b'l';
+
+async fn txn(store: &MemoryStore) -> Box<dyn Txn> {
+    store.new_txn(false).await.unwrap()
+}
+
+async fn collect<S: VectorNodeStore>(
+    store: &S,
+    kind: u8,
+    prefix: &[u8],
+) -> Vec<(Vec<u8>, Vec<u8>)> {
+    let mut out = Vec::new();
+    store
+        .iterate_aux(kind, prefix, |key, value| {
+            out.push((key.to_vec(), value.to_vec()));
+            Ok(())
+        })
+        .await
+        .unwrap();
+    out
+}
+
+/// Both implementations answer the same, or the memory store stops being a
+/// faithful stand-in for the persisted one.
+macro_rules! for_both_stores {
+    ($body:ident) => {{
+        let backing = MemoryStore::new();
+        let mut write = txn(&backing).await;
+        let mut kv = KvNodeStore::new(&mut write, COLLECTION, INDEX, 0);
+        $body(&mut kv).await;
+
+        let mut memory = MemoryNodeStore::new();
+        $body(&mut memory).await;
+    }};
+}
+
+#[tokio::test]
+async fn an_entry_round_trips() {
+    async fn body<S: VectorNodeStore>(store: &mut S) {
+        store.put_aux(CENTROID, b"7", b"payload").await.unwrap();
+        assert_eq!(
+            store.get_aux(CENTROID, b"7").await.unwrap(),
+            Some(b"payload".to_vec())
+        );
+        assert_eq!(store.get_aux(CENTROID, b"8").await.unwrap(), None);
+    }
+    for_both_stores!(body);
+}
+
+#[tokio::test]
+async fn a_later_write_replaces_an_earlier_one() {
+    async fn body<S: VectorNodeStore>(store: &mut S) {
+        store.put_aux(CODEBOOK, b"0", b"first").await.unwrap();
+        store.put_aux(CODEBOOK, b"0", b"second").await.unwrap();
+        assert_eq!(
+            store.get_aux(CODEBOOK, b"0").await.unwrap(),
+            Some(b"second".to_vec())
+        );
+    }
+    for_both_stores!(body);
+}
+
+/// A scan of one kind must not see another's entries, or a list scan would
+/// read codebooks as codes.
+#[tokio::test]
+async fn kinds_do_not_leak_into_each_other() {
+    async fn body<S: VectorNodeStore>(store: &mut S) {
+        store.put_aux(CENTROID, b"1", b"c1").await.unwrap();
+        store.put_aux(CODEBOOK, b"1", b"b1").await.unwrap();
+        store.put_aux(LIST, b"1", b"l1").await.unwrap();
+
+        for (kind, expected) in [(CENTROID, "c1"), (CODEBOOK, "b1"), (LIST, "l1")] {
+            let seen = collect(store, kind, b"").await;
+            assert_eq!(seen.len(), 1, "kind {} saw {seen:?}", kind as char);
+            assert_eq!(seen[0].1, expected.as_bytes());
+        }
+    }
+    for_both_stores!(body);
+}
+
+/// The inverted list depends on this: a prefix scan of one list id must yield
+/// exactly that list.
+#[tokio::test]
+async fn a_prefix_scan_yields_exactly_its_prefix() {
+    async fn body<S: VectorNodeStore>(store: &mut S) {
+        for list in 0u8..3 {
+            for node in 0u8..4 {
+                store
+                    .put_aux(LIST, &[list, node], &[list * 10 + node])
+                    .await
+                    .unwrap();
+            }
+        }
+
+        for list in 0u8..3 {
+            let seen = collect(store, LIST, &[list]).await;
+            assert_eq!(seen.len(), 4, "list {list} saw {seen:?}");
+            for (key, value) in seen {
+                assert_eq!(key[0], list, "a foreign list leaked in");
+                assert_eq!(value[0] / 10, list);
+            }
+        }
+
+        assert_eq!(collect(store, LIST, b"").await.len(), 12);
+    }
+    for_both_stores!(body);
+}
+
+/// The key a scan reports must be the one that was written, not the storage
+/// key with its prefix still attached.
+#[tokio::test]
+async fn a_scan_reports_the_key_as_written() {
+    async fn body<S: VectorNodeStore>(store: &mut S) {
+        store.put_aux(CENTROID, b"abc", b"v").await.unwrap();
+        let seen = collect(store, CENTROID, b"").await;
+        assert_eq!(seen, vec![(b"abc".to_vec(), b"v".to_vec())]);
+
+        let narrowed = collect(store, CENTROID, b"a").await;
+        assert_eq!(narrowed, vec![(b"abc".to_vec(), b"v".to_vec())]);
+    }
+    for_both_stores!(body);
+}
+
+#[tokio::test]
+async fn an_empty_kind_scans_empty() {
+    async fn body<S: VectorNodeStore>(store: &mut S) {
+        assert!(collect(store, CENTROID, b"").await.is_empty());
+    }
+    for_both_stores!(body);
+}
+
+/// Aux entries and the graph share a keyspace, so neither may disturb the
+/// other.
+#[tokio::test]
+async fn the_graph_and_the_aux_space_are_independent() {
+    async fn body<S: VectorNodeStore>(store: &mut S) {
+        store
+            .put_node(Node::new(NodeId(1), vec![1.0, 0.0], 0))
+            .await
+            .unwrap();
+        store.put_aux(CENTROID, b"1", b"not a node").await.unwrap();
+
+        let node = store.get_node(NodeId(1)).await.unwrap().unwrap();
+        assert_eq!(node.vector, vec![1.0, 0.0]);
+
+        let mut nodes = 0;
+        store
+            .iterate_nodes(|_| {
+                nodes += 1;
+                Ok(())
+            })
+            .await
+            .unwrap();
+        assert_eq!(nodes, 1, "an aux entry was read as a node");
+
+        assert_eq!(
+            store.get_aux(CENTROID, b"1").await.unwrap(),
+            Some(b"not a node".to_vec())
+        );
+    }
+    for_both_stores!(body);
+}
+
+/// A rebuild writes a new epoch beside the live one, so the two must not see
+/// each other's entries.
+#[tokio::test]
+async fn epochs_are_isolated() {
+    let backing = MemoryStore::new();
+
+    let mut write = txn(&backing).await;
+    KvNodeStore::new(&mut write, COLLECTION, INDEX, 0)
+        .put_aux(CENTROID, b"1", b"epoch zero")
+        .await
+        .unwrap();
+    KvNodeStore::new(&mut write, COLLECTION, INDEX, 1)
+        .put_aux(CENTROID, b"1", b"epoch one")
+        .await
+        .unwrap();
+    write.commit().await.unwrap();
+
+    let mut read = txn(&backing).await;
+    for (epoch, expected) in [(0u32, "epoch zero"), (1, "epoch one")] {
+        let store = KvNodeStore::new(&mut read, COLLECTION, INDEX, epoch);
+        assert_eq!(
+            store.get_aux(CENTROID, b"1").await.unwrap(),
+            Some(expected.as_bytes().to_vec())
+        );
+        assert_eq!(collect(&store, CENTROID, b"").await.len(), 1);
+    }
+}
+
+/// Two indexes on one collection share the keyspace too.
+#[tokio::test]
+async fn indexes_are_isolated() {
+    let backing = MemoryStore::new();
+
+    let mut write = txn(&backing).await;
+    KvNodeStore::new(&mut write, COLLECTION, 1, 0)
+        .put_aux(LIST, b"k", b"one")
+        .await
+        .unwrap();
+    KvNodeStore::new(&mut write, COLLECTION, 2, 0)
+        .put_aux(LIST, b"k", b"two")
+        .await
+        .unwrap();
+    write.commit().await.unwrap();
+
+    let mut read = txn(&backing).await;
+    let first = KvNodeStore::new(&mut read, COLLECTION, 1, 0);
+    assert_eq!(collect(&first, LIST, b"").await.len(), 1);
+    assert_eq!(first.get_aux(LIST, b"k").await.unwrap().unwrap(), b"one");
+}

--- a/crates/db-index/tests/vector_collection_index.rs
+++ b/crates/db-index/tests/vector_collection_index.rs
@@ -21,6 +21,7 @@ fn vector_config(dimensions: u32) -> VectorIndexDescription {
         metric: DistanceMetric::Cosine,
         dimensions,
         hnsw: Some(HnswParams::default()),
+        ivfpq: None,
     }
 }
 

--- a/crates/db-index/tests/vector_dot_metric.rs
+++ b/crates/db-index/tests/vector_dot_metric.rs
@@ -33,6 +33,7 @@ fn index(metric: DistanceMetric) -> VectorIndex {
         metric,
         dimensions: 2,
         hnsw: Some(HnswParams::default()),
+        ivfpq: None,
     });
     VectorIndex::try_new(COLLECTION, desc).expect("a valid vector description")
 }

--- a/crates/db-index/tests/vector_engine.rs
+++ b/crates/db-index/tests/vector_engine.rs
@@ -69,6 +69,21 @@ impl<S: VectorNodeStore> VectorNodeStore for Counting<S> {
     {
         self.inner.iterate_nodes(visit).await
     }
+
+    async fn get_aux(&self, kind: u8, key: &[u8]) -> Result<Option<Vec<u8>>> {
+        self.inner.get_aux(kind, key).await
+    }
+
+    async fn put_aux(&mut self, kind: u8, key: &[u8], value: &[u8]) -> Result<()> {
+        self.inner.put_aux(kind, key, value).await
+    }
+
+    async fn iterate_aux<F>(&self, kind: u8, key_prefix: &[u8], visit: F) -> Result<()>
+    where
+        F: FnMut(&[u8], &[u8]) -> Result<()> + MaybeSend,
+    {
+        self.inner.iterate_aux(kind, key_prefix, visit).await
+    }
 }
 
 mod common;

--- a/crates/db-index/tests/vector_flat_algorithm.rs
+++ b/crates/db-index/tests/vector_flat_algorithm.rs
@@ -36,6 +36,7 @@ fn description(algorithm: VectorAlgorithm, hnsw: Option<HnswParams>) -> IndexDes
         metric: DistanceMetric::Cosine,
         dimensions: DIMENSIONS,
         hnsw,
+        ivfpq: None,
     })
 }
 
@@ -192,4 +193,72 @@ fn the_engine_kinds_are_distinct() {
 fn only_hnsw_is_go_compatible() {
     assert!(VectorAlgorithm::Hnsw.is_go_compatible());
     assert!(!VectorAlgorithm::Flat.is_go_compatible());
+}
+
+/// IVF-PQ dispatched through `VectorIndex`, the way a collection reaches it.
+#[tokio::test]
+async fn the_ivfpq_algorithm_is_selectable() {
+    let mut desc = description(VectorAlgorithm::IvfPq, None);
+    desc = desc.as_vector(schema::VectorIndexDescription {
+        algorithm: VectorAlgorithm::IvfPq,
+        metric: DistanceMetric::Cosine,
+        dimensions: DIMENSIONS,
+        hnsw: None,
+        ivfpq: Some(schema::IvfPqParams {
+            nlist: 4,
+            nprobe: 4,
+            m: 4,
+            ..schema::IvfPqParams::default()
+        }),
+    });
+    let index = VectorIndex::try_new(COLLECTION, desc).expect("a valid IVF-PQ description");
+
+    let store = MemoryStore::new();
+    let mut corpus = common::Corpus::new(0x1F);
+    let vectors = corpus.vectors(60, DIMENSIONS as usize);
+
+    let mut write = txn(&store).await;
+    for (i, vector) in vectors.iter().enumerate() {
+        let wide: Vec<f64> = vector.iter().map(|x| *x as f64).collect();
+        index
+            .save(&mut write, i as u64 + 1, &[NormalValue::Float64Array(wide)])
+            .await
+            .unwrap();
+    }
+    write.commit().await.unwrap();
+
+    // Untrained, so this is an exact scan and must match brute force exactly.
+    let query: Vec<f64> = vectors[3].iter().map(|x| *x as f64).collect();
+    let mut read = txn(&store).await;
+    let got: Vec<u64> = index
+        .search(&mut read, &query, 5, None)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|hit| hit.id.0)
+        .collect();
+    let want: Vec<u64> = common::scored(&vectors, &vectors[3], 5)
+        .into_iter()
+        .map(|id| id.0 + 1)
+        .collect();
+    assert_eq!(got, want);
+}
+
+/// A metric IVF-PQ cannot rank must be refused where the index is built, not
+/// discovered at query time.
+#[test]
+fn an_ivfpq_index_with_an_unrankable_metric_is_refused() {
+    let desc =
+        description(VectorAlgorithm::IvfPq, None).as_vector(schema::VectorIndexDescription {
+            algorithm: VectorAlgorithm::IvfPq,
+            metric: DistanceMetric::Dot,
+            dimensions: DIMENSIONS,
+            hnsw: None,
+            ivfpq: Some(schema::IvfPqParams::default()),
+        });
+    let err = VectorIndex::try_new(COLLECTION, desc).unwrap_err();
+    assert!(
+        err.to_string().contains("squared distance"),
+        "the error must say why, got: {err}"
+    );
 }

--- a/crates/db-index/tests/vector_kv_cost.rs
+++ b/crates/db-index/tests/vector_kv_cost.rs
@@ -92,6 +92,21 @@ impl<S: VectorNodeStore> VectorNodeStore for Counting<S> {
     {
         self.inner.iterate_nodes(visit).await
     }
+
+    async fn get_aux(&self, kind: u8, key: &[u8]) -> Result<Option<Vec<u8>>> {
+        self.inner.get_aux(kind, key).await
+    }
+
+    async fn put_aux(&mut self, kind: u8, key: &[u8], value: &[u8]) -> Result<()> {
+        self.inner.put_aux(kind, key, value).await
+    }
+
+    async fn iterate_aux<F>(&self, kind: u8, key_prefix: &[u8], visit: F) -> Result<()>
+    where
+        F: FnMut(&[u8], &[u8]) -> Result<()> + MaybeSend,
+    {
+        self.inner.iterate_aux(kind, key_prefix, visit).await
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/db-index/tests/vector_recall_baseline.rs
+++ b/crates/db-index/tests/vector_recall_baseline.rs
@@ -135,6 +135,21 @@ impl<S: VectorNodeStore> VectorNodeStore for Counting<S> {
     {
         self.inner.iterate_nodes(visit).await
     }
+
+    async fn get_aux(&self, kind: u8, key: &[u8]) -> Result<Option<Vec<u8>>> {
+        self.inner.get_aux(kind, key).await
+    }
+
+    async fn put_aux(&mut self, kind: u8, key: &[u8], value: &[u8]) -> Result<()> {
+        self.inner.put_aux(kind, key, value).await
+    }
+
+    async fn iterate_aux<F>(&self, kind: u8, key_prefix: &[u8], visit: F) -> Result<()>
+    where
+        F: FnMut(&[u8], &[u8]) -> Result<()> + MaybeSend,
+    {
+        self.inner.iterate_aux(kind, key_prefix, visit).await
+    }
 }
 
 fn exact(metric: Metric, vectors: &[Vec<f32>], query: &[f32]) -> Vec<NodeId> {

--- a/crates/db/tests/vector_fetcher_lookup.rs
+++ b/crates/db/tests/vector_fetcher_lookup.rs
@@ -45,6 +45,7 @@ fn schema() -> CollectionVersion {
         metric: DistanceMetric::Cosine,
         dimensions: DIMENSIONS,
         hnsw: Some(HnswParams::default()),
+        ivfpq: None,
     })];
     version
 }

--- a/crates/db/tests/vector_index_backfill.rs
+++ b/crates/db/tests/vector_index_backfill.rs
@@ -34,6 +34,7 @@ fn vector_kind() -> IndexKind {
         metric: DistanceMetric::Cosine,
         dimensions: DIMENSIONS,
         hnsw: Some(HnswParams::default()),
+        ivfpq: None,
     })
 }
 

--- a/crates/db/tests/vector_query_routing.rs
+++ b/crates/db/tests/vector_query_routing.rs
@@ -36,6 +36,7 @@ fn vector_kind() -> IndexKind {
         metric: DistanceMetric::Cosine,
         dimensions: DIMENSIONS,
         hnsw: Some(HnswParams::default()),
+        ivfpq: None,
     })
 }
 

--- a/crates/http/tests/vector_index_api.rs
+++ b/crates/http/tests/vector_index_api.rs
@@ -54,6 +54,7 @@ fn the_response_reports_the_kind() {
             metric: DistanceMetric::Cosine,
             dimensions: 4,
             hnsw: Some(HnswParams::default()),
+            ivfpq: None,
         })),
     };
     let json = serde_json::to_value(&described).unwrap();

--- a/crates/query-parse/src/sdl_parse/builder.rs
+++ b/crates/query-parse/src/sdl_parse/builder.rs
@@ -778,6 +778,7 @@ impl<'a> SdlParser<'a> {
             let algorithm = match config.algorithm.as_deref() {
                 None | Some("HNSW") => schema::VectorAlgorithm::Hnsw,
                 Some("FLAT") => schema::VectorAlgorithm::Flat,
+                Some("IVF_PQ") => schema::VectorAlgorithm::IvfPq,
                 Some(other) => {
                     return Err(QueryError::parse(format!(
                         "@vectorIndex has no algorithm named '{other}'"
@@ -822,7 +823,22 @@ impl<'a> SdlParser<'a> {
                                 .unwrap_or(defaults.ef_construction),
                             ef_search: hnsw.ef_search.unwrap_or(defaults.ef_search),
                         }),
-                        schema::VectorAlgorithm::Flat => None,
+                        schema::VectorAlgorithm::Flat | schema::VectorAlgorithm::IvfPq => None,
+                    },
+                    ivfpq: match algorithm {
+                        schema::VectorAlgorithm::IvfPq => {
+                            let ivfpq = config.ivfpq.clone().unwrap_or_default();
+                            let defaults = schema::IvfPqParams::default();
+                            Some(schema::IvfPqParams {
+                                nlist: ivfpq.nlist.unwrap_or(defaults.nlist),
+                                nprobe: ivfpq.nprobe.unwrap_or(defaults.nprobe),
+                                m: ivfpq.m.unwrap_or(defaults.m),
+                                sample_bytes: ivfpq
+                                    .sample_bytes
+                                    .map_or(defaults.sample_bytes, u64::from),
+                            })
+                        }
+                        _ => None,
                     },
                 }),
             );

--- a/crates/query-parse/src/sdl_parse/directives.rs
+++ b/crates/query-parse/src/sdl_parse/directives.rs
@@ -48,7 +48,7 @@ pub fn known_directive_arguments(directive_name: &str) -> &'static [&'static str
         "embedding" => &["provider", "model", "url", "fields", "template"],
         "encryptedIndex" => &["type"],
         "fulltext" => &["language", "k1", "b"],
-        "vectorIndex" => &["dimensions", "algorithm", "HNSW"],
+        "vectorIndex" => &["dimensions", "algorithm", "HNSW", "IVFPQ"],
         "immutable" => &[],
         _ => &[],
     }
@@ -218,6 +218,8 @@ pub struct VectorIndexConfig {
     pub dimensions: Option<u32>,
     /// `None` means HNSW, matching the reference where it is the only value.
     pub algorithm: Option<String>,
+    /// Present when the `IVFPQ` argument was given.
+    pub ivfpq: Option<IvfPqConfig>,
     /// Present when the `HNSW` argument was given. Its absence still means
     /// HNSW, with defaults.
     pub hnsw: Option<HnswConfig>,
@@ -249,4 +251,14 @@ pub enum IndexDirection {
     #[default]
     Asc,
     Desc,
+}
+
+/// The `IVFPQ` argument of `@vectorIndex`. Every member is optional; an omitted
+/// one keeps its default, and a zero is derived from the corpus.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct IvfPqConfig {
+    pub nlist: Option<u32>,
+    pub nprobe: Option<u32>,
+    pub m: Option<u32>,
+    pub sample_bytes: Option<u32>,
 }

--- a/crates/query-parse/src/sdl_parse/fields.rs
+++ b/crates/query-parse/src/sdl_parse/fields.rs
@@ -575,10 +575,41 @@ impl<'a> SdlParser<'a> {
             }
         };
 
+        let ivfpq = match get_directive_arg(directive, "IVFPQ") {
+            None => None,
+            Some(graphql_parser::schema::Value::Object(members)) => {
+                let mut config = super::directives::IvfPqConfig::default();
+                for (name, value) in members {
+                    let slot = match name.as_str() {
+                        "nlist" => &mut config.nlist,
+                        "nprobe" => &mut config.nprobe,
+                        "m" => &mut config.m,
+                        "sampleBytes" => &mut config.sample_bytes,
+                        other => {
+                            return Err(QueryError::parse(format!(
+                                "@vectorIndex IVFPQ has no argument named '{other}'"
+                            )))
+                        }
+                    };
+                    *slot =
+                        Some(directive_u32(name, value).map_err(|message| {
+                            QueryError::parse(format!("@vectorIndex {message}"))
+                        })?);
+                }
+                Some(config)
+            }
+            Some(_) => {
+                return Err(QueryError::parse(
+                    "@vectorIndex IVFPQ must be an object of parameters",
+                ))
+            }
+        };
+
         Ok(super::directives::VectorIndexConfig {
             dimensions,
             algorithm,
             hnsw,
+            ivfpq,
         })
     }
 

--- a/crates/query-parse/tests/vector_index_sdl.rs
+++ b/crates/query-parse/tests/vector_index_sdl.rs
@@ -180,3 +180,66 @@ fn the_dot_metric_is_selectable() {
     );
     assert_eq!(vector.metric, DistanceMetric::Dot);
 }
+
+#[test]
+fn the_ivfpq_algorithm_is_selectable() {
+    let vector = only_vector(
+        r#"type Doc {
+            embedding: [Float!] @vectorIndex(dimensions: 8, algorithm: "IVF_PQ")
+        }"#,
+    );
+    assert_eq!(vector.algorithm, VectorAlgorithm::IvfPq);
+    assert!(vector.hnsw.is_none(), "IVF-PQ carries no HNSW block");
+    let ivfpq = vector.ivfpq.expect("IVF-PQ params");
+    assert_eq!(ivfpq.nprobe, 8);
+    assert_eq!(ivfpq.nlist, 0, "zero derives nlist from the corpus");
+    assert_eq!(ivfpq.m, 0, "zero derives m from the width");
+}
+
+#[test]
+fn ivfpq_parameters_are_read() {
+    let vector = only_vector(
+        r#"type Doc {
+            embedding: [Float!] @vectorIndex(
+                dimensions: 128,
+                algorithm: "IVF_PQ",
+                IVFPQ: { nlist: 256, nprobe: 16, m: 16, sampleBytes: 1048576 }
+            )
+        }"#,
+    );
+    let ivfpq = vector.ivfpq.expect("IVF-PQ params");
+    assert_eq!(
+        (ivfpq.nlist, ivfpq.nprobe, ivfpq.m, ivfpq.sample_bytes),
+        (256, 16, 16, 1_048_576)
+    );
+}
+
+#[test]
+fn an_unknown_ivfpq_argument_is_refused() {
+    let err = parse_sdl(
+        r#"type Doc {
+            embedding: [Float!] @vectorIndex(
+                dimensions: 8, algorithm: "IVF_PQ", IVFPQ: { nlists: 4 }
+            )
+        }"#,
+    )
+    .expect_err("a misspelled argument must not parse");
+    assert!(
+        err.to_string().contains("nlists"),
+        "the error must name it, got: {err}"
+    );
+}
+
+/// An IVFPQ block on an HNSW index is inert rather than an error, the same way
+/// an HNSW block is inert on a flat index.
+#[test]
+fn an_ivfpq_block_on_an_hnsw_index_is_inert() {
+    let vector = only_vector(
+        r#"type Doc {
+            embedding: [Float!] @vectorIndex(dimensions: 8, IVFPQ: { nlist: 4 })
+        }"#,
+    );
+    assert_eq!(vector.algorithm, VectorAlgorithm::Hnsw);
+    assert!(vector.hnsw.is_some());
+    assert!(vector.ivfpq.is_none());
+}

--- a/crates/query-plan/tests/vector_routing.rs
+++ b/crates/query-plan/tests/vector_routing.rs
@@ -27,6 +27,7 @@ fn vector_index(id: u32, field: &str, dimensions: u32) -> IndexDescription {
         metric: DistanceMetric::Cosine,
         dimensions,
         hnsw: Some(HnswParams::default()),
+        ivfpq: None,
     })
 }
 

--- a/crates/query-plan/tests/vector_routing_hybrid.rs
+++ b/crates/query-plan/tests/vector_routing_hybrid.rs
@@ -29,6 +29,7 @@ fn vector_index() -> Vec<IndexDescription> {
         metric: DistanceMetric::Cosine,
         dimensions: VECTOR.len() as u32,
         hnsw: Some(HnswParams::default()),
+        ivfpq: None,
     })]
 }
 

--- a/crates/schema/src/index.rs
+++ b/crates/schema/src/index.rs
@@ -269,11 +269,23 @@ pub enum VectorAlgorithm {
     /// Exhaustive scan. Exact, no build parameters, no tuning.
     #[serde(rename = "FLAT")]
     Flat,
+    /// Coarse lists of product-quantized codes. Approximate and lossy, in
+    /// exchange for a code far smaller than the vector it stands for.
+    #[serde(rename = "IVF_PQ")]
+    IvfPq,
 }
 
 impl VectorAlgorithm {
     pub fn is_go_compatible(self) -> bool {
         matches!(self, Self::Hnsw)
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Hnsw => "HNSW",
+            Self::Flat => "FLAT",
+            Self::IvfPq => "IVF_PQ",
+        }
     }
 }
 
@@ -350,6 +362,48 @@ pub struct VectorIndexDescription {
     /// Present when `algorithm` is HNSW.
     #[serde(rename = "HNSW", default, skip_serializing_if = "Option::is_none")]
     pub hnsw: Option<HnswParams>,
+    /// Present when `algorithm` is IVF_PQ.
+    #[serde(rename = "IVFPQ", default, skip_serializing_if = "Option::is_none")]
+    pub ivfpq: Option<IvfPqParams>,
+}
+
+/// IVF-PQ build and search parameters.
+///
+/// `0` means derive from the corpus: `nlist` from its size, `m` from the
+/// vector width.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IvfPqParams {
+    /// Coarse centroids, and therefore inverted lists.
+    #[serde(rename = "NList", default)]
+    pub nlist: u32,
+    /// Lists probed per query.
+    #[serde(rename = "NProbe", default = "default_ivfpq_nprobe")]
+    pub nprobe: u32,
+    /// Subquantizers, and therefore bytes per code.
+    #[serde(rename = "M", default)]
+    pub m: u32,
+    /// Cap on the resident training sample.
+    #[serde(rename = "SampleBytes", default = "default_ivfpq_sample_bytes")]
+    pub sample_bytes: u64,
+}
+
+fn default_ivfpq_nprobe() -> u32 {
+    8
+}
+
+fn default_ivfpq_sample_bytes() -> u64 {
+    128 << 20
+}
+
+impl Default for IvfPqParams {
+    fn default() -> Self {
+        Self {
+            nlist: 0,
+            nprobe: default_ivfpq_nprobe(),
+            m: 0,
+            sample_bytes: default_ivfpq_sample_bytes(),
+        }
+    }
 }
 
 /// Configuration of an ordered index: one that stores field values in key
@@ -397,6 +451,8 @@ struct IndexKindWire {
     dimensions: Option<u32>,
     #[serde(rename = "HNSW", default, skip_serializing_if = "Option::is_none")]
     hnsw: Option<HnswParams>,
+    #[serde(rename = "IVFPQ", default, skip_serializing_if = "Option::is_none")]
+    ivfpq: Option<IvfPqParams>,
     #[serde(rename = "Unique", default, skip_serializing_if = "Option::is_none")]
     unique: Option<bool>,
 }
@@ -409,6 +465,7 @@ impl From<IndexKindWire> for IndexKind {
                 metric: wire.metric.unwrap_or_default(),
                 dimensions: wire.dimensions.unwrap_or_default(),
                 hnsw: wire.hnsw,
+                ivfpq: wire.ivfpq,
             })
         } else {
             IndexKind::Ordered(OrderedIndexDescription {
@@ -426,6 +483,7 @@ impl From<IndexKind> for IndexKindWire {
                 metric: None,
                 dimensions: None,
                 hnsw: None,
+                ivfpq: None,
                 unique: Some(ordered.unique),
             },
             IndexKind::Vector(vector) => Self {
@@ -433,6 +491,7 @@ impl From<IndexKind> for IndexKindWire {
                 metric: Some(vector.metric),
                 dimensions: Some(vector.dimensions),
                 hnsw: vector.hnsw,
+                ivfpq: vector.ivfpq,
                 unique: None,
             },
         }

--- a/crates/schema/src/lib.rs
+++ b/crates/schema/src/lib.rs
@@ -38,8 +38,8 @@ pub use field::FieldDescription;
 pub use field_kind::{FieldKind, ScalarArrayKind, ScalarKind};
 pub use index::{
     DistanceMetric, EncryptedIndexDescription, EncryptedIndexType, FullTextIndexDescription,
-    HnswParams, IndexDescription, IndexKind, IndexedFieldDescription, OrderedIndexDescription,
-    VectorAlgorithm, VectorIndexDescription,
+    HnswParams, IndexDescription, IndexKind, IndexedFieldDescription, IvfPqParams,
+    OrderedIndexDescription, VectorAlgorithm, VectorIndexDescription,
 };
 pub use policy::PolicyDescription;
 pub use source::{

--- a/crates/schema/tests/index_kind_tests.rs
+++ b/crates/schema/tests/index_kind_tests.rs
@@ -12,6 +12,7 @@ fn vector_description() -> VectorIndexDescription {
         metric: DistanceMetric::Cosine,
         dimensions: 768,
         hnsw: Some(HnswParams::default()),
+        ivfpq: None,
     }
 }
 

--- a/crates/schema/tests/index_wire_shape.rs
+++ b/crates/schema/tests/index_wire_shape.rs
@@ -42,6 +42,7 @@ fn vector() -> VectorIndexDescription {
             ef_construction: 128,
             ef_search: 64,
         }),
+        ivfpq: None,
     }
 }
 
@@ -131,9 +132,11 @@ fn a_partial_kind_resolves_as_go_resolves_it() {
     assert!(ordered.resolved_unique());
 }
 
-/// `HNSW` is a pointer in Go, so it is `null` when absent rather than missing.
+/// `HNSW` is a nil pointer in Go, which `encoding/json` emits as `null`; serde
+/// omits the key instead. Go's decoder reads a missing field as nil, so the two
+/// round-trip, but the emitted bytes differ and that is worth knowing.
 #[test]
-fn an_absent_hnsw_block_is_null_and_parses_back() {
+fn an_absent_hnsw_block_is_omitted_and_parses_back() {
     let desc = IndexDescription::new("i")
         .as_vector(VectorIndexDescription {
             hnsw: None,
@@ -141,10 +144,21 @@ fn an_absent_hnsw_block_is_null_and_parses_back() {
         })
         .normalized();
     let json = serde_json::to_value(&desc).unwrap();
-    assert_eq!(json["Kind"]["HNSW"], Value::Null);
+    assert!(
+        !json["Kind"].as_object().unwrap().contains_key("HNSW"),
+        "serde omits the key rather than emitting null"
+    );
 
     let back: IndexDescription = serde_json::from_value(json).unwrap();
     assert_eq!(back.vector().map(|v| v.hnsw), Some(None));
+
+    // Go's `null` must still parse, since that is what a Go node sends.
+    let from_go: IndexDescription = serde_json::from_value(json!({
+        "Name": "i", "ID": 1,
+        "Kind": {"Algorithm": "HNSW", "Metric": "COSINE", "Dimensions": 4, "HNSW": null}
+    }))
+    .unwrap();
+    assert_eq!(from_go.vector().map(|v| v.hnsw), Some(None));
 }
 
 /// `DOT` is ours alone: Go's `DistanceMetric` defines only `COSINE`, so a
@@ -212,7 +226,7 @@ fn flat_is_an_algorithm_go_cannot_parse() {
         .normalized();
     let json = serde_json::to_value(&desc).unwrap();
     assert_eq!(json["Kind"]["Algorithm"], json!("FLAT"));
-    assert_eq!(json["Kind"]["HNSW"], Value::Null);
+    assert!(!json["Kind"].as_object().unwrap().contains_key("HNSW"));
 
     let back: IndexDescription = serde_json::from_value(json).unwrap();
     assert_eq!(
@@ -243,4 +257,61 @@ fn go_compatibility_is_checkable_across_both_axes() {
             "{diverged:?} must be flagged"
         );
     }
+}
+
+/// `IVF_PQ` is the third divergence, and it brings a parameter block Go has no
+/// field for at all.
+#[test]
+fn ivfpq_is_an_algorithm_go_cannot_parse() {
+    use schema::IvfPqParams;
+
+    assert!(!VectorAlgorithm::IvfPq.is_go_compatible());
+    assert_eq!(
+        serde_json::to_value(VectorAlgorithm::IvfPq).unwrap(),
+        json!("IVF_PQ")
+    );
+
+    let desc = IndexDescription::new("i")
+        .as_vector(VectorIndexDescription {
+            algorithm: VectorAlgorithm::IvfPq,
+            hnsw: None,
+            ivfpq: Some(IvfPqParams {
+                nlist: 256,
+                nprobe: 16,
+                m: 32,
+                sample_bytes: 1 << 20,
+            }),
+            ..vector()
+        })
+        .normalized();
+
+    let json = serde_json::to_value(&desc).unwrap();
+    assert_eq!(json["Kind"]["Algorithm"], json!("IVF_PQ"));
+    assert_eq!(
+        json["Kind"]["IVFPQ"],
+        json!({"NList": 256, "NProbe": 16, "M": 32, "SampleBytes": 1_048_576})
+    );
+    assert!(!json["Kind"].as_object().unwrap().contains_key("HNSW"));
+
+    let back: IndexDescription = serde_json::from_value(json).unwrap();
+    assert_eq!(
+        back.vector().map(|v| v.algorithm),
+        Some(VectorAlgorithm::IvfPq)
+    );
+    assert_eq!(
+        back.vector().and_then(|v| v.ivfpq).map(|p| p.nlist),
+        Some(256)
+    );
+}
+
+/// An HNSW description must not grow an IVFPQ key, or every Go-compatible
+/// definition would start carrying a field Go cannot parse.
+#[test]
+fn an_hnsw_description_carries_no_ivfpq_key() {
+    let json =
+        serde_json::to_value(IndexDescription::new("i").as_vector(vector()).normalized()).unwrap();
+    assert_eq!(
+        keys(&json["Kind"]),
+        ["Algorithm", "Dimensions", "HNSW", "Metric"]
+    );
 }

--- a/crates/storage/src/keys/datastore/vector_index_key.rs
+++ b/crates/storage/src/keys/datastore/vector_index_key.rs
@@ -77,15 +77,21 @@ impl VectorIndexKey {
     }
 }
 
+/// `/<collShortID>/<indexID>/<epoch>/`, shared by every key in this space.
+fn epoch_prefix(collection_short_id: u32, index_id: u32, epoch: u32) -> Vec<u8> {
+    let mut buf = vec![SEPARATOR];
+    buf = encode_uvarint_ascending(buf, collection_short_id as u64);
+    buf.push(SEPARATOR);
+    buf = encode_uvarint_ascending(buf, index_id as u64);
+    buf.push(SEPARATOR);
+    buf = encode_uvarint_ascending(buf, epoch as u64);
+    buf.push(SEPARATOR);
+    buf
+}
+
 impl Key for VectorIndexKey {
     fn bytes(&self) -> Vec<u8> {
-        let mut buf = vec![SEPARATOR];
-        buf = encode_uvarint_ascending(buf, self.collection_short_id as u64);
-        buf.push(SEPARATOR);
-        buf = encode_uvarint_ascending(buf, self.index_id as u64);
-        buf.push(SEPARATOR);
-        buf = encode_uvarint_ascending(buf, self.epoch as u64);
-        buf.push(SEPARATOR);
+        let mut buf = epoch_prefix(self.collection_short_id, self.index_id, self.epoch);
         if self.is_meta {
             buf.push(META_DISCRIMINATOR);
         } else {
@@ -109,6 +115,62 @@ impl Key for VectorIndexKey {
         format!(
             "/{}/{}/{}/{}",
             self.collection_short_id, self.index_id, self.epoch, tail
+        )
+    }
+}
+
+/// A key in one index kind's private space, beside its graph.
+///
+/// `kind` separates concepts (coarse centroids from codebooks from inverted
+/// lists) and `key` is the kind's own encoding, so a kind adds a concept
+/// without a new key type. `m` and `n` are taken by the graph.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VectorAuxKey<'k> {
+    pub collection_short_id: u32,
+    pub index_id: u32,
+    pub epoch: u32,
+    pub kind: u8,
+    /// Empty scans every entry of `kind`.
+    pub key: &'k [u8],
+}
+
+impl<'k> VectorAuxKey<'k> {
+    pub fn new(
+        collection_short_id: u32,
+        index_id: u32,
+        epoch: u32,
+        kind: u8,
+        key: &'k [u8],
+    ) -> Self {
+        Self {
+            collection_short_id,
+            index_id,
+            epoch,
+            kind,
+            key,
+        }
+    }
+}
+
+impl Key for VectorAuxKey<'_> {
+    fn bytes(&self) -> Vec<u8> {
+        let mut buf = epoch_prefix(self.collection_short_id, self.index_id, self.epoch);
+        buf.push(self.kind);
+        if !self.key.is_empty() {
+            buf.push(SEPARATOR);
+            buf.extend_from_slice(self.key);
+        }
+        buf
+    }
+
+    fn to_string(&self) -> String {
+        format!(
+            "/{}/{}/{}/{}/{}",
+            self.collection_short_id,
+            self.index_id,
+            self.epoch,
+            self.kind as char,
+            hex::encode(self.key)
         )
     }
 }


### PR DESCRIPTION
Stacked on #1377 (`vclq/hnsw-indexes`). Adds an IVF-PQ vector index kind behind the `VectorIndexEngine` seam.

## Why

HNSW stores every vector in full. At 768 dimensions that is 3,072 bytes each, which is what makes a large collection expensive. IVF-PQ stores a 96-byte code instead — **32x** — and scans a compact inverted list with a lookup table rather than reading vectors at all.

## Shape

Three orthogonal concerns, three traits, all under `engine/ann/` beside `VectorIndexEngine`:

| Trait | Implementation | What could swap in |
|---|---|---|
| `Sampler` | `Reservoir` | stratified, first-N |
| `Clusterer` | `KMeans` (Lloyd + k-means++) | mini-batch, hierarchical |
| `Quantizer` | `ProductQuantizer` | scalar quantization, OPQ |

`ProductQuantizer::train` takes `&C: Clusterer`, so changing how centroids are fit does not touch quantization. Nothing in `vector/quantize/` imports storage.

## Streaming

Training reads a **sample**, never the corpus. `Reservoir` is capped in bytes rather than count, because the same 100,000 vectors are 6 MB at 16 dimensions and 300 MB at 768. A test asserts resident bytes never exceed the budget across 50,000 offered vectors.

## Phases

- [x] **1 — quantization, pure.** k-means++ seeding, Lloyd iterations, byte-bounded reservoir sampling, PQ codebooks, encode/decode, ADC lookup tables. 25 tests.

All five phases are complete. Highlights below.
- [x] **2 — store port.** `get_aux`/`put_aux`/`iterate_aux` on the existing `VectorNodeStore`, plus centroid/codebook/list key discriminators.
- [x] **3 — the engine and the train-on-threshold lifecycle, with the untrained state answering exactly via `Flat` and an epoch swap on build.
- [x] **4 — wiring.** `VectorAlgorithm::IvfPq`, params, SDL, dispatch, explain.
- [x] **5 — recall and cost, measured against `Flat` as the exact oracle.

## Notes

- Neither IVF-PQ nor SSG exists in Go, so there is no parity oracle and no golden bytes. Correctness is agreement with exhaustive scan.
- PQ is **lossy**: distances are to reconstructed vectors, so ranking can differ from exact even at `nprobe = nlist`. That is a behaviour change from `HNSW`/`FLAT`, not just a speed dial.
- ADC is squared-L2. Under `COSINE` that is exact-equivalent ranking (vectors are normalized on insert, and `‖a−b‖² = 2 − 2·a·b`). Under `DOT` it is not, so `DOT` will be refused at construction rather than silently ranking on the wrong quantity.

Design package: `docs/plans/ivf-pq-and-ssg-vector-indexes.md`.


---

## Measured (added after the phases landed)

Recall against `Flat` as the exact oracle, `nprobe = nlist` so the coarse step is exhaustive and quantization is the only error left:

| d=128, N=5000 | m=4 | m=8 | m=16 | m=32 | m=64 |
|---|---|---|---|---|---|
| recall@10 | 0.3233 | 0.4367 | 0.5167 | 0.6933 | **0.8933** |
| dist/best | 1.1363 | 1.0970 | 1.0596 | 1.0211 | 1.0022 |
| bytes/vector | 512 -> 4 | -> 8 | -> 16 | -> 32 | -> 64 |

**Recall is quantization-bound, not probe-bound.** The first `nprobe` sweep showed recall flat to four decimals from 2 to 64, because with tight clusters and queries drawn from the corpus the true top-10 all sit in the query's own list. Rebuilt with held-out queries and overlapping clusters the curve is real: d=32 climbs 0.49 -> 0.9933, d=128 climbs 0.06 -> 0.5867 before hitting the codec ceiling.

On real data (SIFT-small, #1447): **recall@10 = 0.6200** at the default `m`, which is `dimensions/8` and therefore 64x compression. Worth revisiting that default.

A 2.96s regression gate runs in the ordinary suite; the full curves are `#[ignore]`d.
