### PR TITLE
feat(defra-node): expose the document ACP (DAC) API on EmbeddedNode

### DIFF
--- a/crates/db/tests/patch_collection_tests.rs
+++ b/crates/db/tests/patch_collection_tests.rs
@@ -295,6 +295,13 @@ async fn patch_collection_rejects_mutating_an_existing_policy() {
 #[tokio::test]
 async fn patch_collection_rejects_adding_a_policy_to_a_policy_free_collection() {
     let db = agent_response_db().await;
+    assert!(db
+        .get_collection("AgentResponse")
+        .unwrap()
+        .unwrap()
+        .schema()
+        .policy
+        .is_none());
 
     let err = db
         .patch_collection(

--- a/crates/db/tests/patch_collection_tests.rs
+++ b/crates/db/tests/patch_collection_tests.rs
@@ -250,6 +250,75 @@ async fn patch_collection_rejects_numeric_kind_in_direct_kind_replacement() {
 }
 
 #[tokio::test]
+async fn patch_collection_rejects_mutating_an_existing_policy() {
+    let store = MemoryStore::new();
+    let db = DB::new(store).unwrap();
+    let collections = query::parse_sdl(
+        r#"
+        type Secrets @policy(id: "policy-a", resource: "secrets") {
+            name: String
+        }
+        "#,
+    )
+    .unwrap();
+    db.create_collections_atomic(collections).await.unwrap();
+    assert!(db
+        .get_collection("Secrets")
+        .unwrap()
+        .unwrap()
+        .schema()
+        .policy
+        .is_some());
+
+    let err = db
+        .patch_collection(
+            "Secrets",
+            r#"
+            [{
+                "op": "replace",
+                "path": "/Secrets/Policy",
+                "value": {"ID": "policy-b", "ResourceName": "secrets"}
+            }]
+            "#,
+            None,
+        )
+        .await
+        .unwrap_err();
+
+    assert!(
+        err.to_string()
+            .contains("collection policy cannot be mutated."),
+        "{err}"
+    );
+}
+
+#[tokio::test]
+async fn patch_collection_rejects_adding_a_policy_to_a_policy_free_collection() {
+    let db = agent_response_db().await;
+
+    let err = db
+        .patch_collection(
+            "AgentResponse",
+            r#"
+            [{
+                "op": "replace",
+                "path": "/AgentResponse/Policy",
+                "value": {"ID": "policy-a", "ResourceName": "agents"}
+            }]
+            "#,
+            None,
+        )
+        .await
+        .unwrap_err();
+
+    assert!(
+        err.to_string()
+            .contains("collection policy cannot be mutated."),
+        "{err}"
+    );
+}
+
+#[tokio::test]
 async fn patch_relation_version_switching_preserves_go_canonical_versions() {
     const AUTHOR_V1: &str = "bafyreibvcavbxqwimz5vdxe5q5href63g3skc6ytg45hm4fqh6wsx57wmq";
     const AUTHOR_V2: &str = "bafyreihv2jdbz3sipc7tqdoycerkcjn6gehr5aleiroqlewvsmjd26unfq";

--- a/crates/defra-node/src/acp_ops.rs
+++ b/crates/defra-node/src/acp_ops.rs
@@ -35,32 +35,38 @@ pub(crate) trait AcpOps: Send + Sync {
 #[derive(Clone)]
 pub(crate) struct PolicyLookup {
     pub(crate) local: Option<Arc<dyn acp::ZanzibarStore>>,
+    #[cfg(feature = "sourcehub")]
     pub(crate) sourcehub: Option<Arc<sourcehub::SourceHubDocumentACP>>,
 }
 
 impl PolicyLookup {
     pub(crate) fn new(
         local: Option<Arc<dyn acp::ZanzibarStore>>,
-        sourcehub: Option<Arc<sourcehub::SourceHubDocumentACP>>,
+        #[cfg(feature = "sourcehub")] sourcehub: Option<Arc<sourcehub::SourceHubDocumentACP>>,
     ) -> Self {
-        Self { local, sourcehub }
+        Self {
+            local,
+            #[cfg(feature = "sourcehub")]
+            sourcehub,
+        }
     }
 
     /// Load a policy from whichever ACP backend this node was built with.
     pub(crate) async fn get_policy(&self, policy_id: &str) -> anyhow::Result<Option<acp::Policy>> {
         if let Some(store) = &self.local {
-            store
+            return store
                 .get_policy(policy_id)
                 .await
-                .map_err(|error| anyhow!("failed to get policy: {error}"))
-        } else if let Some(sourcehub) = &self.sourcehub {
-            sourcehub
-                .get_policy(policy_id)
-                .await
-                .map_err(|error| anyhow!("failed to get policy: {error}"))
-        } else {
-            bail!("operation requires ACP, but ACP not available");
+                .map_err(|error| anyhow!("failed to get policy: {error}"));
         }
+        #[cfg(feature = "sourcehub")]
+        if let Some(sourcehub) = &self.sourcehub {
+            return sourcehub
+                .get_policy(policy_id)
+                .await
+                .map_err(|error| anyhow!("failed to get policy: {error}"));
+        }
+        bail!("operation requires ACP, but ACP not available");
     }
 }
 
@@ -223,6 +229,7 @@ impl<S: storage::corekv::Store + 'static> AcpOps for DbAcpOps<S> {
         }
         acp::policy_yaml::validate_policy_expressions(&parsed).map_err(|error| anyhow!(error))?;
 
+        #[cfg(feature = "sourcehub")]
         if let Some(sourcehub_acp) = &self.policy_lookup.sourcehub {
             return sourcehub_acp
                 .add_policy(identity, policy)

--- a/crates/defra-node/src/acp_ops.rs
+++ b/crates/defra-node/src/acp_ops.rs
@@ -1,0 +1,82 @@
+//! Type-erased document-ACP operations bridging DB to EmbeddedNode's public DAC API.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use anyhow::{anyhow, bail};
+use identity::Did;
+
+#[async_trait::async_trait]
+pub(crate) trait AcpOps: Send + Sync {
+    async fn add_dac_policy(&self, identity: &str, policy: &str) -> anyhow::Result<String>;
+}
+
+pub(crate) struct DbAcpOps<S: storage::corekv::Store + 'static> {
+    database: Arc<db::DB<S>>,
+    local_zanzibar_store: Option<Arc<dyn acp::ZanzibarStore>>,
+    sourcehub_acp: Option<Arc<sourcehub::SourceHubDocumentACP>>,
+    policy_counter: AtomicU64,
+}
+
+impl<S: storage::corekv::Store + 'static> DbAcpOps<S> {
+    pub(crate) fn new(
+        database: Arc<db::DB<S>>,
+        local_zanzibar_store: Option<Arc<dyn acp::ZanzibarStore>>,
+        sourcehub_acp: Option<Arc<sourcehub::SourceHubDocumentACP>>,
+    ) -> Self {
+        Self {
+            database,
+            local_zanzibar_store,
+            sourcehub_acp,
+            policy_counter: AtomicU64::new(1),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl<S: storage::corekv::Store + 'static> AcpOps for DbAcpOps<S> {
+    async fn add_dac_policy(&self, identity: &str, policy: &str) -> anyhow::Result<String> {
+        if identity.is_empty() {
+            bail!("policy creator can not be empty");
+        }
+        let did = Did::new(identity).map_err(|error| anyhow!("invalid identity DID: {error}"))?;
+        self.database
+            .check_node_access(Some(&did), acp::nac::NodePermission::DacPolicyAdd)
+            .await
+            .map_err(|error| anyhow!("{error}"))?;
+
+        if policy.is_empty() {
+            bail!("policy data can not be empty");
+        }
+
+        acp::policy_yaml::check_duplicate_yaml_keys(policy).map_err(|error| anyhow!(error))?;
+        let parsed = acp::policy_yaml::parse_policy_yaml(policy).map_err(|error| anyhow!(error))?;
+        if parsed.name.is_empty() {
+            bail!("name required");
+        }
+        acp::policy_yaml::validate_policy_expressions(&parsed).map_err(|error| anyhow!(error))?;
+
+        if let Some(sourcehub_acp) = &self.sourcehub_acp {
+            return sourcehub_acp
+                .add_policy(identity, policy)
+                .await
+                .map_err(|error| anyhow!("SourceHub create policy failed: {error}"));
+        }
+
+        let Some(store) = &self.local_zanzibar_store else {
+            bail!("operation requires ACP, but ACP not available");
+        };
+        let counter = self.policy_counter.fetch_add(1, Ordering::SeqCst);
+        let built = acp::policy_yaml::build_policy(&parsed, counter)
+            .map_err(|error| anyhow!("invalid policy: {error}"))?;
+        let options = acp::StorePolicyOptions::new()
+            .with_validation()
+            .with_dpi_enforcement();
+        store
+            .store_policy_with_options(&built, &options)
+            .await
+            .map_err(|error| anyhow!("failed to store policy: {error}"))?;
+
+        Ok(built.id)
+    }
+}

--- a/crates/defra-node/src/acp_ops.rs
+++ b/crates/defra-node/src/acp_ops.rs
@@ -142,8 +142,13 @@ impl<S: storage::corekv::Store + 'static> DbAcpOps<S> {
 
     /// Announce the document's latest state so subscribers re-evaluate access.
     ///
-    /// A failure here leaves the grant in place: the relationship is already
-    /// stored, and the event is only a notification (matches the FFI path).
+    /// A publish failure is deliberately non-fatal: the relationship is already
+    /// persisted by the time this runs, and the event is only a best-effort
+    /// notification that lets subscribers re-evaluate access. Reporting it as an
+    /// error would tell the caller the grant failed when it did not. The FFI
+    /// surface makes the opposite choice and propagates the same failure
+    /// (`crates/ffi/src/acp/dac.rs:401-409`), so the two surfaces report an
+    /// unpublishable event differently.
     async fn publish_document_update(&self, collection_id: &str, doc_id: &str) {
         match db::block_reader::read_latest_composite_block(&self.database, doc_id).await {
             Ok(result) => {

--- a/crates/defra-node/src/acp_ops.rs
+++ b/crates/defra-node/src/acp_ops.rs
@@ -9,26 +9,159 @@ use identity::Did;
 #[async_trait::async_trait]
 pub(crate) trait AcpOps: Send + Sync {
     async fn add_dac_policy(&self, identity: &str, policy: &str) -> anyhow::Result<String>;
+    async fn add_dac_actor_relationship(
+        &self,
+        identity: &str,
+        collection: &str,
+        doc_id: &str,
+        relation: &str,
+        target: &str,
+    ) -> anyhow::Result<bool>;
+    async fn delete_dac_actor_relationship(
+        &self,
+        identity: &str,
+        collection: &str,
+        doc_id: &str,
+        relation: &str,
+        target: &str,
+    ) -> anyhow::Result<bool>;
 }
 
 pub(crate) struct DbAcpOps<S: storage::corekv::Store + 'static> {
     database: Arc<db::DB<S>>,
+    document_acp: Arc<dyn acp::DocumentACP>,
     local_zanzibar_store: Option<Arc<dyn acp::ZanzibarStore>>,
     sourcehub_acp: Option<Arc<sourcehub::SourceHubDocumentACP>>,
+    event_bus: Arc<dyn events::Bus>,
     policy_counter: AtomicU64,
+}
+
+/// Everything a relationship call needs from the collection and its policy.
+struct RelationshipTarget {
+    target: acp::Subject,
+    policy_id: String,
+    resource_name: String,
+    collection_id: String,
+    managing_relations: Vec<String>,
 }
 
 impl<S: storage::corekv::Store + 'static> DbAcpOps<S> {
     pub(crate) fn new(
         database: Arc<db::DB<S>>,
+        document_acp: Arc<dyn acp::DocumentACP>,
         local_zanzibar_store: Option<Arc<dyn acp::ZanzibarStore>>,
         sourcehub_acp: Option<Arc<sourcehub::SourceHubDocumentACP>>,
+        event_bus: Arc<dyn events::Bus>,
     ) -> Self {
         Self {
             database,
+            document_acp,
             local_zanzibar_store,
             sourcehub_acp,
+            event_bus,
             policy_counter: AtomicU64::new(1),
+        }
+    }
+
+    /// Resolve the caller's DID and check the node-level permission it needs.
+    async fn authorize(
+        &self,
+        identity: &str,
+        permission: acp::nac::NodePermission,
+    ) -> anyhow::Result<Did> {
+        let did = Did::new(identity).map_err(|error| anyhow!("invalid identity DID: {error}"))?;
+        self.database
+            .check_node_access(Some(&did), permission)
+            .await
+            .map_err(|error| anyhow!("{error}"))?;
+        Ok(did)
+    }
+
+    /// Load a policy from whichever ACP backend this node was built with.
+    async fn get_policy(&self, policy_id: &str) -> anyhow::Result<acp::Policy> {
+        let policy = if let Some(store) = &self.local_zanzibar_store {
+            store
+                .get_policy(policy_id)
+                .await
+                .map_err(|error| anyhow!("failed to get policy: {error}"))?
+        } else if let Some(sourcehub_acp) = &self.sourcehub_acp {
+            sourcehub_acp
+                .get_policy(policy_id)
+                .await
+                .map_err(|error| anyhow!("failed to get policy: {error}"))?
+        } else {
+            bail!("operation requires ACP, but ACP not available");
+        };
+        policy.ok_or_else(|| anyhow!("policy '{policy_id}' not found"))
+    }
+
+    async fn relationship_target(
+        &self,
+        collection: &str,
+        relation: &str,
+        target: &str,
+    ) -> anyhow::Result<RelationshipTarget> {
+        let collection_version = self
+            .database
+            .get_collection(collection)
+            .map_err(|error| anyhow!("failed to get collection '{collection}': {error}"))?
+            .ok_or_else(|| anyhow!("collection '{collection}' does not exist"))?;
+        let Some(policy) = collection_version.schema().policy.clone() else {
+            bail!("operation requires ACP, but collection has no policy");
+        };
+
+        // Parse the target into a structured subject once, at the edge: an actor
+        // DID, all-actors `*`, a cross-object edge, or a userset.
+        let target = acp::parse_target_subject(target)
+            .map_err(|error| anyhow!("invalid target: {error}"))?;
+
+        let loaded = self.get_policy(&policy.id).await?;
+        let resource = loaded
+            .get_resource(&policy.resource_name)
+            .ok_or_else(|| anyhow!("resource '{}' not found in policy", policy.resource_name))?;
+        if resource.get_relation(relation).is_none() {
+            bail!(
+                "relation '{relation}' not found in policy resource '{}'",
+                policy.resource_name
+            );
+        }
+        let managing_relations = loaded
+            .get_managers_for_relation(&policy.resource_name, relation)
+            .into_iter()
+            .map(str::to_string)
+            .collect();
+
+        Ok(RelationshipTarget {
+            target,
+            policy_id: policy.id,
+            resource_name: policy.resource_name,
+            collection_id: collection_version.collection_id().to_string(),
+            managing_relations,
+        })
+    }
+
+    /// Announce the document's latest state so subscribers re-evaluate access.
+    ///
+    /// A failure here leaves the grant in place: the relationship is already
+    /// stored, and the event is only a notification (matches the FFI path).
+    async fn publish_document_update(&self, collection_id: &str, doc_id: &str) {
+        match db::block_reader::read_latest_composite_block(&self.database, doc_id).await {
+            Ok(result) => {
+                self.event_bus
+                    .publish(events::Message::update(events::Update::new(
+                        doc_id.to_string(),
+                        result.cid,
+                        collection_id.to_string(),
+                        result.block,
+                        false,
+                        false,
+                    )));
+            }
+            Err(error) => tracing::warn!(
+                doc_id,
+                error,
+                "failed to publish document update after DAC grant"
+            ),
         }
     }
 }
@@ -39,11 +172,8 @@ impl<S: storage::corekv::Store + 'static> AcpOps for DbAcpOps<S> {
         if identity.is_empty() {
             bail!("policy creator can not be empty");
         }
-        let did = Did::new(identity).map_err(|error| anyhow!("invalid identity DID: {error}"))?;
-        self.database
-            .check_node_access(Some(&did), acp::nac::NodePermission::DacPolicyAdd)
-            .await
-            .map_err(|error| anyhow!("{error}"))?;
+        self.authorize(identity, acp::nac::NodePermission::DacPolicyAdd)
+            .await?;
 
         if policy.is_empty() {
             bail!("policy data can not be empty");
@@ -78,5 +208,81 @@ impl<S: storage::corekv::Store + 'static> AcpOps for DbAcpOps<S> {
             .map_err(|error| anyhow!("failed to store policy: {error}"))?;
 
         Ok(built.id)
+    }
+
+    async fn add_dac_actor_relationship(
+        &self,
+        identity: &str,
+        collection: &str,
+        doc_id: &str,
+        relation: &str,
+        target: &str,
+    ) -> anyhow::Result<bool> {
+        let requestor = self
+            .authorize(identity, acp::nac::NodePermission::DacRelationAdd)
+            .await?;
+        if relation == acp::OWNER_RELATION {
+            bail!("OPERATION_FORBIDDEN: cannot add owner relation");
+        }
+        let resolved = self
+            .relationship_target(collection, relation, target)
+            .await?;
+
+        let added = self
+            .document_acp
+            .add_relationship(
+                &requestor,
+                resolved.target,
+                &resolved.policy_id,
+                &resolved.resource_name,
+                doc_id,
+                relation,
+                &resolved.managing_relations,
+            )
+            .await
+            .map_err(|error| anyhow!("{error}"))?;
+
+        if added {
+            self.publish_document_update(&resolved.collection_id, doc_id)
+                .await;
+        }
+
+        // Local ACP relationships are node-local (matches Go): a grant is not
+        // propagated to peers. Cross-node access control is SourceHub's role.
+        Ok(!added)
+    }
+
+    async fn delete_dac_actor_relationship(
+        &self,
+        identity: &str,
+        collection: &str,
+        doc_id: &str,
+        relation: &str,
+        target: &str,
+    ) -> anyhow::Result<bool> {
+        let requestor = self
+            .authorize(identity, acp::nac::NodePermission::DacRelationDelete)
+            .await?;
+        if relation == acp::OWNER_RELATION {
+            bail!("OPERATION_FORBIDDEN: cannot delete owner relation");
+        }
+        let resolved = self
+            .relationship_target(collection, relation, target)
+            .await?;
+
+        // Local ACP relationships are node-local (matches Go): a revoke is not
+        // propagated to peers. Cross-node access control is SourceHub's role.
+        self.document_acp
+            .delete_relationship(
+                &requestor,
+                resolved.target,
+                &resolved.policy_id,
+                &resolved.resource_name,
+                doc_id,
+                relation,
+                &resolved.managing_relations,
+            )
+            .await
+            .map_err(|error| anyhow!("{error}"))
     }
 }

--- a/crates/defra-node/src/acp_ops.rs
+++ b/crates/defra-node/src/acp_ops.rs
@@ -29,6 +29,9 @@ pub(crate) trait AcpOps: Send + Sync {
 
 /// The ACP backends a node was built with, shared by every caller that needs to
 /// resolve a policy id.
+///
+/// `create_document_acp` guarantees exactly one of `local`/`sourcehub` is
+/// `Some`, so every "ACP not available" branch below is defensive only.
 #[derive(Clone)]
 pub(crate) struct PolicyLookup {
     pub(crate) local: Option<Arc<dyn acp::ZanzibarStore>>,
@@ -159,13 +162,15 @@ impl<S: storage::corekv::Store + 'static> DbAcpOps<S> {
 
     /// Announce the document's latest state so subscribers re-evaluate access.
     ///
-    /// A publish failure is deliberately non-fatal: the relationship is already
-    /// persisted by the time this runs, and the event is only a best-effort
-    /// notification that lets subscribers re-evaluate access. Reporting it as an
-    /// error would tell the caller the grant failed when it did not. The FFI
-    /// surface makes the opposite choice and propagates the same failure
-    /// (`crates/ffi/src/acp/dac.rs:401-409`), so the two surfaces report an
-    /// unpublishable event differently.
+    /// Three surfaces treat an unpublishable event differently. Go
+    /// (`internal/db/db_dac.go:129-134`, calling `publishDocUpdateEvent` in
+    /// `internal/db/db.go`) makes a doc that is absent from the store a silent
+    /// no-op and propagates only genuine storage errors. The FFI propagates
+    /// both (`crates/ffi/src/acp/dac.rs:401-409`). defra-node deliberately
+    /// warns on both and continues: the relationship is already persisted by
+    /// the time this runs and the event is only a best-effort notification, so
+    /// surfacing an error here would tell the caller the grant failed when it
+    /// did not.
     async fn publish_document_update(&self, collection_id: &str, doc_id: &str) {
         match db::block_reader::read_latest_composite_block(&self.database, doc_id).await {
             Ok(result) => {
@@ -191,11 +196,21 @@ impl<S: storage::corekv::Store + 'static> DbAcpOps<S> {
 #[async_trait::async_trait]
 impl<S: storage::corekv::Store + 'static> AcpOps for DbAcpOps<S> {
     async fn add_dac_policy(&self, identity: &str, policy: &str) -> anyhow::Result<String> {
+        // Go gates on node access before rejecting an empty creator
+        // (`internal/db/db_dac.go:64-67`), so a NAC denial wins. An empty
+        // identity is Go's `immutable.None`, not a DID to parse.
+        let requestor = match identity {
+            "" => None,
+            did => Some(Did::new(did).map_err(|error| anyhow!("invalid identity DID: {error}"))?),
+        };
+        self.database
+            .check_node_access(requestor.as_ref(), acp::nac::NodePermission::DacPolicyAdd)
+            .await
+            .map_err(|error| anyhow!("{error}"))?;
+
         if identity.is_empty() {
             bail!("policy creator can not be empty");
         }
-        self.authorize(identity, acp::nac::NodePermission::DacPolicyAdd)
-            .await?;
 
         if policy.is_empty() {
             bail!("policy data can not be empty");
@@ -264,13 +279,14 @@ impl<S: storage::corekv::Store + 'static> AcpOps for DbAcpOps<S> {
             .await
             .map_err(|error| anyhow!("{error}"))?;
 
+        // Local ACP relationships are node-local (matches Go): a grant is not
+        // propagated to peers. Cross-node access control is SourceHub's role.
         if added {
             self.publish_document_update(&resolved.collection_id, doc_id)
                 .await;
         }
 
-        // Local ACP relationships are node-local (matches Go): a grant is not
-        // propagated to peers. Cross-node access control is SourceHub's role.
+        // Go returns ExistedAlready; `added` is its inverse.
         Ok(!added)
     }
 

--- a/crates/defra-node/src/acp_ops.rs
+++ b/crates/defra-node/src/acp_ops.rs
@@ -27,11 +27,44 @@ pub(crate) trait AcpOps: Send + Sync {
     ) -> anyhow::Result<bool>;
 }
 
+/// The ACP backends a node was built with, shared by every caller that needs to
+/// resolve a policy id.
+#[derive(Clone)]
+pub(crate) struct PolicyLookup {
+    pub(crate) local: Option<Arc<dyn acp::ZanzibarStore>>,
+    pub(crate) sourcehub: Option<Arc<sourcehub::SourceHubDocumentACP>>,
+}
+
+impl PolicyLookup {
+    pub(crate) fn new(
+        local: Option<Arc<dyn acp::ZanzibarStore>>,
+        sourcehub: Option<Arc<sourcehub::SourceHubDocumentACP>>,
+    ) -> Self {
+        Self { local, sourcehub }
+    }
+
+    /// Load a policy from whichever ACP backend this node was built with.
+    pub(crate) async fn get_policy(&self, policy_id: &str) -> anyhow::Result<Option<acp::Policy>> {
+        if let Some(store) = &self.local {
+            store
+                .get_policy(policy_id)
+                .await
+                .map_err(|error| anyhow!("failed to get policy: {error}"))
+        } else if let Some(sourcehub) = &self.sourcehub {
+            sourcehub
+                .get_policy(policy_id)
+                .await
+                .map_err(|error| anyhow!("failed to get policy: {error}"))
+        } else {
+            bail!("operation requires ACP, but ACP not available");
+        }
+    }
+}
+
 pub(crate) struct DbAcpOps<S: storage::corekv::Store + 'static> {
     database: Arc<db::DB<S>>,
     document_acp: Arc<dyn acp::DocumentACP>,
-    local_zanzibar_store: Option<Arc<dyn acp::ZanzibarStore>>,
-    sourcehub_acp: Option<Arc<sourcehub::SourceHubDocumentACP>>,
+    policy_lookup: PolicyLookup,
     event_bus: Arc<dyn events::Bus>,
     policy_counter: AtomicU64,
 }
@@ -49,15 +82,13 @@ impl<S: storage::corekv::Store + 'static> DbAcpOps<S> {
     pub(crate) fn new(
         database: Arc<db::DB<S>>,
         document_acp: Arc<dyn acp::DocumentACP>,
-        local_zanzibar_store: Option<Arc<dyn acp::ZanzibarStore>>,
-        sourcehub_acp: Option<Arc<sourcehub::SourceHubDocumentACP>>,
+        policy_lookup: PolicyLookup,
         event_bus: Arc<dyn events::Bus>,
     ) -> Self {
         Self {
             database,
             document_acp,
-            local_zanzibar_store,
-            sourcehub_acp,
+            policy_lookup,
             event_bus,
             policy_counter: AtomicU64::new(1),
         }
@@ -75,24 +106,6 @@ impl<S: storage::corekv::Store + 'static> DbAcpOps<S> {
             .await
             .map_err(|error| anyhow!("{error}"))?;
         Ok(did)
-    }
-
-    /// Load a policy from whichever ACP backend this node was built with.
-    async fn get_policy(&self, policy_id: &str) -> anyhow::Result<acp::Policy> {
-        let policy = if let Some(store) = &self.local_zanzibar_store {
-            store
-                .get_policy(policy_id)
-                .await
-                .map_err(|error| anyhow!("failed to get policy: {error}"))?
-        } else if let Some(sourcehub_acp) = &self.sourcehub_acp {
-            sourcehub_acp
-                .get_policy(policy_id)
-                .await
-                .map_err(|error| anyhow!("failed to get policy: {error}"))?
-        } else {
-            bail!("operation requires ACP, but ACP not available");
-        };
-        policy.ok_or_else(|| anyhow!("policy '{policy_id}' not found"))
     }
 
     async fn relationship_target(
@@ -115,7 +128,11 @@ impl<S: storage::corekv::Store + 'static> DbAcpOps<S> {
         let target = acp::parse_target_subject(target)
             .map_err(|error| anyhow!("invalid target: {error}"))?;
 
-        let loaded = self.get_policy(&policy.id).await?;
+        let loaded = self
+            .policy_lookup
+            .get_policy(&policy.id)
+            .await?
+            .ok_or_else(|| anyhow!("policy '{}' not found", policy.id))?;
         let resource = loaded
             .get_resource(&policy.resource_name)
             .ok_or_else(|| anyhow!("resource '{}' not found in policy", policy.resource_name))?;
@@ -191,14 +208,14 @@ impl<S: storage::corekv::Store + 'static> AcpOps for DbAcpOps<S> {
         }
         acp::policy_yaml::validate_policy_expressions(&parsed).map_err(|error| anyhow!(error))?;
 
-        if let Some(sourcehub_acp) = &self.sourcehub_acp {
+        if let Some(sourcehub_acp) = &self.policy_lookup.sourcehub {
             return sourcehub_acp
                 .add_policy(identity, policy)
                 .await
                 .map_err(|error| anyhow!("SourceHub create policy failed: {error}"));
         }
 
-        let Some(store) = &self.local_zanzibar_store else {
+        let Some(store) = &self.policy_lookup.local else {
             bail!("operation requires ACP, but ACP not available");
         };
         let counter = self.policy_counter.fetch_add(1, Ordering::SeqCst);

--- a/crates/defra-node/src/dac_api_tests.rs
+++ b/crates/defra-node/src/dac_api_tests.rs
@@ -13,6 +13,45 @@ resources:
       - name: delete
 "#;
 const DID_A: &str = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+const DID_B: &str = "did:key:z6MkfXG2FkNy3u7Eg3jm8e2YQpGz7Z1JqWgHDAP1hLk9r2bR";
+
+async fn node_with_protected_users() -> (EmbeddedNode, String) {
+    let node = EmbeddedNode::builder().build().await.unwrap();
+    let policy_id = node.add_dac_policy(DID_A, POLICY_YAML).await.unwrap();
+    node.add_schema(&format!(
+        "type Users @policy(id: \"{policy_id}\", resource: \"users\") {{ name: String }}"
+    ))
+    .await
+    .unwrap();
+
+    let did_a = identity::Did::new(DID_A).unwrap();
+    let create = node
+        .execute_request_with_retry(
+            query::QueryRequest::new(
+                "mutation { add_Users(input: {name: \"secret\"}) { _docID } }",
+            )
+            .with_identity(Some(did_a)),
+            Default::default(),
+        )
+        .await;
+    assert!(!create.has_errors(), "{:?}", create.errors);
+    let doc_id = create.data.as_ref().unwrap()["add_Users"][0]["_docID"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    (node, doc_id)
+}
+
+async fn visible_users(node: &EmbeddedNode, identity: Option<identity::Did>) -> usize {
+    let response = node
+        .execute_request_with_retry(
+            query::QueryRequest::new("query { Users { name } }").with_identity(identity),
+            Default::default(),
+        )
+        .await;
+    assert!(!response.has_errors(), "{:?}", response.errors);
+    response.data.unwrap()["Users"].as_array().unwrap().len()
+}
 
 #[tokio::test]
 async fn add_dac_policy_rejects_empty_identity_and_policy() {
@@ -31,5 +70,107 @@ async fn add_dac_policy_returns_id_and_validates_policy() {
     assert!(!policy_id.is_empty());
     let bad = "name: Bad\nresources:\n  - name: users\n    relations:\n      - name: reader\n    permissions:\n      - name: read\n        expr: undeclared\n";
     assert!(node.add_dac_policy(DID_A, bad).await.is_err());
+    node.shutdown().await;
+}
+
+#[tokio::test]
+async fn dac_share_journey_grant_and_revoke() {
+    let (node, doc_id) = node_with_protected_users().await;
+    let did_b = identity::Did::new(DID_B).unwrap();
+
+    assert_eq!(visible_users(&node, Some(did_b.clone())).await, 0);
+    assert_eq!(visible_users(&node, None).await, 0);
+
+    let mut updates = node.subscribe(&[events::EventName::Update]);
+    let existed = node
+        .add_dac_actor_relationship(DID_A, "Users", &doc_id, "reader", DID_B)
+        .await
+        .unwrap();
+    assert!(!existed, "first grant must be newly added");
+    let message = tokio::time::timeout(std::time::Duration::from_secs(2), updates.recv())
+        .await
+        .expect("new grant must publish a doc-update event")
+        .expect("event bus closed");
+    let update = message.as_update().expect("document update");
+    assert_eq!(update.doc_id, doc_id);
+    assert!(!update.block.is_empty());
+    assert_eq!(visible_users(&node, Some(did_b.clone())).await, 1);
+
+    assert!(
+        node.add_dac_actor_relationship(DID_A, "Users", &doc_id, "reader", DID_B)
+            .await
+            .unwrap(),
+        "second grant reports existed_already"
+    );
+    assert!(node
+        .delete_dac_actor_relationship(DID_A, "Users", &doc_id, "reader", DID_B)
+        .await
+        .unwrap());
+    assert_eq!(visible_users(&node, Some(did_b)).await, 0);
+    assert!(!node
+        .delete_dac_actor_relationship(DID_A, "Users", &doc_id, "reader", DID_B)
+        .await
+        .unwrap());
+    node.shutdown().await;
+}
+
+#[tokio::test]
+async fn dac_relationship_rejects_owner_relation() {
+    let (node, doc_id) = node_with_protected_users().await;
+
+    let add = node
+        .add_dac_actor_relationship(DID_A, "Users", &doc_id, "owner", DID_B)
+        .await
+        .unwrap_err();
+    assert_eq!(
+        add.to_string(),
+        "OPERATION_FORBIDDEN: cannot add owner relation"
+    );
+    let delete = node
+        .delete_dac_actor_relationship(DID_A, "Users", &doc_id, "owner", DID_B)
+        .await
+        .unwrap_err();
+    assert_eq!(
+        delete.to_string(),
+        "OPERATION_FORBIDDEN: cannot delete owner relation"
+    );
+    node.shutdown().await;
+}
+
+#[tokio::test]
+async fn dac_wildcard_grant_opens_document_to_every_actor() {
+    let (node, doc_id) = node_with_protected_users().await;
+
+    assert!(!node
+        .add_dac_actor_relationship(DID_A, "Users", &doc_id, "reader", "*")
+        .await
+        .unwrap());
+    assert_eq!(visible_users(&node, None).await, 1);
+    node.shutdown().await;
+}
+
+#[tokio::test]
+async fn dac_relationship_requires_a_collection_policy() {
+    let node = EmbeddedNode::builder().build().await.unwrap();
+    node.add_schema("type Plain { name: String }")
+        .await
+        .unwrap();
+
+    let add = node
+        .add_dac_actor_relationship(DID_A, "Plain", "doc-1", "reader", DID_B)
+        .await
+        .unwrap_err();
+    assert_eq!(
+        add.to_string(),
+        "operation requires ACP, but collection has no policy"
+    );
+    let delete = node
+        .delete_dac_actor_relationship(DID_A, "Plain", "doc-1", "reader", DID_B)
+        .await
+        .unwrap_err();
+    assert_eq!(
+        delete.to_string(),
+        "operation requires ACP, but collection has no policy"
+    );
     node.shutdown().await;
 }

--- a/crates/defra-node/src/dac_api_tests.rs
+++ b/crates/defra-node/src/dac_api_tests.rs
@@ -74,6 +74,45 @@ async fn add_dac_policy_returns_id_and_validates_policy() {
 }
 
 #[tokio::test]
+async fn add_schema_rejects_unregistered_policy_id() {
+    let node = EmbeddedNode::builder().build().await.unwrap();
+    let err = node
+        .add_schema("type Users @policy(id: \"deadbeef\", resource: \"users\") { name: String }")
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("schema policy validation error"),
+        "{err:#}"
+    );
+
+    node.add_schema("type Plain { name: String }")
+        .await
+        .expect("a schema without @policy must not need the policy store");
+    node.shutdown().await;
+}
+
+#[tokio::test]
+async fn add_view_rejects_unregistered_policy_id() {
+    let node = EmbeddedNode::builder().build().await.unwrap();
+    node.add_schema("type Plain { name: String }")
+        .await
+        .unwrap();
+
+    let err = node
+        .add_view(
+            "Plain { name }",
+            "type PlainView @policy(id: \"deadbeef\", resource: \"users\") { name: String }",
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("schema policy validation error"),
+        "{err:#}"
+    );
+    node.shutdown().await;
+}
+
+#[tokio::test]
 async fn dac_share_journey_grant_and_revoke() {
     let (node, doc_id) = node_with_protected_users().await;
     let did_b = identity::Did::new(DID_B).unwrap();

--- a/crates/defra-node/src/dac_api_tests.rs
+++ b/crates/defra-node/src/dac_api_tests.rs
@@ -1,0 +1,35 @@
+use super::EmbeddedNode;
+
+const POLICY_YAML: &str = r#"
+name: Sensitive Rows
+resources:
+  - name: users
+    relations:
+      - name: reader
+    permissions:
+      - name: read
+        expr: reader
+      - name: update
+      - name: delete
+"#;
+const DID_A: &str = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+
+#[tokio::test]
+async fn add_dac_policy_rejects_empty_identity_and_policy() {
+    let node = EmbeddedNode::builder().build().await.unwrap();
+    let err = node.add_dac_policy("", POLICY_YAML).await.unwrap_err();
+    assert_eq!(err.to_string(), "policy creator can not be empty");
+    let err = node.add_dac_policy(DID_A, "").await.unwrap_err();
+    assert_eq!(err.to_string(), "policy data can not be empty");
+    node.shutdown().await;
+}
+
+#[tokio::test]
+async fn add_dac_policy_returns_id_and_validates_policy() {
+    let node = EmbeddedNode::builder().build().await.unwrap();
+    let policy_id = node.add_dac_policy(DID_A, POLICY_YAML).await.unwrap();
+    assert!(!policy_id.is_empty());
+    let bad = "name: Bad\nresources:\n  - name: users\n    relations:\n      - name: reader\n    permissions:\n      - name: read\n        expr: undeclared\n";
+    assert!(node.add_dac_policy(DID_A, bad).await.is_err());
+    node.shutdown().await;
+}

--- a/crates/defra-node/src/dac_api_tests.rs
+++ b/crates/defra-node/src/dac_api_tests.rs
@@ -1,4 +1,8 @@
+use super::tests::SIGNING_STORE_GUARD;
 use super::EmbeddedNode;
+use crypto::Key;
+use defra_core::signing::{SigningConfig, SigningKeyType};
+use identity::{Identity as _, RawIdentity};
 
 const POLICY_YAML: &str = r#"
 name: Sensitive Rows
@@ -40,6 +44,30 @@ async fn node_with_protected_users() -> (EmbeddedNode, String) {
         .unwrap()
         .to_string();
     (node, doc_id)
+}
+
+/// Generate a fresh Ed25519 node identity and register it in the process-local
+/// signing registry with exportable key bytes, so `with_node_acp_enabled` can
+/// match it against the database node DID.
+fn register_local_node_identity() -> String {
+    let private_key = crypto::generate_ed25519().unwrap();
+    let identity = RawIdentity::from_ed25519(private_key.clone()).unwrap();
+    let did = identity.did().unwrap().to_string();
+
+    let public_key_bytes = identity.public_key_bytes();
+    defra_core::signing::store_identity(
+        &did,
+        SigningConfig {
+            key_type: SigningKeyType::Ed25519,
+            private_key_bytes: private_key.raw().to_vec(),
+            public_key_bytes: public_key_bytes.clone(),
+            public_key_hex: hex::encode(&public_key_bytes),
+            remote_signer: None,
+            signing_authorization: None,
+        },
+    );
+
+    did
 }
 
 async fn visible_users(node: &EmbeddedNode, identity: Option<identity::Did>) -> usize {
@@ -212,4 +240,63 @@ async fn dac_relationship_requires_a_collection_policy() {
         "operation requires ACP, but collection has no policy"
     );
     node.shutdown().await;
+}
+
+#[tokio::test]
+async fn document_acp_handle_registers_and_checks_a_document() {
+    let node = EmbeddedNode::builder().build().await.unwrap();
+    let policy_id = node.add_dac_policy(DID_A, POLICY_YAML).await.unwrap();
+    let did_a = identity::Did::new(DID_A).unwrap();
+
+    let document_acp = node.document_acp();
+    document_acp
+        .register_doc_object(&did_a, &policy_id, "users", "doc-x")
+        .await
+        .unwrap();
+
+    assert!(document_acp
+        .check_doc_access(
+            &acp::Identity::Authenticated(did_a),
+            acp::DocumentPermission::Read,
+            &policy_id,
+            "users",
+            "doc-x",
+        )
+        .await
+        .unwrap());
+    assert!(!document_acp
+        .check_doc_access(
+            &acp::Identity::Anonymous,
+            acp::DocumentPermission::Read,
+            &policy_id,
+            "users",
+            "doc-x",
+        )
+        .await
+        .unwrap());
+    node.shutdown().await;
+}
+
+#[tokio::test]
+async fn add_dac_policy_is_gated_by_node_access_control() {
+    let _serial = SIGNING_STORE_GUARD.lock().await;
+    defra_core::signing::clear_identity_store();
+    let node_did = register_local_node_identity();
+
+    let node = EmbeddedNode::builder()
+        .with_node_identity_did(&node_did)
+        .with_node_acp_enabled()
+        .build()
+        .await
+        .unwrap();
+
+    let err = node.add_dac_policy(DID_B, POLICY_YAML).await.unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "not authorized to perform operation. Permission: add-dac-policy"
+    );
+    assert!(node.add_dac_policy(&node_did, POLICY_YAML).await.is_ok());
+
+    node.shutdown().await;
+    defra_core::signing::clear_identity_store();
 }

--- a/crates/defra-node/src/dac_api_tests.rs
+++ b/crates/defra-node/src/dac_api_tests.rs
@@ -169,10 +169,23 @@ async fn dac_share_journey_grant_and_revoke() {
             .unwrap(),
         "second grant reports existed_already"
     );
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(500), updates.recv())
+            .await
+            .is_err(),
+        "an existed-already grant must not publish a doc-update event"
+    );
+
     assert!(node
         .delete_dac_actor_relationship(DID_A, "Users", &doc_id, "reader", DID_B)
         .await
         .unwrap());
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(500), updates.recv())
+            .await
+            .is_err(),
+        "a revoke must not publish a doc-update event"
+    );
     assert_eq!(visible_users(&node, Some(did_b)).await, 0);
     assert!(!node
         .delete_dac_actor_relationship(DID_A, "Users", &doc_id, "reader", DID_B)
@@ -295,7 +308,9 @@ async fn add_dac_policy_is_gated_by_node_access_control() {
         err.to_string(),
         "not authorized to perform operation. Permission: add-dac-policy"
     );
-    assert!(node.add_dac_policy(&node_did, POLICY_YAML).await.is_ok());
+    node.add_dac_policy(&node_did, POLICY_YAML)
+        .await
+        .expect("node identity must bypass NAC");
 
     node.shutdown().await;
     defra_core::signing::clear_identity_store();

--- a/crates/defra-node/src/db_impls.rs
+++ b/crates/defra-node/src/db_impls.rs
@@ -6,6 +6,7 @@ use identity::Did;
 use lens::{LensConfig, TransformId};
 use schema::CollectionVersion;
 
+use crate::acp_ops::PolicyLookup;
 use crate::{BlockOps, SchemaOps};
 
 pub(crate) struct DbBlockOps<S: storage::corekv::Store + 'static> {
@@ -85,6 +86,7 @@ pub(crate) struct DbSchemaOps<S: storage::corekv::Store + 'static> {
     database: Arc<db::DB<S>>,
     query_limits: query::QueryLimits,
     document_acp: Arc<dyn acp::DocumentACP>,
+    policy_lookup: PolicyLookup,
 }
 
 impl<S: storage::corekv::Store + 'static> DbSchemaOps<S> {
@@ -92,12 +94,29 @@ impl<S: storage::corekv::Store + 'static> DbSchemaOps<S> {
         database: Arc<db::DB<S>>,
         query_limits: query::QueryLimits,
         document_acp: Arc<dyn acp::DocumentACP>,
+        policy_lookup: PolicyLookup,
     ) -> Self {
         Self {
             database,
             query_limits,
             document_acp,
+            policy_lookup,
         }
+    }
+
+    /// Reject any `@policy` directive that does not resolve to a usable resource
+    /// in the policy store, so a permissioned collection is never created public.
+    /// Collections without a policy never touch the store.
+    async fn validate_policies(&self, collections: &[CollectionVersion]) -> anyhow::Result<()> {
+        for collection in collections {
+            let Some(policy) = &collection.policy else {
+                continue;
+            };
+            let stored = self.policy_lookup.get_policy(&policy.id).await?;
+            acp::validate_resource_interface(&policy.id, &policy.resource_name, stored.as_ref())
+                .map_err(|e| anyhow::anyhow!("schema policy validation error: {}", e))?;
+        }
+        Ok(())
     }
 
     /// Resolve the ambient identity into a creator DID. Returns `Ok(None)` when
@@ -132,6 +151,8 @@ impl<S: storage::corekv::Store + 'static> SchemaOps for DbSchemaOps<S> {
 
         schema::definition_validation::validate_new_collections(&collections)
             .map_err(|e| anyhow::anyhow!("schema validation error: {}", e))?;
+
+        self.validate_policies(&collections).await?;
 
         self.database
             .create_collections_atomic_with_acp_registration(
@@ -192,6 +213,8 @@ impl<S: storage::corekv::Store + 'static> SchemaOps for DbSchemaOps<S> {
                 downsample_names.push(collection.name.clone());
             }
         }
+
+        self.validate_policies(&collections).await?;
 
         let creator = Self::current_identity()?;
         self.database

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -149,6 +149,7 @@ pub struct EmbeddedNode {
     schema_ops: Arc<dyn SchemaOps>,
     block_ops: Arc<dyn BlockOps>,
     acp_ops: Arc<dyn acp_ops::AcpOps>,
+    document_acp: Arc<dyn acp::DocumentACP>,
     embedding_config: db::EmbeddingClientConfig,
     node_identity_did: Option<String>,
     node_query_identity: Option<identity::Did>,
@@ -531,6 +532,17 @@ impl EmbeddedNode {
         self.acp_ops
             .delete_dac_actor_relationship(identity, collection, doc_id, relation, target)
             .await
+    }
+
+    /// Access the raw document ACP handle (Go: `node.DB.DocumentACP()`).
+    ///
+    /// This is an escape hatch for policy and relationship operations the node
+    /// does not wrap. It bypasses node access control and the collection-policy
+    /// lookup, so standard flows belong on [`Self::add_dac_policy`],
+    /// [`Self::add_dac_actor_relationship`], and
+    /// [`Self::delete_dac_actor_relationship`].
+    pub fn document_acp(&self) -> Arc<dyn acp::DocumentACP> {
+        self.document_acp.clone()
     }
 
     /// Access the resolved node-level embedding runtime config.
@@ -1488,7 +1500,7 @@ impl NodeBuilder {
         ));
         let block_ops: Arc<dyn BlockOps> = Arc::new(db_impls::DbBlockOps::new(
             database,
-            document_acp,
+            document_acp.clone(),
             registry,
             node_query_identity.clone(),
         ));
@@ -1505,6 +1517,7 @@ impl NodeBuilder {
             schema_ops,
             block_ops,
             acp_ops,
+            document_acp,
             embedding_config,
             node_identity_did,
             node_query_identity,

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -17,6 +17,7 @@
 //! - `http` — GraphQL HTTP server.
 //! - `otel` — OpenTelemetry exporter.
 
+mod acp_ops;
 mod benchmark_data_gen;
 mod benchmark_queries;
 mod benchmark_stats;
@@ -24,6 +25,8 @@ mod benchmark_stats;
 pub mod benchmark_support;
 pub mod coding_search;
 pub mod config;
+#[cfg(test)]
+mod dac_api_tests;
 mod db_impls;
 pub mod dense_search;
 #[cfg(test)]
@@ -145,6 +148,7 @@ pub struct EmbeddedNode {
     event_bus: Arc<dyn events::Bus>,
     schema_ops: Arc<dyn SchemaOps>,
     block_ops: Arc<dyn BlockOps>,
+    acp_ops: Arc<dyn acp_ops::AcpOps>,
     embedding_config: db::EmbeddingClientConfig,
     node_identity_did: Option<String>,
     node_query_identity: Option<identity::Did>,
@@ -480,6 +484,11 @@ impl EmbeddedNode {
     /// Access the event bus directly.
     pub fn event_bus(&self) -> &Arc<dyn events::Bus> {
         &self.event_bus
+    }
+
+    /// Register a DAC policy (Go: client.Store::AddDACPolicy). Returns the policy ID.
+    pub async fn add_dac_policy(&self, identity: &str, policy: &str) -> anyhow::Result<String> {
+        self.acp_ops.add_dac_policy(identity, policy).await
     }
 
     /// Access the resolved node-level embedding runtime config.
@@ -1426,6 +1435,11 @@ impl NodeBuilder {
             query_limits,
             document_acp.clone(),
         ));
+        let acp_ops: Arc<dyn acp_ops::AcpOps> = Arc::new(acp_ops::DbAcpOps::new(
+            database.clone(),
+            acp_setup.local_zanzibar_store,
+            acp_setup.sourcehub_acp,
+        ));
         let block_ops: Arc<dyn BlockOps> = Arc::new(db_impls::DbBlockOps::new(
             database,
             document_acp,
@@ -1444,6 +1458,7 @@ impl NodeBuilder {
             event_bus,
             schema_ops,
             block_ops,
+            acp_ops,
             embedding_config,
             node_identity_did,
             node_query_identity,

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -491,6 +491,48 @@ impl EmbeddedNode {
         self.acp_ops.add_dac_policy(identity, policy).await
     }
 
+    /// Grant `target` the `relation` on a document (Go: client.Store::AddDACActorRelationship).
+    ///
+    /// `identity` is the requesting actor's DID; it must own the document or
+    /// hold a relation that manages `relation`. `target` is an actor DID, the
+    /// all-actors wildcard `*`, or a structured subject.
+    ///
+    /// Returns `existed_already`: `true` means the relationship was already
+    /// present and the call was a no-op, `false` means it was newly added. A new
+    /// grant also publishes a document-update event.
+    pub async fn add_dac_actor_relationship(
+        &self,
+        identity: &str,
+        collection: &str,
+        doc_id: &str,
+        relation: &str,
+        target: &str,
+    ) -> anyhow::Result<bool> {
+        self.acp_ops
+            .add_dac_actor_relationship(identity, collection, doc_id, relation, target)
+            .await
+    }
+
+    /// Revoke `target`'s `relation` on a document (Go: client.Store::DeleteDACActorRelationship).
+    ///
+    /// `identity` is the requesting actor's DID; it must own the document or
+    /// hold a relation that manages `relation`.
+    ///
+    /// Returns `record_found`: `true` means the relationship existed and was
+    /// deleted, `false` means there was nothing to delete.
+    pub async fn delete_dac_actor_relationship(
+        &self,
+        identity: &str,
+        collection: &str,
+        doc_id: &str,
+        relation: &str,
+        target: &str,
+    ) -> anyhow::Result<bool> {
+        self.acp_ops
+            .delete_dac_actor_relationship(identity, collection, doc_id, relation, target)
+            .await
+    }
+
     /// Access the resolved node-level embedding runtime config.
     pub fn embedding_config(&self) -> &db::EmbeddingClientConfig {
         &self.embedding_config
@@ -1437,8 +1479,10 @@ impl NodeBuilder {
         ));
         let acp_ops: Arc<dyn acp_ops::AcpOps> = Arc::new(acp_ops::DbAcpOps::new(
             database.clone(),
+            document_acp.clone(),
             acp_setup.local_zanzibar_store,
             acp_setup.sourcehub_acp,
+            event_bus.clone(),
         ));
         let block_ops: Arc<dyn BlockOps> = Arc::new(db_impls::DbBlockOps::new(
             database,

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -46,6 +46,9 @@ use defra_core::signing::SigningConfig;
 use identity::{Identity as _, IdentityKeyType, RawIdentity};
 use rand::Rng;
 
+/// Re-exported so callers can name `Arc<dyn acp::DocumentACP>` (the type
+/// [`EmbeddedNode::document_acp`] returns) without depending on `acp` directly.
+pub use acp;
 pub use coding_search::{
     CodingHybridSearchHit, CodingHybridSearchRequest, CodingHybridSearchResponse,
     CodingSearchTarget,

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -46,9 +46,9 @@ use defra_core::signing::SigningConfig;
 use identity::{Identity as _, IdentityKeyType, RawIdentity};
 use rand::Rng;
 
-/// Re-exported so callers can name `Arc<dyn acp::DocumentACP>` (the type
+/// Re-exported so callers can name `Arc<dyn DocumentACP>` (the type
 /// [`EmbeddedNode::document_acp`] returns) without depending on `acp` directly.
-pub use acp;
+pub use acp::{DocumentACP, DocumentPermission, Identity as AcpIdentity};
 pub use coding_search::{
     CodingHybridSearchHit, CodingHybridSearchRequest, CodingHybridSearchResponse,
     CodingSearchTarget,

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -1462,7 +1462,10 @@ impl NodeBuilder {
         let acp_setup =
             node_acp::create_document_acp(store.clone(), persistence, &document_acp_config).await?;
         let document_acp = acp_setup.document_acp.clone();
+        #[cfg(feature = "sourcehub")]
         let _strict_replicated_doc_access = acp_setup.sourcehub_acp.is_some();
+        #[cfg(not(feature = "sourcehub"))]
+        let _strict_replicated_doc_access = false;
 
         #[cfg(feature = "p2p")]
         if let Some(wire_document_acp) = p2p_result
@@ -1487,8 +1490,11 @@ impl NodeBuilder {
         };
 
         let runner: Arc<dyn QueryExecutor> = Arc::new(query_runner);
+        #[cfg(feature = "sourcehub")]
         let policy_lookup =
             acp_ops::PolicyLookup::new(acp_setup.local_zanzibar_store, acp_setup.sourcehub_acp);
+        #[cfg(not(feature = "sourcehub"))]
+        let policy_lookup = acp_ops::PolicyLookup::new(acp_setup.local_zanzibar_store);
         let schema_ops: Arc<dyn SchemaOps> = Arc::new(db_impls::DbSchemaOps::new(
             database.clone(),
             query_limits,

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -1472,16 +1472,18 @@ impl NodeBuilder {
         };
 
         let runner: Arc<dyn QueryExecutor> = Arc::new(query_runner);
+        let policy_lookup =
+            acp_ops::PolicyLookup::new(acp_setup.local_zanzibar_store, acp_setup.sourcehub_acp);
         let schema_ops: Arc<dyn SchemaOps> = Arc::new(db_impls::DbSchemaOps::new(
             database.clone(),
             query_limits,
             document_acp.clone(),
+            policy_lookup.clone(),
         ));
         let acp_ops: Arc<dyn acp_ops::AcpOps> = Arc::new(acp_ops::DbAcpOps::new(
             database.clone(),
             document_acp.clone(),
-            acp_setup.local_zanzibar_store,
-            acp_setup.sourcehub_acp,
+            policy_lookup,
             event_bus.clone(),
         ));
         let block_ops: Arc<dyn BlockOps> = Arc::new(db_impls::DbBlockOps::new(

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -746,7 +746,7 @@ pub struct NodeBuilder {
 }
 
 struct StoreBuildArgs {
-    acp_store: Arc<dyn acp::AcpStore>,
+    persistence: node_acp::Persistence,
     document_acp_config: DocumentAcpConfig,
     db_options: db::DbOptions,
     event_bus: Arc<dyn events::Bus>,
@@ -1112,12 +1112,11 @@ impl NodeBuilder {
                 "embedded node starting (ephemeral, no data_path)"
             );
             let store = Arc::new(storage::MemoryStore::new());
-            let acp_store: Arc<dyn acp::AcpStore> = Arc::new(acp::MemoryAcpStore::new());
 
             Self::build_with_store(
                 store,
                 StoreBuildArgs {
-                    acp_store,
+                    persistence: node_acp::Persistence::Memory,
                     document_acp_config: self.document_acp,
                     db_options,
                     event_bus,
@@ -1238,13 +1237,10 @@ impl NodeBuilder {
             telemetry_handle,
         } = args;
 
-        let acp_store: Arc<dyn acp::AcpStore> =
-            Arc::new(acp::PersistentAcpStore::from_store(store.clone()));
-
         Self::build_with_store(
             store,
             StoreBuildArgs {
-                acp_store,
+                persistence: node_acp::Persistence::Persistent,
                 document_acp_config,
                 db_options,
                 event_bus,
@@ -1268,7 +1264,7 @@ impl NodeBuilder {
         args: StoreBuildArgs,
     ) -> anyhow::Result<EmbeddedNode> {
         let StoreBuildArgs {
-            acp_store,
+            persistence,
             document_acp_config,
             db_options,
             event_bus,
@@ -1397,8 +1393,10 @@ impl NodeBuilder {
             registry.start_stale_transaction_cleanup(cleanup.max_idle_age, cleanup.sweep_interval)
         });
 
-        let (document_acp, _strict_replicated_doc_access) =
-            node_acp::create_document_acp(acp_store, &document_acp_config).await?;
+        let acp_setup =
+            node_acp::create_document_acp(store.clone(), persistence, &document_acp_config).await?;
+        let document_acp = acp_setup.document_acp.clone();
+        let _strict_replicated_doc_access = acp_setup.sourcehub_acp.is_some();
 
         #[cfg(feature = "p2p")]
         if let Some(wire_document_acp) = p2p_result

--- a/crates/defra-node/src/node_acp.rs
+++ b/crates/defra-node/src/node_acp.rs
@@ -4,10 +4,26 @@ use std::sync::Arc;
 use anyhow::anyhow;
 use anyhow::Result;
 
-pub(crate) async fn create_document_acp(
-    acp_store: Arc<dyn acp::AcpStore>,
+pub(crate) enum Persistence {
+    Persistent,
+    Memory,
+}
+
+pub(crate) struct DocumentAcpSetup {
+    pub document_acp: Arc<dyn acp::DocumentACP>,
+    #[allow(dead_code)]
+    pub local_zanzibar_store: Option<Arc<dyn acp::ZanzibarStore>>,
+    pub sourcehub_acp: Option<Arc<sourcehub::SourceHubDocumentACP>>,
+}
+
+pub(crate) async fn create_document_acp<S>(
+    store: Arc<S>,
+    persistence: Persistence,
     config: &crate::DocumentAcpConfig,
-) -> Result<(Arc<dyn acp::DocumentACP>, bool)> {
+) -> Result<DocumentAcpSetup>
+where
+    S: storage::corekv::Store + 'static,
+{
     match config {
         #[cfg(feature = "sourcehub")]
         crate::DocumentAcpConfig::SourceHub(sourcehub_config) => {
@@ -26,11 +42,122 @@ pub(crate) async fn create_document_acp(
                 provider,
                 tuning.cache_ttl,
             ));
-            Ok((sh_acp, true))
+            Ok(DocumentAcpSetup {
+                document_acp: sh_acp.clone(),
+                local_zanzibar_store: None,
+                sourcehub_acp: Some(sh_acp),
+            })
         }
-        crate::DocumentAcpConfig::Local => {
-            let document_acp = Arc::new(acp::LocalDocumentACP::new(acp_store));
-            Ok((document_acp, false))
-        }
+        crate::DocumentAcpConfig::Local => match persistence {
+            Persistence::Persistent => {
+                let zanzibar_store = Arc::new(acp::PersistentZanzibarStore::from_store(store));
+                let document_acp = Arc::new(acp::ZanzibarDocumentACP::new(zanzibar_store.clone()));
+                Ok(local_document_acp_setup(document_acp, zanzibar_store))
+            }
+            Persistence::Memory => {
+                let zanzibar_store = Arc::new(acp::MemoryZanzibarStore::new());
+                let document_acp = Arc::new(acp::ZanzibarDocumentACP::new(zanzibar_store.clone()));
+                Ok(local_document_acp_setup(document_acp, zanzibar_store))
+            }
+        },
+    }
+}
+
+fn local_document_acp_setup(
+    document_acp: Arc<dyn acp::DocumentACP>,
+    zanzibar_store: Arc<dyn acp::ZanzibarStore>,
+) -> DocumentAcpSetup {
+    DocumentAcpSetup {
+        document_acp,
+        local_zanzibar_store: Some(zanzibar_store),
+        sourcehub_acp: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{create_document_acp, Persistence};
+    use crate::DocumentAcpConfig;
+    use acp::{DocumentPermission, Identity, StorePolicyOptions};
+    use identity::Did;
+    use std::sync::Arc;
+
+    fn did(value: &str) -> Did {
+        Did::new(value).unwrap()
+    }
+
+    #[tokio::test]
+    async fn local_document_acp_enforces_stored_custom_policy() {
+        let store = Arc::new(storage::MemoryStore::new());
+        let acp_setup = create_document_acp(store, Persistence::Memory, &DocumentAcpConfig::Local)
+            .await
+            .unwrap();
+
+        assert!(acp_setup.sourcehub_acp.is_none());
+        let document_acp = acp_setup.document_acp;
+        let local_store = acp_setup
+            .local_zanzibar_store
+            .expect("local ACP should expose a Zanzibar store");
+
+        let parsed = acp::policy_yaml::parse_policy_yaml(
+            r#"
+name: Viewer Policy
+resources:
+  - name: users
+    relations:
+      - name: viewer
+      - name: editor
+      - name: remover
+    permissions:
+      - name: read
+        expr: viewer
+      - name: update
+        expr: editor
+      - name: delete
+        expr: remover
+"#,
+        )
+        .unwrap();
+        let policy = acp::policy_yaml::build_policy(&parsed, 1).unwrap();
+        let options = StorePolicyOptions::new()
+            .with_validation()
+            .with_dpi_enforcement();
+        local_store
+            .store_policy_with_options(&policy, &options)
+            .await
+            .unwrap();
+
+        let owner = did("did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK");
+        let viewer = did("did:key:z6MkfXG2FkNy3u7Eg3jm8e2YQpGz7Z1JqWgHDAP1hLk9r2bR");
+
+        document_acp
+            .register_doc_object(&owner, &policy.id, "users", "doc1")
+            .await
+            .unwrap();
+        document_acp
+            .add_actor_relationship(&owner, &viewer, &policy.id, "users", "doc1", "viewer", &[])
+            .await
+            .unwrap();
+
+        assert!(document_acp
+            .check_doc_access(
+                &Identity::Authenticated(viewer.clone()),
+                DocumentPermission::Read,
+                &policy.id,
+                "users",
+                "doc1",
+            )
+            .await
+            .unwrap());
+        assert!(!document_acp
+            .check_doc_access(
+                &Identity::Authenticated(viewer),
+                DocumentPermission::Update,
+                &policy.id,
+                "users",
+                "doc1",
+            )
+            .await
+            .unwrap());
     }
 }

--- a/crates/defra-node/src/node_acp.rs
+++ b/crates/defra-node/src/node_acp.rs
@@ -12,6 +12,7 @@ pub(crate) enum Persistence {
 pub(crate) struct DocumentAcpSetup {
     pub document_acp: Arc<dyn acp::DocumentACP>,
     pub local_zanzibar_store: Option<Arc<dyn acp::ZanzibarStore>>,
+    #[cfg(feature = "sourcehub")]
     pub sourcehub_acp: Option<Arc<sourcehub::SourceHubDocumentACP>>,
 }
 
@@ -69,6 +70,7 @@ fn local_document_acp_setup(
     DocumentAcpSetup {
         document_acp,
         local_zanzibar_store: Some(zanzibar_store),
+        #[cfg(feature = "sourcehub")]
         sourcehub_acp: None,
     }
 }
@@ -92,6 +94,7 @@ mod tests {
             .await
             .unwrap();
 
+        #[cfg(feature = "sourcehub")]
         assert!(acp_setup.sourcehub_acp.is_none());
         let document_acp = acp_setup.document_acp;
         let local_store = acp_setup

--- a/crates/defra-node/src/node_acp.rs
+++ b/crates/defra-node/src/node_acp.rs
@@ -11,7 +11,6 @@ pub(crate) enum Persistence {
 
 pub(crate) struct DocumentAcpSetup {
     pub document_acp: Arc<dyn acp::DocumentACP>,
-    #[allow(dead_code)]
     pub local_zanzibar_store: Option<Arc<dyn acp::ZanzibarStore>>,
     pub sourcehub_acp: Option<Arc<sourcehub::SourceHubDocumentACP>>,
 }


### PR DESCRIPTION
Closes #1318

## Problem
`EmbeddedNode` exposes no document-ACP API: there is no way to add a policy, register a document, or manage actor relationships from the embedded surface. A `@policy` directive on an embedded schema is inert.

Worse, the embedded `add_schema` path never validated the `@policy` id against the policy store (the CLI/HTTP paths do, since #746), so a missing or mistyped policy id was accepted silently and every document on the collection stayed publicly readable.

Go DefraDB exposes all of these operations on its client surface, so this is a confirmed 1.0 parity gap (maintainer-triaged on #1318). The embedded use case in gents (#1059, #1066) is blocked on it.

## What changed

- Local document ACP is now backed by the persistent Zanzibar policy store instead of the in-memory engine.
- `EmbeddedNode::add_dac_policy` creates a DAC policy with Go-parity validation, gated by NAC when enabled.
- Refusal strings match Go exactly for the empty-identity and empty-policy cases; the owner-relation and invalid-expression refusals carry Go's classifier token (`OPERATION_FORBIDDEN` / `BAD_INPUT`) but not its wording, because Go's messages embed run-specific ids and DIDs.
- `EmbeddedNode::add_dac_actor_relationship` / `delete_dac_actor_relationship` grant and revoke per-document access, rejecting the `owner` relation and supporting the `*` wildcard actor.
- A successful relationship add publishes a doc-update event for replication; delete publishes none, matching Go.
- Deviation from Go: a failed event publish warns and continues instead of erroring, since the grant has already persisted either way.
- `add_schema` and `add_view` now fail closed when `@policy` names an unregistered policy id, matching the CLI/HTTP validation.
- `EmbeddedNode::document_acp()` exposes the raw `LocalDocumentACP` handle, and `defra-node` re-exports `acp` so callers need no direct dependency.
- Regression tests pin that `patch_collection` rejects policy mutation on both exit paths (policy immutability, mirrors Go).
- Note: `with_dpi_enforcement(false)` is effectively a no-op because `build_policy` always injects the owner relation; kept for API parity, flagged for a follow-up issue.
- Migration note: persistent local-ACP tuples move from the old `acp::persistent` namespace to `/zanzibar/*`; tuples written by older builds are unreachable after upgrade, which fails closed (re-grant to restore access).

## Verification

- `cargo fmt --all --check` clean; `cargo clippy --all -- -D warnings` exit 0.
- `cargo test -p defra-node` 61 passed / 0 failed (5 ignored are HuggingFace-model benchmarks); `cargo test -p acp` 296 passed / 0 failed.
- `cargo test -p integration-test --test acp` 198 passed / 0 failed with the pinned Go binary (`13c46ec9`) on PATH.
- Divergence audit against Go **v1.0.0** as well (`3de01484`): `--test acp` 198 passed / 0 failed, `--test nac` 26 passed / 0 failed — identical to the pinned-commit run, so nothing here is keyed to a single Go build.
- `cargo test -p integration-test --test encryption` 15 passed / 4 failed; the 4 are the pre-existing `go_*` KMS failures blocked on a hardcoded `GO_KMS_BINARY` path in files identical to main.
- `cargo test -p ffi` 158 passed / 0 failed (includes the DAC FFI tests); `cargo test -p ffi-test` 4 passed / 0 failed.
- SourceHub arm is compile-only per spec (routing through `sourcehub_acp.add_policy` builds clean; `--test sourcehub` / `--test hubrs` need external daemons and those areas are byte-identical to main).
- Pre-existing `--all-targets` clippy failures in `tools/integration-test` are untouched by this branch.
- Scope note: no `go_*` integration test or `ffi-test` case executes this code — `defra-node` has no workspace reverse-dependencies, so the evidence above is non-regression plus in-crate unit tests. A follow-up branch closes that gap with a cross-runtime differential test area.

