### PR TITLE
fix(query): remove wall-clock race from downsample rollup test

### DIFF
--- a/tools/integration-test/tests/query/downsample.rs
+++ b/tools/integration-test/tests/query/downsample.rs
@@ -37,9 +37,9 @@ const WAIT_TIMEOUT: Duration = Duration::from_secs(20);
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
 const BUCKET_MS: i64 = 1_000;
 const PARENT_BUCKET_MS: i64 = 2_000;
-const BASE_OFFSET_BUCKETS: i64 = 3;
-const FIRST_WINDOW_SETTLE_MS: i64 = 350;
+const BASE_OFFSET_BUCKETS: i64 = 4;
 const FINAL_WINDOW_SETTLE_MS: i64 = 350;
+const LEAD_IN_MARGIN_MS: i64 = 250;
 
 fn format_timestamp(timestamp: DateTime<Utc>) -> String {
     if timestamp.timestamp_subsec_nanos() == 0 {
@@ -330,44 +330,6 @@ async fn downsample_test(cluster: TestCluster) {
         ))
         .expect("update metric to 20");
 
-    assert!(
-        query_rollup(&client, "Metric2Rollup", &source_doc_id).is_none(),
-        "Metric2Rollup should stay empty before the first time bucket closes",
-    );
-
-    sleep_until(first_window_end + ChronoDuration::milliseconds(FIRST_WINDOW_SETTLE_MS)).await;
-
-    let first_rollup = wait_for_rollup(
-        &client,
-        "Metric2Rollup",
-        &source_doc_id,
-        2,
-        &format_timestamp(t1),
-        &format_timestamp(first_window_end),
-        2,
-        30,
-        15.0,
-        10,
-        20,
-    )
-    .await;
-    assert_rollup_row(
-        &first_rollup,
-        &source_doc_id,
-        2,
-        &format_timestamp(t1),
-        &format_timestamp(first_window_end),
-        2,
-        30,
-        15.0,
-        10,
-        20,
-    );
-    let rollup2_doc_id = first_rollup["_docID"]
-        .as_str()
-        .expect("Metric2Rollup row should include _docID")
-        .to_string();
-
     client
         .query(&format!(
             r#"mutation {{ update_Metric(docID: "{source_doc_id}", input: {{ts: "{}", value: 30}}) {{ _docID }} }}"#,
@@ -382,19 +344,22 @@ async fn downsample_test(cluster: TestCluster) {
         ))
         .expect("update metric to 40");
 
-    let stale_rollup = query_rollup(&client, "Metric2Rollup", &source_doc_id)
-        .expect("Metric2Rollup row should still exist during an incomplete bucket");
-    assert_rollup_row(
-        &stale_rollup,
-        &source_doc_id,
-        2,
-        &format_timestamp(t1),
-        &format_timestamp(first_window_end),
-        2,
-        30,
-        15.0,
-        10,
-        20,
+    // Every source write lands before any bucket closes, so no rollup target
+    // exists yet and none of them can be rejected as late data. Overrunning
+    // that budget is a harness problem, not a product one, so name it here
+    // rather than letting it surface as an opaque server rejection.
+    let lead_in_remaining = first_window_end
+        .signed_duration_since(Utc::now())
+        .num_milliseconds();
+    assert!(
+        lead_in_remaining > LEAD_IN_MARGIN_MS,
+        "test lead-in budget exceeded: source writes finished {lead_in_remaining}ms before the \
+         first window closes, under the {LEAD_IN_MARGIN_MS}ms margin; raise BASE_OFFSET_BUCKETS",
+    );
+
+    assert!(
+        query_rollup(&client, "Metric2Rollup", &source_doc_id).is_none(),
+        "Metric2Rollup should stay empty before the first time bucket closes",
     );
 
     sleep_until(second_window_end + ChronoDuration::milliseconds(FINAL_WINDOW_SETTLE_MS)).await;
@@ -425,16 +390,27 @@ async fn downsample_test(cluster: TestCluster) {
         30,
         40,
     );
-    assert_eq!(
-        second_rollup["_docID"].as_str(),
-        Some(rollup2_doc_id.as_str()),
-        "Metric2Rollup should keep a stable document identity for the series",
-    );
+    let rollup2_doc_id = second_rollup["_docID"]
+        .as_str()
+        .expect("Metric2Rollup row should include _docID")
+        .to_string();
 
+    // The first window's emission is only the live state for one bucket, so it
+    // is asserted through the target's commit history instead of a wall-clock
+    // race. Exactly two `sum` writes totalling 100 with a 70 maximum, and two
+    // `source_height` writes topping out at 4, can only come from an emission
+    // of the closed first window (sum=30, height=2) followed by an in-place
+    // update for the second (sum=70, height=4) — on this one document, which
+    // is also what proves the series keeps a stable identity. Any premature
+    // emission of an incomplete bucket would show up as extra commits.
     let rollup2_sum_history = aggregate_commit_field(&client, &rollup2_doc_id, "sum");
     assert_eq!(rollup2_sum_history["count"].as_i64(), Some(2));
     assert_eq!(rollup2_sum_history["total"].as_i64(), Some(100));
     assert_eq!(rollup2_sum_history["maxValue"].as_i64(), Some(70));
+
+    let rollup2_height_history = aggregate_commit_field(&client, &rollup2_doc_id, "source_height");
+    assert_eq!(rollup2_height_history["count"].as_i64(), Some(2));
+    assert_eq!(rollup2_height_history["maxValue"].as_i64(), Some(4));
 
     let rollup4 = wait_for_rollup(
         &client,


### PR DESCRIPTION
`rust_downsample_updates_stable_rollup_docs` is currently failing on `main` and on
every open PR that runs the `query` integration binary (#1323, #1441, #1439):

```
panicked at tools/integration-test/tests/query/downsample.rs:383:10:
update metric to 40: ... late data is not accepted for downsample source 'Metric':
timestamp '2026-08-13 15:30:15.500 +00:00' falls in closed bucket '2026-08-13 15:30:15 +00:00'
```

## Root cause

The server is behaving correctly; the test had a wall-clock race with effectively zero margin.

- Window emission is gated purely on wall clock: `aggregate_samples_into_windows` emits any
  window whose `window_end <= Utc::now()` (`crates/db/src/downsample/aggregate.rs`), driven by
  the 250ms downsample ticker (`crates/db/src/downsample/task.rs`). Emission advances the rollup
  target's `window_start`.
- `validate_downsample_write` (`crates/db/src/downsample/validate.rs:111`) then rejects any
  source write whose bucket start is at or before that `window_start`.
- The test observed the first rollup window live and only then wrote the two second-bucket
  samples, so that entire segment had to finish inside one bucket
  (`BUCKET_MS - FIRST_WINDOW_SETTLE_MS` = 650ms) or the `t4` write was correctly rejected.

Measured locally on an idle machine: **322–655ms against the 650ms budget**. It reproduced on
the first local run. CI's ~1.25s is the same segment under load.

## Fix

- Move all four source writes into the lead-in. No rollup target exists yet at that point, so
  `validate_downsample_write` cannot reject any of them, and emission still cannot happen early.
- Assert the intermediate first-window state through the target's commit history instead of a
  live race: exactly two `sum` writes totalling 100 with a 70 maximum, and two `source_height`
  writes topping out at 4. That set also subsumes the previous stable-identity check (two `sum`
  commits on the single document the second-window query returns) and catches premature emission
  of an incomplete bucket, all with no wall-clock budget.
- The first window's boundaries and aggregates remain pinned transitively by the untouched
  `Metric4Rollup` assertions (`window_start=t1`, `count=4`, `sum=100`, `min=10`, `max=40`), which
  can only hold if the first child window emitted as `window_start=t1, count=2, sum=30, min=10, max=20`.
- Guard the one remaining wall-clock assumption (all writes land before the first bucket closes)
  with an explicit message, and raise `BASE_OFFSET_BUCKETS` to 4 so the lead-in floor is 6–8s
  against the 4.5–6s of slack measured locally. Costs ~2s of test runtime.

`downsample_gc.rs` already drives the engine this way and does not flake, which is independent
confirmation the shape is sound.

## Testing

| Check | Result |
|---|---|
| 5x consecutive single-test runs | 5/5 pass |
| Full `--test query` binary (44 tests in parallel, CI-shaped) | downsample passes; `44 passed; 0 failed` excluding pre-existing `go_*` env failures |
| 1200ms delay injected at the formerly-fatal point | passes (was a hard failure before) |
| 3000ms delay injected in the observation phase | passes |
| Lead-in guard with a deliberately blown budget | fires with a clear message |
| `cargo fmt --all -- --check` / `cargo clippy --all -- -D warnings` | clean |

Test-only change; no product code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
