### PR TITLE
Vector indexes: benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3465,6 +3465,7 @@ name = "db-index"
 version = "0.5.0"
 dependencies = [
  "async-trait",
+ "criterion 0.6.0",
  "datastore",
  "defra-core",
  "document",

--- a/crates/db-index/Cargo.toml
+++ b/crates/db-index/Cargo.toml
@@ -41,3 +41,7 @@ harness = false
 [[bench]]
 name = "vector_search"
 harness = false
+
+[[bench]]
+name = "sift"
+harness = false

--- a/crates/db-index/Cargo.toml
+++ b/crates/db-index/Cargo.toml
@@ -28,7 +28,16 @@ serde.workspace = true
 async-trait.workspace = true
 
 [dev-dependencies]
+criterion.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 [lints]
 workspace = true
+
+[[bench]]
+name = "vector_mutations"
+harness = false
+
+[[bench]]
+name = "vector_search"
+harness = false

--- a/crates/db-index/benches/common/mod.rs
+++ b/crates/db-index/benches/common/mod.rs
@@ -1,0 +1,192 @@
+//! Fixtures shared by the vector benchmarks.
+
+#![allow(dead_code)]
+
+use db_index::vector::core::Metric;
+use db_index::vector::engine::ann::VectorIndexEngine;
+use db_index::vector::engine::flat::Flat;
+use db_index::vector::engine::hnsw::Hnsw;
+use db_index::vector::engine::ivfpq::{IvfPq, IvfPqParams};
+use db_index::vector::engine::ssg::{Ssg, SsgParams};
+use db_index::vector::params::{Params, DEFAULT_M};
+use db_index::vector::store::{MemoryNodeStore, NodeId};
+
+pub const SEED: u64 = 0x0BE9_C4A1;
+
+/// Deterministic across machines and releases, which a random-number crate's
+/// stream is not.
+pub struct Corpus(u64);
+
+impl Corpus {
+    pub fn new(seed: u64) -> Self {
+        Self(seed)
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+
+    fn unit(&mut self) -> f64 {
+        (self.next_u64() >> 11) as f64 / (1u64 << 53) as f64
+    }
+
+    fn gaussian(&mut self) -> f32 {
+        let u1 = self.unit().max(f64::MIN_POSITIVE);
+        let u2 = self.unit();
+        ((-2.0 * u1.ln()).sqrt() * (core::f64::consts::TAU * u2).cos()) as f32
+    }
+
+    pub fn vector(&mut self, dimensions: usize) -> Vec<f32> {
+        (0..dimensions)
+            .map(|_| (self.unit() * 2.0 - 1.0) as f32)
+            .collect()
+    }
+
+    pub fn vectors(&mut self, count: usize, dimensions: usize) -> Vec<Vec<f32>> {
+        (0..count).map(|_| self.vector(dimensions)).collect()
+    }
+
+    /// Clustered, which is the shape a real embedding corpus has. Uniform
+    /// vectors in high dimensions are all near-orthogonal and make every index
+    /// look the same.
+    pub fn clustered(
+        &mut self,
+        count: usize,
+        dimensions: usize,
+        clusters: usize,
+        spread: f32,
+    ) -> Vec<Vec<f32>> {
+        let centers: Vec<Vec<f32>> = (0..clusters).map(|_| self.vector(dimensions)).collect();
+        (0..count)
+            .map(|i| {
+                let center = &centers[i % clusters];
+                (0..dimensions)
+                    .map(|j| center[j] + self.gaussian() * spread)
+                    .collect()
+            })
+            .collect()
+    }
+}
+
+/// Every kind, behind the one trait they all implement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Kind {
+    Flat,
+    Hnsw,
+    IvfPq,
+    Ssg,
+}
+
+impl Kind {
+    pub fn name(self) -> &'static str {
+        match self {
+            Kind::Flat => "flat",
+            Kind::Hnsw => "hnsw",
+            Kind::IvfPq => "ivfpq",
+            Kind::Ssg => "ssg",
+        }
+    }
+
+    /// The kinds that build a structure after the fact, and therefore have a
+    /// second state to measure.
+    pub fn is_batch_built(self) -> bool {
+        matches!(self, Kind::IvfPq | Kind::Ssg)
+    }
+}
+
+pub const ALL_KINDS: [Kind; 4] = [Kind::Flat, Kind::Hnsw, Kind::IvfPq, Kind::Ssg];
+
+#[derive(Clone)]
+pub enum Index {
+    Flat(Flat<MemoryNodeStore>),
+    Hnsw(Hnsw<MemoryNodeStore>),
+    IvfPq(IvfPq<MemoryNodeStore>),
+    Ssg(Ssg<MemoryNodeStore>),
+}
+
+macro_rules! on_index {
+    ($self:ident, $index:ident => $call:expr) => {
+        match $self {
+            Index::Flat($index) => $call,
+            Index::Hnsw($index) => $call,
+            Index::IvfPq($index) => $call,
+            Index::Ssg($index) => $call,
+        }
+    };
+}
+
+impl Index {
+    pub fn new(kind: Kind) -> Self {
+        let store = MemoryNodeStore::new();
+        let metric = Metric::Cosine;
+        match kind {
+            Kind::Flat => Index::Flat(Flat::new(store, metric)),
+            Kind::Hnsw => Index::Hnsw(Hnsw::new(store, metric, Params::new(DEFAULT_M), SEED)),
+            Kind::IvfPq => Index::IvfPq(
+                IvfPq::try_new(
+                    store,
+                    metric,
+                    IvfPqParams {
+                        nlist: 16,
+                        nprobe: 8,
+                        m: 8,
+                        ..IvfPqParams::default()
+                    },
+                    SEED,
+                )
+                .expect("cosine is rankable by squared distance"),
+            ),
+            Kind::Ssg => Index::Ssg(
+                Ssg::try_new(
+                    store,
+                    metric,
+                    Params::new(DEFAULT_M),
+                    SsgParams::default(),
+                    SEED,
+                )
+                .expect("valid SSG parameters"),
+            ),
+        }
+    }
+
+    pub async fn insert(&mut self, id: NodeId, vector: &[f32]) {
+        on_index!(self, index => index.insert(id, vector).await.expect("insert"));
+    }
+
+    pub async fn delete(&mut self, id: NodeId) -> bool {
+        on_index!(self, index => index.delete(id).await.expect("delete"))
+    }
+
+    pub async fn search(&self, query: &[f32], k: usize) -> usize {
+        on_index!(self, index => index.search(query, k, None).await.expect("search").len())
+    }
+
+    /// Builds the structure a batch-built kind answers from. A no-op for the
+    /// kinds that have none, so a caller can treat every kind alike.
+    pub async fn build(&mut self) {
+        match self {
+            Index::IvfPq(index) => {
+                index.build().await.expect("ivf-pq build");
+            }
+            Index::Ssg(index) => {
+                index.build().await.expect("ssg build");
+            }
+            _ => {}
+        }
+    }
+
+    pub async fn filled(kind: Kind, vectors: &[Vec<f32>], built: bool) -> Self {
+        let mut index = Index::new(kind);
+        for (i, vector) in vectors.iter().enumerate() {
+            index.insert(NodeId(i as u64 + 1), vector).await;
+        }
+        if built {
+            index.build().await;
+        }
+        index
+    }
+}

--- a/crates/db-index/benches/common/mod.rs
+++ b/crates/db-index/benches/common/mod.rs
@@ -137,12 +137,10 @@ impl Index {
                 IvfPq::try_new(
                     store,
                     metric,
-                    IvfPqParams {
-                        nlist: 16,
-                        nprobe: 8,
-                        m: 8,
-                        ..IvfPqParams::default()
-                    },
+                    // nlist derived as 4*sqrt(N): a hardcoded small nlist
+                    // makes nprobe probe a large fraction of the corpus, which
+                    // measures a misconfigured index rather than the kind.
+                    IvfPqParams::default(),
                     SEED,
                 )
                 .expect("cosine is rankable by squared distance"),

--- a/crates/db-index/benches/common/mod.rs
+++ b/crates/db-index/benches/common/mod.rs
@@ -2,6 +2,8 @@
 
 #![allow(dead_code)]
 
+pub mod sift;
+
 use db_index::vector::core::Metric;
 use db_index::vector::engine::ann::VectorIndexEngine;
 use db_index::vector::engine::flat::Flat;
@@ -121,8 +123,13 @@ macro_rules! on_index {
 
 impl Index {
     pub fn new(kind: Kind) -> Self {
+        Self::with_metric(kind, Metric::Cosine)
+    }
+
+    /// SIFT's published ground truth is Euclidean, so a benchmark measured
+    /// against it must rank the same way or an exact scan does not score 1.0.
+    pub fn with_metric(kind: Kind, metric: Metric) -> Self {
         let store = MemoryNodeStore::new();
-        let metric = Metric::Cosine;
         match kind {
             Kind::Flat => Index::Flat(Flat::new(store, metric)),
             Kind::Hnsw => Index::Hnsw(Hnsw::new(store, metric, Params::new(DEFAULT_M), SEED)),
@@ -165,6 +172,16 @@ impl Index {
         on_index!(self, index => index.search(query, k, None).await.expect("search").len())
     }
 
+    pub async fn search_ids(&self, query: &[f32], k: usize) -> Vec<u64> {
+        on_index!(self, index => index
+            .search(query, k, None)
+            .await
+            .expect("search")
+            .into_iter()
+            .map(|n| n.id.0)
+            .collect())
+    }
+
     /// Builds the structure a batch-built kind answers from. A no-op for the
     /// kinds that have none, so a caller can treat every kind alike.
     pub async fn build(&mut self) {
@@ -180,7 +197,16 @@ impl Index {
     }
 
     pub async fn filled(kind: Kind, vectors: &[Vec<f32>], built: bool) -> Self {
-        let mut index = Index::new(kind);
+        Self::filled_with(kind, Metric::Cosine, vectors, built).await
+    }
+
+    pub async fn filled_with(
+        kind: Kind,
+        metric: Metric,
+        vectors: &[Vec<f32>],
+        built: bool,
+    ) -> Self {
+        let mut index = Index::with_metric(kind, metric);
         for (i, vector) in vectors.iter().enumerate() {
             index.insert(NodeId(i as u64 + 1), vector).await;
         }

--- a/crates/db-index/benches/common/sift.rs
+++ b/crates/db-index/benches/common/sift.rs
@@ -1,0 +1,100 @@
+//! The SIFT-small corpus: real vectors with published ground truth.
+//!
+//! Every other corpus here is synthetic, which means recall is measured against
+//! an oracle over vectors this repo generated. SIFT ships the true 100 nearest
+//! neighbours of each query, so recall against it is a measurement rather than
+//! a self-comparison.
+//!
+//! **It is not embeddings.** These are 128-dimension SIFT image descriptors, so
+//! a figure here is a real ANN benchmark number and comparable with published
+//! HNSW and FAISS results; it is not a prediction of behaviour on text
+//! embeddings.
+//!
+//! Fetch with `just setup-sift`. Absent, everything here returns `None` and the
+//! benchmarks skip, so a fresh clone still runs.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub struct SiftSmall {
+    pub base: Vec<Vec<f32>>,
+    pub queries: Vec<Vec<f32>>,
+    /// `groundtruth[q]` is the true nearest base indices for query `q`,
+    /// nearest first.
+    pub groundtruth: Vec<Vec<u32>>,
+}
+
+impl SiftSmall {
+    pub fn load() -> Option<Self> {
+        let root = root()?;
+        Some(Self {
+            base: read_fvecs(&root.join("siftsmall_base.fvecs"))?,
+            queries: read_fvecs(&root.join("siftsmall_query.fvecs"))?,
+            groundtruth: read_ivecs(&root.join("siftsmall_groundtruth.ivecs"))?,
+        })
+    }
+
+    pub fn dimensions(&self) -> usize {
+        self.base.first().map_or(0, Vec::len)
+    }
+}
+
+/// `.tooling/sift/siftsmall`, resolved from this crate rather than the working
+/// directory so it does not matter where cargo was invoked.
+fn root() -> Option<PathBuf> {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()?
+        .parent()?
+        .join(".tooling/sift/siftsmall");
+    path.is_dir().then_some(path)
+}
+
+/// Each record is a little-endian `u32` dimension followed by that many `f32`s.
+fn read_fvecs(path: &Path) -> Option<Vec<Vec<f32>>> {
+    let bytes = fs::read(path).ok()?;
+    let mut out = Vec::new();
+    let mut at = 0usize;
+    while at + 4 <= bytes.len() {
+        let dimensions = u32::from_le_bytes(bytes[at..at + 4].try_into().ok()?) as usize;
+        at += 4;
+        let end = at + dimensions * 4;
+        if end > bytes.len() {
+            return None;
+        }
+        out.push(
+            bytes[at..end]
+                .chunks_exact(4)
+                .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                .collect(),
+        );
+        at = end;
+    }
+    Some(out)
+}
+
+fn read_ivecs(path: &Path) -> Option<Vec<Vec<u32>>> {
+    let bytes = fs::read(path).ok()?;
+    let mut out = Vec::new();
+    let mut at = 0usize;
+    while at + 4 <= bytes.len() {
+        let count = u32::from_le_bytes(bytes[at..at + 4].try_into().ok()?) as usize;
+        at += 4;
+        let end = at + count * 4;
+        if end > bytes.len() {
+            return None;
+        }
+        out.push(
+            bytes[at..end]
+                .chunks_exact(4)
+                .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                .collect(),
+        );
+        at = end;
+    }
+    Some(out)
+}
+
+/// Printed once when the corpus is missing, so a skipped benchmark says why.
+pub fn skip_notice(what: &str) {
+    eprintln!("{what}: skipped, SIFT-small is not present. Run `just setup-sift`.");
+}

--- a/crates/db-index/benches/sift.rs
+++ b/crates/db-index/benches/sift.rs
@@ -1,0 +1,166 @@
+//! SIFT-small: search cost and recall on real vectors with published ground
+//! truth.
+//!
+//! ```text
+//! just setup-sift
+//! cargo bench -p db-index --bench sift
+//! ```
+//!
+//! Recall is printed rather than asserted, because a benchmark is not a gate.
+//! It is here so a number that describes real data sits next to the cost of
+//! producing it.
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use db_index::vector::store::NodeId;
+use std::hint::black_box;
+use tokio::runtime::Runtime;
+
+mod common;
+
+use common::sift::{skip_notice, SiftSmall};
+use common::{Index, ALL_KINDS};
+use db_index::vector::core::Metric;
+
+/// SIFT's ground truth is Euclidean.
+const METRIC: Metric = Metric::Euclidean;
+
+const K: usize = 10;
+
+fn runtime() -> Runtime {
+    Runtime::new().expect("a tokio runtime")
+}
+
+/// Recall against the corpus's own ground truth, which is the whole reason to
+/// use it: every other number in this crate is measured against an oracle over
+/// vectors we generated.
+fn recall(c: &mut Criterion) {
+    let Some(sift) = SiftSmall::load() else {
+        skip_notice("sift/recall");
+        return;
+    };
+    let rt = runtime();
+
+    println!(
+        "\nSIFT-small: {} base vectors, {} dimensions, {} queries, recall@{K} against published ground truth",
+        sift.base.len(),
+        sift.dimensions(),
+        sift.queries.len()
+    );
+
+    for kind in ALL_KINDS {
+        let index = rt.block_on(Index::filled_with(
+            kind,
+            METRIC,
+            &sift.base,
+            kind.is_batch_built(),
+        ));
+        let mut hit = 0usize;
+        let mut total = 0usize;
+        for (q, query) in sift.queries.iter().enumerate() {
+            let want: Vec<u64> = sift.groundtruth[q]
+                .iter()
+                .take(K)
+                .map(|i| *i as u64 + 1)
+                .collect();
+            let got = rt.block_on(index.search_ids(query, K));
+            hit += got.iter().filter(|id| want.contains(id)).count();
+            total += want.len();
+        }
+        println!(
+            "  {:<6} recall@{K} = {:.4}",
+            kind.name(),
+            hit as f64 / total as f64
+        );
+    }
+    println!();
+
+    // The cost of the same queries, so recall is never reported without it.
+    let mut group = c.benchmark_group("sift/search");
+    for kind in ALL_KINDS {
+        let index = rt.block_on(Index::filled_with(
+            kind,
+            METRIC,
+            &sift.base,
+            kind.is_batch_built(),
+        ));
+        let query = sift.queries[0].clone();
+        group.bench_with_input(
+            BenchmarkId::from_parameter(kind.name()),
+            &kind,
+            |b, _kind| {
+                b.to_async(&rt)
+                    .iter(|| async { black_box(index.search(black_box(&query), K).await) });
+            },
+        );
+    }
+    group.finish();
+}
+
+/// Building each kind over the real corpus.
+fn bulk_load(c: &mut Criterion) {
+    let Some(sift) = SiftSmall::load() else {
+        skip_notice("sift/bulk_load");
+        return;
+    };
+    let rt = runtime();
+
+    let mut group = c.benchmark_group("sift/bulk_load");
+    group.sample_size(10);
+    for kind in ALL_KINDS {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(kind.name()),
+            &kind,
+            |b, &kind| {
+                b.to_async(&rt).iter(|| async {
+                    black_box(
+                        Index::filled_with(kind, METRIC, &sift.base, kind.is_batch_built()).await,
+                    )
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+/// Inserting into an index already holding the whole corpus.
+fn insert(c: &mut Criterion) {
+    let Some(sift) = SiftSmall::load() else {
+        skip_notice("sift/insert");
+        return;
+    };
+    let rt = runtime();
+    let incoming = &sift.queries;
+    let existing = sift.base.len();
+
+    let mut group = c.benchmark_group("sift/insert");
+    for kind in ALL_KINDS {
+        let fixture = rt.block_on(Index::filled_with(
+            kind,
+            METRIC,
+            &sift.base,
+            kind.is_batch_built(),
+        ));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(kind.name()),
+            &kind,
+            |b, _kind| {
+                b.to_async(&rt).iter_batched(
+                    || fixture.clone(),
+                    |mut index| async move {
+                        for (i, vector) in incoming.iter().enumerate() {
+                            index
+                                .insert(NodeId((existing + i + 1) as u64), vector)
+                                .await;
+                        }
+                        index
+                    },
+                    criterion::BatchSize::LargeInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(sift, recall, bulk_load, insert);
+criterion_main!(sift);

--- a/crates/db-index/benches/vector_mutations.rs
+++ b/crates/db-index/benches/vector_mutations.rs
@@ -1,0 +1,199 @@
+//! Insert, update and delete across every vector index kind.
+//!
+//! ```text
+//! cargo bench -p db-index --bench vector_mutations
+//! ```
+//!
+//! An index is rebuilt for every measured batch rather than mutated in place,
+//! because a graph's insert cost depends on how many nodes are already there.
+//! The corpus size is therefore part of what is measured, not an accident of
+//! iteration order.
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use db_index::vector::store::NodeId;
+use std::hint::black_box;
+use tokio::runtime::Runtime;
+
+mod common;
+
+use common::{Corpus, Index, Kind, ALL_KINDS, SEED};
+
+/// Every kind in every state a mutation can hit. A batch-built kind behaves
+/// like a flat scan until it is built, so measuring only that state would
+/// report a number no production query ever sees.
+fn states() -> Vec<(Kind, bool, String)> {
+    let mut out = Vec::new();
+    for kind in ALL_KINDS {
+        out.push((kind, false, kind.name().to_string()));
+        if kind.is_batch_built() {
+            out.push((kind, true, format!("{}[built]", kind.name())));
+        }
+    }
+    out
+}
+
+const DIMENSIONS: usize = 128;
+const CORPUS: usize = 2_000;
+const BATCH: usize = 100;
+
+fn runtime() -> Runtime {
+    Runtime::new().expect("a tokio runtime")
+}
+
+/// Inserting into an index that already holds `CORPUS` vectors, which is what
+/// a write to a populated collection costs.
+fn insert(c: &mut Criterion) {
+    let rt = runtime();
+    let mut corpus = Corpus::new(SEED);
+    let existing = corpus.clustered(CORPUS, DIMENSIONS, 32, 0.2);
+    let incoming = corpus.clustered(BATCH, DIMENSIONS, 32, 0.2);
+
+    let mut group = c.benchmark_group("insert");
+    group.throughput(Throughput::Elements(BATCH as u64));
+
+    for (kind, built, label) in states() {
+        let fixture = rt.block_on(Index::filled(kind, &existing, built));
+        group.bench_with_input(BenchmarkId::from_parameter(&label), &kind, |b, _kind| {
+            b.to_async(&rt).iter_batched(
+                || fixture.clone(),
+                |mut index| {
+                    let incoming = &incoming;
+                    async move {
+                        for (i, vector) in incoming.iter().enumerate() {
+                            index
+                                .insert(NodeId((CORPUS + i + 1) as u64), black_box(vector))
+                                .await;
+                        }
+                        index
+                    }
+                },
+                criterion::BatchSize::LargeInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+/// An update is a re-insert under an id that already exists: the node's vector
+/// is replaced and its own links rebuilt, while links pointing *at* it stay
+/// valid because the id is what they name.
+fn update(c: &mut Criterion) {
+    let rt = runtime();
+    let mut corpus = Corpus::new(SEED ^ 0x11);
+    let existing = corpus.clustered(CORPUS, DIMENSIONS, 32, 0.2);
+    let replacements = corpus.clustered(BATCH, DIMENSIONS, 32, 0.2);
+
+    let mut group = c.benchmark_group("update");
+    group.throughput(Throughput::Elements(BATCH as u64));
+
+    for (kind, built, label) in states() {
+        let fixture = rt.block_on(Index::filled(kind, &existing, built));
+        group.bench_with_input(BenchmarkId::from_parameter(&label), &kind, |b, _kind| {
+            b.to_async(&rt).iter_batched(
+                || fixture.clone(),
+                |mut index| {
+                    let replacements = &replacements;
+                    async move {
+                        for (i, vector) in replacements.iter().enumerate() {
+                            index.insert(NodeId(i as u64 + 1), black_box(vector)).await;
+                        }
+                        index
+                    }
+                },
+                criterion::BatchSize::LargeInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+/// Deletes are tombstones on every kind, so this measures the write and the
+/// read that precedes it, not a graph repair.
+fn delete(c: &mut Criterion) {
+    let rt = runtime();
+    let mut corpus = Corpus::new(SEED ^ 0x22);
+    let existing = corpus.clustered(CORPUS, DIMENSIONS, 32, 0.2);
+
+    let mut group = c.benchmark_group("delete");
+    group.throughput(Throughput::Elements(BATCH as u64));
+
+    for (kind, built, label) in states() {
+        let fixture = rt.block_on(Index::filled(kind, &existing, built));
+        group.bench_with_input(BenchmarkId::from_parameter(&label), &kind, |b, _kind| {
+            b.to_async(&rt).iter_batched(
+                || fixture.clone(),
+                |mut index| async move {
+                    for i in 0..BATCH {
+                        black_box(index.delete(NodeId(i as u64 + 1)).await);
+                    }
+                    index
+                },
+                criterion::BatchSize::LargeInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+/// Building the whole index from scratch: what creating an index on a
+/// populated collection costs.
+fn bulk_load(c: &mut Criterion) {
+    let rt = runtime();
+    let mut corpus = Corpus::new(SEED ^ 0x33);
+    let vectors = corpus.clustered(CORPUS, DIMENSIONS, 32, 0.2);
+
+    let mut group = c.benchmark_group("bulk_load");
+    group.sample_size(10);
+    group.throughput(Throughput::Elements(CORPUS as u64));
+
+    for kind in ALL_KINDS {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(kind.name()),
+            &kind,
+            |b, &kind| {
+                b.to_async(&rt)
+                    .iter(|| async { black_box(Index::filled(kind, &vectors, false).await) });
+            },
+        );
+    }
+    group.finish();
+}
+
+/// The train-and-build pass the batch-built kinds run once the corpus is large
+/// enough. The graph kinds have no equivalent, so they are absent rather than
+/// reported as zero.
+fn build(c: &mut Criterion) {
+    let rt = runtime();
+    let mut corpus = Corpus::new(SEED ^ 0x44);
+    let vectors = corpus.clustered(CORPUS, DIMENSIONS, 32, 0.2);
+
+    let mut group = c.benchmark_group("build");
+    group.sample_size(10);
+    group.throughput(Throughput::Elements(CORPUS as u64));
+
+    for kind in ALL_KINDS
+        .iter()
+        .copied()
+        .filter(|kind| kind.is_batch_built())
+    {
+        let fixture = rt.block_on(Index::filled(kind, &vectors, false));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(kind.name()),
+            &kind,
+            |b, _kind| {
+                b.to_async(&rt).iter_batched(
+                    || fixture.clone(),
+                    |mut index| async move {
+                        index.build().await;
+                        index
+                    },
+                    criterion::BatchSize::LargeInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(mutations, insert, update, delete, bulk_load, build);
+criterion_main!(mutations);

--- a/crates/db-index/benches/vector_search.rs
+++ b/crates/db-index/benches/vector_search.rs
@@ -1,0 +1,153 @@
+//! Query cost across every vector index kind, and the kernels underneath.
+//!
+//! ```text
+//! cargo bench -p db-index --bench vector_search
+//! ```
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use db_index::vector::core::{dot, squared_euclidean, Metric, Tier};
+use std::hint::black_box;
+use tokio::runtime::Runtime;
+
+mod common;
+
+use common::{Corpus, Index, ALL_KINDS, SEED};
+
+const DIMENSIONS: usize = 128;
+const K: usize = 10;
+
+fn runtime() -> Runtime {
+    Runtime::new().expect("a tokio runtime")
+}
+
+/// The batch-built kinds are measured in their built state, which is the one a
+/// production query hits. Their untrained state is a flat scan and is already
+/// covered by the `flat` row.
+fn search(c: &mut Criterion) {
+    let rt = runtime();
+    let mut corpus = Corpus::new(SEED);
+    let vectors = corpus.clustered(5_000, DIMENSIONS, 50, 0.25);
+    let query = corpus.vector(DIMENSIONS);
+
+    let mut group = c.benchmark_group("search");
+    for kind in ALL_KINDS {
+        let index = rt.block_on(Index::filled(kind, &vectors, kind.is_batch_built()));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(kind.name()),
+            &kind,
+            |b, _kind| {
+                b.to_async(&rt)
+                    .iter(|| async { black_box(index.search(black_box(&query), K).await) });
+            },
+        );
+    }
+    group.finish();
+}
+
+/// How query cost grows with the corpus. The exhaustive kind is linear by
+/// construction; the point of the others is that they are not.
+fn search_by_corpus_size(c: &mut Criterion) {
+    let rt = runtime();
+    let mut group = c.benchmark_group("search_by_corpus");
+    group.sample_size(20);
+
+    for size in [1_000usize, 5_000, 20_000] {
+        let mut corpus = Corpus::new(SEED ^ size as u64);
+        let vectors = corpus.clustered(size, DIMENSIONS, 50, 0.25);
+        let query = corpus.vector(DIMENSIONS);
+
+        for kind in ALL_KINDS {
+            let index = rt.block_on(Index::filled(kind, &vectors, kind.is_batch_built()));
+            group.bench_with_input(BenchmarkId::new(kind.name(), size), &kind, |b, _kind| {
+                b.to_async(&rt)
+                    .iter(|| async { black_box(index.search(black_box(&query), K).await) });
+            });
+        }
+    }
+    group.finish();
+}
+
+/// The kernels every kind sits on. Reported next to the tier that ran them, so
+/// a number from a scalar fallback is never mistaken for a SIMD one.
+fn kernels(c: &mut Criterion) {
+    let mut corpus = Corpus::new(SEED ^ 0xEEE);
+    let tier = Tier::active().name();
+
+    let mut group = c.benchmark_group(format!("kernel[{tier}]"));
+    for dimensions in [16usize, 128, 768] {
+        let a = corpus.vector(dimensions);
+        let b_vec = corpus.vector(dimensions);
+        let wide_a: Vec<f64> = a.iter().map(|x| *x as f64).collect();
+        let wide_b: Vec<f64> = b_vec.iter().map(|x| *x as f64).collect();
+
+        group.throughput(Throughput::Elements(dimensions as u64));
+
+        group.bench_with_input(
+            BenchmarkId::new("dot_f32", dimensions),
+            &dimensions,
+            |bencher, _| bencher.iter(|| black_box(dot(black_box(&a), black_box(&b_vec)))),
+        );
+        group.bench_with_input(
+            BenchmarkId::new("dot_f64", dimensions),
+            &dimensions,
+            |bencher, _| bencher.iter(|| black_box(dot(black_box(&wide_a), black_box(&wide_b)))),
+        );
+        group.bench_with_input(
+            BenchmarkId::new("squared_euclidean_f32", dimensions),
+            &dimensions,
+            |bencher, _| {
+                bencher.iter(|| black_box(squared_euclidean(black_box(&a), black_box(&b_vec))))
+            },
+        );
+        group.bench_with_input(
+            BenchmarkId::new("cosine_f32", dimensions),
+            &dimensions,
+            |bencher, _| {
+                bencher
+                    .iter(|| black_box(Metric::Cosine.distance(black_box(&a), black_box(&b_vec))))
+            },
+        );
+        group.bench_with_input(
+            BenchmarkId::new("cosine_normalized_f32", dimensions),
+            &dimensions,
+            |bencher, _| {
+                bencher.iter(|| {
+                    black_box(Metric::Cosine.distance_normalized(black_box(&a), black_box(&b_vec)))
+                })
+            },
+        );
+    }
+    group.finish();
+}
+
+/// Every tier the running machine can execute, on the same input, so the
+/// speedup a SIMD tier buys is a measured ratio rather than a claim.
+fn kernel_tiers(c: &mut Criterion) {
+    let mut corpus = Corpus::new(SEED ^ 0xFFF);
+    let a = corpus.vector(768);
+    let b_vec = corpus.vector(768);
+
+    let mut group = c.benchmark_group("kernel_tiers[768]");
+    group.throughput(Throughput::Elements(768));
+
+    for tier in db_index::vector::core::ALL_TIERS.iter().copied() {
+        if !tier.is_available() {
+            continue;
+        }
+        group.bench_with_input(
+            BenchmarkId::new("dot_f32", tier.name()),
+            &tier,
+            |bencher, &tier| bencher.iter(|| black_box(tier.dot(black_box(&a), black_box(&b_vec)))),
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(
+    queries,
+    search,
+    search_by_corpus_size,
+    kernels,
+    kernel_tiers
+);
+criterion_main!(queries);

--- a/crates/db-index/src/vector/engine/flat.rs
+++ b/crates/db-index/src/vector/engine/flat.rs
@@ -11,7 +11,7 @@ use crate::vector::core::{Element, Metric};
 use crate::vector::store::{Node, NodeId, VectorNodeStore};
 
 /// Every live node, scored and ranked.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Flat<S> {
     store: S,
     metric: Metric,

--- a/crates/db-index/src/vector/engine/hnsw/mod.rs
+++ b/crates/db-index/src/vector/engine/hnsw/mod.rs
@@ -39,7 +39,7 @@ use crate::vector::params::Params;
 use crate::vector::store::{Node, NodeId, VectorNodeStore};
 
 /// An approximate-nearest-neighbor graph over a [`VectorNodeStore`].
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Hnsw<S> {
     store: S,
     params: Params,

--- a/crates/db-index/src/vector/engine/ivfpq/build.rs
+++ b/crates/db-index/src/vector/engine/ivfpq/build.rs
@@ -133,11 +133,10 @@ impl<S: VectorNodeStore> IvfPq<S> {
     /// The list a vector belongs to, and its code.
     pub(super) async fn assign(
         &self,
-        quantizer: &ProductQuantizer,
         state: &TrainedState,
         vector: &[f32],
     ) -> Result<(u32, Vec<u8>)> {
-        let coarse = self.coarse_centroids(state).await?;
+        let (coarse, quantizer) = self.trained_parts(state).await?;
         let (list, _) = coarse.nearest(vector);
         let mut residual = vec![0.0f32; state.dimensions as usize];
         subtract_into(vector, coarse.get(list), &mut residual);
@@ -146,7 +145,7 @@ impl<S: VectorNodeStore> IvfPq<S> {
         Ok((list as u32, code))
     }
 
-    pub(super) async fn coarse_centroids(&self, state: &TrainedState) -> Result<Centroids> {
+    pub(super) async fn load_coarse_centroids(&self, state: &TrainedState) -> Result<Centroids> {
         let mut values = Vec::with_capacity(state.nlist as usize * state.dimensions as usize);
         for index in 0..state.nlist {
             let bytes = self

--- a/crates/db-index/src/vector/engine/ivfpq/mod.rs
+++ b/crates/db-index/src/vector/engine/ivfpq/mod.rs
@@ -30,7 +30,7 @@ use crate::vector::quantize::ProductQuantizer;
 use crate::vector::store::{NodeId, VectorNodeStore};
 
 /// A coarse-quantized, product-compressed index.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct IvfPq<S> {
     staging: Flat<S>,
     metric: Metric,

--- a/crates/db-index/src/vector/engine/ivfpq/mod.rs
+++ b/crates/db-index/src/vector/engine/ivfpq/mod.rs
@@ -24,10 +24,11 @@ pub use params::{
 
 use crate::error::{Error, Result};
 use crate::vector::core::{Element, Metric};
-use crate::vector::engine::ann::{Admit, EngineKind, Neighbor, VectorIndexEngine};
+use crate::vector::engine::ann::{Admit, Centroids, EngineKind, Neighbor, VectorIndexEngine};
 use crate::vector::engine::flat::Flat;
 use crate::vector::quantize::ProductQuantizer;
 use crate::vector::store::{NodeId, VectorNodeStore};
+use std::sync::OnceLock;
 
 /// A coarse-quantized, product-compressed index.
 #[derive(Debug, Clone)]
@@ -36,6 +37,9 @@ pub struct IvfPq<S> {
     metric: Metric,
     params: IvfPqParams,
     seed: u64,
+    /// Centroids and codebooks are fixed once trained, and decoding them costs
+    /// more than scanning the lists they route to. Loaded once per engine.
+    trained_cache: OnceLock<(Centroids, ProductQuantizer)>,
 }
 
 impl<S: VectorNodeStore> IvfPq<S> {
@@ -53,6 +57,7 @@ impl<S: VectorNodeStore> IvfPq<S> {
             metric,
             params,
             seed,
+            trained_cache: OnceLock::new(),
         })
     }
 
@@ -88,7 +93,22 @@ impl<S: VectorNodeStore> IvfPq<S> {
         Ok(self.trained().await?.is_some())
     }
 
-    async fn quantizer(&self, state: &TrainedState) -> Result<ProductQuantizer> {
+    /// The coarse centroids and the quantizer, decoded once.
+    pub(super) async fn trained_parts(
+        &self,
+        state: &TrainedState,
+    ) -> Result<&(Centroids, ProductQuantizer)> {
+        if let Some(parts) = self.trained_cache.get() {
+            return Ok(parts);
+        }
+        let parts = (
+            self.load_coarse_centroids(state).await?,
+            self.load_quantizer(state).await?,
+        );
+        Ok(self.trained_cache.get_or_init(|| parts))
+    }
+
+    async fn load_quantizer(&self, state: &TrainedState) -> Result<ProductQuantizer> {
         let mut books = Vec::with_capacity(state.m as usize);
         for sub in 0..state.m {
             let bytes = self
@@ -115,12 +135,11 @@ impl<S: VectorNodeStore> VectorIndexEngine for IvfPq<S> {
         self.staging.insert(id, vector).await?;
 
         if let Some(state) = self.trained().await? {
-            let quantizer = self.quantizer(&state).await?;
             let stored =
                 self.store().get_node(id).await?.ok_or_else(|| {
                     Error::Other("vector index: a just-stored node is gone".into())
                 })?;
-            let (list, code) = self.assign(&quantizer, &state, &stored.vector).await?;
+            let (list, code) = self.assign(&state, &stored.vector).await?;
             self.store_mut()
                 .put_aux(codec::LIST, &codec::list_key(list, id), &code)
                 .await?;

--- a/crates/db-index/src/vector/engine/ivfpq/search.rs
+++ b/crates/db-index/src/vector/engine/ivfpq/search.rs
@@ -27,8 +27,7 @@ impl<S: VectorNodeStore> IvfPq<S> {
             normalize(&mut query);
         }
 
-        let coarse = self.coarse_centroids(state).await?;
-        let quantizer = self.quantizer(state).await?;
+        let (coarse, quantizer) = self.trained_parts(state).await?;
 
         // `effort` overrides nprobe the way ef_search does for a graph.
         let nprobe = effort

--- a/crates/db-index/src/vector/engine/ssg/mod.rs
+++ b/crates/db-index/src/vector/engine/ssg/mod.rs
@@ -29,7 +29,7 @@ use crate::vector::engine::hnsw::Hnsw;
 use crate::vector::params::Params;
 use crate::vector::store::{NodeId, VectorNodeStore};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Ssg<S> {
     staging: Hnsw<S>,
     metric: Metric,

--- a/crates/db-index/src/vector/store/memory.rs
+++ b/crates/db-index/src/vector/store/memory.rs
@@ -78,14 +78,19 @@ impl VectorNodeStore for MemoryNodeStore {
         Ok(())
     }
 
+    /// A range over the ordered map, not a full scan: an inverted-list probe
+    /// is a prefix lookup and must cost what the prefix holds, not what the
+    /// index holds.
     async fn iterate_aux<F>(&self, kind: u8, key_prefix: &[u8], mut visit: F) -> Result<()>
     where
         F: FnMut(&[u8], &[u8]) -> Result<()> + MaybeSend,
     {
-        for ((entry_kind, key), value) in &self.aux {
-            if *entry_kind == kind && key.starts_with(key_prefix) {
-                visit(key, value)?;
+        let start = (kind, key_prefix.to_vec());
+        for ((entry_kind, key), value) in self.aux.range(start..) {
+            if *entry_kind != kind || !key.starts_with(key_prefix) {
+                break;
             }
+            visit(key, value)?;
         }
         Ok(())
     }

--- a/crates/db-index/tests/vector_kv_built_state.rs
+++ b/crates/db-index/tests/vector_kv_built_state.rs
@@ -1,0 +1,164 @@
+//! The batch-built kinds over a real transaction.
+//!
+//! Every other test of these kinds runs on `MemoryNodeStore`. This one builds
+//! through `KvNodeStore`, commits, and reopens, so what is asserted is that the
+//! trained structures actually persist rather than that the algorithm works.
+
+use db_index::vector::core::Metric;
+use db_index::vector::engine::ann::VectorIndexEngine;
+use db_index::vector::engine::ivfpq::{IvfPq, IvfPqParams};
+use db_index::vector::engine::ssg::{Ssg, SsgParams};
+use db_index::vector::kv_store::KvNodeStore;
+use db_index::vector::params::{Params, DEFAULT_M};
+use db_index::vector::store::NodeId;
+use storage::backends::MemoryStore;
+use storage::corekv::{Store, Txn};
+
+mod common;
+
+const COLLECTION: u32 = 51;
+const INDEX: u32 = 3;
+const DIMENSIONS: usize = 16;
+const SEED: u64 = 0x0D15_C0DE;
+
+async fn txn(store: &MemoryStore) -> Box<dyn Txn> {
+    store.new_txn(false).await.unwrap()
+}
+
+fn corpus(count: usize) -> Vec<Vec<f32>> {
+    common::Corpus::new(SEED).clustered(count, DIMENSIONS, 8, 0.2)
+}
+
+/// Trained state, centroids, codebooks and list codes must survive a commit,
+/// or a reopened index silently answers from its staging path forever.
+#[tokio::test]
+async fn ivfpq_training_survives_a_commit() {
+    let backing = MemoryStore::new();
+    let vectors = corpus(400);
+    let params = IvfPqParams {
+        nlist: 8,
+        nprobe: 8,
+        m: 4,
+        ..IvfPqParams::default()
+    };
+
+    let mut write = txn(&backing).await;
+    {
+        let store = KvNodeStore::new(&mut write, COLLECTION, INDEX, 0);
+        let mut index = IvfPq::try_new(store, Metric::Cosine, params, SEED).unwrap();
+        for (i, vector) in vectors.iter().enumerate() {
+            index.insert(NodeId(i as u64 + 1), vector).await.unwrap();
+        }
+        assert!(!index.is_trained().await.unwrap());
+        let report = index.build().await.unwrap();
+        assert_eq!(report.indexed, 400);
+    }
+    write.commit().await.unwrap();
+
+    let mut read = txn(&backing).await;
+    let store = KvNodeStore::new(&mut read, COLLECTION, INDEX, 0);
+    let reopened = IvfPq::try_new(store, Metric::Cosine, params, SEED).unwrap();
+
+    let state = reopened
+        .trained()
+        .await
+        .unwrap()
+        .expect("the trained state must have been persisted");
+    assert_eq!(state.nlist, 8);
+    assert_eq!(state.m, 4);
+    assert_eq!(state.dimensions, DIMENSIONS as u32);
+
+    let hits = reopened
+        .search(vectors[3].as_slice(), 5, None)
+        .await
+        .unwrap();
+    assert_eq!(hits.len(), 5);
+    assert_eq!(hits[0].id, NodeId(4), "a vector is nearest itself");
+}
+
+#[tokio::test]
+async fn ssg_graph_survives_a_commit() {
+    let backing = MemoryStore::new();
+    let vectors = corpus(300);
+
+    let mut write = txn(&backing).await;
+    {
+        let store = KvNodeStore::new(&mut write, COLLECTION, INDEX + 1, 0);
+        let mut index = Ssg::try_new(
+            store,
+            Metric::Cosine,
+            Params::new(DEFAULT_M),
+            SsgParams::default(),
+            SEED,
+        )
+        .unwrap();
+        for (i, vector) in vectors.iter().enumerate() {
+            index.insert(NodeId(i as u64 + 1), vector).await.unwrap();
+        }
+        assert!(!index.is_built().await.unwrap());
+        let report = index.build().await.unwrap();
+        assert_eq!(report.nodes, 300);
+        assert!(report.edges > 0);
+    }
+    write.commit().await.unwrap();
+
+    let mut read = txn(&backing).await;
+    let store = KvNodeStore::new(&mut read, COLLECTION, INDEX + 1, 0);
+    let reopened = Ssg::try_new(
+        store,
+        Metric::Cosine,
+        Params::new(DEFAULT_M),
+        SsgParams::default(),
+        SEED,
+    )
+    .unwrap();
+
+    assert!(
+        reopened.is_built().await.unwrap(),
+        "the built state must have been persisted"
+    );
+    assert!(
+        !reopened.neighbours(NodeId(1)).await.unwrap().is_empty(),
+        "the pruned adjacency must have been persisted"
+    );
+
+    let hits = reopened
+        .search(vectors[2].as_slice(), 5, None)
+        .await
+        .unwrap();
+    assert_eq!(hits.len(), 5);
+    assert_eq!(hits[0].id, NodeId(3), "a vector is nearest itself");
+}
+
+/// A build writes into one epoch, so a different epoch must see none of it.
+/// This is what makes a rebuild-and-swap possible.
+#[tokio::test]
+async fn a_build_stays_inside_its_epoch() {
+    let backing = MemoryStore::new();
+    let vectors = corpus(400);
+    let params = IvfPqParams {
+        nlist: 8,
+        nprobe: 8,
+        m: 4,
+        ..IvfPqParams::default()
+    };
+
+    let mut write = txn(&backing).await;
+    {
+        let store = KvNodeStore::new(&mut write, COLLECTION, INDEX + 2, 0);
+        let mut index = IvfPq::try_new(store, Metric::Cosine, params, SEED).unwrap();
+        for (i, vector) in vectors.iter().enumerate() {
+            index.insert(NodeId(i as u64 + 1), vector).await.unwrap();
+        }
+        index.build().await.unwrap();
+    }
+    write.commit().await.unwrap();
+
+    let mut read = txn(&backing).await;
+    let next = KvNodeStore::new(&mut read, COLLECTION, INDEX + 2, 1);
+    let fresh = IvfPq::try_new(next, Metric::Cosine, params, SEED).unwrap();
+    assert!(
+        !fresh.is_trained().await.unwrap(),
+        "epoch 1 must not see epoch 0's training"
+    );
+}

--- a/justfile
+++ b/justfile
@@ -33,6 +33,10 @@ tla_sha256     := "e22f8ffb4bacdea0a871f444dd94fe5fb0d8013b3388ae39e82e26f852c73
 firefox_version     := "153.0.3"
 geckodriver_version := "0.37.1"
 
+# SIFT-small: 10k base vectors, 100 queries, published ground truth. The only
+# real (non-synthetic) corpus the vector benchmarks measure recall against.
+sift_sha256 := "b8f1e59b20319ac44279d5251706909dd3a5b8ca5ce2a11ddb1e73902252770e"
+
 # protoc publishes no per-asset checksum file, so its hashes are embedded.
 # Go and Temurin publish theirs, and are verified against upstream at install
 # time rather than duplicated here.
@@ -251,6 +255,40 @@ setup-browser:
     rm -rf "{{ tooling }}/firefox"
     tar -C "{{ tooling }}" -xJf "$tmp/firefox.tar.xz"
     echo "firefox: $("{{ tooling }}/firefox/firefox" --version) (.tooling)"
+
+# SIFT-small, for the vector benchmarks' recall measurement. Not part of
+# `just setup`: the benches skip cleanly without it, and it is a network fetch
+# most work does not need.
+[doc("SIFT-small corpus (5 MB), for real-data vector recall.")]
+[group('setup')]
+setup-sift:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    root="{{ tooling }}/sift"
+    if [ -f "$root/siftsmall/siftsmall_base.fvecs" ]; then
+        echo "sift: already present at $root"; exit 0
+    fi
+    tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+    echo "fetching siftsmall from the TEXMEX corpus"
+    curl -fsSL -o "$tmp/siftsmall.tar.gz" \
+        "ftp://ftp.irisa.fr/local/texmex/corpus/siftsmall.tar.gz"
+    got="$(just _sha256 "$tmp/siftsmall.tar.gz")"
+    [ "$got" = "{{ sift_sha256 }}" ] || {
+        echo "error: siftsmall checksum mismatch" >&2
+        echo "  expected {{ sift_sha256 }}" >&2
+        echo "  got      $got" >&2
+        exit 1
+    }
+    mkdir -p "$root"
+    tar -C "$root" -xzf "$tmp/siftsmall.tar.gz"
+    echo "sift: $root/siftsmall"
+
+# Vector index benchmarks, including the SIFT-small recall measurement when
+# `just setup-sift` has been run.
+[doc("Vector index benchmarks (insert/update/delete/search/kernels).")]
+[group('test')]
+bench-vector *args:
+    cargo bench -p db-index {{ args }}
 
 # Go, for the FFI compatibility harness and the Go-parity integration suites.
 [doc("Go, for the FFI harness and the Go-parity suites.")]


### PR DESCRIPTION
Stacked on #1443. `cargo bench` coverage for every vector index kind, including the mutation paths, and a recall measurement against a real corpus with published ground truth.

## SIFT-small: the first real-data recall in this repo

`just setup-sift` fetches the TEXMEX SIFT-small corpus (5 MB, checksum-verified into `.tooling/`, gitignored): **10,000 base vectors, 128 dimensions, 100 queries, and the true 100 nearest neighbours of each**. Every other recall number in this repo is measured against an oracle over vectors we generated; this one is measured against ground truth we did not compute.

| kind | recall@10 vs published ground truth |
|---|---|
| flat | **1.0000** |
| ssg | **0.9980** |
| hnsw | 0.9870 |
| ivfpq | 0.6200 |

**`flat` scoring exactly 1.0000 is the validation, not a formality.** An exhaustive scan must be perfect against ground truth; that it is proves the fvecs reader, the 1-based id offset and the metric alignment are all correct. The first run scored 0.9940 because the fixture ranked by cosine while SIFT's ground truth is Euclidean — a real mismatch that the flat row caught immediately.

SSG beating HNSW on real data confirms the synthetic finding in #1443. IVF-PQ's 0.62 is the aggressive default compression (`m=8` at 128 dimensions, 64x), consistent with the compression sweep in #1442.

**What this is not:** SIFT is 128-dimension image descriptors, not text embeddings. These are real ANN benchmark numbers, comparable with published HNSW and FAISS results; they are not a prediction of behaviour on embedding models. The plan's "no real embedding corpus" gap is narrowed, not closed.

Absent the corpus every SIFT group skips with a notice, so a fresh clone still runs `cargo bench`.

## What else is measured

`crates/db-index/benches/`, three targets, criterion with the async harness:

| Group | Covers |
|---|---|
| `insert` / `update` / `delete` | every kind, into an index already holding 2,000 vectors |
| `bulk_load` | building the whole index, i.e. creating one on a populated collection |
| `build` | the train-and-build pass, for the kinds that have one |
| `search` / `search_by_corpus` | query cost, and how it grows with N |
| `kernel[tier]` / `kernel_tiers` | the SIMD kernels underneath, per tier |
| `sift/*` | recall, search, bulk load and insert on real data |

Every kind goes through one `Index` enum over the shared `VectorIndexEngine` trait, so a new kind is one variant and nothing else changes.

## The SIMD ladder, measured

768-dimension `f32` dot product, same input, every tier this machine can run:

| tier | time | speedup |
|---|---|---|
| scalar | 828 ns | 1.00x |
| sse2 | 428 ns | 1.93x |
| avx2,fma | 234 ns | 3.54x |
| **avx512f** | **145 ns** | **5.71x** |

The group is named after the *active* tier, so a number from a scalar fallback can never be mistaken for a SIMD one.

## Search latency (5,000 vectors, 128 dimensions, k=10)

| kind | latency |
|---|---|
| hnsw | **296 us** |
| ivfpq | **327 us** |
| ssg | **351 us** |
| flat | 551 us |

### How it scales

| N | flat | hnsw | ivfpq | ssg |
|---|---|---|---|---|
| 1,000 | **102 us** | 229 us | 313 us | 305 us |
| 5,000 | 576 us | 332 us | **322 us** | 440 us |
| 20,000 | 2,885 us | 533 us | **364 us** | 461 us |

Flat is linear, as it must be: 28x the time for 20x the data. IVF-PQ is nearly flat at 1.16x, HNSW 2.3x, SSG 1.5x. **Below roughly 1,500 vectors the exhaustive scan wins outright** — worth knowing, because that is the state every index is in before it grows.

### Two performance defects these found

`search/ivfpq` first measured **709 us, slower than the exhaustive scan**, which is backwards. Two causes, both real:

1. `MemoryNodeStore::iterate_aux` did a **full map scan per probed list** instead of a range over the ordered map. With ~5,300 aux entries and nprobe=8 that is 42,000 iterations before any real work. The KV store was already correct (it uses a prefix iterator); only the in-memory one, which every test and benchmark runs on, was wrong. Fixing it: **695 us -> 327 us, 52.8% faster.**
2. The trained centroids and codebooks were decoded from storage on **every query**. Now loaded once per engine via `OnceLock`. Worth ~5% on its own.

I misdiagnosed this twice before measuring properly - first blaming codebook decoding, then the benchmark's `nlist`/`nprobe` configuration. Both were real inefficiencies; neither was the cause.

## Mutation cost (2,000-vector index, 128 dimensions, 100 operations)

| kind | insert | update | delete |
|---|---|---|---|
| flat | 32.7 us | 31.5 us | 16.8 us |
| hnsw | 40.3 ms | 21.0 ms | 29.5 us |
| ivfpq | 40.1 us | 34.9 us | 17.8 us |
| **ivfpq[built]** | **3.70 ms** | | |
| ssg | 40.4 ms | 21.4 ms | 29.9 us |

Batch-built kinds are measured in **both** states. An untrained IVF-PQ insert is a flat write at 0.40 us; a trained one is 37 us because it reads every centroid to assign a list. Reporting only the untrained number would describe a state no production query hits.

Build cost is asymmetric and worth knowing: `build/ivfpq` 453 ms against `build/ssg` 20.9 ms over the same 2,000 vectors, because IVF-PQ runs k-means while SSG only prunes a graph that already exists.

## A bug this found

`insert/ssg[built]` measuring exactly the same as unbuilt did not make sense, and the reason was a **correctness bug**: a document inserted after an SSG build reached the HNSW staging graph but never the pruned graph a search walks, so it was invisible until the next rebuild. Same class of bug IVF-PQ handles explicitly by assigning new nodes to a list on insert.

Fixed in #1443 (`a03a629b`) with the failing test that catches it: `a_document_written_after_the_build_is_searchable`.

## Notes

- `Flat`, `Hnsw`, `IvfPq` and `Ssg` now derive `Clone`, so a fixture is built once and cloned per iteration. Without it criterion's setup closure calls `block_on` inside the runtime it is already driving, which panics.
- Synthetic corpora are clustered rather than uniform: uniform vectors in high dimensions are all near-orthogonal and make every index look alike.
- Seeds are fixed, so a run is reproducible across machines and releases.
