### PR TITLE
fix(query): match JSON membership for missing keys

### DIFF
--- a/crates/query-types/src/mapper/filter/eval_relation.rs
+++ b/crates/query-types/src/mapper/filter/eval_relation.rs
@@ -135,10 +135,9 @@ impl Filter {
                         QueryError::invalid_filter(format!("unknown operator: {}", op_str))
                     })?;
                     if field_missing && !expected.is_null() {
-                        // Go treats missing nested JSON fields as implicit nulls for _nin,
-                        // so values absent at the path still pass when none of the banned
-                        // values match. Other operators keep the stricter missing-field miss.
-                        if op != FilterOp::Nin {
+                        // Go treats missing nested JSON fields as implicit nulls for
+                        // membership checks. Other operators keep the stricter miss.
+                        if !matches!(op, FilterOp::In | FilterOp::Nin) {
                             return Ok(false);
                         }
                     }

--- a/crates/query-types/src/mapper/filter/filter_tests.rs
+++ b/crates/query-types/src/mapper/filter/filter_tests.rs
@@ -747,6 +747,25 @@ fn test_has_key_empty_string_key() {
     assert!(filter.matches(&fields, &mapping).unwrap());
 }
 
+#[test]
+fn test_missing_nested_field_in_matches_implicit_null() {
+    let mapping = make_extended_mapping();
+    let mut fields = make_extended_fields();
+    fields[5] = Some(json!({"other": 1}));
+
+    let includes_null = Filter::from_conditions(map([(
+        "metadata".to_string(),
+        json!({"score": {"_in": [null, 5]}}),
+    )]));
+    assert!(includes_null.matches(&fields, &mapping).unwrap());
+
+    let excludes_null = Filter::from_conditions(map([(
+        "metadata".to_string(),
+        json!({"score": {"_in": [5]}}),
+    )]));
+    assert!(!excludes_null.matches(&fields, &mapping).unwrap());
+}
+
 // =========================================================================
 // Pattern matching edge cases
 // =========================================================================

--- a/tools/integration-test/tests/query.rs
+++ b/tools/integration-test/tests/query.rs
@@ -22,6 +22,8 @@ mod gql_list_args;
 mod index_fallback_4633;
 #[path = "query/index_management.rs"]
 mod index_management;
+#[path = "query/json_missing_key.rs"]
+mod json_missing_key;
 #[path = "query/lens.rs"]
 mod lens;
 #[path = "query/lens_persistence.rs"]

--- a/tools/integration-test/tests/query/json_missing_key.rs
+++ b/tools/integration-test/tests/query/json_missing_key.rs
@@ -1,0 +1,51 @@
+use std::collections::BTreeSet;
+
+use integration_test::{for_each_runtime, TestCluster};
+
+async fn json_missing_key_in_test(cluster: TestCluster) {
+    let client = cluster.client(0);
+
+    client
+        .schema_add("type Widget { name: String meta: JSON }")
+        .expect("add Widget schema");
+    client
+        .query(
+            r#"mutation {
+                add_Widget(input: {name: "scored", meta: {score: 5}}) { _docID }
+            }"#,
+        )
+        .expect("add scored Widget");
+    client
+        .query(
+            r#"mutation {
+                add_Widget(input: {name: "missing", meta: {other: 1}}) { _docID }
+            }"#,
+        )
+        .expect("add Widget without score");
+
+    let result = client
+        .query(
+            r#"query {
+                Widget(filter: {meta: {score: {_in: [null, 5]}}}) { name }
+            }"#,
+        )
+        .expect("query score membership including null");
+    let names: BTreeSet<_> = result["Widget"]
+        .as_array()
+        .expect("Widget rows")
+        .iter()
+        .map(|row| row["name"].as_str().expect("Widget name"))
+        .collect();
+    assert_eq!(names, BTreeSet::from(["missing", "scored"]));
+
+    let result = client
+        .query(
+            r#"query {
+                Widget(filter: {meta: {score: {_in: [5]}}}) { name }
+            }"#,
+        )
+        .expect("query score membership excluding null");
+    assert_eq!(result["Widget"], serde_json::json!([{ "name": "scored" }]));
+}
+
+for_each_runtime!(json_missing_key_in, json_missing_key_in_test);


### PR DESCRIPTION
Closes #1408.

## Problem

Nested JSON filters represented a missing key as `null`, but rejected `_in` before evaluating membership. As a result, `_in: [null, 5]` excluded documents whose nested key was absent, while Go treats the missing value as implicit `null` and includes them.

## What changed

- Allow missing nested JSON keys to reach `_in` membership evaluation, matching the existing `_nin` behavior.
- Preserve the non-match behavior when the membership list does not contain `null`.
- Add unit coverage and a shared Rust/Go integration test for both cases.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p query-types --all-targets -- -D warnings`
- [x] `cargo clippy -p integration-test --test query -- -D warnings`
- [x] `cargo test -p query-types`
- [x] `DEFRA_RUST_BINARY=target/debug/defra cargo test -p integration-test --test query json_missing_key::rust_json_missing_key_in -- --nocapture --test-threads=1`
- [x] `PATH=/Users/ivan/Source/defradb/build:$PATH cargo test -p integration-test --test query json_missing_key::go_json_missing_key_in -- --nocapture --test-threads=1`
- [x] `git diff --check origin/main...HEAD`