### PR TITLE
ci: run rust integration suites at 8 threads instead of serialized

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -628,34 +628,40 @@ jobs:
             exit 1
           fi
 
-      # `basic` is serialized because its tests start rust nodes and the
-      # harness port allocator (`defra-harness::ports`) has a TOCTOU race
-      # between dropping the port guard listener and the child process
-      # binding. Under high parallelism the race triggers EADDRINUSE.
-      # Track the underlying harness fix in the backbone repo; this flag
-      # is the tactical mitigation.
-      - name: Run rust integration tests (serialized — port race)
+      # Parallelism is bounded at 8 rather than left to libtest's default.
+      # The guard-release port race that once forced `--test-threads=1` is
+      # handled in the harness (`defra-harness` retries a node start with
+      # fresh ports, 3 attempts, on an EADDRINUSE exit), so serializing is
+      # no longer the mitigation it was.
+      #
+      # 8 is the knee of the measured curve: it recovers 3.8x of the 4.3x
+      # total speedup available at 16 threads while halving the number of
+      # concurrently live node clusters. That headroom is deliberate —
+      # studio-1 also hosts runners for seven other repos, and
+      # `Cluster::restart_node` re-binds a node's original port holding no
+      # guard and with no retry, so the steal window widens with concurrency.
+      - name: Run rust integration tests (basic)
         if: matrix.suite == 'rust' || matrix.suite == 'signed-docs'
         run: >-
           cargo test -p integration-test
           --test basic
-          -- --test-threads=1 --skip ::go_
+          -- --test-threads=8 --skip ::go_
 
-      - name: Run rust integration tests (serialized — port race)
+      - name: Run rust integration tests (core suites)
         if: matrix.suite == 'rust' || matrix.suite == 'signed-docs'
         run: >-
           cargo test -p integration-test
           --test query --test acp --test nac
           --test encryption --test identity
           --test backup --test fts
-          -- --test-threads=1 --skip ::go_
+          -- --test-threads=8 --skip ::go_
 
       - name: Run rust P2P integration tests
         if: matrix.suite == 'rust' || matrix.suite == 'signed-docs'
         run: >-
           cargo test -p integration-test
           --test p2p
-          -- --test-threads=1 --skip ::go_
+          -- --test-threads=8 --skip ::go_
 
       # go-compat runs the `go_*` half of every dual-runtime test against
       # the upstream Go DefraDB binary. Catches cross-implementation
@@ -792,8 +798,11 @@ jobs:
           "$DEFRA_IROH_BINARY" version --format json
 
       # Same selection as the macOS rust leg: pure-Rust P2P topologies only
-      # (`--skip ::go_` drops the go_go_/go_rust_ variants). Serialized because
-      # the harness port allocator has a TOCTOU bind race under parallelism.
+      # (`--skip ::go_` drops the go_go_/go_rust_ variants). Kept serial while
+      # the macOS legs run at 8: this leg exists to expose Linux scheduling
+      # races, so a fixed serial schedule keeps a failure attributable to the
+      # code under test rather than to harness contention, and at ~6 minutes
+      # it is nowhere near the critical path.
       - name: Run rust P2P integration tests
         run: >-
           cargo test -p integration-test


### PR DESCRIPTION
The rust integration suites run with `--test-threads=1`. The workflow comment explains why:

> the harness port allocator (`defra-harness::ports`) has a TOCTOU race between dropping the port
> guard listener and the child process binding. Under high parallelism the race triggers EADDRINUSE.
> Track the underlying harness fix in the backbone repo; this flag is the tactical mitigation.

**That harness fix landed and is already in use.** `tools/integration-test/Cargo.toml` pins
`defra-harness` to tag `defra-harness/2026-08-07-port-conflict` → `d141721`, backbone `main`'s HEAD
(backbone PR #25), which retries a node start with fresh ports up to 3 times on a `PortConflict`.
`Cargo.lock` confirms the resolution.

The flag was added 2026-04-13 (#751) and reinforced 2026-07-03 (#1085); the harness fix was pinned
2026-08-07. The mitigation outlived its own fix by four months.

## Measured locally (18-core, medians, seconds)

| binary | t=1 | t=2 | t=4 | t=8 | t=16 |
|---|---|---|---|---|---|
| basic | 19 | 11 | 8 | 7 | 6 |
| query | 71 | 37 | 24 | 20 | 19 |
| acp | 112 | 63 | 39 | 29 | 28 |
| nac | 34 | 19 | 17 | 15 | 15 |
| encryption | 11 | 7 | 6 | 5 | 4 |
| identity | 5 | 3 | 2 | 2 | 2 |
| backup | 3 | 3 | 3 | 3 | 3 |
| fts | 11 | 6 | 5 | 4 | 4 |
| p2p | 215 | 115 | 67 | 42 | 31 |
| **total** | **481** | **264** | **171** | **127** | **112** |
| **speedup** | 1.0x | 1.8x | 2.8x | 3.8x | 4.3x |

The `signed-docs` shape (`DEFRA_MULTIPLIERS=signed-docs`) is the slower leg and the bigger prize:
**567 s serialized → ~132 s at t=8, 3/3 green, 4.3x**.

## Why 8 and not 16

8 is the knee: it recovers 3.8x of the 4.3x available while halving the number of concurrently live
node clusters. studio-1 also hosts runners for seven other repos, so the headroom is deliberate.

Nothing failed at any setting from 2 to 16 across 3+ passes per setting, so the evidence didn't
support per-binary thread counts — it's a uniform 8.

**Port-conflict retries at t=8: 0 across 1875 node starts** (5 clean passes). At t=16: 0 / 1125. The
3-attempt budget is never entered, so there's no evidence `PORT_CONFLICT_ATTEMPTS` needs raising.

`p2p-linux` stays serial deliberately — it exists to expose Linux scheduling races, so a fixed
schedule keeps a failure attributable to the code rather than to harness contention, and at ~6 min
it isn't on the critical path. Its stale port-race comment is rewritten rather than left in place.

## Projected saving

Projection from real green runs, not measured in CI: signed-docs ~49 min saved, rust ~15 min, so
roughly **1 hour per full CI run**. The binary build (~40 min on a cache miss) is untouched by this.

## Two harness bugs found along the way

Neither blocks this change; both belong in backbone and I'll file them there.

1. **`Cluster::restart_node` has no guard and no retry** — it kills the node, sleeps 200 ms, and
   re-binds the *same* fixed port via an inlined spawn, bypassing the `PortConflict` retry entirely.
   That steal window is wider than the one backbone fixed and it widens with concurrency. Used by
   `basic/lark_crash_reopen`, `query/lens_persistence`, and three `p2p` tests.
2. **Four p2p tests bypass the retry loop**, calling `allocate_transport_ports` + `start_node`
   directly (3 in `p2p/transports.rs`, 1 in `p2p/connection_manager.rs`).

## What only a real CI run can confirm

Local hardware was 18-core/128 GB and idle; studio-1 is 32-core/512 GB shared across eight repos.
Peak here was 9 concurrent `defra` processes at ~998 MB total RSS with never less than 54 GB free,
but that's without cross-repo load. Also unconfirmed: runner fd/process limits under launchd, and
whether any test carries a wall-clock budget that only a loaded 32-core box violates.

`--skip ::go_` semantics and the go-compat and iroh legs are byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
