### PR TITLE
ci: publish the binary cache to both studio hosts

### DIFF
--- a/.github/scripts/studio-peer.sh
+++ b/.github/scripts/studio-peer.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Prints the sibling studio host's ssh name, or nothing when this machine has
+# no sibling. The two studio hosts hold each other's binary cache, so both the
+# producer's push and the consumer's pull need to agree on who the peer is.
+#
+# The machine's own hostname is the primary source: it is what actually
+# determines which host-local cache the binaries land in. RUNNER_NAME is a
+# fallback for a slot whose runner was registered under a name that does not
+# match its host — it is a GitHub-side label and can drift from the machine.
+set -euo pipefail
+
+SELF=$(hostname -s 2>/dev/null || true)
+case "$SELF" in
+  studio-1 | studio-2) ;;
+  *) SELF="${RUNNER_NAME:-}" ;;
+esac
+
+case "$SELF" in
+  studio-1*) echo studio-2 ;;
+  studio-2*) echo studio-1 ;;
+esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,9 +78,10 @@ jobs:
   #
   #   primary (labels ...,studio,studio-N) — one job at a time, so two
   #   node-spawning jobs can only co-run on DIFFERENT hosts, where they
-  #   cannot contend on localhost ports. studio-1 carries build → rust →
-  #   signed-docs (consumers of build's host-local binary cache); studio-2
-  #   carries conformance, go-compat, and iroh (each self-builds on miss).
+  #   cannot contend on localhost ports. studio-1 carries rust and
+  #   signed-docs; studio-2 carries conformance, go-compat, and iroh. `build`
+  #   floats between the two and publishes its binaries to both, so every
+  #   suite restores from its own host's cache whichever host built them.
   #
   #   light (labels ...,defra-light,studio-N-b) — deliberately NOT labeled
   #   `studio`/`studio-N`, so node-spawning jobs can never land there. Serves
@@ -313,6 +314,46 @@ jobs:
           # Symlink for backbone CI consumption
           ln -sf "$CACHE_DIR/defra-iroh" "$HOME/.sourcenetwork/bin/defra-iroh"
 
+      # This job floats across both studio hosts but in practice lands on
+      # whichever one is idle, and studio-1's single `studio` slot is usually
+      # still occupied by the previous run's ~100-minute suites — so the
+      # producer keeps landing on studio-2 while the two most expensive
+      # consumers (rust, signed-docs) sit on studio-1 with an empty cache.
+      # Pushing now, while nothing is waiting on this job, is what turns the
+      # sibling's first integration job from a full rebuild into a file copy;
+      # its own pull fallback only ever runs once the clock is already
+      # ticking. Best-effort: a failure is a warning, never a red run, and the
+      # consumer still falls back to building.
+      - name: Publish binaries to sibling studio
+        run: |
+          HASH=$(git rev-parse HEAD)
+          CACHE_DIR="$HOME/.sourcenetwork/bin/defradb.rs/$HASH"
+          PEER=$(.github/scripts/studio-peer.sh)
+
+          if [ -z "$PEER" ]; then
+            echo "No sibling studio for this host — nothing to publish"
+            exit 0
+          fi
+
+          # ServerAlive* bounds a transfer that stalls after connecting: the
+          # whole integration matrix waits on this job, so a hung scp here
+          # would cost more than the rebuild it is trying to avoid.
+          SSH_OPTS="-o BatchMode=yes -o ConnectTimeout=5 -o ServerAliveInterval=5 -o ServerAliveCountMax=3"
+
+          # Staged through .tmp and renamed on the peer, so an interrupted
+          # copy cannot leave a truncated binary that the peer would later
+          # treat as a valid cache hit.
+          if ssh $SSH_OPTS "$PEER" "mkdir -p '$CACHE_DIR'" \
+            && scp -p $SSH_OPTS "$CACHE_DIR/defra" "$PEER:$CACHE_DIR/defra.tmp" \
+            && scp -p $SSH_OPTS "$CACHE_DIR/defra-iroh" "$PEER:$CACHE_DIR/defra-iroh.tmp" \
+            && ssh $SSH_OPTS "$PEER" \
+                 "mv '$CACHE_DIR/defra.tmp' '$CACHE_DIR/defra' \
+                  && mv '$CACHE_DIR/defra-iroh.tmp' '$CACHE_DIR/defra-iroh'"; then
+            echo "Published binaries to $PEER:$CACHE_DIR"
+          else
+            echo "::warning::could not publish binary cache to $PEER — its first integration job will rebuild"
+          fi
+
       # OTel-only tests, run AFTER caching so the otel rebuild of target/debug/defra
       # never pollutes the cached standard binary. The cli otel test spawns a real
       # node against an unreachable collector and asserts the dedup hint fires
@@ -446,9 +487,9 @@ jobs:
       # host runs one defradb.rs runner process (one job at a time), so
       # pinning suites to hosts serializes same-host suites for free while
       # letting the two hosts run in parallel — replacing the old
-      # `max-parallel: 1` whole-matrix serialization. studio-1 suites consume
-      # the binary cache the `build` job (also studio-1) populated; studio-2
-      # suites self-build on miss into their own host-local cache.
+      # `max-parallel: 1` whole-matrix serialization. Both hosts restore from
+      # a host-local binary cache that `build` publishes to each of them; the
+      # self-build below is the fallback for when that publish did not land.
       matrix:
         include:
           # Each host uses sccache with incremental compilation disabled so
@@ -501,26 +542,24 @@ jobs:
           CACHE_DIR="$HOME/.sourcenetwork/bin/defradb.rs/$HASH"
           mkdir -p target/ci "$CACHE_DIR"
 
-          # The two studio hosts share a Thunderbolt link, so a cache miss can
-          # be served by the sibling for the price of copying ~100MB rather
-          # than a full rebuild. Best-effort by design: any failure here falls
-          # through to the build path below, so an unreachable or rebooting
-          # peer costs time, never a red run.
-          case "${RUNNER_NAME:-}" in
-            studio-1*) PEER=studio-2 ;;
-            studio-2*) PEER=studio-1 ;;
-            *)         PEER="" ;;
-          esac
+          # The `build` job pushes its binaries to both hosts, so the local
+          # branch below is the expected path. Pulling from the sibling is the
+          # backstop for when that push failed. Best-effort by design: any
+          # failure here falls through to the build path below, so an
+          # unreachable or rebooting peer costs time, never a red run. Errors
+          # are NOT discarded — a silent pull failure is indistinguishable from
+          # a peer that never had the binaries, and that ambiguity is what let
+          # a 41-minute rebuild hide on every run for days.
+          PEER=$(.github/scripts/studio-peer.sh)
+          SSH_OPTS="-o BatchMode=yes -o ConnectTimeout=5 -o ServerAliveInterval=5 -o ServerAliveCountMax=3"
 
           if [ -f "$CACHE_DIR/defra" ] && [ -f "$CACHE_DIR/defra-iroh" ]; then
             echo "Cache hit (local) — restoring from $CACHE_DIR"
             cp "$CACHE_DIR/defra" target/ci/defra
             cp "$CACHE_DIR/defra-iroh" target/ci/defra-iroh
           elif [ -n "$PEER" ] \
-            && scp -q -o BatchMode=yes -o ConnectTimeout=5 \
-                 "$PEER:$CACHE_DIR/defra" "$CACHE_DIR/defra.tmp" 2>/dev/null \
-            && scp -q -o BatchMode=yes -o ConnectTimeout=5 \
-                 "$PEER:$CACHE_DIR/defra-iroh" "$CACHE_DIR/defra-iroh.tmp" 2>/dev/null; then
+            && scp -p $SSH_OPTS "$PEER:$CACHE_DIR/defra" "$CACHE_DIR/defra.tmp" \
+            && scp -p $SSH_OPTS "$PEER:$CACHE_DIR/defra-iroh" "$CACHE_DIR/defra-iroh.tmp"; then
             # Staged via .tmp so an interrupted copy cannot leave a truncated
             # binary that later runs would treat as a valid cache hit.
             mv "$CACHE_DIR/defra.tmp" "$CACHE_DIR/defra"
@@ -530,7 +569,8 @@ jobs:
             cp "$CACHE_DIR/defra-iroh" target/ci/defra-iroh
           else
             rm -f "$CACHE_DIR/defra.tmp" "$CACHE_DIR/defra-iroh.tmp"
-            echo "Cache miss (local and peer) — building binaries"
+            echo "::warning::binary cache missed on this host and on peer '${PEER:-none}' — rebuilding (~40 min)"
+            echo "Cache miss (local and peer ${PEER:-none}) — building binaries"
             cargo build -p cli
             cp target/debug/defra target/ci/defra
             cp target/debug/defra "$CACHE_DIR/defra"
@@ -725,6 +765,13 @@ jobs:
           cargo test -p integration-test
           --test p2p_iroh
           -- --test-threads=1 connection::
+
+      # Every other studio job reports these; this matrix did not, which left
+      # the fallback rebuild above as the one compile in CI with no visibility
+      # into whether sccache was serving it.
+      - name: Show sccache stats
+        if: always()
+        run: .github/scripts/show-sccache-stats.sh
 
       - name: Cleanup
         if: always()


### PR DESCRIPTION
`Integration (rust)` spends **41 minutes** rebuilding `defra` + `defra-iroh` on most runs, while
`Integration (signed-docs)` — same run, same commit, same host, same cache key — restores in **9
seconds**. Verified from the API on run `31763720993`:

```
Integration (rust)        @ studio-1: Restore or build binaries = 2461s
Integration (signed-docs) @ studio-1: Restore or build binaries = 9s
```

## Mechanism

Two facts compose.

**1. The cache producer always lands on the wrong host.** The `build` job — the only one that
populates `~/.sourcenetwork/bin/defradb.rs/<merge-sha>/` — uses `runs-on: [self-hosted, macOS, ARM64,
studio]`, floating between hosts. It is not random: studio-1's single `studio` slot is nearly always
still occupied by the previous run's ~100-minute suites, so the scheduler hands `build` to studio-2
every time. **11/11 sampled runs.** Its cheap consumers (go-compat 5 min, iroh 1 min) are on
studio-2 and hit locally; its expensive consumers (rust, signed-docs) are on studio-1 with an empty
cache.

**2. The pull-from-sibling fallback has never worked.** 0 peer hits across 44 sampled integration job
instances — every result was `HIT-local` or `MISS`, and `Cache hit (peer … over Thunderbolt)` has not
appeared once since the feature merged (b7b92e43).

So on studio-1 the first suite to start rebuilds from scratch and the second inherits its cache.
Which suite pays varies; that one always does.

The cache key itself is fine (merge SHA, identical across all four jobs — all computed hash
`5df1459e…`), studio-2 held both binaries at that exact path 78 minutes before studio-1 tried to pull
them, there is no eviction (1.6 TiB free), and there is no race (`integration` `needs: build`).

| Run | Branch | build host | rust | signed-docs |
|---|---|---|---|---|
| 31643250119 | main | studio-2 | HIT-local | **MISS** |
| 31651250506 | main | studio-2 | **MISS** | HIT-local |
| 31660723909 | iverc/1415 | studio-2 | HIT-local | **MISS** |
| 31661868002 | iverc/1406 | studio-2 | HIT-local | **MISS** |
| 31662750605 | iverc/1409 | studio-2 | **MISS** | HIT-local |
| 31704349976 | fix/#1001 (attempt 2) | studio-2 | HIT-local | HIT-local |
| 31713690728 | vclq/hnsw | studio-2 | **MISS** | HIT-local |
| 31729337658 | vclq/ivf-pq | studio-2 | HIT-local | **MISS** |
| 31735705301 | fix/downsample | studio-2 | **MISS** | HIT-local |
| 31736026642 | vclq/ssg | studio-2 | **MISS** | HIT-local |
| 31763720993 | fix/#1001 | studio-2 | **MISS** | HIT-local |

Structural rather than incidental — `main` behaves like PR branches, and the single clean row is
`attempt=2` of a re-run, where studio-1 was already warm. **Every first-attempt run in the sample
paid the rebuild: 10/10.**

## Fix

1. **`build` now publishes both binaries to the sibling host** immediately after populating its local
   cache, while nothing is waiting on the job. Staged via `.tmp` and renamed remotely, so an
   interrupted copy cannot leave a truncated binary that a later run treats as valid. Failures emit
   `::warning::` and never turn the job red.
2. **Peer derived from `hostname -s`**, with `RUNNER_NAME` only as a fallback.
3. **The pull fallback stops hiding its errors** — dropped `-q` and `2>/dev/null`. scp prints no
   progress meter when stdout isn't a tty, so the only change is that failures now reach the log.
4. `ServerAliveInterval`/`CountMax` bound a transfer that stalls after connecting, since the
   integration matrix waits on `build`.
5. Added `Show sccache stats` to the integration matrix — the 41-minute build is currently the one
   compile in CI with no visibility.
6. Corrected two design comments that claimed `build` runs on studio-1.

## Honest limits

**The pull failure was not reproduced.** Running the exact `scp` chain on the real hosts under a
reconstructed runner environment succeeds both directions in 0.37 s for the 164 MB file. Two
candidates survive and the log cannot separate them, because `-q` plus `2>/dev/null` discarded
scp's stderr: `RUNNER_NAME` not matching the `case` (leaving `PEER=""`, branch never attempted), or
scp failing only in the runner's launchd context. Timing doesn't discriminate — pre-build deltas on
miss steps ran 0.40–1.25 s, consistent with either. This is a null result and is stated as one; the
fix addresses both candidates rather than betting on one.

Validated by extracting each `run:` block verbatim from the parsed YAML and executing it against the
real hosts with `CACHE_DIR` redirected to `/tmp`, including the error-visibility path:

```
Published binaries to studio-2:/tmp/pubtest-31357
Cache hit (peer studio-2 over Thunderbolt)
scp: /tmp/definitely-absent-xyz/defra: No such file or directory
```

`shellcheck` and `bash -n` clean, YAML parses, all scratch files removed from both hosts. No caches,
jobs, or services were touched.

## Saving

**~41 min off `Integration (rust)`**, and since `signed-docs` queues behind it on studio-1's single
slot, roughly 41 min off the run's end-to-end wall clock. Composes with #1454 (which cuts test time)
rather than overlapping it.

## Only CI can confirm

- That ssh/scp works from the actual launchd runner context. If it doesn't, the push fails the way
  the pull did — but now with a named reason, in one run instead of never.
- Whether `RUNNER_NAME` was the culprit: if so, studio-1's first suite shows `Cache hit (local)` next
  run.
- That the publish step costs seconds inside `build`.

## Noted, deliberately not done

Binary caches are never pruned (18 GB/54 entries on studio-1, 20 GB/61 on studio-2, ~360 MB per
commit; 1.6 TiB free). Deleting an entry a concurrent job is about to read is a real hazard and it
isn't what's costing time. Also on studio-1: two leaked `defradb` Go nodes from an old e2e run
(pids 90463, 90469), and `actions/checkout@v4` taking 1m43s there vs 1s on studio-2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
