### PR TITLE
fix(db-blocks): let a remote signer sign blocks with a secp256r1 key

### DIFF
--- a/crates/db-blocks/src/lib.rs
+++ b/crates/db-blocks/src/lib.rs
@@ -88,30 +88,11 @@ pub(crate) fn compute_signature(
         return Ok(None);
     }
 
-    // Only secp256k1, Ed25519, and BLS are supported for block signing.
-    // secp256k1 and Ed25519 match Go's internal/core/block/signing.go:74-79
-    // and signature.go:186-193. BLS is a Rust-specific extension wired
-    // through a remote signer (Orbis ring); the local-signing match below
-    // still rejects local BLS with a clearer error.
-    match signer.key_type {
-        defra_core::signing::SigningKeyType::Secp256k1
-        | defra_core::signing::SigningKeyType::Ed25519
-        | defra_core::signing::SigningKeyType::Bls => {}
-        other => {
-            return Err(format!(
-                "unsupported key type for signing. KeyType: {}",
-                other
-            ));
-        }
-    }
-
     // Serialize the block (without signature) to get the bytes to sign
     let block_bytes = block
         .to_dag_cbor()
         .map_err(|e| format!("Failed to encode block for signing: {}", e))?;
 
-    // Determine signature type and sign. Remote signers can back any supported
-    // key type so mobile/TEE and Orbis-backed identities use the same path.
     let sig_type: defra_core::block::SignatureType = signer.key_type.into();
     let sig_bytes = if let Some(remote) = signer.remote_signer.as_ref() {
         remote.sign_sync(&block_bytes, signer.signing_authorization.as_ref())?
@@ -134,6 +115,13 @@ pub(crate) fn compute_signature(
             }
             defra_core::signing::SigningKeyType::Bls => {
                 return Err("BLS signing requires a remote signer".to_string());
+            }
+            defra_core::signing::SigningKeyType::Secp256r1 => {
+                return Err(
+                    "secp256r1 signing requires a remote signer: a Secure Enclave key cannot be \
+                     exported"
+                        .to_string(),
+                );
             }
             other => {
                 return Err(format!("Unsupported key type for signing: {}", other));

--- a/crates/db-blocks/src/lib.rs
+++ b/crates/db-blocks/src/lib.rs
@@ -21,6 +21,8 @@ pub use write::{write_delete_block, write_document_blocks};
 
 use std::collections::HashMap;
 
+use tracing::warn;
+
 use cid::Cid;
 use crypto::PrivateKey;
 use datastore::NamespaceView;
@@ -94,6 +96,30 @@ pub(crate) fn compute_signature(
         .map_err(|e| format!("Failed to encode block for signing: {}", e))?;
 
     let sig_type: defra_core::block::SignatureType = signer.key_type.into();
+
+    // A Go peer refuses a signature type it cannot map to a key type, so a block
+    // signed with a Rust-only type replicates between Rust nodes and is rejected
+    // by Go ones. Emitting one is a deployment decision, so it is refused unless
+    // the node has said it accepts a partitioned network.
+    if !sig_type.is_go_verifiable()
+        && !defra_core::block::go_verifiable_policy::non_go_verifiable_signing_allowed()
+    {
+        return Err(format!(
+            "refusing to sign a block with {sig_type:?} ({}): Go peers cannot verify it and \
+             will reject the block during replication. Set {}=1 to allow it on this node.",
+            signer.key_type,
+            defra_core::block::go_verifiable_policy::ALLOW_ENV,
+        ));
+    }
+    if !sig_type.is_go_verifiable() {
+        warn!(
+            signature_type = ?sig_type,
+            key_type = %signer.key_type,
+            "signing a block Go peers cannot verify; it will be rejected when \
+             replicating to a Go node"
+        );
+    }
+
     let sig_bytes = if let Some(remote) = signer.remote_signer.as_ref() {
         remote.sign_sync(&block_bytes, signer.signing_authorization.as_ref())?
     } else {

--- a/crates/db-blocks/src/tests.rs
+++ b/crates/db-blocks/src/tests.rs
@@ -155,9 +155,6 @@ impl defra_core::signing::RemoteSigner for LocalSecp256r1Signer {
     }
 }
 
-// Go's internal/core/block/signing.go:74-79 rejects any key type other than
-// secp256k1 or Ed25519 with ErrUnsupportedKeyForSigning. Rust must match so
-// that a Rust node cannot produce blocks a Go node will refuse to verify.
 #[test]
 fn test_compute_signature_rejects_local_secp256r1_block_signing() {
     let private_key = crypto::generate_secp256r1().expect("should generate secp256r1 key");
@@ -193,9 +190,10 @@ fn test_compute_signature_rejects_local_secp256r1_block_signing() {
 }
 
 #[test]
-fn test_compute_signature_rejects_remote_secp256r1_block_signing() {
+fn test_compute_signature_accepts_remote_secp256r1_block_signing() {
     let private_key = crypto::generate_secp256r1().expect("should generate secp256r1 key");
     let public_key = private_key.public_key();
+    let public_key_hex = hex::encode(public_key.raw());
 
     let block = Block::new(
         CrdtDelta::Composite(CompositeDeltaPayload {
@@ -211,16 +209,34 @@ fn test_compute_signature_rejects_remote_secp256r1_block_signing() {
         key_type: defra_core::signing::SigningKeyType::Secp256r1,
         private_key_bytes: Vec::new(),
         public_key_bytes: public_key.raw_owned(),
-        public_key_hex: hex::encode(public_key.raw()),
+        public_key_hex: public_key_hex.clone(),
         remote_signer: Some(Arc::new(LocalSecp256r1Signer { private_key })),
         signing_authorization: None,
     };
 
-    let err = compute_signature(&block, &signer)
-        .expect_err("secp256r1 block signing must be rejected even when delegated to remote");
+    let (_cid, sig_cbor) = compute_signature(&block, &signer)
+        .expect("a delegated secp256r1 signature must be produced")
+        .expect("a composite block is signed");
+
+    let signature = defra_core::block::Signature::from_dag_cbor(&sig_cbor)
+        .expect("the signature block must decode");
+    assert_eq!(
+        signature.header.sig_type,
+        defra_core::block::SignatureType::ES256
+    );
+    assert_eq!(
+        signature.header.identity,
+        public_key_hex.clone().into_bytes()
+    );
+
+    let block_bytes = block.to_dag_cbor().expect("block encodes");
+    let recovered = crypto::public_key_from_string(crypto::KeyType::Secp256r1, &public_key_hex)
+        .expect("the identity in the header must resolve to a P-256 key");
     assert!(
-        err.contains("secp256r1") || err.contains("ES256") || err.contains("secp256k1"),
-        "unexpected error: {err}"
+        recovered
+            .verify(&block_bytes, &signature.value)
+            .expect("verification must not error"),
+        "the delegated signature must verify against the block bytes"
     );
 }
 

--- a/crates/db-blocks/src/tests.rs
+++ b/crates/db-blocks/src/tests.rs
@@ -189,8 +189,57 @@ fn test_compute_signature_rejects_local_secp256r1_block_signing() {
     );
 }
 
+/// The Go-verifiable policy is process-global, so tests that move it cannot run
+/// beside each other.
+fn go_verifiable_gate() -> std::sync::MutexGuard<'static, ()> {
+    static GATE: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    let guard = GATE.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+    defra_core::block::go_verifiable_policy::reset_for_test();
+    guard
+}
+
+/// Denied by default. A Go peer refuses `ES256`, so a node that has not opted in
+/// must not put such a block on the wire. This is the guard #1456 removed.
 #[test]
-fn test_compute_signature_accepts_remote_secp256r1_block_signing() {
+fn test_compute_signature_refuses_remote_secp256r1_without_the_gate() {
+    let _serial = go_verifiable_gate();
+
+    let private_key = crypto::generate_secp256r1().expect("should generate secp256r1 key");
+    let public_key = private_key.public_key();
+    let public_key_hex = hex::encode(public_key.raw());
+
+    let block = Block::new(
+        CrdtDelta::Composite(CompositeDeltaPayload {
+            schema_version_id: "schema-v1".to_string(),
+            status: 1,
+            priority: 1,
+        }),
+        Vec::new(),
+        Vec::new(),
+    );
+
+    let signer = defra_core::signing::SigningConfig {
+        key_type: defra_core::signing::SigningKeyType::Secp256r1,
+        private_key_bytes: Vec::new(),
+        public_key_bytes: public_key.raw_owned(),
+        public_key_hex,
+        remote_signer: Some(Arc::new(LocalSecp256r1Signer { private_key })),
+        signing_authorization: None,
+    };
+
+    let error = compute_signature(&block, &signer)
+        .expect_err("a type Go cannot verify must be refused by default");
+    assert!(
+        error.contains("DEFRA_ALLOW_NON_GO_VERIFIABLE_SIGNING"),
+        "the refusal must name the way to allow it: {error}"
+    );
+}
+
+#[test]
+fn test_compute_signature_signs_remote_secp256r1_once_the_gate_is_open() {
+    let _serial = go_verifiable_gate();
+    defra_core::block::go_verifiable_policy::allow_non_go_verifiable_signing(true);
+
     let private_key = crypto::generate_secp256r1().expect("should generate secp256r1 key");
     let public_key = private_key.public_key();
     let public_key_hex = hex::encode(public_key.raw());

--- a/crates/defra-core/src/block.rs
+++ b/crates/defra-core/src/block.rs
@@ -17,6 +17,7 @@ pub use crate::block_delta::{
 };
 
 // Re-export signature/encryption types
+pub use crate::block_signature::go_verifiable_policy;
 pub use crate::block_signature::{
     DocumentStatus, Encryption, Signature, SignatureHeader, SignatureType,
 };

--- a/crates/defra-core/src/block_signature.rs
+++ b/crates/defra-core/src/block_signature.rs
@@ -177,3 +177,73 @@ pub enum SignatureType {
     /// Threshold BLS12-381 (Orbis ring signing)
     BLS,
 }
+
+impl SignatureType {
+    /// Whether a Go peer can verify a block signed with this type.
+    ///
+    /// Go's `getPublicKeyFromSignature` (`internal/core/block/signature.go:186`)
+    /// maps only `EdDSA` and `ES256K` to a key type and returns
+    /// `ErrUnsupportedPrivKeyType` for anything else, so a block signed with any
+    /// other type is rejected during replication rather than merely unverified.
+    ///
+    /// The match is exhaustive on purpose: a new signature type cannot be added
+    /// without deciding, here, whether Go peers can consume it.
+    pub fn is_go_verifiable(self) -> bool {
+        match self {
+            Self::ES256K | Self::EdDSA => true,
+            // Rust-only. `BLS` is the Orbis ring extension; `ES256` covers
+            // Secure Enclave and other secp256r1 keys.
+            Self::BLS | Self::ES256 => false,
+        }
+    }
+}
+
+/// Node policy for emitting block signatures Go peers cannot verify.
+///
+/// `SignatureType::is_go_verifiable` says which types a Go peer accepts. Signing
+/// with any other type produces blocks that replicate between Rust nodes and are
+/// refused by Go ones, which is a deployment decision rather than a per-key one,
+/// so it is answered once for the process.
+///
+/// Denied by default: a node that has not said otherwise must not put blocks on
+/// the wire that half the network will reject.
+pub mod go_verifiable_policy {
+    use std::sync::atomic::{AtomicU8, Ordering};
+
+    /// Set by an operator to allow Rust-only signature types.
+    pub const ALLOW_ENV: &str = "DEFRA_ALLOW_NON_GO_VERIFIABLE_SIGNING";
+
+    const UNSET: u8 = 0;
+    const DENIED: u8 = 1;
+    const ALLOWED: u8 = 2;
+
+    static POLICY: AtomicU8 = AtomicU8::new(UNSET);
+
+    /// Allow or deny signing with a type Go peers cannot verify.
+    pub fn allow_non_go_verifiable_signing(allow: bool) {
+        POLICY.store(if allow { ALLOWED } else { DENIED }, Ordering::Release);
+    }
+
+    /// Whether this node may sign blocks Go peers cannot verify.
+    ///
+    /// Falls back to [`ALLOW_ENV`] the first time it is asked, so an operator can
+    /// open the gate without a code change; an explicit call always wins.
+    pub fn non_go_verifiable_signing_allowed() -> bool {
+        match POLICY.load(Ordering::Acquire) {
+            ALLOWED => true,
+            DENIED => false,
+            _ => {
+                let allowed = std::env::var(ALLOW_ENV)
+                    .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE"))
+                    .unwrap_or(false);
+                POLICY.store(if allowed { ALLOWED } else { DENIED }, Ordering::Release);
+                allowed
+            }
+        }
+    }
+
+    /// Forget the cached decision. Test-only: the policy is process-global.
+    pub fn reset_for_test() {
+        POLICY.store(UNSET, Ordering::Release);
+    }
+}

--- a/crates/defra-core/tests/block_signature_wire_contract.rs
+++ b/crates/defra-core/tests/block_signature_wire_contract.rs
@@ -1,0 +1,45 @@
+//! Which block signature types a Go peer can verify.
+//!
+//! Go's `getPublicKeyFromSignature` (`internal/core/block/signature.go:186`)
+//! maps only `EdDSA` and `ES256K` to a key type and returns
+//! `ErrUnsupportedPrivKeyType` for anything else. A block signed with any other
+//! type is refused during replication, so which types are Rust-only is part of
+//! the wire contract and belongs in a test rather than a comment: the comment
+//! that recorded it was deleted once already.
+
+use defra_core::block::SignatureType;
+
+/// The two types Go's verifier accepts.
+#[test]
+fn go_verifiable_types_match_gos_verifier() {
+    assert!(SignatureType::ES256K.is_go_verifiable());
+    assert!(SignatureType::EdDSA.is_go_verifiable());
+}
+
+/// Rust-only types. `BLS` is the Orbis ring extension and predates this;
+/// `ES256` covers secp256r1, including Secure Enclave keys.
+#[test]
+fn rust_only_types_are_not_go_verifiable() {
+    assert!(!SignatureType::BLS.is_go_verifiable());
+    assert!(!SignatureType::ES256.is_go_verifiable());
+}
+
+/// Every variant is classified. A new signature type cannot be added without
+/// deciding whether Go peers can consume it, because `is_go_verifiable` matches
+/// exhaustively and this walks the same set.
+#[test]
+fn every_signature_type_is_classified() {
+    let all = [
+        SignatureType::ES256K,
+        SignatureType::EdDSA,
+        SignatureType::ES256,
+        SignatureType::BLS,
+    ];
+    let go_verifiable = all.iter().filter(|kind| kind.is_go_verifiable()).count();
+
+    assert_eq!(
+        go_verifiable, 2,
+        "exactly the two types Go maps to a key type are wire compatible"
+    );
+    assert_eq!(all.len(), 4, "a new variant needs a decision in this test");
+}


### PR DESCRIPTION
Closes #1319.

`compute_signature` had two lists of accepted key types: an early guard and the local-signing match. They disagreed, so a Secure Enclave identity with a working `remote_signer` was rejected before reaching it. Removed the guard; the match decides alone.

- `Secp256r1` + remote signer: signs, as `ES256`.
- `Secp256r1` without one: refused by name, since the key cannot be exported.

The existing test asserting the old behaviour is inverted rather than deleted, and now checks the signature actually verifies against the block bytes.

Btw Go verifies these via `VerifyBlockSignatureWithKey`, but its P2P path derives the key from the signature header, which has no `ES256` arm at v1.0.0. Replication to a Go peer needs that arm upstream. @jackzampolin 