### PR TITLE
Persist the policy-ID counter so ids do not repeat after a restart

### DIFF
--- a/crates/acp/src/zanzibar/store/persistent.rs
+++ b/crates/acp/src/zanzibar/store/persistent.rs
@@ -42,6 +42,7 @@ impl PersistentZanzibarStore<RedbStore> {
 const POLICY_COUNTER_KEY: &str = "/zanzibar/counter";
 
 const POLICY_PREFIX: &str = "/zanzibar/policy/";
+const MAX_COUNTER_CONFLICT_RETRIES: u32 = 16;
 
 impl<S: Store> PersistentZanzibarStore<S> {
     fn policy_key(policy_id: &str) -> String {
@@ -138,57 +139,70 @@ impl<S: Store + Send + Sync> ZanzibarStore for PersistentZanzibarStore<S> {
 
     async fn next_policy_counter(&self) -> Result<u64> {
         let _guard = self.counter_lock.lock().await;
+        let mut conflicts = 0;
 
-        let mut txn = self.store.new_txn(false).await.map_err(|e| {
-            Error::Serialization(format!("next_policy_counter: create transaction: {}", e))
-        })?;
+        loop {
+            let mut txn = self.store.new_txn(false).await.map_err(|e| {
+                Error::Serialization(format!("next_policy_counter: create transaction: {}", e))
+            })?;
 
-        let stored = txn
-            .get(POLICY_COUNTER_KEY.as_bytes())
-            .await
-            .map_err(|e| Error::Serialization(format!("next_policy_counter: get: {}", e)))?;
+            let stored = txn
+                .get(POLICY_COUNTER_KEY.as_bytes())
+                .await
+                .map_err(|e| Error::Serialization(format!("next_policy_counter: get: {}", e)))?;
 
-        let last_issued = match stored {
-            Some(bytes) => {
-                let value: [u8; 8] = bytes.as_slice().try_into().map_err(|_| {
-                    Error::Serialization(format!(
-                        "next_policy_counter: expected 8 bytes, found {}",
-                        bytes.len()
-                    ))
-                })?;
-                u64::from_be_bytes(value)
-            }
-            None => {
-                let iter_opts = IterOptions::new().with_prefix(POLICY_PREFIX.as_bytes().to_vec());
-                let mut iter = txn.iterator(iter_opts).await.map_err(|e| {
-                    Error::Serialization(format!("next_policy_counter: create iterator: {}", e))
-                })?;
-
-                let mut seeded = 0u64;
-                while let Some(kv) = iter.next().await.map_err(|e| {
-                    Error::Serialization(format!("next_policy_counter: iterate: {}", e))
-                })? {
-                    // NAC shares this key space but mints its id from a
-                    // constant, so it never consumed a counter value.
-                    if !kv.key.ends_with(crate::nac::NODE_POLICY_ID.as_bytes()) {
-                        seeded += 1;
-                    }
+            let last_issued = match stored {
+                Some(bytes) => {
+                    let value: [u8; 8] = bytes.as_slice().try_into().map_err(|_| {
+                        Error::Serialization(format!(
+                            "next_policy_counter: expected 8 bytes, found {}",
+                            bytes.len()
+                        ))
+                    })?;
+                    u64::from_be_bytes(value)
                 }
-                seeded
+                None => {
+                    let iter_opts =
+                        IterOptions::new().with_prefix(POLICY_PREFIX.as_bytes().to_vec());
+                    let mut iter = txn.iterator(iter_opts).await.map_err(|e| {
+                        Error::Serialization(format!("next_policy_counter: create iterator: {}", e))
+                    })?;
+
+                    let mut seeded = 0u64;
+                    while let Some(kv) = iter.next().await.map_err(|e| {
+                        Error::Serialization(format!("next_policy_counter: iterate: {}", e))
+                    })? {
+                        // NAC shares this key space but mints its id from a
+                        // constant, so it never consumed a counter value.
+                        if !kv.key.ends_with(crate::nac::NODE_POLICY_ID.as_bytes()) {
+                            seeded += 1;
+                        }
+                    }
+                    seeded
+                }
+            };
+
+            let next = last_issued + 1;
+
+            txn.set(POLICY_COUNTER_KEY.as_bytes(), &next.to_be_bytes())
+                .await
+                .map_err(|e| Error::Serialization(format!("next_policy_counter: set: {}", e)))?;
+
+            match txn.commit().await {
+                Ok(()) => return Ok(next),
+                Err(error)
+                    if error.is_txn_conflict() && conflicts < MAX_COUNTER_CONFLICT_RETRIES =>
+                {
+                    conflicts += 1;
+                }
+                Err(error) => {
+                    return Err(Error::Serialization(format!(
+                        "next_policy_counter: commit: {}",
+                        error
+                    )))
+                }
             }
-        };
-
-        let next = last_issued + 1;
-
-        txn.set(POLICY_COUNTER_KEY.as_bytes(), &next.to_be_bytes())
-            .await
-            .map_err(|e| Error::Serialization(format!("next_policy_counter: set: {}", e)))?;
-
-        txn.commit()
-            .await
-            .map_err(|e| Error::Serialization(format!("next_policy_counter: commit: {}", e)))?;
-
-        Ok(next)
+        }
     }
 
     async fn delete_policy(&self, policy_id: &str) -> Result<bool> {

--- a/crates/acp/src/zanzibar/store/persistent.rs
+++ b/crates/acp/src/zanzibar/store/persistent.rs
@@ -16,6 +16,7 @@ use zanzibar::types::{ObjectRef, Policy, Relationship, Subject};
 /// Persistent Zanzibar store backed by any Store implementation.
 pub struct PersistentZanzibarStore<S: Store> {
     store: NamespacedStore<S>,
+    counter_lock: async_lock::Mutex<()>,
 }
 
 impl<S: Store> PersistentZanzibarStore<S> {
@@ -23,6 +24,7 @@ impl<S: Store> PersistentZanzibarStore<S> {
     pub fn from_store(store: Arc<S>) -> Self {
         Self {
             store: NamespacedStore::new(store, Namespace::Acpstore),
+            counter_lock: async_lock::Mutex::new(()),
         }
     }
 }
@@ -36,9 +38,14 @@ impl PersistentZanzibarStore<RedbStore> {
     }
 }
 
+/// Key holding the last issued policy-ID counter.
+const POLICY_COUNTER_KEY: &str = "/zanzibar/counter";
+
+const POLICY_PREFIX: &str = "/zanzibar/policy/";
+
 impl<S: Store> PersistentZanzibarStore<S> {
     fn policy_key(policy_id: &str) -> String {
-        format!("/zanzibar/policy/{}", policy_id)
+        format!("{}{}", POLICY_PREFIX, policy_id)
     }
 
     fn relationship_key(policy_id: &str, rel: &Relationship) -> String {
@@ -109,8 +116,7 @@ impl<S: Store + Send + Sync> ZanzibarStore for PersistentZanzibarStore<S> {
             Error::Serialization(format!("list_policies: create transaction: {}", e))
         })?;
 
-        let prefix = "/zanzibar/policy/";
-        let iter_opts = IterOptions::new().with_prefix(prefix.as_bytes().to_vec());
+        let iter_opts = IterOptions::new().with_prefix(POLICY_PREFIX.as_bytes().to_vec());
 
         let mut iter = txn
             .iterator(iter_opts)
@@ -128,6 +134,61 @@ impl<S: Store + Send + Sync> ZanzibarStore for PersistentZanzibarStore<S> {
         }
 
         Ok(policies)
+    }
+
+    async fn next_policy_counter(&self) -> Result<u64> {
+        let _guard = self.counter_lock.lock().await;
+
+        let mut txn = self.store.new_txn(false).await.map_err(|e| {
+            Error::Serialization(format!("next_policy_counter: create transaction: {}", e))
+        })?;
+
+        let stored = txn
+            .get(POLICY_COUNTER_KEY.as_bytes())
+            .await
+            .map_err(|e| Error::Serialization(format!("next_policy_counter: get: {}", e)))?;
+
+        let last_issued = match stored {
+            Some(bytes) => {
+                let value: [u8; 8] = bytes.as_slice().try_into().map_err(|_| {
+                    Error::Serialization(format!(
+                        "next_policy_counter: expected 8 bytes, found {}",
+                        bytes.len()
+                    ))
+                })?;
+                u64::from_be_bytes(value)
+            }
+            None => {
+                let iter_opts = IterOptions::new().with_prefix(POLICY_PREFIX.as_bytes().to_vec());
+                let mut iter = txn.iterator(iter_opts).await.map_err(|e| {
+                    Error::Serialization(format!("next_policy_counter: create iterator: {}", e))
+                })?;
+
+                let mut seeded = 0u64;
+                while let Some(kv) = iter.next().await.map_err(|e| {
+                    Error::Serialization(format!("next_policy_counter: iterate: {}", e))
+                })? {
+                    // NAC shares this key space but mints its id from a
+                    // constant, so it never consumed a counter value.
+                    if !kv.key.ends_with(crate::nac::NODE_POLICY_ID.as_bytes()) {
+                        seeded += 1;
+                    }
+                }
+                seeded
+            }
+        };
+
+        let next = last_issued + 1;
+
+        txn.set(POLICY_COUNTER_KEY.as_bytes(), &next.to_be_bytes())
+            .await
+            .map_err(|e| Error::Serialization(format!("next_policy_counter: set: {}", e)))?;
+
+        txn.commit()
+            .await
+            .map_err(|e| Error::Serialization(format!("next_policy_counter: commit: {}", e)))?;
+
+        Ok(next)
     }
 
     async fn delete_policy(&self, policy_id: &str) -> Result<bool> {

--- a/crates/acp/tests/policy_counter_tests.rs
+++ b/crates/acp/tests/policy_counter_tests.rs
@@ -149,9 +149,7 @@ async fn persistent_store_counter_seeds_at_one_when_empty() {
 }
 
 /// Two store instances over one backing store are past the reach of the
-/// in-process lock, so the transaction's conflict detection is what has to hold.
-/// A losing caller may be told to retry; what it must never do is receive a
-/// counter value another caller already got.
+/// in-process lock, so transaction conflicts must be retried by the store.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn persistent_store_counter_never_repeats_across_instances() {
     let backing = Arc::new(MemoryStore::new());
@@ -166,21 +164,15 @@ async fn persistent_store_counter_never_repeats_across_instances() {
 
     let mut issued = Vec::new();
     for handle in handles {
-        if let Ok(counter) = handle.await.unwrap() {
-            issued.push(counter);
-        }
+        issued.push(handle.await.unwrap().unwrap());
     }
 
-    let mut deduped = issued.clone();
-    deduped.sort_unstable();
-    deduped.dedup();
+    issued.sort_unstable();
 
-    assert!(!issued.is_empty(), "at least one caller should succeed");
     assert_eq!(
-        deduped.len(),
-        issued.len(),
-        "a counter value was issued twice: {:?}",
-        issued
+        issued,
+        (1..=8).collect::<Vec<u64>>(),
+        "concurrent store instances must each receive a distinct counter value"
     );
 }
 

--- a/crates/acp/tests/policy_counter_tests.rs
+++ b/crates/acp/tests/policy_counter_tests.rs
@@ -1,0 +1,214 @@
+//! Policy-ID counter persistence (#1448).
+//!
+//! Go's `acp_core` keeps the policy-ID counter in its KV store and advances it
+//! with a read-modify-write on every create, so re-registering identical policy
+//! YAML after a restart yields a fresh id. These tests pin that behavior.
+
+use std::sync::Arc;
+
+use acp::policy_yaml::{generate_policy_id, parse_policy_yaml};
+use acp::PersistentZanzibarStore;
+use storage::MemoryStore;
+use zanzibar::store::{MemoryZanzibarStore, ZanzibarStore};
+use zanzibar::types::Policy;
+
+/// The policy used to capture the golden vectors below, byte-for-byte as it was
+/// fed to a Go node.
+const GO_ORACLE_POLICY: &str = r#"
+name: test policy
+description: A Valid DefraDB Policy Interface
+resources:
+  - name: users
+    permissions:
+      - name: read
+        expr: reader + writer
+      - name: update
+        expr: writer
+      - name: delete
+        expr: writer
+    relations:
+      - name: reader
+        types:
+          - actor
+      - name: writer
+        types:
+          - actor
+"#;
+
+/// Ids observed from Go DefraDB v1.0.0 (`3de01484`, acp_core v0.8.1) registering
+/// GO_ORACLE_POLICY as the first, second and third policy on a node.
+const GO_POLICY_IDS: [&str; 3] = [
+    "d2a431a4492a7a75794df940f3d4727ac13c0c80260392d894ea0fac203a2f20",
+    "4948314a3ace74f52296a1ee73640a26541ac2b6198cc04c8d78daf39eab3d16",
+    "6986a6565d38df9494f930bd7cacfa366ac319a064751fe6188a345dc6a73cb8",
+];
+
+/// Our id derivation must agree with Go's byte-for-byte, or persisting the
+/// counter fixes nothing.
+#[test]
+fn policy_id_matches_go_oracle() {
+    let parsed = parse_policy_yaml(GO_ORACLE_POLICY).expect("parse oracle policy");
+
+    for (index, expected) in GO_POLICY_IDS.iter().enumerate() {
+        let counter = index as u64 + 1;
+        assert_eq!(
+            &generate_policy_id(&parsed, counter),
+            expected,
+            "policy id diverged from Go at counter={}",
+            counter
+        );
+    }
+}
+
+#[tokio::test]
+async fn memory_store_counter_starts_at_one_and_increments() {
+    let store = MemoryZanzibarStore::new();
+
+    assert_eq!(store.next_policy_counter().await.unwrap(), 1);
+    assert_eq!(store.next_policy_counter().await.unwrap(), 2);
+    assert_eq!(store.next_policy_counter().await.unwrap(), 3);
+}
+
+#[tokio::test]
+async fn persistent_store_counter_starts_at_one_and_increments() {
+    let store = PersistentZanzibarStore::from_store(Arc::new(MemoryStore::new()));
+
+    assert_eq!(store.next_policy_counter().await.unwrap(), 1);
+    assert_eq!(store.next_policy_counter().await.unwrap(), 2);
+    assert_eq!(store.next_policy_counter().await.unwrap(), 3);
+}
+
+/// The restart case: a new store instance over the same backing store must
+/// continue the sequence, not restart at 1.
+#[tokio::test]
+async fn persistent_store_counter_survives_reopen() {
+    let backing = Arc::new(MemoryStore::new());
+
+    let before = PersistentZanzibarStore::from_store(backing.clone());
+    assert_eq!(before.next_policy_counter().await.unwrap(), 1);
+    assert_eq!(before.next_policy_counter().await.unwrap(), 2);
+    drop(before);
+
+    let after = PersistentZanzibarStore::from_store(backing);
+    assert_eq!(
+        after.next_policy_counter().await.unwrap(),
+        3,
+        "counter must survive reopening the store"
+    );
+}
+
+/// Stores written before this change have policies but no counter key. Starting
+/// from 1 there would re-mint an id that is already in use, so the absent key is
+/// seeded from the number of policies already stored.
+#[tokio::test]
+async fn persistent_store_counter_seeds_from_existing_policies() {
+    let store = PersistentZanzibarStore::from_store(Arc::new(MemoryStore::new()));
+
+    for id in ["policy-a", "policy-b", "policy-c"] {
+        store
+            .store_policy(&Policy::new(id, "legacy"))
+            .await
+            .unwrap();
+    }
+
+    assert_eq!(
+        store.next_policy_counter().await.unwrap(),
+        4,
+        "three pre-existing policies means counters 1..3 are spent"
+    );
+}
+
+/// NAC shares this key space but mints its policy id from a constant rather
+/// than the counter, so it must not shift the seed. Go keeps NAC and DAC in
+/// separate stores with independent counters, where its first DAC policy is
+/// always counter 1.
+#[tokio::test]
+async fn persistent_store_counter_seed_ignores_the_nac_policy() {
+    let store = PersistentZanzibarStore::from_store(Arc::new(MemoryStore::new()));
+
+    store
+        .store_policy(&Policy::new(
+            acp::nac::NODE_POLICY_ID,
+            "Node Access Control Policy",
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        store.next_policy_counter().await.unwrap(),
+        1,
+        "a NAC-enabled node's first DAC policy must still be counter 1"
+    );
+}
+
+#[tokio::test]
+async fn persistent_store_counter_seeds_at_one_when_empty() {
+    let store = PersistentZanzibarStore::from_store(Arc::new(MemoryStore::new()));
+
+    assert_eq!(store.next_policy_counter().await.unwrap(), 1);
+}
+
+/// Two store instances over one backing store are past the reach of the
+/// in-process lock, so the transaction's conflict detection is what has to hold.
+/// A losing caller may be told to retry; what it must never do is receive a
+/// counter value another caller already got.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn persistent_store_counter_never_repeats_across_instances() {
+    let backing = Arc::new(MemoryStore::new());
+
+    let mut handles = Vec::new();
+    for _ in 0..8 {
+        let store = PersistentZanzibarStore::from_store(backing.clone());
+        handles.push(tokio::spawn(
+            async move { store.next_policy_counter().await },
+        ));
+    }
+
+    let mut issued = Vec::new();
+    for handle in handles {
+        if let Ok(counter) = handle.await.unwrap() {
+            issued.push(counter);
+        }
+    }
+
+    let mut deduped = issued.clone();
+    deduped.sort_unstable();
+    deduped.dedup();
+
+    assert!(!issued.is_empty(), "at least one caller should succeed");
+    assert_eq!(
+        deduped.len(),
+        issued.len(),
+        "a counter value was issued twice: {:?}",
+        issued
+    );
+}
+
+/// Go's counter is a non-atomic read-modify-write guarded by a per-call mutex,
+/// so concurrent creates there can mint colliding ids. Ours must not.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn persistent_store_counter_is_atomic_under_concurrency() {
+    let store = Arc::new(PersistentZanzibarStore::from_store(Arc::new(
+        MemoryStore::new(),
+    )));
+
+    let mut handles = Vec::new();
+    for _ in 0..8 {
+        let store = store.clone();
+        handles.push(tokio::spawn(async move {
+            store.next_policy_counter().await.unwrap()
+        }));
+    }
+
+    let mut counters = Vec::new();
+    for handle in handles {
+        counters.push(handle.await.unwrap());
+    }
+    counters.sort_unstable();
+
+    assert_eq!(
+        counters,
+        (1..=8).collect::<Vec<u64>>(),
+        "concurrent callers must each receive a distinct counter value"
+    );
+}

--- a/crates/cli/src/acp_adapter.rs
+++ b/crates/cli/src/acp_adapter.rs
@@ -1,6 +1,5 @@
 //! Adapter to bridge ACP policy operations to HTTP's AcpOperations trait.
 
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -11,17 +10,12 @@ use defra_http::router::{AcpOperations, PolicyInfo};
 /// Adapter that implements AcpOperations backed by a ZanzibarStore.
 pub struct AcpAdapter {
     store: Arc<dyn ZanzibarStore>,
-    counter: AtomicU64,
     nac_checker: Arc<dyn db::NodeAccessChecker>,
 }
 
 impl AcpAdapter {
     pub fn new(store: Arc<dyn ZanzibarStore>, nac_checker: Arc<dyn db::NodeAccessChecker>) -> Self {
-        Self {
-            store,
-            counter: AtomicU64::new(1),
-            nac_checker,
-        }
+        Self { store, nac_checker }
     }
 
     pub fn new_arc(
@@ -76,7 +70,11 @@ impl AcpOperations for AcpAdapter {
         }
         acp::policy_yaml::validate_policy_expressions(&parsed)?;
 
-        let counter = self.counter.fetch_add(1, Ordering::SeqCst);
+        let counter = self
+            .store
+            .next_policy_counter()
+            .await
+            .map_err(|e| format!("failed to advance policy counter: {}", e))?;
         let policy = acp::policy_yaml::build_policy(&parsed, counter)
             .map_err(|e| format!("invalid policy: {}", e))?;
         let policy_id = policy.id.clone();

--- a/crates/cli/src/sourcehub_acp_adapter.rs
+++ b/crates/cli/src/sourcehub_acp_adapter.rs
@@ -124,7 +124,7 @@ impl AcpOperations for SourceHubAcpAdapter {
             .map_err(|e| format!("SourceHub create policy failed: {}", e))?;
 
         // The schema references the on-chain id, and doc_acp_adapter validates
-        // against this store. Go caches nothing here, querying SourceHub instead.
+        // against this store.
         policy.id = policy_id.clone();
         self.local_store
             .store_policy_with_options(&policy, &options)

--- a/crates/cli/src/sourcehub_acp_adapter.rs
+++ b/crates/cli/src/sourcehub_acp_adapter.rs
@@ -3,7 +3,6 @@
 //! Policies are created on-chain via SourceHub transactions, then cached locally
 //! in the ZanzibarStore for reads (list/get). This matches the FFI pattern.
 
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -11,11 +10,13 @@ use async_trait::async_trait;
 use acp::{Policy, StorePolicyOptions, ZanzibarStore};
 use defra_http::router::{AcpLightClientStatus, AcpOperations, PolicyInfo};
 
+/// Placeholder: SourceHub assigns the id, so this value never reaches storage.
+const UNASSIGNED_ID_COUNTER: u64 = 1;
+
 /// Adapter that implements AcpOperations with SourceHub for writes and local store for reads.
 pub struct SourceHubAcpAdapter {
     sourcehub_acp: Arc<sourcehub::SourceHubDocumentACP>,
     local_store: Arc<dyn ZanzibarStore>,
-    counter: AtomicU64,
     nac_checker: Arc<dyn db::NodeAccessChecker>,
 }
 
@@ -28,7 +29,6 @@ impl SourceHubAcpAdapter {
         Self {
             sourcehub_acp,
             local_store,
-            counter: AtomicU64::new(1),
             nac_checker,
         }
     }
@@ -101,18 +101,19 @@ impl AcpOperations for SourceHubAcpAdapter {
         }
         acp::policy_yaml::validate_policy_expressions(&parsed)?;
 
-        let counter = self.counter.fetch_add(1, Ordering::SeqCst);
-        let policy = acp::policy_yaml::build_policy(&parsed, counter)
+        let mut policy = acp::policy_yaml::build_policy(&parsed, UNASSIGNED_ID_COUNTER)
             .map_err(|e| format!("invalid policy: {}", e))?;
 
         let options = StorePolicyOptions::new()
             .with_validation()
             .with_dpi_enforcement();
 
-        // DPI validation before submitting on-chain
-        self.local_store
-            .store_policy_with_options(&policy, &options)
-            .await
+        // Reject an invalid policy before it reaches the chain.
+        policy
+            .validate()
+            .map_err(|e| format!("failed to validate policy: {}", e))?;
+        policy
+            .validate_dpi()
             .map_err(|e| format!("failed to validate policy: {}", e))?;
 
         // Submit on-chain via SourceHub
@@ -122,19 +123,13 @@ impl AcpOperations for SourceHubAcpAdapter {
             .await
             .map_err(|e| format!("SourceHub create policy failed: {}", e))?;
 
-        // Re-store the policy under the on-chain ID so relationship validation
-        // can find it. The initial store used a locally-computed SHA256 ID, but
-        // the schema references the on-chain ID. Go doesn't cache locally at all
-        // (it queries Source Hub on-demand), but since our doc_acp_adapter validates
-        // against the local store, we need the policy indexed by on-chain ID.
-        if policy_id != policy.id {
-            let mut on_chain_policy = policy;
-            on_chain_policy.id = policy_id.clone();
-            self.local_store
-                .store_policy_with_options(&on_chain_policy, &options)
-                .await
-                .map_err(|e| format!("failed to cache policy with on-chain ID: {}", e))?;
-        }
+        // The schema references the on-chain id, and doc_acp_adapter validates
+        // against this store. Go caches nothing here, querying SourceHub instead.
+        policy.id = policy_id.clone();
+        self.local_store
+            .store_policy_with_options(&policy, &options)
+            .await
+            .map_err(|e| format!("failed to cache policy with on-chain ID: {}", e))?;
 
         Ok(policy_id)
     }

--- a/crates/ffi/src/acp/dac.rs
+++ b/crates/ffi/src/acp/dac.rs
@@ -164,19 +164,23 @@ pub unsafe extern "C" fn add_dac_policy(
                 None => return FfiResult::error(ERR_INVALID_NODE_HANDLE),
             };
 
-            let policy_id = policy_store.next_policy_id(&parsed);
-            let policy = match acp::policy_yaml::build_policy(&parsed, 1) {
-                Ok(policy) => acp::Policy {
-                    id: policy_id.clone(),
-                    ..policy
-                },
-                Err(e) => return FfiResult::error(format!("invalid policy: {}", e)),
-            };
-            policy_store.store_policy(&policy_id, &policy_str);
-
             let Some(local_zanzibar_store) = local_zanzibar_store else {
                 return FfiResult::error("local ACP backend is not available");
             };
+
+            let counter = match rt.block_on(local_zanzibar_store.next_policy_counter()) {
+                Ok(counter) => counter,
+                Err(e) => {
+                    return FfiResult::error(format!("failed to advance policy counter: {}", e))
+                }
+            };
+
+            let policy = match acp::policy_yaml::build_policy(&parsed, counter) {
+                Ok(policy) => policy,
+                Err(e) => return FfiResult::error(format!("invalid policy: {}", e)),
+            };
+            let policy_id = policy.id.clone();
+            policy_store.store_policy(&policy_id, &policy_str);
 
             let options = StorePolicyOptions::new()
                 .with_validation()

--- a/crates/ffi/src/state/policy_store.rs
+++ b/crates/ffi/src/state/policy_store.rs
@@ -1,17 +1,10 @@
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use parking_lot::RwLock;
 
-use crate::policy_yaml::ParsedPolicy;
-
-/// In-memory policy store for DAC policies.
-///
-/// Generates Go-compatible policy IDs using parsed-field hashing
-/// combined with a monotonic sequence counter.
+/// In-memory cache of DAC policy documents, keyed by policy ID.
 pub struct PolicyStore {
     policies: RwLock<HashMap<String, String>>,
-    counter: AtomicU64,
 }
 
 impl Default for PolicyStore {
@@ -25,24 +18,7 @@ impl PolicyStore {
     pub fn new() -> Self {
         Self {
             policies: RwLock::new(HashMap::new()),
-            counter: AtomicU64::new(1), // Go's counter starts at 1 (GetNext returns currID + 1)
         }
-    }
-
-    /// Add a policy and return its Go-compatible ID.
-    pub fn add_policy(&self, policy: &str, parsed: &ParsedPolicy) -> String {
-        let policy_id = self.next_policy_id(parsed);
-        self.policies
-            .write()
-            .insert(policy_id.clone(), policy.to_string());
-
-        policy_id
-    }
-
-    /// Generate the next Go-compatible policy ID without storing the policy body.
-    pub fn next_policy_id(&self, parsed: &ParsedPolicy) -> String {
-        let counter_val = self.counter.fetch_add(1, Ordering::SeqCst);
-        acp::policy_yaml::generate_policy_id(parsed, counter_val)
     }
 
     /// Store a policy with a known ID (used for SourceHub-created policies).

--- a/crates/zanzibar/src/store/memory.rs
+++ b/crates/zanzibar/src/store/memory.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use parking_lot::RwLock;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::did::Did;
 
@@ -11,6 +12,7 @@ use crate::types::{ObjectRef, Policy, Relationship, Subject};
 pub struct MemoryZanzibarStore {
     policies: RwLock<HashMap<String, Policy>>,
     relationships: RwLock<HashMap<String, HashMap<String, Relationship>>>,
+    policy_counter: AtomicU64,
 }
 
 impl MemoryZanzibarStore {
@@ -18,6 +20,7 @@ impl MemoryZanzibarStore {
         Self {
             policies: RwLock::new(HashMap::new()),
             relationships: RwLock::new(HashMap::new()),
+            policy_counter: AtomicU64::new(0),
         }
     }
 }
@@ -40,6 +43,10 @@ impl ZanzibarStore for MemoryZanzibarStore {
 
     async fn get_policy(&self, policy_id: &str) -> Result<Option<Policy>> {
         Ok(self.policies.read().get(policy_id).cloned())
+    }
+
+    async fn next_policy_counter(&self) -> Result<u64> {
+        Ok(self.policy_counter.fetch_add(1, Ordering::SeqCst) + 1)
     }
 
     async fn list_policies(&self) -> Result<Vec<Policy>> {

--- a/crates/zanzibar/src/store/traits.rs
+++ b/crates/zanzibar/src/store/traits.rs
@@ -36,6 +36,9 @@ pub trait ZanzibarStore: MaybeSendSync {
 
     async fn list_policies(&self) -> Result<Vec<Policy>>;
 
+    /// Return the next policy-ID counter value, advancing the stored counter.
+    async fn next_policy_counter(&self) -> Result<u64>;
+
     async fn delete_policy(&self, policy_id: &str) -> Result<bool>;
 
     async fn store_relationship(&self, policy_id: &str, rel: &Relationship) -> Result<()>;

--- a/tools/integration-test/tests/acp.rs
+++ b/tools/integration-test/tests/acp.rs
@@ -26,6 +26,8 @@ mod node_access;
 mod p2p;
 #[path = "acp/p2p_lifecycle.rs"]
 mod p2p_lifecycle;
+#[path = "acp/policy_counter_restart.rs"]
+mod policy_counter_restart;
 #[path = "acp/policy_validation.rs"]
 mod policy_validation;
 #[path = "acp/register_ops.rs"]

--- a/tools/integration-test/tests/acp/policy_counter_restart.rs
+++ b/tools/integration-test/tests/acp/policy_counter_restart.rs
@@ -1,0 +1,102 @@
+//! Policy-ID counter must survive a node restart (#1448).
+//!
+//! Go's `acp_core` persists the counter that salts each policy-ID hash, so
+//! re-registering identical policy YAML after a restart yields a *fresh* id. Go
+//! pins this itself in
+//! `Test_LocalACP_PersistentMemory_AddPolicy_CreatingSamePolicyReturnsDifferentIDs`
+//! (`acp/dac/local_test.go`). Rust previously reset an in-memory counter on
+//! every start and returned the original id, silently adopting the earlier
+//! policy's identity.
+//!
+//! These run under `for_each_runtime!`, so the Go node acts as the oracle rather
+//! than the assertion merely restating Rust's own behavior.
+//!
+//! A persistent store is required: the harness defaults to `--store memory`,
+//! where the ACP backend is a `MemoryZanzibarStore` and a restart wipes the
+//! counter along with everything else, so the divergence cannot appear.
+//!
+//! NAC is left off. It stores its policy in the same key space, and the
+//! counter's absent-key seeding deliberately skips it, which is covered by a
+//! unit test rather than here.
+
+use std::time::Duration;
+
+use integration_test::{for_each_runtime, generate_identity, TestCluster, USER_ACP_POLICY};
+
+fn policy_id_of(result: &serde_json::Value) -> String {
+    result["PolicyID"]
+        .as_str()
+        .or_else(|| result["policyID"].as_str())
+        .expect("missing PolicyID in policy add result")
+        .to_string()
+}
+
+async fn policy_counter_survives_restart_test(mut cluster: TestCluster) {
+    let node = cluster.client(0);
+    let binary_path = node.binary_path().to_path_buf();
+    let alice = generate_identity(&binary_path).expect("failed to generate identity");
+
+    let before = policy_id_of(
+        &node
+            .acp_policy_add(USER_ACP_POLICY, &alice.private_key_hex)
+            .expect("failed to add policy before restart"),
+    );
+
+    cluster
+        .restart_node(0, Duration::from_secs(30))
+        .await
+        .expect("restart node");
+
+    let node = cluster.client(0);
+    let after = policy_id_of(
+        &node
+            .acp_policy_add(USER_ACP_POLICY, &alice.private_key_hex)
+            .expect("failed to add policy after restart"),
+    );
+
+    assert_ne!(
+        before, after,
+        "re-registering identical policy YAML after a restart must mint a new \
+         policy id; the same id twice means the counter reset"
+    );
+}
+
+/// Guards the other half of the contract: the counter advances within a single
+/// session, so the restart assertion cannot pass for the wrong reason.
+async fn policy_counter_advances_in_session_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let binary_path = node.binary_path().to_path_buf();
+    let alice = generate_identity(&binary_path).expect("failed to generate identity");
+
+    let first = policy_id_of(
+        &node
+            .acp_policy_add(USER_ACP_POLICY, &alice.private_key_hex)
+            .expect("failed to add first policy"),
+    );
+    let second = policy_id_of(
+        &node
+            .acp_policy_add(USER_ACP_POLICY, &alice.private_key_hex)
+            .expect("failed to add second policy"),
+    );
+
+    assert_ne!(
+        first, second,
+        "identical policy YAML submitted twice in one session must mint distinct ids"
+    );
+}
+
+for_each_runtime!(
+    policy_counter_survives_restart,
+    policy_counter_survives_restart_test,
+    // One store string for both runtimes: Go takes badger, and Rust accepts it
+    // as the alias for its persistent redb backend.
+    .with_acp_local().with_store("badger")
+);
+
+for_each_runtime!(
+    policy_counter_advances_in_session,
+    policy_counter_advances_in_session_test,
+    // One store string for both runtimes: Go takes badger, and Rust accepts it
+    // as the alias for its persistent redb backend.
+    .with_acp_local().with_store("badger")
+);


### PR DESCRIPTION
Closes #1448

## Problem

Policy ids hash a monotonic counter, but every entrypoint kept that counter in an in-memory `AtomicU64` reset to 1 on construction. Registering identical policy YAML after a restart therefore returned the original id, where Go returns a fresh one.

Because `store_policy` writes by id with no existence check, that re-registration silently adopted the earlier policy's identity and any Zanzibar tuples already granted under it. Two runtimes given the same sequence of operations report different policy ids, which is a 1.0 parity break.

## What Changed

- Add `ZanzibarStore::next_policy_counter`, implemented once per store instead of per entrypoint.
- Persistent store does Go's read-modify-write in a single transaction at `/zanzibar/counter`.
- Memory store keeps an in-process atomic.
- The CLI and FFI entrypoints take the counter from the store; no policy `AtomicU64` remains.
- An absent counter key seeds from the stored policy count, skipping NAC's constant-id policy.
- The SourceHub path validates in memory and caches only under the on-chain id, minting no local id.
- FFI `PolicyStore` loses its counter and becomes a policy-document cache.
- Unit tests pin three policy ids captured from a real Go v1.0.0 node.
- An integration test registers, restarts, re-registers identical YAML, and asserts the ids differ.
- Both integration tests run under `for_each_runtime!`, so the Go node is the oracle.

## Verification

Go's behavior was verified three independent ways before any code was written:

- Go pins it itself in `Test_LocalACP_PersistentMemory_AddPolicy_CreatingSamePolicyReturnsDifferentIDs` (`acp/dac/local_test.go`), commented "Should generate a different ID for the new policy, even though the payload is the same."
- A real Go v1.0.0 node returned a different id across a restart, with a control run proving the id is a deterministic function of (counter, content) rather than nondeterministic.
- Go PR #2691 documents the intent: the pre-#2691 local implementation returned the same id on re-submission and was deliberately changed for SourceHub compatibility.

Our generator reproduces all three captured Go ids byte-for-byte, so the counter's persistence was the only remaining divergence. The integration test was confirmed to fail against `main` (identical ids) and pass with this change.

Local run: `cargo fmt --all -- --check`, `cargo clippy --all -- -D warnings`, the three `cli` feature-contract lint lines, `just check-node-graph`, 37 unit suites, and the full ACP integration suite (202 passed, 0 failed).

## Notes

- **We are stricter than Go under concurrency.** Go's `NewCounterStore` returns the struct by value with a per-call mutex, so its `Acquire()` guards nothing; ours is atomic. No single-threaded sequence differs.
- **Counter burn on rejected adds is not addressed here.** Go increments before any validation, we increment after; Go also contradicts itself, reverting the increment on-chain but not locally.
- **`store_policy` still has no existence check** while Go's zanzi layer returns `ErrEntityExists`. Adding one is not a drop-in and needs its own design.
- **`crates/defra-node/src/acp_ops.rs`** adds a fourth counter site but is not on `main` yet (#1445); whichever merges second adopts `next_policy_counter`.
- **Pre-existing and untouched:** three `clippy::useless_borrows_in_formatting` errors surface under `--all-targets` in `tools/integration-test/tests/query/subscription_docid.rs:277,341` and `tools/integration-test/tests/p2p_iroh/peer/create.rs:509`. CI's clippy line omits `--all-targets`, so they are invisible to CI today.

