### PR TITLE
fix(p2p): keep one connection per peer to stop gossipsub dying against Go

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4843,8 +4843,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -5591,7 +5591,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -6068,7 +6068,7 @@ dependencies = [
 [[package]]
 name = "iroh-bitswap"
 version = "0.2.0"
-source = "git+https://github.com/sourcenetwork/beetle?rev=d1e12c7cf6dc653d8f0abeb9f804824656fb3621#d1e12c7cf6dc653d8f0abeb9f804824656fb3621"
+source = "git+https://github.com/sourcenetwork/beetle?rev=255e4cfee016697c77ec92136dbe5d57225eb2d5#255e4cfee016697c77ec92136dbe5d57225eb2d5"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -14107,8 +14107,8 @@ dependencies = [
  "log",
  "serde",
  "thiserror 2.0.18",
- "windows 0.62.2",
- "windows-core 0.62.2",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ web-time = "1.1"
 # P2P networking
 # Keep these on the same libp2p-swarm release line.
 libp2p = { version = "0.56", features = ["tcp", "noise", "yamux", "gossipsub", "kad", "identify", "relay", "dns", "quic", "websocket", "secp256k1"] }
-iroh-bitswap = { git = "https://github.com/sourcenetwork/beetle", rev = "d1e12c7cf6dc653d8f0abeb9f804824656fb3621" }
+iroh-bitswap = { git = "https://github.com/sourcenetwork/beetle", rev = "255e4cfee016697c77ec92136dbe5d57225eb2d5" }
 libp2p-stream = "0.4.0-alpha"
 multiaddr = "0.18"
 

--- a/crates/p2p/src/host/p2p_host/connection_manager.rs
+++ b/crates/p2p/src/host/p2p_host/connection_manager.rs
@@ -1,10 +1,25 @@
 //! Active connection pruning for libp2p hosts.
+//!
+//! Two policies share one registry: a global high-water prune that sheds whole
+//! peers when the host holds too many connections, and a per-peer rule that
+//! keeps a single connection to each peer. Both mark their victims `closing` in
+//! the same map, so neither re-selects what the other already gave up.
 
 use std::collections::HashMap;
 use std::time::Duration;
 
 use libp2p::{swarm::ConnectionId, PeerId};
 use tokio::time::Instant;
+
+/// How a connection reaches its peer.
+///
+/// Ordered so `Direct` outranks `Relayed`: a circuit-relayed connection is only
+/// ever a fallback, and a direct one that arrives later must replace it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(super) enum ConnectionPath {
+    Relayed,
+    Direct,
+}
 
 #[derive(Debug)]
 pub(super) struct ActiveConnectionManager {
@@ -24,6 +39,8 @@ pub(super) struct PruneCandidate {
 #[derive(Debug)]
 struct ManagedConnection {
     peer_id: PeerId,
+    path: ConnectionPath,
+    dialed_by_us: bool,
     established_at: Instant,
     closing: bool,
 }
@@ -45,12 +62,16 @@ impl ActiveConnectionManager {
         &mut self,
         connection_id: ConnectionId,
         peer_id: PeerId,
+        path: ConnectionPath,
+        dialed_by_us: bool,
         now: Instant,
     ) {
         self.connections.insert(
             connection_id,
             ManagedConnection {
                 peer_id,
+                path,
+                dialed_by_us,
                 established_at: now,
                 closing: false,
             },
@@ -59,6 +80,57 @@ impl ActiveConnectionManager {
 
     pub(super) fn on_closed(&mut self, connection_id: ConnectionId) {
         self.connections.remove(&connection_id);
+    }
+
+    /// Connections to `peer_id` that must close so exactly one survives.
+    ///
+    /// A second connection to the same peer is what breaks gossipsub against Go
+    /// (#1449): rust-libp2p gives every connection its own handler draining one
+    /// shared per-peer send queue, so each opens its own `/meshsub` substream,
+    /// while go-libp2p-pubsub keeps a single inbound stream per peer and resets
+    /// the rest. The survivors then ping-pong until rust-libp2p disables the
+    /// handler, silencing this node's gossip to that peer for good.
+    ///
+    /// The survivor is the connection on the best available path, so a direct
+    /// connection always displaces a relayed one — the relayed-to-direct upgrade
+    /// keeps the direct link and sheds the relay, never the reverse.
+    ///
+    /// Within a path the winner is the one dialed by the lower of the two peer
+    /// ids. Both ends compute that from the same two ids and the same direction,
+    /// so they always drop the same connection. Choosing locally instead — by
+    /// age, say — lets two peers that dialed each other simultaneously each drop
+    /// what the other kept and sever the link outright.
+    pub(super) fn redundant_connections(
+        &mut self,
+        local_peer_id: PeerId,
+        peer_id: PeerId,
+    ) -> Vec<ConnectionId> {
+        let keep_our_dial = local_peer_id < peer_id;
+        let mut live: Vec<(ConnectionId, ConnectionPath, bool, Instant)> = self
+            .connections
+            .iter()
+            .filter(|(_, connection)| connection.peer_id == peer_id && !connection.closing)
+            .map(|(id, connection)| {
+                (
+                    *id,
+                    connection.path,
+                    connection.dialed_by_us == keep_our_dial,
+                    connection.established_at,
+                )
+            })
+            .collect();
+        if live.len() < 2 {
+            return Vec::new();
+        }
+
+        live.sort_by(|a, b| b.1.cmp(&a.1).then(b.2.cmp(&a.2)).then(a.3.cmp(&b.3)));
+        let redundant: Vec<ConnectionId> = live.into_iter().skip(1).map(|(id, ..)| id).collect();
+        for connection_id in &redundant {
+            if let Some(connection) = self.connections.get_mut(connection_id) {
+                connection.closing = true;
+            }
+        }
+        redundant
     }
 
     pub(super) fn prune_candidates(&mut self, now: Instant) -> Vec<PruneCandidate> {
@@ -126,13 +198,38 @@ mod tests {
         ConnectionId::new_unchecked(id)
     }
 
+    fn direct(
+        manager: &mut ActiveConnectionManager,
+        id: usize,
+        peer_id: PeerId,
+        established_at: Instant,
+    ) {
+        manager.on_established(
+            connection_id(id),
+            peer_id,
+            ConnectionPath::Direct,
+            true,
+            established_at,
+        );
+    }
+
+    /// A `(low, high)` peer-id pair, so tests can state which side dials.
+    fn ordered_peers() -> (PeerId, PeerId) {
+        let (a, b) = (PeerId::random(), PeerId::random());
+        if a < b {
+            (a, b)
+        } else {
+            (b, a)
+        }
+    }
+
     #[test]
     fn below_high_water_does_not_prune() {
         let mut manager = ActiveConnectionManager::new(2, 4, Duration::from_secs(20));
         let now = Instant::now();
 
         for id in 0..4 {
-            manager.on_established(connection_id(id), PeerId::random(), now);
+            direct(&mut manager, id, PeerId::random(), now);
         }
 
         assert!(manager
@@ -146,7 +243,7 @@ mod tests {
         let now = Instant::now();
 
         for id in 0..5 {
-            manager.on_established(connection_id(id), PeerId::random(), now);
+            direct(&mut manager, id, PeerId::random(), now);
         }
 
         assert!(manager
@@ -160,8 +257,9 @@ mod tests {
         let now = Instant::now();
 
         for id in 0..5 {
-            manager.on_established(
-                connection_id(id),
+            direct(
+                &mut manager,
+                id,
                 PeerId::random(),
                 now + Duration::from_secs(id as u64),
             );
@@ -184,15 +282,17 @@ mod tests {
         let now = Instant::now();
         let oldest_peer = PeerId::random();
 
-        manager.on_established(connection_id(0), oldest_peer, now);
-        manager.on_established(connection_id(1), oldest_peer, now + Duration::from_secs(25));
-        manager.on_established(
-            connection_id(2),
+        direct(&mut manager, 0, oldest_peer, now);
+        direct(&mut manager, 1, oldest_peer, now + Duration::from_secs(25));
+        direct(
+            &mut manager,
+            2,
             PeerId::random(),
             now + Duration::from_secs(1),
         );
-        manager.on_established(
-            connection_id(3),
+        direct(
+            &mut manager,
+            3,
             PeerId::random(),
             now + Duration::from_secs(2),
         );
@@ -213,7 +313,7 @@ mod tests {
         let now = Instant::now();
 
         for id in 0..5 {
-            manager.on_established(connection_id(id), PeerId::random(), now);
+            direct(&mut manager, id, PeerId::random(), now);
         }
 
         assert_eq!(
@@ -224,6 +324,191 @@ mod tests {
         );
         assert!(manager
             .prune_candidates(now + Duration::from_secs(31))
+            .is_empty());
+    }
+
+    #[test]
+    fn single_connection_is_never_redundant() {
+        let mut manager = ActiveConnectionManager::new(2, 4, Duration::from_secs(20));
+        let (local, remote) = ordered_peers();
+
+        direct(&mut manager, 0, remote, Instant::now());
+
+        assert!(manager.redundant_connections(local, remote).is_empty());
+    }
+
+    /// #1449: the second connection to a peer is what breaks gossipsub against
+    /// Go. The lower peer id owns the surviving dial.
+    #[test]
+    fn duplicate_direct_connection_keeps_the_dial_from_the_lower_peer_id() {
+        let mut manager = ActiveConnectionManager::new(2, 4, Duration::from_secs(20));
+        let now = Instant::now();
+        let (local, remote) = ordered_peers();
+
+        manager.on_established(connection_id(0), remote, ConnectionPath::Direct, true, now);
+        manager.on_established(
+            connection_id(1),
+            remote,
+            ConnectionPath::Direct,
+            false,
+            now + Duration::from_secs(1),
+        );
+
+        assert_eq!(
+            manager.redundant_connections(local, remote),
+            vec![connection_id(1)]
+        );
+    }
+
+    /// The same simultaneous connect seen from both nodes. Connection 0 is the
+    /// dial the low peer made, connection 1 the dial the high peer made, so each
+    /// node records them with opposite `dialed_by_us`. Both must drop 1 — if
+    /// they disagreed, each would close what the other kept and sever the link.
+    #[test]
+    fn both_ends_drop_the_same_connection() {
+        let (low, high) = ordered_peers();
+        let now = Instant::now();
+
+        let mut at_low = ActiveConnectionManager::new(2, 4, Duration::from_secs(20));
+        at_low.on_established(connection_id(0), high, ConnectionPath::Direct, true, now);
+        at_low.on_established(
+            connection_id(1),
+            high,
+            ConnectionPath::Direct,
+            false,
+            now + Duration::from_secs(1),
+        );
+
+        let mut at_high = ActiveConnectionManager::new(2, 4, Duration::from_secs(20));
+        at_high.on_established(connection_id(0), low, ConnectionPath::Direct, false, now);
+        at_high.on_established(
+            connection_id(1),
+            low,
+            ConnectionPath::Direct,
+            true,
+            now + Duration::from_secs(1),
+        );
+
+        assert_eq!(
+            at_low.redundant_connections(low, high),
+            vec![connection_id(1)]
+        );
+        assert_eq!(
+            at_high.redundant_connections(high, low),
+            vec![connection_id(1)]
+        );
+    }
+
+    /// The relayed-to-direct upgrade: a direct connection arriving after a
+    /// relayed one must survive, and the relay is what gets dropped.
+    #[test]
+    fn direct_connection_supersedes_an_older_relayed_one() {
+        let mut manager = ActiveConnectionManager::new(2, 4, Duration::from_secs(20));
+        let now = Instant::now();
+        let (local, remote) = ordered_peers();
+
+        manager.on_established(connection_id(0), remote, ConnectionPath::Relayed, true, now);
+        manager.on_established(
+            connection_id(1),
+            remote,
+            ConnectionPath::Direct,
+            false,
+            now + Duration::from_secs(5),
+        );
+
+        assert_eq!(
+            manager.redundant_connections(local, remote),
+            vec![connection_id(0)]
+        );
+    }
+
+    /// The mirror: a relay arriving while a direct connection is live is the
+    /// redundant one, so a late relay cannot displace a working direct link.
+    #[test]
+    fn relayed_connection_never_supersedes_a_direct_one() {
+        let mut manager = ActiveConnectionManager::new(2, 4, Duration::from_secs(20));
+        let now = Instant::now();
+        let (local, remote) = ordered_peers();
+
+        manager.on_established(connection_id(0), remote, ConnectionPath::Direct, false, now);
+        manager.on_established(
+            connection_id(1),
+            remote,
+            ConnectionPath::Relayed,
+            true,
+            now + Duration::from_secs(5),
+        );
+
+        assert_eq!(
+            manager.redundant_connections(local, remote),
+            vec![connection_id(1)]
+        );
+    }
+
+    #[test]
+    fn redundant_connections_are_not_reported_twice() {
+        let mut manager = ActiveConnectionManager::new(2, 4, Duration::from_secs(20));
+        let now = Instant::now();
+        let (local, remote) = ordered_peers();
+
+        direct(&mut manager, 0, remote, now);
+        direct(&mut manager, 1, remote, now + Duration::from_secs(1));
+
+        assert_eq!(manager.redundant_connections(local, remote).len(), 1);
+        assert!(manager.redundant_connections(local, remote).is_empty());
+    }
+
+    /// Per-peer dedup and the high-water prune share one registry, so a
+    /// connection one policy already gave up is invisible to the other.
+    #[test]
+    fn watermark_prune_skips_connections_dedup_already_closed() {
+        let mut manager = ActiveConnectionManager::new(1, 1, Duration::from_secs(20));
+        let now = Instant::now();
+        let (local, remote) = ordered_peers();
+
+        direct(&mut manager, 0, remote, now);
+        direct(&mut manager, 1, remote, now + Duration::from_secs(1));
+        direct(
+            &mut manager,
+            2,
+            PeerId::random(),
+            now + Duration::from_secs(2),
+        );
+        assert_eq!(
+            manager.redundant_connections(local, remote),
+            vec![connection_id(1)]
+        );
+
+        let candidates = manager
+            .prune_candidates(now + Duration::from_secs(30))
+            .into_iter()
+            .map(|candidate| candidate.connection_id)
+            .collect::<Vec<_>>();
+
+        assert_eq!(candidates, vec![connection_id(0)]);
+    }
+
+    /// The other half of composing: dedup lowers the active count, so a host
+    /// that was only over its high-water mark because of duplicates stops
+    /// shedding whole peers.
+    #[test]
+    fn dedup_relieves_high_water_pressure() {
+        let mut manager = ActiveConnectionManager::new(1, 2, Duration::from_secs(20));
+        let now = Instant::now();
+        let (local, remote) = ordered_peers();
+
+        direct(&mut manager, 0, remote, now);
+        direct(&mut manager, 1, remote, now + Duration::from_secs(1));
+        direct(
+            &mut manager,
+            2,
+            PeerId::random(),
+            now + Duration::from_secs(2),
+        );
+        assert_eq!(manager.redundant_connections(local, remote).len(), 1);
+
+        assert!(manager
+            .prune_candidates(now + Duration::from_secs(30))
             .is_empty());
     }
 }

--- a/crates/p2p/src/host/p2p_host/mod.rs
+++ b/crates/p2p/src/host/p2p_host/mod.rs
@@ -16,8 +16,13 @@ use futures::StreamExt;
 use iroh_bitswap::Store;
 use libp2p::{
     identity::Keypair,
+    multiaddr::Protocol,
     noise, request_response,
-    swarm::{behaviour::toggle::Toggle, dial_opts::DialOpts},
+    swarm::{
+        behaviour::toggle::Toggle,
+        dial_opts::{DialOpts, PeerCondition},
+        DialError,
+    },
     tcp, yamux, Multiaddr, PeerId, Swarm, SwarmBuilder,
 };
 use sysinfo::{MemoryRefreshKind, RefreshKind, System};
@@ -715,25 +720,49 @@ impl<S: Store + Clone + Send + Sync + 'static> P2PHost<S> {
     }
 
     /// Dial a peer at the given addresses.
+    ///
+    /// Naming the peer lets libp2p skip the dial when one is already connected
+    /// or in flight, so a repeated connect cannot stack a second connection
+    /// (#1449). Like Go's `Connect`, which returns nil once connected, a
+    /// skipped dial is success rather than an error.
     pub(super) fn dial_peer(&mut self, peer_id: PeerId, addrs: Vec<Multiaddr>) -> Result<()> {
-        for addr in addrs {
-            let dial_addr = addr.with(libp2p::multiaddr::Protocol::P2p(peer_id));
-            // Preserve ephemeral source ports now that TCP config no longer controls reuse.
-            let dial_opts = DialOpts::unknown_peer_id()
-                .address(dial_addr.clone())
-                .allocate_new_port()
-                .build();
-            match self.swarm.dial(dial_opts) {
-                Ok(_) => {
-                    debug!("Dialing peer {} at {}", peer_id, dial_addr);
-                    return Ok(());
+        let dial_addrs: Vec<Multiaddr> = addrs
+            .into_iter()
+            .map(|addr| {
+                if addr.iter().any(|part| matches!(part, Protocol::P2p(_))) {
+                    addr
+                } else {
+                    addr.with(Protocol::P2p(peer_id))
                 }
-                Err(e) => {
-                    warn!("Failed to dial {}: {}", dial_addr, e);
-                }
+            })
+            .collect();
+        if dial_addrs.is_empty() {
+            return Err(Error::Dial(format!("no addresses to dial peer {peer_id}")));
+        }
+
+        // `allocate_new_port` keeps outbound dials on an ephemeral source port.
+        // libp2p 0.56 moved that choice from the TCP transport to the dial, so
+        // dropping it would restore the persistent `EADDRINUSE` dial failures
+        // that #1021 traced to binding dials to the listen port.
+        let dial_opts = DialOpts::peer_id(peer_id)
+            .condition(PeerCondition::DisconnectedAndNotDialing)
+            .addresses(dial_addrs.clone())
+            .allocate_new_port()
+            .build();
+        match self.swarm.dial(dial_opts) {
+            Ok(()) => {
+                debug!("Dialing peer {} at {:?}", peer_id, dial_addrs);
+                Ok(())
+            }
+            Err(DialError::DialPeerConditionFalse(_)) => {
+                debug!("Peer {} already connected or being dialed", peer_id);
+                Ok(())
+            }
+            Err(e) => {
+                warn!("Failed to dial {}: {}", peer_id, e);
+                Err(Error::Dial(format!("Failed to dial peer {peer_id}: {e}")))
             }
         }
-        Err(Error::Dial(format!("Failed to dial peer {}", peer_id)))
     }
 
     /// Send a PushLog response through the given channel.

--- a/crates/p2p/src/host/p2p_host/swarm.rs
+++ b/crates/p2p/src/host/p2p_host/swarm.rs
@@ -1,14 +1,30 @@
 //! Swarm event handling.
 
 use iroh_bitswap::Store;
+use libp2p::core::ConnectedPoint;
+use libp2p::multiaddr::Protocol;
 use libp2p::swarm::{ConnectionId, SwarmEvent};
 use libp2p::PeerId;
 use tracing::{debug, error, info, warn};
 
 use crate::behaviour::DefraEvent;
 
+use super::connection_manager::ConnectionPath;
 use super::P2PHost;
 use crate::host::event::HostEvent;
+
+/// Whether a connection reaches the peer directly or through a circuit relay.
+fn connection_path(endpoint: &ConnectedPoint) -> ConnectionPath {
+    let address = match endpoint {
+        ConnectedPoint::Dialer { address, .. } => address,
+        ConnectedPoint::Listener { send_back_addr, .. } => send_back_addr,
+    };
+    if address.iter().any(|part| part == Protocol::P2pCircuit) {
+        ConnectionPath::Relayed
+    } else {
+        ConnectionPath::Direct
+    }
+}
 
 impl<S: Store> P2PHost<S> {
     /// Handle a swarm event.
@@ -37,11 +53,34 @@ impl<S: Store> P2PHost<S> {
                 ..
             } => {
                 info!(peer_id = %peer_id, "Peer connected");
+                let local_peer_id = *self.swarm.local_peer_id();
                 self.connection_manager.on_established(
                     connection_id,
                     peer_id,
+                    connection_path(&endpoint),
+                    endpoint.is_dialer(),
                     tokio::time::Instant::now(),
                 );
+
+                let mut superseded = false;
+                for redundant in self
+                    .connection_manager
+                    .redundant_connections(local_peer_id, peer_id)
+                {
+                    superseded |= redundant == connection_id;
+                    debug!(
+                        peer_id = %peer_id,
+                        connection_id = %redundant,
+                        "Closing redundant connection; one connection per peer"
+                    );
+                    self.swarm.close_connection(redundant);
+                }
+                // A superseded connection contributes nothing: its address is
+                // about to disappear, and `PeerConnected` already fired for the
+                // connection that survives.
+                if superseded {
+                    return false;
+                }
 
                 // Store the remote peer's address from the connection endpoint.
                 // For dialer: the address we dialed (peer's listen addr).


### PR DESCRIPTION
Fixes #1449. Depends on and includes the bump for #1452.

## The bug

When more than one libp2p connection exists between a Rust node and a Go node, **Rust→Go gossipsub
is permanently destroyed** — doc-sync replies, KMS traffic and broadcast all go one-way in silence
while the peer still reports `active=true`.

- rust-libp2p gives every connection its own gossipsub handler draining one shared per-peer send
  queue (`libp2p-gossipsub-0.49.5` `behaviour.rs:3174/3201` → `rpc.rs:68`, a cloned MPMC receiver),
  so a second connection means a second `/meshsub` substream.
- go-libp2p-pubsub keeps exactly one inbound stream per peer and resets the rest
  (`go-libp2p-pubsub@v0.15.0/comm.go:44-52`).
- The two substreams reset each other until rust-libp2p disables the handler after
  `MAX_SUBSTREAM_ATTEMPTS` (`handler.rs:504-510`) — `Handler::Disabled`, with no recovery path.

This is what has been failing `parity::parity_lww_tie_partition_mixed` on the `go-compat` leg at
roughly a 1-in-4 rate — it hit #1446, #1440 and #1454, none of which go anywhere near P2P.

## Two commits, bump first

```
e96d6022  chore(deps): bump iroh-bitswap for the shared-connection fix (#1452)
67425033  fix(p2p): keep one connection per peer to stop gossipsub dying against Go (#1449)
```

The order is deliberate and bisect-safe: at `e96d6022` the tree has the bitswap fix without the
dedup, which is strictly an improvement; at `67425033` both are present. Reversed, the intermediate
commit would be the ~40-60% storm-failure state.

**The bump is load-bearing, not incidental.** iroh-bitswap pinned peer state to a single
`ConnectionId` and re-dialed with `PeerCondition::Always` — it *required* its own connection, and was
itself a producer of the duplicate connections this PR removes. Collapsing to one connection per peer
killed bitswap outright (0 substreams, 0 messages), which surfaced as lost CRDT deltas in
`convergence_concurrent_same_doc_merge_storm`. Fixed upstream in
[beetle#6](https://github.com/sourcenetwork/beetle/pull/6) (merged, `255e4cfe`), which also fixed a
dial-resolution deadlock found along the way: `HandlerEvent::Connected` is never constructed
anywhere in that crate, so *no* dial had ever resolved on success — every first-contact dial burned
the full 20s `CONNECT_TIMEOUT`.

## The dedup

- `dial_peer` names the peer and dials only when disconnected and not already dialing, so a repeated
  connect stops stacking connections. A skipped dial is success, matching Go's `Connect`. It keeps
  `allocate_new_port`, which is where libp2p 0.56 moved the ephemeral source port that #1021 depends
  on — dropping it would restore those `EADDRINUSE` failures.
- `ActiveConnectionManager` reports redundant connections on establishment, preferring the direct
  path so a relayed-to-direct upgrade keeps the direct link, and **breaking ties on which peer id
  dialed** so both ends drop the *same* connection. That second key matters: "oldest wins" is
  computed locally, so two peers dialing simultaneously can disagree and sever the link entirely.
  Pinned by `both_ends_drop_the_same_connection`.
- Per-peer dedup and the existing high-water prune share one registry and one `closing` flag, so
  neither re-selects what the other gave up.

Rejected: `ConnectionLimits::with_max_established_per_peer(1)`. Denying at establishment makes the
*remote's* dial fail, and Go's `SetReplicator` calls `Connect`, so `p2p replicator add` would error.

## Verification, on current main against the merged upstream rev

```
== parity TOTAL pass=10 fail=0 of 10      (parity_lww_tie_partition_mixed; baseline 0/8)
== storm  TOTAL pass=10 fail=0 of 10      (convergence_concurrent_same_doc_merge_storm)
== pncounter TOTAL pass=2 fail=0 of 2
```

| Check | Result |
|---|---|
| `--test p2p` | 75 passed, 0 failed |
| `--test p2p_iroh -- connection::` | 27 passed, 0 failed |
| `tla_conformance` (serial, full) | 5 passed + 28 passed, 0 failed |
| `cargo test -p p2p --lib` | 453 passed, 0 failed |
| `#1021` EADDRINUSE regression (`bughunt_counter_3node`) | 5/5, no `Address already in use` |
| fmt / `clippy --all -D warnings` | clean / exit 0 |

Bitswap trace against the merged rev with no `[patch]` anywhere: `outbound=10 inbound=10
server_recv=10`, with **2 connections per node in a 3-node mesh** — one per peer. Both invariants
hold at once, which is the point. Note the absolute count varies between runs (50, 23, 10 measured
across sessions) because bitswap is the DAG fetcher's *fallback*, engaged only when a CAR request
fails; the signal is non-zero vs zero, not the magnitude.

## Known gaps, stated rather than implied

- **No DCUtR coverage exists.** `DefraBehaviour` has no dcutr or autonat behaviour — only a relay
  *client* transport — and no test establishes a circuit-relayed connection. The direct-over-relayed
  preference is covered by unit tests only; a live relayed→direct upgrade could not be demonstrated
  because the code path to produce one does not exist.
- `--test p2p_backlog` still fails with `retained task handles grew unbounded: 41`. Pre-existing on
  baseline, unchanged here, not chased.
- Related latent defect filed as #1450: `push_docs.rs` pushes field blocks as standalone PushLog
  heads, which Go rejects. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
