### PR TITLE
fix(schema): reject multiple active collection versions

### DIFF
--- a/crates/schema/src/definition_validation/mod.rs
+++ b/crates/schema/src/definition_validation/mod.rs
@@ -54,6 +54,7 @@ const UPDATE_VALIDATORS: &[Validator] = &[
     validate_collection_id_not_mutated,
     validate_id_not_empty,
     validate_id_unique,
+    validate_single_version_active,
     validate_field_not_moved,
     validate_field_not_mutated,
     validate_policy_not_modified,

--- a/crates/schema/src/definition_validation/update_validators.rs
+++ b/crates/schema/src/definition_validation/update_validators.rs
@@ -136,7 +136,6 @@ pub(super) fn validate_id_unique(
 }
 
 /// Matches Go's validateSingleVersionActive.
-#[allow(dead_code)]
 pub(super) fn validate_single_version_active(
     new_state: &DefinitionState,
     _old_state: &DefinitionState,

--- a/crates/schema/tests/validation_tests.rs
+++ b/crates/schema/tests/validation_tests.rs
@@ -110,6 +110,27 @@ fn test_unique_collection_names_ok() {
     assert!(validate_schema(&collections).is_ok());
 }
 
+#[test]
+fn test_multiple_active_versions_of_collection_fail() {
+    let mut old_version = user_collection();
+    old_version.is_active = false;
+
+    let mut active_version = old_version.clone();
+    active_version.name = "people".into();
+    active_version.version_id = "v2".into();
+    active_version.is_active = true;
+
+    let old_state = vec![old_version.clone(), active_version.clone()];
+    old_version.is_active = true;
+
+    let error = schema::definition_validation::validate_collection_changes(
+        &old_state,
+        &[old_version, active_version],
+    )
+    .unwrap_err();
+    assert!(error.contains("multiple versions of same collection cannot be active"));
+}
+
 // ============================================================================
 // Relation Primary Validation Tests
 // ============================================================================


### PR DESCRIPTION
Refs #1404.

## Problem

Rust already implemented the Go-compatible single-active-version validator, but omitted it from the update validator list. A collection update could therefore leave multiple definitions with the same collection ID active, accepting a state that Go rejects.

## What changed

- Register `validate_single_version_active` for collection updates.
- Remove the obsolete dead-code allowance from the validator.
- Add regression coverage through the public collection-change validation path.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p schema`
- [x] `cargo test -p db patch`
- [x] `cargo clippy -p schema --all-targets -- -D warnings`
- [x] `git diff --check origin/main...HEAD`