### PR TITLE
fix(schema): validate relation ID field kinds

### DIFF
--- a/crates/schema/src/collection.rs
+++ b/crates/schema/src/collection.rs
@@ -330,6 +330,7 @@ impl CollectionVersion {
         self.validate_no_duplicate_index_names()?;
         self.validate_encrypted_indexes()?;
         self.validate_fields()?;
+        self.validate_relation_id_field_kinds()?;
         self.validate_policy()?;
         self.validate_downsample()?;
         Ok(())
@@ -357,6 +358,24 @@ impl CollectionVersion {
                 return Err(SchemaError::EncryptedIndexAlreadyExists(
                     index.field_name.clone(),
                 ));
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_relation_id_field_kinds(&self) -> Result<()> {
+        for field in self
+            .relation_fields()
+            .filter(|field| !field.kind.is_array())
+        {
+            let id_field_name = Self::relation_id_field_name(&field.name);
+            if let Some(id_field) = self.field_by_name(&id_field_name) {
+                if id_field.kind != FieldKind::doc_id() {
+                    return Err(SchemaError::InvalidRelationIdFieldKind {
+                        field_name: id_field_name,
+                        actual: id_field.kind.graphql_type_name().to_string(),
+                    });
+                }
             }
         }
         Ok(())

--- a/crates/schema/src/collection.rs
+++ b/crates/schema/src/collection.rs
@@ -328,6 +328,7 @@ impl CollectionVersion {
     pub fn validate(&self) -> Result<()> {
         self.validate_no_duplicate_names()?;
         self.validate_no_duplicate_index_names()?;
+        self.validate_encrypted_indexes()?;
         self.validate_fields()?;
         self.validate_policy()?;
         self.validate_downsample()?;
@@ -339,6 +340,23 @@ impl CollectionVersion {
         for index in &self.indexes {
             if !seen.insert(&index.name) {
                 return Err(SchemaError::DuplicateIndexName(index.name.clone()));
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_encrypted_indexes(&self) -> Result<()> {
+        let mut encrypted_fields = HashSet::new();
+        for index in &self.encrypted_indexes {
+            if self.field_by_name(&index.field_name).is_none() {
+                return Err(SchemaError::EncryptedIndexUnknownField(
+                    index.field_name.clone(),
+                ));
+            }
+            if !encrypted_fields.insert(index.field_name.as_str()) {
+                return Err(SchemaError::EncryptedIndexAlreadyExists(
+                    index.field_name.clone(),
+                ));
             }
         }
         Ok(())

--- a/crates/schema/src/error.rs
+++ b/crates/schema/src/error.rs
@@ -60,6 +60,12 @@ pub enum SchemaError {
     #[error("index with name already exists. Name: {0}")]
     DuplicateIndexName(String),
 
+    #[error("encrypted index on non-existent field. Field: {0}")]
+    EncryptedIndexUnknownField(String),
+
+    #[error("encrypted index already exists on this field. Field: {0}")]
+    EncryptedIndexAlreadyExists(String),
+
     #[error("invalid downsample configuration: {0}")]
     InvalidDownsample(String),
 

--- a/crates/schema/src/error.rs
+++ b/crates/schema/src/error.rs
@@ -27,6 +27,11 @@ pub enum SchemaError {
     #[error("relation primary conflict: exactly one side of relation {relation_name} must be marked primary")]
     RelationPrimaryConflict { relation_name: String },
 
+    #[error(
+        "relational id field of invalid kind. Field: {field_name}, Expected: ID, Actual: {actual}"
+    )]
+    InvalidRelationIdFieldKind { field_name: String, actual: String },
+
     #[error("duplicate collection name: {0}")]
     DuplicateCollectionName(String),
 

--- a/crates/schema/tests/collection_tests.rs
+++ b/crates/schema/tests/collection_tests.rs
@@ -8,8 +8,8 @@
 //! - Serialization roundtrip
 
 use schema::{
-    CType, CollectionBuilder, CollectionVersion, FieldDescription, FieldKind, PolicyDescription,
-    SchemaError,
+    CType, CollectionBuilder, CollectionVersion, EncryptedIndexDescription, FieldDescription,
+    FieldKind, PolicyDescription, SchemaError,
 };
 use std::collections::HashMap;
 
@@ -143,6 +143,31 @@ fn test_validate_invalid_crdt_fails() {
 fn test_validate_valid_collection() {
     let coll = CollectionVersion::new("users", "v1", "coll-1", sample_fields());
     assert!(coll.validate().is_ok());
+}
+
+#[test]
+fn test_validate_encrypted_index_field_exists() {
+    let mut coll = CollectionVersion::new("users", "v1", "coll-1", sample_fields());
+    coll.encrypted_indexes = vec![EncryptedIndexDescription::new("missing")];
+
+    assert!(matches!(
+        coll.validate().unwrap_err(),
+        SchemaError::EncryptedIndexUnknownField(field) if field == "missing"
+    ));
+}
+
+#[test]
+fn test_validate_encrypted_index_field_is_unique() {
+    let mut coll = CollectionVersion::new("users", "v1", "coll-1", sample_fields());
+    coll.encrypted_indexes = vec![
+        EncryptedIndexDescription::new("name"),
+        EncryptedIndexDescription::new("name"),
+    ];
+
+    assert!(matches!(
+        coll.validate().unwrap_err(),
+        SchemaError::EncryptedIndexAlreadyExists(field) if field == "name"
+    ));
 }
 
 // ============================================================================

--- a/crates/schema/tests/collection_tests.rs
+++ b/crates/schema/tests/collection_tests.rs
@@ -170,6 +170,22 @@ fn test_validate_encrypted_index_field_is_unique() {
     ));
 }
 
+#[test]
+fn test_validate_relation_id_field_kind() {
+    let fields = vec![
+        FieldDescription::new("1", "author", FieldKind::relation("users", false))
+            .with_relation_name("post_author"),
+        FieldDescription::new("2", "_authorID", FieldKind::string()),
+    ];
+    let coll = CollectionVersion::new("posts", "v1", "coll-1", fields);
+
+    assert!(matches!(
+        coll.validate().unwrap_err(),
+        SchemaError::InvalidRelationIdFieldKind { field_name, actual }
+            if field_name == "_authorID" && actual == "String"
+    ));
+}
+
 // ============================================================================
 // Policy Validation Tests
 // ============================================================================


### PR DESCRIPTION
Refs #1404.

Depends on #1488.

## Problem

Relation finalization skips generating a backing field when one already exists. Rust did not verify that an existing field such as `_authorID` was a `DocID`, so a malformed definition could preserve another scalar kind and be persisted. Go rejects this state through `validateRelationalFieldIDType`.

## What changed

- Validate existing backing fields for non-array relations.
- Return a specific schema error when the backing field is not `DocID`.
- Add regression coverage for a relation backed by a string field.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p schema`
- [x] `cargo test -p db collection`
- [x] `cargo clippy -p schema --all-targets -- -D warnings`
- [x] `git diff --check`