### PR TITLE
fix(http): add the P2P disconnect route

### DIFF
--- a/crates/http/src/handlers/p2p/mod.rs
+++ b/crates/http/src/handlers/p2p/mod.rs
@@ -44,8 +44,8 @@ pub use collections::{
 pub use documents::{add_documents, list_documents, remove_documents, sync_documents};
 pub use manage::{manage, manage_query};
 pub use peers::{
-    active_peers, connect, connect_peer, get_info, get_shareable_address, list_peers, sync_status,
-    ConnectPeerRequest, P2pInfoResponse, PeerInfo, ShareableAddressResponse,
+    active_peers, connect, connect_peer, disconnect, get_info, get_shareable_address, list_peers,
+    sync_status, ConnectPeerRequest, P2pInfoResponse, PeerInfo, ShareableAddressResponse,
 };
 pub use replicators::{
     add_replicator, list_replicators, remove_replicator, ReplicatorDeleteRequest,

--- a/crates/http/src/handlers/p2p/peers.rs
+++ b/crates/http/src/handlers/p2p/peers.rs
@@ -200,6 +200,32 @@ pub async fn connect(
     Ok(())
 }
 
+/// Disconnect from peers (Go-compatible format).
+///
+/// POST /api/v0/p2p/disconnect
+///
+/// Body: ["/ip4/.../p2p/...", ...]
+///
+/// Requires `P2pPeerDisconnect` permission when NAC is enabled.
+pub async fn disconnect(
+    State(state): State<AppState>,
+    identity: ExtractIdentity,
+    Json(addresses): Json<Vec<String>>,
+) -> Result<(), HttpError> {
+    require_permission(&state, &identity, NodePermission::P2pPeerDisconnect).await?;
+
+    let p2p = state.require_p2p()?;
+
+    for addr in &addresses {
+        validate_multiaddr(addr)?;
+        p2p.disconnect_peer(addr)
+            .await
+            .map_err(map_p2p_bad_request)?;
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -38,6 +38,7 @@
 //! - `GET /api/v1/p2p/shareable-address` - Get the single best shareable P2P address (`handlers/p2p/peers.rs`)
 //! - `GET /api/v1/p2p/active-peers` - List connected peers in Go-compatible format (`handlers/p2p/peers.rs`)
 //! - `POST /api/v1/p2p/connect` - Connect to peers in Go-compatible format (`handlers/p2p/peers.rs`)
+//! - `POST /api/v1/p2p/disconnect` - Disconnect from peers in Go-compatible format (`handlers/p2p/peers.rs`)
 //! - `GET /api/v1/p2p/peers` - List connected peers (`handlers/p2p/peers.rs`)
 //! - `POST /api/v1/p2p/peers` - Connect to peer (`handlers/p2p/peers.rs`)
 //! - `GET /api/v1/p2p/replicators` - List replicators (`handlers/p2p/replicators.rs`)

--- a/crates/http/src/route_permissions.rs
+++ b/crates/http/src/route_permissions.rs
@@ -343,4 +343,3 @@ fn normalize_api_version(path: &str) -> Cow<'_, str> {
         None => Cow::Borrowed(path),
     }
 }
-

--- a/crates/http/src/route_permissions.rs
+++ b/crates/http/src/route_permissions.rs
@@ -343,3 +343,4 @@ fn normalize_api_version(path: &str) -> Cow<'_, str> {
         None => Cow::Borrowed(path),
     }
 }
+

--- a/crates/http/src/route_permissions.rs
+++ b/crates/http/src/route_permissions.rs
@@ -147,6 +147,7 @@ pub fn route_permission(path: &str, method: &Method) -> RoutePermission {
         "/api/v0/p2p/shareable-address" => RoutePermission::Required(NodePermission::P2pPeerInfo),
         "/api/v0/p2p/active-peers" => RoutePermission::Required(NodePermission::P2pPeerActive),
         "/api/v0/p2p/connect" => RoutePermission::Required(NodePermission::P2pPeerConnect),
+        "/api/v0/p2p/disconnect" => RoutePermission::Required(NodePermission::P2pPeerDisconnect),
         "/api/v0/p2p/peers" => match *method {
             Method::GET => RoutePermission::Required(NodePermission::P2pPeerConnect),
             Method::POST => RoutePermission::Required(NodePermission::P2pPeerConnect),

--- a/crates/http/src/router/routes.rs
+++ b/crates/http/src/router/routes.rs
@@ -168,6 +168,7 @@ pub(crate) fn create_router_with_state_and_body_limits(
         )
         .route("/active-peers", get(handlers::p2p::active_peers)) // Go-compatible
         .route("/connect", post(handlers::p2p::connect)) // Go-compatible
+        .route("/disconnect", post(handlers::p2p::disconnect)) // Go-compatible
         .route("/peers", get(handlers::p2p::list_peers))
         .route("/peers", post(handlers::p2p::connect_peer)) // Legacy
         .route("/replicators", get(handlers::p2p::list_replicators)) // Go uses /replicators
@@ -356,7 +357,8 @@ pub(crate) fn create_router_with_state_and_body_limits(
 mod tests {
     use super::*;
     use crate::mock::{
-        FailingMockP2POperations, MockDocumentAcpOperations, MockQueryExecutor, MockRestOperations,
+        FailingMockP2POperations, MockDocumentAcpOperations, MockP2POperations, MockQueryExecutor,
+        MockRestOperations,
     };
     use crate::router::{
         DocumentAcpOperations, ManageRequester, P2POperations, P2PResult, P2pDocumentInfo,
@@ -558,6 +560,31 @@ mod tests {
             status_for_p2p_request(Method::POST, "/api/v0/p2p/collections", r#"["Users"]"#).await;
 
         assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[tokio::test]
+    async fn p2p_disconnect_removes_connected_peer() {
+        let executor = Arc::new(MockQueryExecutor::new()) as Arc<dyn QueryExecutor>;
+        let p2p = Arc::new(MockP2POperations::new().with_peer("12D3KooWtest"));
+        let state = AppStateBuilder::new(executor).with_p2p(p2p.clone()).build();
+        let router = create_router_with_state(state);
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/v0/p2p/disconnect")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"["/ip4/127.0.0.1/tcp/9000/p2p/12D3KooWtest"]"#,
+                    ))
+                    .expect("request should build"),
+            )
+            .await
+            .expect("router should respond");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(p2p.connected_peers().await.unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/crates/http/tests/route_permissions.rs
+++ b/crates/http/tests/route_permissions.rs
@@ -135,6 +135,10 @@ fn p2p_routes() {
         RoutePermission::Required(NodePermission::P2pPeerInfo)
     );
     assert_eq!(
+        route_permission("/api/v0/p2p/disconnect", &Method::POST),
+        RoutePermission::Required(NodePermission::P2pPeerDisconnect)
+    );
+    assert_eq!(
         route_permission("/api/v0/p2p/replicators", &Method::GET),
         RoutePermission::Required(NodePermission::P2pReplicatorList)
     );
@@ -361,6 +365,11 @@ fn all_registered_routes_return_expected_permission() {
             "/api/v0/p2p/connect",
             Method::POST,
             RoutePermission::Required(NodePermission::P2pPeerConnect),
+        ),
+        (
+            "/api/v0/p2p/disconnect",
+            Method::POST,
+            RoutePermission::Required(NodePermission::P2pPeerDisconnect),
         ),
         (
             "/api/v0/p2p/replicators",


### PR DESCRIPTION
## Problem

The Rust HTTP API does not expose the Go-compatible `POST /api/v0/p2p/disconnect` route, so API clients cannot explicitly disconnect peers through the same interface. This is one of the route parity gaps tracked in #1425.

## What changed

- register `/p2p/disconnect` under both API versions
- accept Go-compatible address arrays, validate each address, and delegate to the existing P2P disconnect operation
- enforce the `P2pPeerDisconnect` permission
- cover route delegation and permission selection

## Validation

- [x] `cargo test -p defra-http`
- [x] `cargo clippy -p defra-http --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`

Refs #1425