### PR TITLE
ci: make signed-docs the sole PR integration leg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,25 +51,50 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       full: ${{ steps.decide.outputs.full }}
+      integration_matrix: ${{ steps.decide.outputs.integration_matrix }}
     steps:
       - id: decide
         uses: actions/github-script@v7
         with:
           script: |
-            if (context.eventName !== 'pull_request') {
-              core.setOutput('full', 'true');
-              return;
+            let full = true;
+            if (context.eventName === 'pull_request') {
+              const stack = context.payload.pull_request && context.payload.pull_request.stack;
+              if (stack) {
+                const isTip = stack.position === stack.size;
+                const isLowest = stack.base && stack.base.ref === context.payload.pull_request.base.ref;
+                full = isTip || isLowest;
+                core.info(`stack #${stack.number} pos ${stack.position}/${stack.size} full=${full}`);
+              }
             }
-            const stack = context.payload.pull_request && context.payload.pull_request.stack;
-            if (!stack) {
-              core.setOutput('full', 'true');
-              return;
-            }
-            const isTip = stack.position === stack.size;
-            const isLowest = stack.base && stack.base.ref === context.payload.pull_request.base.ref;
-            const full = isTip || isLowest;
             core.setOutput('full', full ? 'true' : 'false');
-            core.info(`stack #${stack.number} pos ${stack.position}/${stack.size} full=${full}`);
+
+            // Integration matrix. Defined here rather than statically on the
+            // `integration` job so the suite list can depend on the event.
+            //
+            // signed-docs (#978) sets DEFRA_MULTIPLIERS=signed-docs so every
+            // cluster gets .with_signing() auto-applied. Signing is the
+            // node's DEFAULT configuration, so this leg is the primary
+            // integration signal and runs on every PR. The `rust` suite is
+            // the --no-signing mirror of the same test set; it runs only on
+            // non-PR events (push to main, merge queue) so each PR occupies
+            // the studio-1 slot with one full suite instead of two. An
+            // unsigned-only regression therefore surfaces on the main run
+            // after merge rather than at PR time — accepted trade, revert to
+            // unconditional if that starts biting.
+            //
+            // Each host uses sccache with incremental compilation disabled so
+            // jobs sharing its persistent target tree keep consistent flags.
+            const slot = { cargo_incremental: '0', rustc_wrapper: 'sccache' };
+            const suites = [
+              { suite: 'signed-docs', needs_go: false, multipliers: 'signed-docs', host: 'studio-1', ...slot },
+              { suite: 'go-compat', needs_go: true, host: 'studio-2', ...slot },
+              { suite: 'iroh', needs_go: false, host: 'studio-2', ...slot },
+            ];
+            if (context.eventName !== 'pull_request') {
+              suites.push({ suite: 'rust', needs_go: false, host: 'studio-1', ...slot });
+            }
+            core.setOutput('integration_matrix', JSON.stringify({ include: suites }));
 
   # Studio jobs are pinned to a runner slot so each job's incremental target
   # state stays warm on one machine (a suite that bounces between hosts turns
@@ -78,10 +103,11 @@ jobs:
   #
   #   primary (labels ...,studio,studio-N) — one job at a time, so two
   #   node-spawning jobs can only co-run on DIFFERENT hosts, where they
-  #   cannot contend on localhost ports. studio-1 carries rust and
-  #   signed-docs; studio-2 carries conformance, go-compat, and iroh. `build`
-  #   floats between the two and publishes its binaries to both, so every
-  #   suite restores from its own host's cache whichever host built them.
+  #   cannot contend on localhost ports. studio-1 carries signed-docs (plus
+  #   the unsigned rust mirror on non-PR runs); studio-2 carries conformance,
+  #   go-compat, and iroh. `build` floats between the two and publishes its
+  #   binaries to both, so every suite restores from its own host's cache
+  #   whichever host built them.
   #
   #   light (labels ...,defra-light,studio-N-b) — deliberately NOT labeled
   #   `studio`/`studio-N`, so node-spawning jobs can never land there. Serves
@@ -352,16 +378,25 @@ jobs:
 
           # Staged through .tmp and renamed on the peer, so an interrupted
           # copy cannot leave a truncated binary that the peer would later
-          # treat as a valid cache hit.
-          if ssh $SSH_OPTS "$PEER" "mkdir -p '$CACHE_DIR'" \
-            && scp -p $SSH_OPTS "$CACHE_DIR/defra" "$PEER:$CACHE_DIR/defra.tmp" \
-            && scp -p $SSH_OPTS "$CACHE_DIR/defra-iroh" "$PEER:$CACHE_DIR/defra-iroh.tmp" \
-            && ssh $SSH_OPTS "$PEER" \
-                 "mv '$CACHE_DIR/defra.tmp' '$CACHE_DIR/defra' \
-                  && mv '$CACHE_DIR/defra-iroh.tmp' '$CACHE_DIR/defra-iroh'"; then
-            echo "Published binaries to $PEER:$CACHE_DIR"
-          else
-            echo "::warning::could not publish binary cache to $PEER — its first integration job will rebuild"
+          # treat as a valid cache hit. Two attempts: on 2026-08-14 a single
+          # transient SSH failure here (and on the consumer's pull) cost the
+          # sibling's first integration job a 40-minute rebuild.
+          published=""
+          for attempt in 1 2; do
+            if ssh $SSH_OPTS "$PEER" "mkdir -p '$CACHE_DIR'" \
+              && scp -p $SSH_OPTS "$CACHE_DIR/defra" "$PEER:$CACHE_DIR/defra.tmp" \
+              && scp -p $SSH_OPTS "$CACHE_DIR/defra-iroh" "$PEER:$CACHE_DIR/defra-iroh.tmp" \
+              && ssh $SSH_OPTS "$PEER" \
+                   "mv '$CACHE_DIR/defra.tmp' '$CACHE_DIR/defra' \
+                    && mv '$CACHE_DIR/defra-iroh.tmp' '$CACHE_DIR/defra-iroh'"; then
+              echo "Published binaries to $PEER:$CACHE_DIR (attempt $attempt)"
+              published=1
+              break
+            fi
+            [ "$attempt" -eq 1 ] && sleep 10
+          done
+          if [ -z "$published" ]; then
+            echo "::warning::could not publish binary cache to $PEER after 2 attempts — its first integration job will rebuild"
           fi
 
       # OTel-only tests, run AFTER caching so the otel rebuild of target/debug/defra
@@ -500,36 +535,11 @@ jobs:
       # `max-parallel: 1` whole-matrix serialization. Both hosts restore from
       # a host-local binary cache that `build` publishes to each of them; the
       # self-build below is the fallback for when that publish did not land.
-      matrix:
-        include:
-          # Each host uses sccache with incremental compilation disabled so
-          # jobs sharing its persistent target tree keep consistent flags.
-          - suite: rust
-            needs_go: false
-            host: studio-1
-            cargo_incremental: "0"
-            rustc_wrapper: sccache
-          - suite: go-compat
-            needs_go: true
-            host: studio-2
-            cargo_incremental: "0"
-            rustc_wrapper: sccache
-          - suite: iroh
-            needs_go: false
-            host: studio-2
-            cargo_incremental: "0"
-            rustc_wrapper: sccache
-          # #978: re-run the rust integration suite with
-          # DEFRA_MULTIPLIERS=signed-docs so every cluster gets
-          # .with_signing() auto-applied. Catches regressions in
-          # unrelated features that only surface when blocks carry
-          # Signature links (mirrors Go DefraDB PR #4746).
-          - suite: signed-docs
-            needs_go: false
-            multipliers: signed-docs
-            host: studio-1
-            cargo_incremental: "0"
-            rustc_wrapper: sccache
+      #
+      # The suite list comes from `ci-scope`: signed-docs (the node default)
+      # runs on every full run, while the unsigned `rust` mirror is scoped to
+      # non-PR events. See the matrix construction there for the rationale.
+      matrix: ${{ fromJson(needs.ci-scope.outputs.integration_matrix) }}
     env:
       DEFRA_RUST_BINARY: ${{ github.workspace }}/target/ci/defra
       DEFRA_IROH_BINARY: ${{ github.workspace }}/target/ci/defra-iroh
@@ -563,15 +573,29 @@ jobs:
           PEER=$(.github/scripts/studio-peer.sh)
           SSH_OPTS="-o BatchMode=yes -o ConnectTimeout=5 -o ServerAliveInterval=5 -o ServerAliveCountMax=3"
 
+          # Staged via .tmp so an interrupted copy cannot leave a truncated
+          # binary that later runs would treat as a valid cache hit. Two
+          # attempts, matching the producer's publish: a transient SSH
+          # failure on this pull is what turned 2026-08-14's runs into
+          # 40-minute rebuilds.
+          pulled=""
+          if ! { [ -f "$CACHE_DIR/defra" ] && [ -f "$CACHE_DIR/defra-iroh" ]; } && [ -n "$PEER" ]; then
+            for attempt in 1 2; do
+              if scp -p $SSH_OPTS "$PEER:$CACHE_DIR/defra" "$CACHE_DIR/defra.tmp" \
+                && scp -p $SSH_OPTS "$PEER:$CACHE_DIR/defra-iroh" "$CACHE_DIR/defra-iroh.tmp"; then
+                pulled=1
+                break
+              fi
+              rm -f "$CACHE_DIR/defra.tmp" "$CACHE_DIR/defra-iroh.tmp"
+              [ "$attempt" -eq 1 ] && sleep 10
+            done
+          fi
+
           if [ -f "$CACHE_DIR/defra" ] && [ -f "$CACHE_DIR/defra-iroh" ]; then
             echo "Cache hit (local) — restoring from $CACHE_DIR"
             cp "$CACHE_DIR/defra" target/ci/defra
             cp "$CACHE_DIR/defra-iroh" target/ci/defra-iroh
-          elif [ -n "$PEER" ] \
-            && scp -p $SSH_OPTS "$PEER:$CACHE_DIR/defra" "$CACHE_DIR/defra.tmp" \
-            && scp -p $SSH_OPTS "$PEER:$CACHE_DIR/defra-iroh" "$CACHE_DIR/defra-iroh.tmp"; then
-            # Staged via .tmp so an interrupted copy cannot leave a truncated
-            # binary that later runs would treat as a valid cache hit.
+          elif [ -n "$pulled" ]; then
             mv "$CACHE_DIR/defra.tmp" "$CACHE_DIR/defra"
             mv "$CACHE_DIR/defra-iroh.tmp" "$CACHE_DIR/defra-iroh"
             echo "Cache hit (peer $PEER over Thunderbolt)"
@@ -854,7 +878,7 @@ jobs:
           "$DEFRA_RUST_BINARY" version --format json
           "$DEFRA_IROH_BINARY" version --format json
 
-      # Same selection as the macOS rust leg: pure-Rust P2P topologies only
+      # Same selection as the macOS signed-docs/rust legs: pure-Rust P2P topologies only
       # (`--skip ::go_` drops the go_go_/go_rust_ variants). Kept serial while
       # the macOS legs run at 8: this leg exists to expose Linux scheduling
       # races, so a fixed serial schedule keeps a failure attributable to the


### PR DESCRIPTION
## Problem

The `rust` and `signed-docs` integration suites run identical tests — the only difference is that `rust` passes `--no-signing`, the node's **non-default** configuration. Both were pinned to studio-1, so every PR serialized two full integration suites through one runner slot, and studio-1 became the CI critical path (42–102 min signed-docs legs during busy periods).

## Diagnosis (measured)

Signing itself is nearly free: running exactly what CI runs locally, the basic suite is identical signed vs unsigned (~9.5s), and the p2p suite is 64.7s unsigned vs 74.5s signed (+15%). The slow signed-docs legs decompose into:

- **Cache-miss rebuild (40 min)**: on 2026-08-14 the studio-1↔studio-2 SSH link failed transiently; the publish from the build job and the consumer's fallback pull both failed *as warnings*, and the leg silently rebuilt `defra` from scratch.
- **Per-commit compile/link toll (~13–15 min)**: whichever studio-1 leg runs first compiles and links all 13 integration-test binaries inside its test steps; the second leg runs warm. Recently signed-docs kept drawing the short straw (pre-#1454 data shows the toll flipping legs: rust=163m/signed=50m on one run).
- **Host contention noise**: the same unsigned p2p step swings 4–15 min run to run.

## What changed

- The integration matrix is now built in `ci-scope`: **signed-docs (the production default) is the PR leg**; the unsigned `rust` mirror runs on non-PR events only (push to main, merge queue). Per-PR studio-1 occupancy drops from two full suites + toll to one.
- The binary-cache publish and peer pull each retry once, so a single transient SSH failure no longer becomes a warned-but-green 40-minute rebuild.

An unsigned-only regression now surfaces on the post-merge main run instead of at PR time — accepted trade, easy to revert if it bites.

## Follow-up

A separate PR will evaluate moving the integration legs to the existing `super-dev` profile (7.5x less debug object volume) to cut the per-commit link toll and cold rebuilds further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)