### PR TITLE
fix(p2p): surface the io error when a listen address fails to bind

### DIFF
--- a/crates/p2p/src/host/command_handler/network.rs
+++ b/crates/p2p/src/host/command_handler/network.rs
@@ -10,6 +10,19 @@ use crate::error::{Error, Result};
 
 use super::super::p2p_host::P2PHost;
 
+/// libp2p's `TransportError::Other` Displays as an empty string — the io
+/// error is only reachable through `source()` — so `to_string()` on a failed
+/// listen erased the "Address already in use" detail that the test harness
+/// keys its fresh-port start retry on (#1501). Surface the io error directly.
+fn format_listen_error(error: &libp2p::TransportError<std::io::Error>) -> String {
+    match error {
+        libp2p::TransportError::MultiaddrNotSupported(addr) => {
+            format!("multiaddr not supported: {addr}")
+        }
+        libp2p::TransportError::Other(io_error) => io_error.to_string(),
+    }
+}
+
 impl<S: Store> P2PHost<S> {
     pub(super) fn handle_listen(
         &mut self,
@@ -20,7 +33,7 @@ impl<S: Store> P2PHost<S> {
             .swarm
             .listen_on(addr.clone())
             .map(|_| ())
-            .map_err(|e| Error::Transport(e.to_string()));
+            .map_err(|e| Error::Transport(format_listen_error(&e)));
         if response.send(result).is_err() {
             debug!(addr = %addr, "Listen command response dropped - caller cancelled");
         }
@@ -70,5 +83,36 @@ impl<S: Store> P2PHost<S> {
         if response.send(addrs).is_err() {
             debug!("PeerAddresses command response dropped - caller cancelled");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_listen_error;
+
+    #[test]
+    fn listen_error_surfaces_the_bind_failure() {
+        let eaddrinuse = if cfg!(target_os = "linux") { 98 } else { 48 };
+        let error = libp2p::TransportError::Other(std::io::Error::from_raw_os_error(eaddrinuse));
+
+        let formatted = format_listen_error(&error);
+
+        // The harness retries a node start with fresh ports only when it can
+        // see this phrase in the node's output (#1501).
+        assert!(
+            formatted.to_lowercase().contains("address already in use"),
+            "expected the bind failure detail, got: {formatted:?}"
+        );
+    }
+
+    #[test]
+    fn listen_error_names_the_unsupported_multiaddr() {
+        let addr: libp2p::Multiaddr = "/ip4/127.0.0.1/tcp/9171".parse().unwrap();
+        let error = libp2p::TransportError::<std::io::Error>::MultiaddrNotSupported(addr);
+
+        assert_eq!(
+            format_listen_error(&error),
+            "multiaddr not supported: /ip4/127.0.0.1/tcp/9171"
+        );
     }
 }


### PR DESCRIPTION
Root cause of #1501, the did-not-become-ready flake that hit six branches this week (#1439, #1440, #1453, #1488, #1489, #1491).

## The chain

1. The harness's port allocation has a documented release-then-spawn window; under 8-thread suites a starting node can lose its port.
2. `swarm.listen_on` then fails with `TransportError::Other(EADDRINUSE)` — and libp2p's `TransportError::Other` **Displays as an empty string** (the io error is only reachable via `source()`).
3. `e.to_string()` in `handle_listen` therefore produced `P2P error: transport error: ` with nothing after the colon, and the node exited.
4. defra-harness retries a node start with fresh ports only when it sees `address already in use` / `addrinuse` in the node's output — which never appeared. The built-in remedy for the race never fired.

## What changed

Format the `TransportError` variants explicitly: `MultiaddrNotSupported` names the address, `Other` passes the io error through, so a lost bind now prints `transport error: Address already in use (os error 48)` and the harness's fresh-port retry engages.

Unit tests pin both variants, including the exact phrase the harness matcher keys on (EADDRINUSE code cfg-gated for macOS/Linux).

Closes #1501.

🤖 Generated with [Claude Code](https://claude.com/claude-code)