### PR TITLE
fix(p2p): align replicator replay triggers

### DIFF
--- a/crates/p2p-adapter/src/iroh.rs
+++ b/crates/p2p-adapter/src/iroh.rs
@@ -436,17 +436,17 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
             self.transport.local_peer_id().as_str(),
             peer_id.as_str(),
         )?;
-        let collections_with_changed_capabilities: HashSet<String> = validated_capabilities
-            .iter()
-            .filter(|(collection_id, capability)| {
-                !self.transport.explicit_replay_capability_matches(
+        let collections_with_changed_capabilities = crate::collections_with_changed_capabilities(
+            &collection_cids,
+            &validated_capabilities,
+            |collection_id, capability| {
+                self.transport.explicit_replay_capability_matches(
                     &peer_id,
                     collection_id,
                     capability,
                 )
-            })
-            .map(|(collection_id, _)| collection_id.clone())
-            .collect();
+            },
+        );
         self.transport
             .clear_explicit_replay_capabilities(&peer_id, &collection_cids);
         for (collection_id, capability) in validated_capabilities {

--- a/crates/p2p-adapter/src/iroh.rs
+++ b/crates/p2p-adapter/src/iroh.rs
@@ -383,8 +383,8 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         collections: Vec<String>,
         addr: Option<&str>,
         filters: ReplicationFilters,
-        _explicit_replay_capabilities: Vec<ExplicitReplayCapabilityInput>,
-        _expected_authorizer_did: Option<&str>,
+        explicit_replay_capabilities: Vec<ExplicitReplayCapabilityInput>,
+        expected_authorizer_did: Option<&str>,
     ) -> P2PResult<()> {
         self.check_nac(acp::nac::NodePermission::P2pReplicatorAdd)
             .await?;
@@ -428,6 +428,33 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
                 .validate_replication_filters(&replication_filters)?;
         }
 
+        let requested_collections: HashSet<String> = collection_cids.iter().cloned().collect();
+        let validated_capabilities = crate::validate_explicit_replay_capabilities(
+            explicit_replay_capabilities,
+            expected_authorizer_did,
+            &requested_collections,
+            self.transport.local_peer_id().as_str(),
+            peer_id.as_str(),
+        )?;
+        let collections_with_changed_capabilities: HashSet<String> = validated_capabilities
+            .iter()
+            .filter(|(collection_id, capability)| {
+                !self.transport.explicit_replay_capability_matches(
+                    &peer_id,
+                    collection_id,
+                    capability,
+                )
+            })
+            .map(|(collection_id, _)| collection_id.clone())
+            .collect();
+        self.transport
+            .clear_explicit_replay_capabilities(&peer_id, &collection_cids);
+        for (collection_id, capability) in validated_capabilities {
+            self.transport
+                .set_explicit_replay_capability(&peer_id, &collection_id, &capability)
+                .map_err(|error| P2PError::invalid_input(error.to_string()))?;
+        }
+
         // Check existing replicator state before creating/updating so we can
         // skip the expensive initial replay when the replicator already exists
         // with the same collections (idempotent reconnect path).
@@ -459,12 +486,6 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
                 }
             }
         };
-        let existing_collection_ids = if existing_filters == replication_filters {
-            existing_collection_ids
-        } else {
-            HashSet::new()
-        };
-
         // Same rationale as `connect_peer`: in the common pairing flow the
         // replicator is installed over an already-live connection, and a
         // redundant dial can spuriously time out (Linux). The registration and
@@ -512,15 +533,16 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
                 .map_err(|error| P2PError::transport(error.to_string()))?;
         }
 
-        // Only replay collections that weren't already replicated by this peer.
-        let new_collection_names: Vec<String> = effective_collections
-            .iter()
-            .zip(collection_cids.iter())
-            .filter(|(_, cid)| !existing_collection_ids.contains(*cid))
-            .map(|(name, _)| name.clone())
-            .collect();
+        let collection_names_requiring_replay = crate::collections_requiring_replay(
+            &effective_collections,
+            &collection_cids,
+            &existing_collection_ids,
+            &existing_filters,
+            &replication_filters,
+            &collections_with_changed_capabilities,
+        );
 
-        if !new_collection_names.is_empty() {
+        if !collection_names_requiring_replay.is_empty() {
             if let Some(ref pusher) = self.doc_pusher {
                 let push_pusher = Arc::clone(pusher);
                 let push_event_bus = self.event_bus.clone();
@@ -532,15 +554,15 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
 
                 tracing::info!(
                     peer_id = %push_peer,
-                    new_collections = ?new_collection_names,
-                    "Replaying existing docs for new collections only"
+                    replay_collections = ?collection_names_requiring_replay,
+                    "Replaying existing docs for collections requiring replay"
                 );
 
                 tokio::spawn(async move {
                     if let Err(error) = push_pusher
                         .push_existing_docs(
                             &push_peer,
-                            &new_collection_names,
+                            &collection_names_requiring_replay,
                             &push_filters,
                             push_se_key.as_ref().map(|key| key.as_slice()),
                             push_identity.as_deref(),
@@ -559,7 +581,7 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         } else {
             tracing::debug!(
                 peer_id = %peer_id,
-                "Replicator already exists with same collections, skipping initial replay"
+                "Replicator already exists with same collections, filters, and replay capability; skipping initial replay"
             );
             if let Some(ref bus) = self.event_bus {
                 bus.publish(events::Message::replicator_completed());

--- a/crates/p2p-adapter/src/lib.rs
+++ b/crates/p2p-adapter/src/lib.rs
@@ -62,13 +62,14 @@ where
 
 /// Collections that need an initial document replay when adding a replicator.
 ///
-/// Replays collections that are newly authorized, plus existing collections whose
-/// explicit replay capability changed (so a previously invalid authorizer can be
-/// corrected without requiring a remove/add cycle).
+/// Replays collections that are newly authorized, or whose filter or explicit
+/// replay capability changed.
 pub fn collections_requiring_replay(
     effective_collections: &[String],
     collection_cids: &[String],
     existing_collection_ids: &std::collections::HashSet<String>,
+    existing_filters: &p2p::ReplicationFilters,
+    requested_filters: &p2p::ReplicationFilters,
     collections_with_changed_capabilities: &std::collections::HashSet<String>,
 ) -> Vec<String> {
     effective_collections
@@ -76,9 +77,57 @@ pub fn collections_requiring_replay(
         .zip(collection_cids.iter())
         .filter(|(_, cid)| {
             !existing_collection_ids.contains(*cid)
+                || existing_filters.get(*cid) != requested_filters.get(*cid)
                 || collections_with_changed_capabilities.contains(*cid)
         })
         .map(|(name, _)| name.clone())
+        .collect()
+}
+
+fn validate_explicit_replay_capabilities(
+    capabilities: Vec<ExplicitReplayCapabilityInput>,
+    expected_authorizer_did: Option<&str>,
+    requested_collections: &std::collections::HashSet<String>,
+    source_peer_id: &str,
+    target_peer_id: &str,
+) -> P2PResult<Vec<(String, String)>> {
+    if capabilities.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let expected_authorizer_did = expected_authorizer_did.ok_or_else(|| {
+        P2PError::invalid_input("explicit replay capabilities require an authenticated identity")
+    })?;
+    capabilities
+        .into_iter()
+        .map(|input| {
+            if !requested_collections.contains(&input.collection_id) {
+                return Err(P2PError::invalid_input(format!(
+                    "explicit replay capability collection '{}' was not requested",
+                    input.collection_id
+                )));
+            }
+
+            let authorization = p2p::verify_explicit_replay_capability(
+                &input.capability,
+                source_peer_id,
+                target_peer_id,
+                &input.collection_id,
+            )
+            .map_err(|error| {
+                P2PError::invalid_input(format!(
+                    "invalid explicit replay capability for collection '{}': {}",
+                    input.collection_id, error
+                ))
+            })?;
+            if authorization.authorizer_did != expected_authorizer_did {
+                return Err(P2PError::invalid_input(format!(
+                    "explicit replay capability authorizer '{}' did not match authenticated identity '{}'",
+                    authorization.authorizer_did, expected_authorizer_did
+                )));
+            }
+            Ok((input.collection_id, input.capability))
+        })
         .collect()
 }
 
@@ -177,6 +226,8 @@ mod resolve_remove_collections_tests {
             &effective_collections,
             &collection_cids,
             &existing_collection_ids,
+            &p2p::ReplicationFilters::new(),
+            &p2p::ReplicationFilters::new(),
             &changed_capabilities,
         );
 
@@ -194,10 +245,50 @@ mod resolve_remove_collections_tests {
             &effective_collections,
             &collection_cids,
             &existing_collection_ids,
+            &p2p::ReplicationFilters::new(),
+            &p2p::ReplicationFilters::new(),
             &changed_capabilities,
         );
 
         assert!(replay_collections.is_empty());
+    }
+
+    #[test]
+    fn collections_requiring_replay_scopes_filter_changes() {
+        let effective_collections = vec!["User".to_string(), "Post".to_string()];
+        let collection_cids = vec!["cid-user".to_string(), "cid-post".to_string()];
+        let existing_collection_ids = collection_cids.iter().cloned().collect();
+        let existing_filters = p2p::ReplicationFilters::from([
+            (
+                "cid-user".to_string(),
+                p2p::ReplicationFilter::new("name".to_string(), serde_json::json!("old")),
+            ),
+            (
+                "cid-post".to_string(),
+                p2p::ReplicationFilter::new("title".to_string(), serde_json::json!("same")),
+            ),
+        ]);
+        let requested_filters = p2p::ReplicationFilters::from([
+            (
+                "cid-user".to_string(),
+                p2p::ReplicationFilter::new("name".to_string(), serde_json::json!("new")),
+            ),
+            (
+                "cid-post".to_string(),
+                p2p::ReplicationFilter::new("title".to_string(), serde_json::json!("same")),
+            ),
+        ]);
+
+        let replay_collections = collections_requiring_replay(
+            &effective_collections,
+            &collection_cids,
+            &existing_collection_ids,
+            &existing_filters,
+            &requested_filters,
+            &HashSet::new(),
+        );
+
+        assert_eq!(replay_collections, vec!["User".to_string()]);
     }
 
     #[test]

--- a/crates/p2p-adapter/src/lib.rs
+++ b/crates/p2p-adapter/src/lib.rs
@@ -1,5 +1,6 @@
 //! Shared P2P adapters implementing the HTTP P2P operation surface.
 
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock};
 
 use zeroize::Zeroizing;
@@ -81,6 +82,28 @@ pub fn collections_requiring_replay(
                 || collections_with_changed_capabilities.contains(*cid)
         })
         .map(|(name, _)| name.clone())
+        .collect()
+}
+
+fn collections_with_changed_capabilities(
+    collection_cids: &[String],
+    validated_capabilities: &[(String, String)],
+    capability_matches: impl Fn(&str, Option<&str>) -> bool,
+) -> HashSet<String> {
+    let requested_capabilities: HashMap<&str, &str> = validated_capabilities
+        .iter()
+        .map(|(collection_id, capability)| (collection_id.as_str(), capability.as_str()))
+        .collect();
+
+    collection_cids
+        .iter()
+        .filter(|collection_id| {
+            !capability_matches(
+                collection_id,
+                requested_capabilities.get(collection_id.as_str()).copied(),
+            )
+        })
+        .cloned()
         .collect()
 }
 
@@ -185,8 +208,8 @@ pub fn merge_live_replicators_with_persisted_metadata(
 #[cfg(test)]
 mod resolve_remove_collections_tests {
     use super::{
-        collections_requiring_replay, merge_live_replicators_with_persisted_metadata,
-        resolve_remove_collections,
+        collections_requiring_replay, collections_with_changed_capabilities,
+        merge_live_replicators_with_persisted_metadata, resolve_remove_collections,
     };
     use std::collections::{HashMap, HashSet};
 
@@ -251,6 +274,19 @@ mod resolve_remove_collections_tests {
         );
 
         assert!(replay_collections.is_empty());
+    }
+
+    #[test]
+    fn removing_a_cached_capability_counts_as_a_change() {
+        let cached_capabilities = HashMap::from([("cid-user", "old-capability")]);
+
+        let changed = collections_with_changed_capabilities(
+            &["cid-user".to_string()],
+            &[],
+            |collection_id, requested| cached_capabilities.get(collection_id).copied() == requested,
+        );
+
+        assert_eq!(changed, HashSet::from(["cid-user".to_string()]));
     }
 
     #[test]

--- a/crates/p2p-adapter/src/libp2p.rs
+++ b/crates/p2p-adapter/src/libp2p.rs
@@ -428,46 +428,13 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
         let requested_collections: HashSet<String> = collection_cids.iter().cloned().collect();
         let local_peer_id = self.handle.local_peer_id_cached().to_string();
         let target_peer_id = peer_id.to_string();
-        let mut validated_capabilities = Vec::new();
-
-        if !explicit_replay_capabilities.is_empty() {
-            let expected_authorizer_did = expected_authorizer_did.ok_or_else(|| {
-                P2PError::invalid_input(
-                    "explicit replay capabilities require an authenticated identity",
-                )
-            })?;
-
-            for capability in explicit_replay_capabilities {
-                if !requested_collections.contains(&capability.collection_id) {
-                    return Err(P2PError::invalid_input(format!(
-                        "explicit replay capability collection '{}' was not requested",
-                        capability.collection_id
-                    )));
-                }
-
-                let authorization = p2p::verify_explicit_replay_capability(
-                    &capability.capability,
-                    &local_peer_id,
-                    &target_peer_id,
-                    &capability.collection_id,
-                )
-                .map_err(|error| {
-                    P2PError::invalid_input(format!(
-                        "invalid explicit replay capability for collection '{}': {}",
-                        capability.collection_id, error
-                    ))
-                })?;
-
-                if authorization.authorizer_did != expected_authorizer_did {
-                    return Err(P2PError::invalid_input(format!(
-                        "explicit replay capability authorizer '{}' did not match authenticated identity '{}'",
-                        authorization.authorizer_did, expected_authorizer_did
-                    )));
-                }
-
-                validated_capabilities.push((capability.collection_id, capability.capability));
-            }
-        }
+        let validated_capabilities = crate::validate_explicit_replay_capabilities(
+            explicit_replay_capabilities,
+            expected_authorizer_did,
+            &requested_collections,
+            &local_peer_id,
+            &target_peer_id,
+        )?;
 
         let collections_with_changed_capabilities: HashSet<String> = validated_capabilities
             .iter()
@@ -527,12 +494,6 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
                 }
             }
         };
-        let existing_collection_ids = if existing_filters == replication_filters {
-            existing_collection_ids
-        } else {
-            HashSet::new()
-        };
-
         self.handle
             .dial(peer_id, vec![parsed.transport_addr])
             .await
@@ -581,6 +542,8 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
             &effective_collections,
             &collection_cids,
             &existing_collection_ids,
+            &existing_filters,
+            &replication_filters,
             &collections_with_changed_capabilities,
         );
 

--- a/crates/p2p-adapter/src/libp2p.rs
+++ b/crates/p2p-adapter/src/libp2p.rs
@@ -436,21 +436,14 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
             &target_peer_id,
         )?;
 
-        let collections_with_changed_capabilities: HashSet<String> = validated_capabilities
-            .iter()
-            .filter_map(|(collection_id, capability)| {
-                let matches_existing = self.handle.explicit_replay_capability_matches(
-                    peer_id,
-                    collection_id.as_str(),
-                    capability,
-                );
-                if matches_existing {
-                    None
-                } else {
-                    Some(collection_id.clone())
-                }
-            })
-            .collect();
+        let collections_with_changed_capabilities = crate::collections_with_changed_capabilities(
+            &collection_cids,
+            &validated_capabilities,
+            |collection_id, capability| {
+                self.handle
+                    .explicit_replay_capability_matches(peer_id, collection_id, capability)
+            },
+        );
 
         self.handle
             .clear_explicit_replay_capability(peer_id, &collection_cids);

--- a/crates/p2p/src/explicit_replay.rs
+++ b/crates/p2p/src/explicit_replay.rs
@@ -88,12 +88,13 @@ impl ExplicitReplayCapabilityCache {
         &self,
         target_peer_id: &str,
         collection_id: &str,
-        capability: &str,
+        capability: Option<&str>,
     ) -> bool {
         self.capabilities
             .read()
             .get(&(target_peer_id.to_string(), collection_id.to_string()))
-            .is_some_and(|existing| existing.capability == capability)
+            .map(|existing| existing.capability.as_str())
+            == capability
     }
 
     pub(crate) fn attach(&self, target_peer_id: &str, request: &mut crate::PushLogRequest) {

--- a/crates/p2p/src/explicit_replay.rs
+++ b/crates/p2p/src/explicit_replay.rs
@@ -11,7 +11,10 @@
 //! call [`revoke_capability`], or use [`ExplicitReplayRevocationRegistry`] with
 //! [`verify_capability_with_revocations`] for a custom synced deny-list.
 
-use std::collections::{HashMap, HashSet};
+#[cfg(any(feature = "libp2p-transport", feature = "iroh-transport"))]
+use std::collections::HashMap;
+use std::collections::HashSet;
+#[cfg(any(feature = "libp2p-transport", feature = "iroh-transport"))]
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -34,17 +37,20 @@ pub const MAX_CAPABILITY_TTL: Duration = DEFAULT_CAPABILITY_TTL;
 static PROCESS_REVOCATIONS: LazyLock<ExplicitReplayRevocationRegistry> =
     LazyLock::new(ExplicitReplayRevocationRegistry::default);
 
+#[cfg(any(feature = "libp2p-transport", feature = "iroh-transport"))]
 #[derive(Debug, Clone)]
 struct CachedExplicitReplayCapability {
     capability: String,
     authorizer_did: String,
 }
 
+#[cfg(any(feature = "libp2p-transport", feature = "iroh-transport"))]
 #[derive(Debug, Clone, Default)]
 pub(crate) struct ExplicitReplayCapabilityCache {
     capabilities: Arc<RwLock<HashMap<(String, String), CachedExplicitReplayCapability>>>,
 }
 
+#[cfg(any(feature = "libp2p-transport", feature = "iroh-transport"))]
 impl ExplicitReplayCapabilityCache {
     pub(crate) fn set(
         &self,

--- a/crates/p2p/src/explicit_replay.rs
+++ b/crates/p2p/src/explicit_replay.rs
@@ -11,7 +11,8 @@
 //! call [`revoke_capability`], or use [`ExplicitReplayRevocationRegistry`] with
 //! [`verify_capability_with_revocations`] for a custom synced deny-list.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
@@ -32,6 +33,78 @@ pub const MAX_CAPABILITY_TTL: Duration = DEFAULT_CAPABILITY_TTL;
 
 static PROCESS_REVOCATIONS: LazyLock<ExplicitReplayRevocationRegistry> =
     LazyLock::new(ExplicitReplayRevocationRegistry::default);
+
+#[derive(Debug, Clone)]
+struct CachedExplicitReplayCapability {
+    capability: String,
+    authorizer_did: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct ExplicitReplayCapabilityCache {
+    capabilities: Arc<RwLock<HashMap<(String, String), CachedExplicitReplayCapability>>>,
+}
+
+impl ExplicitReplayCapabilityCache {
+    pub(crate) fn set(
+        &self,
+        source_peer_id: &str,
+        target_peer_id: &str,
+        collection_id: &str,
+        capability: &str,
+    ) -> Result<()> {
+        let authorization =
+            verify_capability(capability, source_peer_id, target_peer_id, collection_id)?;
+        self.capabilities.write().insert(
+            (target_peer_id.to_string(), collection_id.to_string()),
+            CachedExplicitReplayCapability {
+                capability: capability.to_string(),
+                authorizer_did: authorization.authorizer_did,
+            },
+        );
+        Ok(())
+    }
+
+    pub(crate) fn clear(&self, target_peer_id: &str, collections: &[String]) {
+        let mut capabilities = self.capabilities.write();
+        for collection_id in collections {
+            capabilities.remove(&(target_peer_id.to_string(), collection_id.clone()));
+        }
+    }
+
+    pub(crate) fn clear_all(&self, target_peer_id: &str) {
+        self.capabilities
+            .write()
+            .retain(|(stored_peer_id, _), _| stored_peer_id != target_peer_id);
+    }
+
+    pub(crate) fn matches(
+        &self,
+        target_peer_id: &str,
+        collection_id: &str,
+        capability: &str,
+    ) -> bool {
+        self.capabilities
+            .read()
+            .get(&(target_peer_id.to_string(), collection_id.to_string()))
+            .is_some_and(|existing| existing.capability == capability)
+    }
+
+    pub(crate) fn attach(&self, target_peer_id: &str, request: &mut crate::PushLogRequest) {
+        if request.explicit_replay_capability.is_some() {
+            return;
+        }
+
+        let cached = self
+            .capabilities
+            .read()
+            .get(&(target_peer_id.to_string(), request.collection_id.clone()))
+            .cloned();
+        if let Some(cached) = cached.filter(|cached| request.creator == cached.authorizer_did) {
+            request.explicit_replay_capability = Some(cached.capability);
+        }
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ExplicitReplayCapabilityClaims {

--- a/crates/p2p/src/host/handle.rs
+++ b/crates/p2p/src/host/handle.rs
@@ -1,14 +1,11 @@
 //! P2P host handle for interacting with the host.
 
-use std::collections::HashMap;
-use std::sync::Arc;
-
 use cid::Cid;
 use libp2p::{gossipsub, identity::Keypair, Multiaddr, PeerId};
-use parking_lot::RwLock;
 use tokio::sync::{mpsc, oneshot};
 
 use crate::error::{Error, Result};
+use crate::explicit_replay::ExplicitReplayCapabilityCache;
 use crate::message::{PushLogBroadcast, PushLogReply, PushLogRequest};
 use crate::replicator::ReplicatorInfo;
 use crate::signing::sign_message;
@@ -17,12 +14,6 @@ use crate::QueryId;
 
 use super::command::HostCommand;
 use super::ResponseChannel;
-
-#[derive(Clone)]
-struct CachedExplicitReplayCapability {
-    capability: String,
-    authorizer_did: String,
-}
 
 /// Handle to interact with the P2P host.
 #[derive(Clone)]
@@ -35,8 +26,7 @@ pub struct P2PHostHandle {
     /// Keypair for signing messages.
     keypair: Keypair,
     /// Optional explicit replay capabilities keyed by (peer_id, collection_id).
-    explicit_replay_capabilities:
-        Arc<RwLock<HashMap<(String, String), CachedExplicitReplayCapability>>>,
+    explicit_replay_capabilities: ExplicitReplayCapabilityCache,
 }
 
 impl P2PHostHandle {
@@ -46,78 +36,36 @@ impl P2PHostHandle {
         collections: &[String],
         capability: &str,
     ) {
-        let source_peer_id = self.local_peer_id.to_string();
-        let target_peer_id = peer_id.to_string();
-        let mut validated = Vec::with_capacity(collections.len());
         for collection_id in collections {
-            let authorization = match crate::verify_explicit_replay_capability(
-                capability,
-                &source_peer_id,
-                &target_peer_id,
+            if let Err(error) = self.explicit_replay_capabilities.set(
+                &self.local_peer_id.to_string(),
+                &peer_id.to_string(),
                 collection_id,
+                capability,
             ) {
-                Ok(authorization) => authorization,
-                Err(error) => {
-                    tracing::warn!(
-                        peer_id = %peer_id,
-                        collection_id,
-                        error = %error,
-                        "Refusing to cache invalid explicit replay capability"
-                    );
-                    continue;
-                }
-            };
-            validated.push((
-                collection_id.clone(),
-                CachedExplicitReplayCapability {
-                    capability: capability.to_string(),
-                    authorizer_did: authorization.authorizer_did,
-                },
-            ));
-        }
-
-        let mut capabilities = self.explicit_replay_capabilities.write();
-        for (collection_id, capability) in validated {
-            capabilities.insert((target_peer_id.clone(), collection_id), capability);
+                tracing::warn!(
+                    peer_id = %peer_id,
+                    collection_id,
+                    error = %error,
+                    "Refusing to cache invalid explicit replay capability"
+                );
+            }
         }
     }
 
     fn clear_explicit_replay_capability_inner(&self, peer_id: &PeerId, collections: &[String]) {
-        let peer_id = peer_id.to_string();
-        let mut capabilities = self.explicit_replay_capabilities.write();
-        for collection_id in collections {
-            capabilities.remove(&(peer_id.clone(), collection_id.clone()));
-        }
+        self.explicit_replay_capabilities
+            .clear(&peer_id.to_string(), collections);
     }
 
     fn clear_all_explicit_replay_capabilities_inner(&self, peer_id: &PeerId) {
         let peer_id = peer_id.to_string();
-        self.explicit_replay_capabilities
-            .write()
-            .retain(|(stored_peer_id, _), _| stored_peer_id != &peer_id);
+        self.explicit_replay_capabilities.clear_all(&peer_id);
     }
 
     fn attach_explicit_replay_capability(&self, peer_id: &PeerId, request: &mut PushLogRequest) {
-        if request.explicit_replay_capability.is_some() {
-            return;
-        }
-
-        let cached = self
-            .explicit_replay_capabilities
-            .read()
-            .get(&(peer_id.to_string(), request.collection_id.clone()))
-            .cloned();
-        let Some(cached) = cached else {
-            return;
-        };
-
-        // A capability delegates replay authority for one DID. Attaching it to
-        // an unrelated live/public push makes the receiver validate that block
-        // against the wrong authorizer and reject otherwise valid replication.
-        // Keep ordinary pushes on the normal admission path (#1161).
-        if request.creator == cached.authorizer_did {
-            request.explicit_replay_capability = Some(cached.capability);
-        }
+        self.explicit_replay_capabilities
+            .attach(&peer_id.to_string(), request);
     }
 
     /// Create a new handle (internal use only).
@@ -132,7 +80,7 @@ impl P2PHostHandle {
             local_public_key_proto,
             local_peer_id,
             keypair,
-            explicit_replay_capabilities: Arc::new(RwLock::new(HashMap::new())),
+            explicit_replay_capabilities: ExplicitReplayCapabilityCache::default(),
         }
     }
 
@@ -530,9 +478,7 @@ impl P2PHostHandle {
         capability: &str,
     ) -> bool {
         self.explicit_replay_capabilities
-            .read()
-            .get(&(peer_id.to_string(), collection.to_string()))
-            .is_some_and(|existing| existing.capability == capability)
+            .matches(&peer_id.to_string(), collection, capability)
     }
 
     /// Delete a replicator.

--- a/crates/p2p/src/host/handle.rs
+++ b/crates/p2p/src/host/handle.rs
@@ -475,7 +475,7 @@ impl P2PHostHandle {
         &self,
         peer_id: PeerId,
         collection: &str,
-        capability: &str,
+        capability: Option<&str>,
     ) -> bool {
         self.explicit_replay_capabilities
             .matches(&peer_id.to_string(), collection, capability)

--- a/crates/p2p/src/iroh/transport.rs
+++ b/crates/p2p/src/iroh/transport.rs
@@ -12,6 +12,7 @@ use iroh::SecretKey;
 use tokio::sync::{mpsc, oneshot};
 
 use crate::error::{Error, Result};
+use crate::explicit_replay::ExplicitReplayCapabilityCache;
 use crate::message::{
     BranchableSyncReply, BranchableSyncRequest, DocSyncReply, DocSyncRequest, ManageQueryReply,
     ManageQueryRequest, ManageReply, ManageRequest, PushLogBroadcast, PushLogReply, PushLogRequest,
@@ -36,6 +37,7 @@ pub struct IrohTransport {
     local_peer_id: PeerId,
     local_public_key_bytes: Vec<u8>,
     secret_key: Arc<SecretKey>,
+    explicit_replay_capabilities: ExplicitReplayCapabilityCache,
 }
 
 impl IrohTransport {
@@ -50,7 +52,37 @@ impl IrohTransport {
             local_peer_id,
             local_public_key_bytes,
             secret_key: Arc::new(secret_key),
+            explicit_replay_capabilities: ExplicitReplayCapabilityCache::default(),
         }
+    }
+
+    pub fn set_explicit_replay_capability(
+        &self,
+        peer_id: &PeerId,
+        collection_id: &str,
+        capability: &str,
+    ) -> Result<()> {
+        self.explicit_replay_capabilities.set(
+            self.local_peer_id.as_str(),
+            peer_id.as_str(),
+            collection_id,
+            capability,
+        )
+    }
+
+    pub fn clear_explicit_replay_capabilities(&self, peer_id: &PeerId, collections: &[String]) {
+        self.explicit_replay_capabilities
+            .clear(peer_id.as_str(), collections);
+    }
+
+    pub fn explicit_replay_capability_matches(
+        &self,
+        peer_id: &PeerId,
+        collection_id: &str,
+        capability: &str,
+    ) -> bool {
+        self.explicit_replay_capabilities
+            .matches(peer_id.as_str(), collection_id, capability)
     }
 
     /// Send a command and await the oneshot reply.
@@ -231,6 +263,8 @@ impl P2PTransport for IrohTransport {
         peer_id: &PeerId,
         mut req: PushLogRequest,
     ) -> Result<PushLogReply> {
+        self.explicit_replay_capabilities
+            .attach(peer_id.as_str(), &mut req);
         // Advertise that this iroh sender consumes the ACK from the request
         // stream. Re-sign because the capability is part of the wire message.
         req.supports_same_stream_reply = true;
@@ -482,7 +516,10 @@ impl P2PTransport for IrohTransport {
             peer_id: peer_id.clone(),
             reply,
         })
-        .await
+        .await?;
+        self.explicit_replay_capabilities
+            .clear_all(peer_id.as_str());
+        Ok(())
     }
 
     async fn list_replicators(&self) -> Result<Vec<ReplicatorInfo>> {
@@ -503,12 +540,22 @@ impl P2PTransport for IrohTransport {
         peer_id: &PeerId,
         collections: Vec<String>,
     ) -> Result<bool> {
-        self.send_command(|reply| IrohCommand::RemoveReplicatorCollections {
-            peer_id: peer_id.clone(),
-            collections,
-            reply,
-        })
-        .await
+        let removed_collections = collections.clone();
+        let fully_deleted = self
+            .send_command(|reply| IrohCommand::RemoveReplicatorCollections {
+                peer_id: peer_id.clone(),
+                collections,
+                reply,
+            })
+            .await?;
+        if fully_deleted {
+            self.explicit_replay_capabilities
+                .clear_all(peer_id.as_str());
+        } else {
+            self.explicit_replay_capabilities
+                .clear(peer_id.as_str(), &removed_collections);
+        }
+        Ok(fully_deleted)
     }
 
     async fn shutdown(&self) -> Result<()> {

--- a/crates/p2p/src/iroh/transport.rs
+++ b/crates/p2p/src/iroh/transport.rs
@@ -79,7 +79,7 @@ impl IrohTransport {
         &self,
         peer_id: &PeerId,
         collection_id: &str,
-        capability: &str,
+        capability: Option<&str>,
     ) -> bool {
         self.explicit_replay_capabilities
             .matches(peer_id.as_str(), collection_id, capability)

--- a/crates/p2p/src/iroh/two_stream_tests.rs
+++ b/crates/p2p/src/iroh/two_stream_tests.rs
@@ -3,6 +3,8 @@ use std::net::{IpAddr, Ipv4Addr};
 use std::time::Duration;
 
 use bytes::Bytes;
+use crypto::generate_ed25519;
+use identity::{Identity, RawIdentity};
 use iroh::SecretKey;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
@@ -133,6 +135,61 @@ async fn two_stream_request_receives_reply_on_request_stream() {
         .unwrap()
         .unwrap();
     assert_eq!(received_reply.message_id, message_id);
+
+    sender.shutdown().await;
+    receiver.shutdown().await;
+}
+
+#[tokio::test]
+async fn two_stream_request_carries_cached_explicit_replay_capability() {
+    let sender = TestNode::spawn().await;
+    let mut receiver = TestNode::spawn().await;
+    connect(&sender.transport, &receiver.transport).await;
+
+    let authorizer = RawIdentity::from_private_key(generate_ed25519().unwrap()).unwrap();
+    let creator = authorizer.did().unwrap().to_string();
+    let target = receiver.transport.local_peer_id().clone();
+    let capability = crate::generate_explicit_replay_capability(
+        &authorizer,
+        sender.transport.local_peer_id().as_str(),
+        target.as_str(),
+        "collection1",
+        Duration::from_secs(60),
+    )
+    .unwrap();
+    sender
+        .transport
+        .set_explicit_replay_capability(&target, "collection1", &capability)
+        .unwrap();
+
+    let request = PushLogRequest::new(
+        "doc-capability".to_string(),
+        Bytes::from_static(&[1, 2, 3]),
+        "collection1".to_string(),
+        creator,
+        Bytes::from_static(b"block-capability"),
+    );
+    let sender_transport = sender.transport.clone();
+    let send_target = target.clone();
+    let send_task = tokio::spawn(async move {
+        sender_transport
+            .send_two_stream_request(&send_target, request)
+            .await
+    });
+
+    let (_, received, token) = next_two_stream_request(&mut receiver.events).await;
+    assert_eq!(
+        received.explicit_replay_capability.as_deref(),
+        Some(capability.as_str())
+    );
+    let mut reply = PushLogReply::success(&received.message_id);
+    sign_with_transport(&receiver.transport, &mut reply).unwrap();
+    receiver
+        .transport
+        .send_pushlog_response(token, reply)
+        .await
+        .unwrap();
+    send_task.await.unwrap().unwrap();
 
     sender.shutdown().await;
     receiver.shutdown().await;

--- a/crates/p2p/src/sync/coordinator/event_handler/pushlog.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/pushlog.rs
@@ -30,6 +30,32 @@ fn build_pushlog_reply(message_id: &str, process_result: &Result<()>) -> PushLog
     }
 }
 
+fn verify_embedded_replay_capability(
+    request: &crate::message::PushLogRequest,
+    source_peer_id: &str,
+    target_peer_id: &str,
+) -> Option<ExplicitReplayAuthorization> {
+    let capability = request.explicit_replay_capability.as_deref()?;
+    match crate::verify_explicit_replay_capability(
+        capability,
+        source_peer_id,
+        target_peer_id,
+        &request.collection_id,
+    ) {
+        Ok(authorization) => Some(authorization),
+        Err(error) => {
+            tracing::warn!(
+                peer_id = source_peer_id,
+                creator = %request.creator,
+                collection_id = %request.collection_id,
+                error = %error,
+                "Rejected explicit replay capability for two-stream PushLog"
+            );
+            None
+        }
+    }
+}
+
 impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     pub(super) async fn handle_pushlog_request(
         &self,
@@ -208,6 +234,15 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
 
         tracing::trace!(?cid, "Parsed valid CID from two-stream request");
 
+        let explicit_replay_authorization = explicit_replay_authorization.or_else(|| {
+            verify_embedded_replay_capability(
+                &request,
+                peer_id.as_str(),
+                self.runtime.transport.local_peer_id().as_str(),
+            )
+        });
+        let is_explicit_replicator =
+            is_explicit_replicator || explicit_replay_authorization.is_some();
         let broadcast = PushLogBroadcast::from_request(&request);
         let process_result = self
             .manager
@@ -284,6 +319,11 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
+    use crypto::generate_ed25519;
+    use identity::{Identity, RawIdentity};
+
     use super::*;
 
     #[test]
@@ -298,5 +338,32 @@ mod tests {
             reply.err_message.as_deref(),
             Some(crate::error::RATE_LIMITED_MESSAGE)
         );
+    }
+
+    #[test]
+    fn verifies_capability_embedded_by_transport_generic_sender() {
+        let authorizer = RawIdentity::from_private_key(generate_ed25519().unwrap()).unwrap();
+        let mut request = crate::message::PushLogRequest::new(
+            "doc".to_string(),
+            Vec::new().into(),
+            "collection".to_string(),
+            authorizer.did().unwrap().to_string(),
+            Vec::new().into(),
+        );
+        request.explicit_replay_capability = Some(
+            crate::generate_explicit_replay_capability(
+                &authorizer,
+                "source",
+                "target",
+                "collection",
+                Duration::from_secs(60),
+            )
+            .unwrap(),
+        );
+
+        let authorization =
+            verify_embedded_replay_capability(&request, "source", "target").unwrap();
+
+        assert_eq!(authorization.authorizer_did, request.creator);
     }
 }


### PR DESCRIPTION
## Problem

The libp2p and Iroh adapters disagree on when an existing replicator needs replay. Iroh ignores explicit replay capability changes, while either adapter replays every requested collection when only one collection filter changes.

## What changed

- select replay collections with one shared per-collection filter and capability rule
- validate, cache, attach, and receive explicit replay capabilities on Iroh using the same authorization boundary as libp2p
- preserve capability cleanup when replicators or individual collections are removed
- cover scoped filter replay and capability delivery over a real Iroh stream

## Validation

- [x] `cargo test --profile super-dev -p p2p --all-features`
- [x] `cargo test --profile super-dev -p defra-p2p-adapter --all-features`
- [x] `cargo clippy --profile super-dev -p p2p -p defra-p2p-adapter --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`

Closes #1506