### PR TITLE
ci: fall back when sccache is unavailable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  # Cache-server communication failures should fall back to direct compilation.
+  SCCACHE_IGNORE_SERVER_IO_ERROR: '1'
   # Two defradb.rs runner slots per studio host can now co-run jobs (plus
   # other repos' runners on the same hosts). Bound each Cargo process so two
   # simultaneous compiles fit inside a 32-core host with room for linking and


### PR DESCRIPTION
## Problem

A transient sccache client/server communication failure currently fails otherwise valid builds instead of treating the cache as an optional optimization.

## What changed

- enable sccache’s supported direct-compilation fallback for CI jobs
- keep existing cache usage and runner allocation unchanged when the server is healthy

## Validation

- [x] parsed `.github/workflows/ci.yml` as YAML
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`

Closes #1429