### PR TITLE
fix(defra-node): stop asserting an exact delta on process-global retry metrics

### DIFF
--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -1755,9 +1755,21 @@ mod tests {
         assert_eq!(attempts.load(Ordering::SeqCst), 3);
         assert!(!response.has_errors());
         assert_eq!(response.data, Some(serde_json::json!({"ok": true})));
+        // The conflict counters are process-global and every test that runs a
+        // query through the retry loop moves them, so an exact delta is a race:
+        // it read 3 where it wanted 2 in CI. The loop's own behaviour is pinned
+        // exactly by `attempts` above; what is left to check here is that the
+        // telemetry fired at all, which a lower bound does without depending on
+        // what else the binary is running.
         let metrics_after = telemetry::conflict_metrics_snapshot().embedded_execute;
-        assert_eq!(metrics_after.attempts - metrics_before.attempts, 2);
-        assert_eq!(metrics_after.successes - metrics_before.successes, 1);
+        assert!(
+            metrics_after.attempts - metrics_before.attempts >= 2,
+            "the two retried attempts must be recorded"
+        );
+        assert!(
+            metrics_after.successes - metrics_before.successes >= 1,
+            "the eventual success must be recorded"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
`Build & Test` is red on `main` and on every branch cut from it, on one test:

```
tests::execute_retry_loop_retries_conflicts_until_success
crates/defra-node/src/lib.rs:1763
assertion `left == right` failed
  left: 3
  right: 2
```

## Cause

The test asserts an **exact delta** on `telemetry::conflict_metrics_snapshot().embedded_execute`, which is a process-global counter. Every test in the binary that runs a query through the retry loop bumps it (`lib.rs:668-677`), including the `benchmark_support` fixture tests. When one of those lands between this test's before and after reads, the delta is 3 rather than 2.

## Fix

The loop's own behaviour is already pinned exactly and locally by `assert_eq!(attempts.load(..), 3)` plus the response assertions. What the counter check adds is "the telemetry fired", which a lower bound gives without depending on what else the binary is running.

Serializing the test behind a mutex was considered and rejected: it would have to be taken by every test that runs a query, and missing one puts the flake back.

## Verification

The failure reproduces exactly by injecting a single concurrent bump before the snapshot:

- old assertion, one concurrent bump: `left: 3, right: 2`, the CI message byte for byte
- new assertion, same bump: passes

`defra-node --lib` is 44 passed / 0 failed; fmt and clippy clean.

Not reproducible on a fast local machine without the injected bump (0 failures in 25 full-lib runs either way), which is why it only shows up on a contended runner.
