### PR TITLE
refactor(p2p): isolate transport-only dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8547,7 +8547,6 @@ dependencies = [
  "chrono",
  "ciborium",
  "cid",
- "crdt",
  "crypto",
  "defra-core",
  "document",

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -14,11 +14,10 @@ defra-core = { path = "../defra-core" }
 document = { path = "../document" }
 crypto = { path = "../crypto" }
 blockstore = { path = "../blockstore" }
-crdt = { path = "../crdt" }
 storage = { path = "../storage" }
 identity = { path = "../identity" }
 acp = { path = "../acp" }
-kms = { path = "../kms" }
+kms = { path = "../kms", optional = true }
 
 # libp2p transport
 libp2p = { workspace = true, features = ["tcp", "noise", "yamux", "identify", "request-response", "macros", "tokio", "gossipsub", "kad", "relay", "dns", "quic", "websocket", "memory-connection-limits"], optional = true }
@@ -82,6 +81,7 @@ default = []
 test-utils = ["libp2p-transport"]
 libp2p-transport = [
     "dep:iroh-bitswap",
+    "dep:kms",
     "dep:libp2p",
     "dep:libp2p-stream",
     "dep:multiaddr",
@@ -95,7 +95,7 @@ tokio = { workspace = true, features = ["test-util"] }
 p2p = { path = ".", features = ["test-utils"] }
 
 [package.metadata.cargo-machete]
-ignored = ["crdt", "multiaddr", "noq", "rand"]
+ignored = ["multiaddr", "noq", "rand"]
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Problem

The `p2p` crate directly depends on unused `crdt` code and unconditionally includes `kms`, even though KMS is only used by the libp2p transport. This adds unrelated dependencies to featureless and Iroh-only builds and obscures transport boundaries.

## What changed

- remove the unused direct `crdt` dependency
- make `kms` optional and enable it through `libp2p-transport`
- update the lockfile and cargo-machete configuration

## Validation

- [x] `cargo check --profile super-dev -p p2p --lib --no-default-features`
- [x] `cargo check --profile super-dev -p p2p --lib --no-default-features --features libp2p-transport`
- [x] `cargo check --profile super-dev -p p2p --lib --no-default-features --features iroh-transport`
- [x] `cargo test --profile super-dev -p p2p --lib --all-features`
- [x] `cargo clippy --profile super-dev -p p2p --lib --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`