### PR TITLE
test(p2p): honor transport feature boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,6 +342,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - run: cargo test --workspace --exclude integration-test --exclude ffi-test --exclude conformance
+
       # The cached node binaries are built with the `super-dev` profile
       # (Cargo.toml): dependencies at opt-level 2 with no debug info,
       # workspace crates with line tables. Integration nodes spend their time

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,6 +342,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - run: cargo test --workspace --exclude integration-test --exclude ffi-test --exclude conformance
+      - run: cargo test -p p2p --all-features
 
       # The cached node binaries are built with the `super-dev` profile
       # (Cargo.toml): dependencies at opt-level 2 with no debug info,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,8 +342,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - run: cargo test --workspace --exclude integration-test --exclude ffi-test --exclude conformance
-      - run: cargo test -p p2p --all-features
-
       # The cached node binaries are built with the `super-dev` profile
       # (Cargo.toml): dependencies at opt-level 2 with no debug info,
       # workspace crates with line tables. Integration nodes spend their time

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8564,7 +8564,6 @@ dependencies = [
  "multiaddr",
  "multihash-codetable",
  "noq",
- "p2p",
  "parking_lot 0.12.5",
  "postcard",
  "rand 0.9.2",

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -91,8 +91,7 @@ libp2p-transport = [
 iroh-transport = ["dep:iroh", "dep:iroh-gossip", "dep:iroh-tickets", "dep:noq", "dep:rand", "dep:blake3"]
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["test-util"] }
-p2p = { path = ".", features = ["test-utils"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "test-util"] }
 
 [package.metadata.cargo-machete]
 ignored = ["multiaddr", "noq", "rand"]

--- a/crates/p2p/src/bitswap/registry.rs
+++ b/crates/p2p/src/bitswap/registry.rs
@@ -194,11 +194,14 @@ impl ReplicatorRegistry {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
     use super::*;
     use crate::replicator::{ReplicationFilter, ReplicationFilters};
 
     fn random_peer_id() -> String {
-        libp2p::PeerId::random().to_string()
+        static NEXT_PEER_ID: AtomicU64 = AtomicU64::new(0);
+        format!("test-peer-{}", NEXT_PEER_ID.fetch_add(1, Ordering::Relaxed))
     }
 
     #[test]
@@ -330,38 +333,44 @@ mod tests {
     #[test]
     fn test_replicator_registry_load_from_infos() {
         let registry = ReplicatorRegistry::new();
-        let peer1 = libp2p::PeerId::random();
-        let peer2 = libp2p::PeerId::random();
+        let peer1 = random_peer_id();
+        let peer2 = random_peer_id();
 
         let infos = vec![
-            ReplicatorInfo::new(peer1, vec!["users".to_string(), "posts".to_string()]).unwrap(),
-            ReplicatorInfo::new(peer2, vec!["comments".to_string()]).unwrap(),
+            ReplicatorInfo::from_raw(
+                peer1.clone(),
+                vec!["users".to_string(), "posts".to_string()],
+                vec![],
+            ),
+            ReplicatorInfo::from_raw(peer2.clone(), vec!["comments".to_string()], vec![]),
         ];
 
         let (loaded, skipped) = registry.load_from_infos(&infos);
         assert_eq!(loaded, 2);
         assert_eq!(skipped, 0);
 
-        let p1 = peer1.to_string();
-        let p2 = peer2.to_string();
-        assert!(registry.is_replicator("users", &p1));
-        assert!(registry.is_replicator("posts", &p1));
-        assert!(!registry.is_replicator("comments", &p1));
+        assert!(registry.is_replicator("users", &peer1));
+        assert!(registry.is_replicator("posts", &peer1));
+        assert!(!registry.is_replicator("comments", &peer1));
 
-        assert!(registry.is_replicator("comments", &p2));
-        assert!(!registry.is_replicator("users", &p2));
+        assert!(registry.is_replicator("comments", &peer2));
+        assert!(!registry.is_replicator("users", &peer2));
     }
 
     #[test]
     fn test_replicator_registry_load_clears_existing() {
         let registry = ReplicatorRegistry::new();
         let peer1 = random_peer_id();
-        let peer2 = libp2p::PeerId::random();
+        let peer2 = random_peer_id();
 
         registry.add_replicator("users", &peer1);
         assert!(registry.is_replicator("users", &peer1));
 
-        let infos = vec![ReplicatorInfo::new(peer2, vec!["comments".to_string()]).unwrap()];
+        let infos = vec![ReplicatorInfo::from_raw(
+            peer2.clone(),
+            vec!["comments".to_string()],
+            vec![],
+        )];
         let (loaded, skipped) = registry.load_from_infos(&infos);
         assert_eq!(loaded, 1);
         assert_eq!(skipped, 0);
@@ -369,7 +378,7 @@ mod tests {
         assert!(!registry.is_replicator("users", &peer1));
         assert!(!registry.is_any_replicator(&peer1));
 
-        assert!(registry.is_replicator("comments", &peer2.to_string()));
+        assert!(registry.is_replicator("comments", &peer2));
     }
 
     #[test]

--- a/crates/p2p/src/sync/broadcaster.rs
+++ b/crates/p2p/src/sync/broadcaster.rs
@@ -168,7 +168,7 @@ impl<T: P2PTransport> Broadcaster<T> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "libp2p-transport"))]
 mod tests {
     use super::*;
 

--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -312,7 +312,9 @@ fn create_test_coordinator_with_blockstore_and_head_provider<B: Blockstore + 'st
         classifier: Arc::new(crate::bitswap::DefaultBlockClassifier),
         serve_acp: Arc::new(crate::bitswap::LateBoundServeAcp::new()),
         document_acp: std::sync::OnceLock::new(),
+        #[cfg(feature = "libp2p-transport")]
         kms_transport: std::sync::OnceLock::new(),
+        #[cfg(feature = "libp2p-transport")]
         pubsub_services: None,
     };
 
@@ -770,8 +772,11 @@ fn branchable_sync_reply_event(
 }
 
 fn random_peer_id() -> PeerId {
-    let libp2p_peer = libp2p::PeerId::random();
-    PeerId::from(libp2p_peer)
+    static NEXT_PEER_ID: AtomicUsize = AtomicUsize::new(0);
+    PeerId::new(format!(
+        "test-peer-{}",
+        NEXT_PEER_ID.fetch_add(1, Ordering::Relaxed)
+    ))
 }
 
 fn cid_for(data: &[u8]) -> Cid {

--- a/crates/p2p/src/sync/peer_state/tracker/tests.rs
+++ b/crates/p2p/src/sync/peer_state/tracker/tests.rs
@@ -1,9 +1,11 @@
 use super::*;
 use std::str::FromStr;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 fn test_peer_id() -> String {
-    libp2p::PeerId::random().to_string()
+    static NEXT_PEER_ID: AtomicU64 = AtomicU64::new(0);
+    format!("test-peer-{}", NEXT_PEER_ID.fetch_add(1, Ordering::Relaxed))
 }
 
 fn test_cid() -> Cid {
@@ -334,7 +336,7 @@ pub fn test_concurrent_peer_operations() {
     for i in 0..10 {
         let tracker_clone = Arc::clone(&tracker);
         let handle = thread::spawn(move || {
-            let peer = libp2p::PeerId::random().to_string();
+            let peer = test_peer_id();
             let cid = Cid::from_str("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi")
                 .unwrap();
 
@@ -372,7 +374,7 @@ pub fn test_concurrent_cid_tracking() {
     use std::thread;
 
     let tracker = Arc::new(PeerStateTracker::new());
-    let peer = libp2p::PeerId::random().to_string();
+    let peer = test_peer_id();
     tracker.peer_connected(&peer);
 
     let mut handles = vec![];
@@ -419,7 +421,7 @@ pub fn test_global_peer_limits_enforced_on_connect() {
 
     // Add 6 peers - peer 6 should trigger eviction
     for _ in 0..6 {
-        let peer = libp2p::PeerId::random().to_string();
+        let peer = test_peer_id();
         tracker.peer_connected(&peer);
     }
 
@@ -441,8 +443,8 @@ pub fn test_global_limits_evicts_disconnected_first() {
     );
 
     // Add 2 peers
-    let peer1 = libp2p::PeerId::random().to_string();
-    let peer2 = libp2p::PeerId::random().to_string();
+    let peer1 = test_peer_id();
+    let peer2 = test_peer_id();
     tracker.peer_connected(&peer1);
     tracker.peer_connected(&peer2);
 
@@ -450,8 +452,8 @@ pub fn test_global_limits_evicts_disconnected_first() {
     tracker.peer_disconnected(&peer2);
 
     // Add 2 more peers
-    let peer3 = libp2p::PeerId::random().to_string();
-    let peer4 = libp2p::PeerId::random().to_string();
+    let peer3 = test_peer_id();
+    let peer4 = test_peer_id();
     tracker.peer_connected(&peer3);
     tracker.peer_connected(&peer4);
 

--- a/crates/p2p/tests/bitswap_acp_filter_tests.rs
+++ b/crates/p2p/tests/bitswap_acp_filter_tests.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "test-utils")]
+
 //! End-to-end tests for per-peer Bitswap access control (#830).
 //!
 //! Spins up two real `P2PHost` instances over loopback TCP with the

--- a/crates/p2p/tests/codec_tests.rs
+++ b/crates/p2p/tests/codec_tests.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "libp2p-transport")]
+
 //! Tests for the CBOR codec module.
 
 use bytes::Bytes;

--- a/crates/p2p/tests/dag_sync_tests.rs
+++ b/crates/p2p/tests/dag_sync_tests.rs
@@ -1,6 +1,7 @@
 //! Tests for DAG synchronization.
 
 use std::str::FromStr;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -20,7 +21,8 @@ fn test_cid3() -> Cid {
 }
 
 fn random_peer_str() -> String {
-    p2p::PeerId::random().to_string()
+    static NEXT_PEER_ID: AtomicU64 = AtomicU64::new(0);
+    format!("test-peer-{}", NEXT_PEER_ID.fetch_add(1, Ordering::Relaxed))
 }
 
 #[tokio::test]

--- a/crates/p2p/tests/encryption_topic_mesh.rs
+++ b/crates/p2p/tests/encryption_topic_mesh.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "test-utils")]
+
 //! Step-1 discriminator probe for issue #976: does the `"encryption"`
 //! gossipsub topic form a usable publish mesh between two Rust nodes?
 //!

--- a/crates/p2p/tests/error_tests.rs
+++ b/crates/p2p/tests/error_tests.rs
@@ -106,6 +106,7 @@ fn test_error_from_io() {
 }
 
 #[test]
+#[cfg(feature = "libp2p-transport")]
 fn test_error_from_multiaddr() {
     // Create an invalid multiaddr to test the conversion
     let result: std::result::Result<libp2p::Multiaddr, _> = "/invalid/addr".parse();

--- a/crates/p2p/tests/gossipsub_message_id_go_parity.rs
+++ b/crates/p2p/tests/gossipsub_message_id_go_parity.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "libp2p-transport")]
+
 use std::str::FromStr;
 
 use libp2p::{

--- a/crates/p2p/tests/host_tests.rs
+++ b/crates/p2p/tests/host_tests.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "test-utils")]
+
 //! Tests for P2P host functionality.
 
 use bytes::Bytes;

--- a/crates/p2p/tests/live_go_pubsub_rpc.rs
+++ b/crates/p2p/tests/live_go_pubsub_rpc.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "test-utils")]
+
 //! Live Go↔Rust pubsub_rpc parity test (#828).
 //!
 //! Spins up a Rust libp2p host + SyncCoordinator, dials a pre-running

--- a/crates/p2p/tests/replicator_tests.rs
+++ b/crates/p2p/tests/replicator_tests.rs
@@ -1,10 +1,12 @@
 //! Tests for replicator types, including Go wire-format parity.
 
 use chrono::{TimeZone, Utc};
+#[cfg(feature = "libp2p-transport")]
+use p2p::replicator::ReplicatorError;
 use p2p::replicator::{
-    EqOnlyFilterMatcher, ReplicationFilterMatcher as _, ReplicatorError, ReplicatorInfo,
-    ReplicatorStatus,
+    EqOnlyFilterMatcher, ReplicationFilterMatcher as _, ReplicatorInfo, ReplicatorStatus,
 };
+#[cfg(feature = "libp2p-transport")]
 use p2p::{Multiaddr, PeerId};
 use p2p::{ReplicationFilter, ReplicationFilters};
 
@@ -190,6 +192,7 @@ fn filter_matches_numbers_numerically() {
 // ---------------------------------------------------------------------------
 
 #[test]
+#[cfg(feature = "libp2p-transport")]
 fn json_round_trip_preserves_all_fields() {
     let peer_id = PeerId::random();
     let mut info =
@@ -203,6 +206,7 @@ fn json_round_trip_preserves_all_fields() {
 }
 
 #[test]
+#[cfg(feature = "libp2p-transport")]
 fn status_update_records_first_transition_only() {
     let peer_id = PeerId::random();
     let mut info = ReplicatorInfo::new(peer_id, vec!["users".to_string()]).unwrap();
@@ -223,6 +227,7 @@ fn status_update_records_first_transition_only() {
 }
 
 #[test]
+#[cfg(feature = "libp2p-transport")]
 fn set_status_if_changed_now_matches_go_recovery_rule() {
     // Go's `updateReplicatorStatus` (`defradb/internal/db/p2p/replicator.go:495`)
     // resets `LastStatusChange` to `time.Time{}` on `Inactive → Active`,
@@ -300,6 +305,7 @@ fn decode_ignores_unknown_fields() {
 // ---------------------------------------------------------------------------
 
 #[test]
+#[cfg(feature = "libp2p-transport")]
 fn new_rejects_empty_collections() {
     let peer_id = PeerId::random();
     let result = ReplicatorInfo::new(peer_id, vec![]);
@@ -307,6 +313,7 @@ fn new_rejects_empty_collections() {
 }
 
 #[test]
+#[cfg(feature = "libp2p-transport")]
 fn new_accepts_non_empty_collections() {
     let peer_id = PeerId::random();
     let info = ReplicatorInfo::new(peer_id, vec!["users".to_string()]).unwrap();
@@ -320,12 +327,16 @@ fn from_raw_skips_validation() {
     // from_raw is the escape hatch for reconstructing from storage or
     // building test fixtures — no checks on collections or peer ID.
     let info = ReplicatorInfo::from_raw("invalid".to_string(), vec![], vec![]);
+    assert_eq!(info.peer_id_str(), "invalid");
+    #[cfg(feature = "libp2p-transport")]
     assert!(info.peer_id().is_none());
+    #[cfg(feature = "libp2p-transport")]
     assert!(info.try_peer_id().is_err());
     assert!(info.collections.is_empty());
 }
 
 #[test]
+#[cfg(feature = "libp2p-transport")]
 fn invalid_addresses_filtered_on_read() {
     let peer_id = PeerId::random();
     let info = ReplicatorInfo::from_raw(

--- a/crates/p2p/tests/signing_tests.rs
+++ b/crates/p2p/tests/signing_tests.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "libp2p-transport")]
+
 //! Tests for message signing and verification.
 
 use uuid::Uuid;


### PR DESCRIPTION
## Problem

The `p2p` crate has a self dev-dependency that enables `test-utils`, which silently turns on libp2p for every test build. As a result, `--no-default-features` does not actually exercise the transport-independent crate surface.

## What changed

- remove the feature-enabling self dev-dependency
- gate transport-specific unit and integration tests on their required features
- replace incidental libp2p peer IDs with transport-neutral test identifiers
- enable the Tokio runtime features required directly by the test suite
- preserve full transport coverage through explicit feature builds and workspace tests

## Validation

- [x] `cargo test --profile super-dev -p p2p --no-default-features`
- [x] `cargo test --profile super-dev -p p2p --all-features`
- [x] `cargo clippy --profile super-dev -p p2p --all-targets --no-default-features -- -D warnings`
- [x] `cargo clippy --profile super-dev -p p2p --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`