### PR TITLE
test(p2p-adapter): isolate transport fixtures

### DIFF
--- a/crates/p2p-adapter/Cargo.toml
+++ b/crates/p2p-adapter/Cargo.toml
@@ -46,7 +46,6 @@ crypto = { path = "../crypto" }
 data-encoding = "2"
 db-nac = { path = "../db-nac" }
 iroh.workspace = true
-p2p = { path = "../p2p", features = ["test-utils"] }
 
 [features]
 default = ["native", "wasmtime-runtime", "iroh", "libp2p"]

--- a/crates/p2p-adapter/src/libp2p.rs
+++ b/crates/p2p-adapter/src/libp2p.rs
@@ -1125,7 +1125,7 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
 mod tests {
     use super::*;
     use blockstore::DefraBlockstore;
-    use p2p::testutil::MockBitswapStore;
+    use p2p::BitswapStoreAdapter;
     use storage::backends::MemoryStore;
 
     #[tokio::test]
@@ -1183,6 +1183,7 @@ mod tests {
 
     /// The adapter under test carries no sync coordinator, so the blockstore
     /// generic is never exercised; a do-nothing implementation satisfies it.
+    #[derive(Debug)]
     struct NoopBlockstore;
 
     #[async_trait]
@@ -1264,11 +1265,11 @@ mod tests {
     #[tokio::test]
     async fn doc_sync_with_unresponsive_peer_returns_ok() {
         let (host_a, handle_a, _events_a, _replicators_a) =
-            p2p::host::P2PHost::new(MockBitswapStore::new())
+            p2p::host::P2PHost::new(BitswapStoreAdapter::new(Arc::new(NoopBlockstore)))
                 .await
                 .expect("host a");
         let (host_b, handle_b, _events_b, _replicators_b) =
-            p2p::host::P2PHost::new(MockBitswapStore::new())
+            p2p::host::P2PHost::new(BitswapStoreAdapter::new(Arc::new(NoopBlockstore)))
                 .await
                 .expect("host b");
 


### PR DESCRIPTION
## Problem

The adapter test manifest enables `p2p/test-utils`, which pulls libp2p into `defra-p2p-adapter` even under `--no-default-features`. One libp2p behavior test is the only consumer of that cross-crate test fixture.

## What changed

- replace the cross-crate mock with the production `BitswapStoreAdapter`
- reuse the test-local no-op blockstore for the host fixture
- remove the feature-enabling `p2p` dev-dependency
- preserve the existing real-host behavior test

## Validation

- [x] `cargo test --profile super-dev -p defra-p2p-adapter --no-default-features`
- [x] `cargo test --profile super-dev -p defra-p2p-adapter --all-features`
- [x] `cargo clippy --profile super-dev -p defra-p2p-adapter --all-targets --all-features -- -D warnings`
- [x] confirmed `libp2p` is absent from the no-feature adapter dependency graph
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`