### PR TITLE
feat(node): typed document read/write for embedded nodes

### DIFF
--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -60,10 +60,14 @@ pub use config::HttpConfig;
 pub use config::P2PConfig;
 #[cfg(feature = "sourcehub")]
 pub use config::SourceHubConfig;
+/// Typed document access, for values JSON cannot carry — binary above all.
+/// See [`EmbeddedNode::doc_mutator`] and [`EmbeddedNode::doc_fetcher`].
+pub use db::{DocID, Document, NormalValue};
 pub use dense_search::{DenseHybridSearchHit, DenseHybridSearchRequest, DenseHybridSearchResponse};
 pub use events::EventName;
 pub use lens::{LensConfig, LensModule, TransformId};
 pub use query::QueryLimits;
+pub use query::{DocFetcher, DocMutator};
 pub use query::{QueryExecutor, QueryRequest, QueryResponse, TransactionHandle};
 pub use schema::CollectionVersion;
 pub use telemetry::{ConflictMetricsSnapshot, RetryLayerSnapshot};
@@ -166,6 +170,8 @@ pub struct EmbeddedNode {
     rocksdb_stats: Option<storage::RocksDbStatsHandle>,
     #[cfg(feature = "http")]
     txn_cleanup_task: tokio::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
+    doc_mutator: Arc<dyn query::DocMutator>,
+    doc_fetcher: Arc<dyn query::DocFetcher>,
     #[cfg(feature = "p2p")]
     p2p_ops: Option<Arc<dyn defra_http::P2POperations>>,
     #[cfg(feature = "p2p")]
@@ -485,6 +491,30 @@ impl EmbeddedNode {
     /// or [`Self::execute_request_in_txn`] for document reads and writes.
     pub fn runner(&self) -> &Arc<dyn QueryExecutor> {
         &self.runner
+    }
+
+    /// Write documents with typed field values.
+    ///
+    /// GraphQL is the usual path, but its variables are JSON, which has no
+    /// binary type: bytes have to be hex or base64 to get through, costing
+    /// double or a third again on every write, in storage, and on the wire.
+    /// A [`Document`] carries [`NormalValue::Bytes`] as bytes, and the CBOR
+    /// block encoding keeps them that way.
+    ///
+    /// This is the same seam the GraphQL planner mutates through, so
+    /// validation, indexing, ACP, and P2P broadcast all behave identically —
+    /// only the JSON step is skipped.
+    pub fn doc_mutator(&self) -> &Arc<dyn query::DocMutator> {
+        &self.doc_mutator
+    }
+
+    /// Read documents with typed field values, the counterpart to
+    /// [`doc_mutator`](Self::doc_mutator).
+    ///
+    /// Query results are JSON, which renders [`NormalValue::Bytes`] as a hex
+    /// string. Reading through the fetcher returns the bytes themselves.
+    pub fn doc_fetcher(&self) -> &Arc<dyn query::DocFetcher> {
+        &self.doc_fetcher
     }
 
     /// Access the event bus directly.
@@ -1454,7 +1484,15 @@ impl NodeBuilder {
         let mutator: Arc<dyn query::DocMutator> =
             Arc::new(db::AutoCommitMutator::new(database.clone()));
 
-        // Query runner components
+        let doc_mutator = mutator.clone();
+
+        // Query runner components. The fetcher is built twice rather than
+        // shared: `DocFetcher` has no blanket impl for `Arc`, and a delegating
+        // wrapper is exactly how `FetcherWrapper` once lost method overrides
+        // silently. Both instances read the same `Arc<DB>`; only a migration
+        // cache is duplicated.
+        let doc_fetcher: Arc<dyn query::DocFetcher> =
+            Arc::new(db::LensedAutoCommitFetcher::new(database.clone()));
         let fetcher = db::LensedAutoCommitFetcher::new(database.clone());
         let provider: Arc<dyn query::CollectionProvider> =
             db::DbCollectionProvider::new_arc(database.clone());
@@ -1565,6 +1603,8 @@ impl NodeBuilder {
             rocksdb_stats: None,
             #[cfg(feature = "http")]
             txn_cleanup_task: tokio::sync::Mutex::new(txn_cleanup_task),
+            doc_mutator,
+            doc_fetcher,
             #[cfg(feature = "p2p")]
             p2p_ops,
             #[cfg(feature = "p2p")]

--- a/crates/defra-node/tests/typed_document_bytes.rs
+++ b/crates/defra-node/tests/typed_document_bytes.rs
@@ -1,0 +1,89 @@
+//! Binary values reach storage as bytes, not as text.
+//!
+//! GraphQL variables are JSON, which has no binary type, so writing bytes
+//! through a query means hex or base64 — double or a third again on every
+//! write, in storage, and on the wire. `doc_mutator` and `doc_fetcher` skip
+//! that boundary. These tests pin both directions and the fact that the JSON
+//! rendering is a view, not the stored form.
+
+use defra_node::{Document, EmbeddedNode, NormalValue};
+
+const SDL: &str = "type Payload { name: String @index(unique: true) data: Blob }";
+
+async fn node() -> EmbeddedNode {
+    let node = EmbeddedNode::builder()
+        .build()
+        .await
+        .expect("build in-memory node");
+    node.add_schema(SDL).await.expect("add schema");
+    node
+}
+
+/// Every byte value, including those no text encoding survives by accident.
+fn payload() -> Vec<u8> {
+    (0..=255u8).cycle().take(4096).collect()
+}
+
+#[tokio::test]
+async fn bytes_written_typed_come_back_typed() {
+    let node = node().await;
+    let collection = node
+        .get_collection("Payload")
+        .expect("look up collection")
+        .expect("collection exists");
+
+    let mut doc = Document::with_collection(collection);
+    doc.set("name", "round-trip");
+    doc.set("data", NormalValue::Bytes(payload()));
+
+    node.doc_mutator()
+        .create("Payload", doc)
+        .await
+        .expect("create through the typed seam");
+
+    let fetched = node
+        .doc_fetcher()
+        .get_by_field_value("Payload", "name", "round-trip")
+        .await
+        .expect("fetch by field value");
+    assert_eq!(fetched.len(), 1, "expected exactly one document");
+
+    match fetched[0].get("data") {
+        Some(NormalValue::Bytes(bytes)) => assert_eq!(bytes, &payload()),
+        other => panic!("expected NormalValue::Bytes, got {other:?}"),
+    }
+}
+
+/// The hex a query returns is a JSON rendering of stored bytes. If this ever
+/// came back as raw text the value was never binary in the first place.
+#[tokio::test]
+async fn the_same_value_renders_as_hex_through_graphql() {
+    let node = node().await;
+    let collection = node
+        .get_collection("Payload")
+        .expect("look up collection")
+        .expect("collection exists");
+
+    let mut doc = Document::with_collection(collection);
+    doc.set("name", "rendered");
+    doc.set("data", NormalValue::Bytes(vec![0xde, 0xad, 0xbe, 0xef]));
+    node.doc_mutator()
+        .create("Payload", doc)
+        .await
+        .expect("create through the typed seam");
+
+    let response = node
+        .execute(r#"query { Payload(filter: {name: {_eq: "rendered"}}) { data } }"#)
+        .await;
+    assert!(response.errors.is_empty(), "errors: {:?}", response.errors);
+
+    let rendered = response
+        .data
+        .as_ref()
+        .and_then(|data| data.get("Payload"))
+        .and_then(|rows| rows.get(0))
+        .and_then(|row| row.get("data"))
+        .and_then(|value| value.as_str())
+        .expect("data field present");
+    assert_eq!(rendered, "deadbeef");
+}


### PR DESCRIPTION
`EmbeddedNode` read and wrote documents only through GraphQL, whose variables and results are JSON. JSON has no binary type, so an embedder storing bytes had to encode them: the `Blob` convention spells them hex, costing double on every write, in storage, and on the wire, and base64 still costs a third again.

`doc_mutator()` and `doc_fetcher()` expose the seams the query planner already uses, so a `Document` carrying `NormalValue::Bytes` reaches storage as bytes and comes back as bytes. Writes enter where the GraphQL planner enters, so validation, indexing, ACP, and P2P broadcast are unchanged; only the JSON step is skipped.

The fetcher is constructed twice rather than shared. `DocFetcher` has no blanket impl for `Arc`, and a delegating wrapper is how `FetcherWrapper` once lost method overrides silently. Both read the same `Arc<DB>`; only a migration cache is duplicated.

`DocID`, `Document`, `NormalValue`, `DocFetcher`, and `DocMutator` are re-exported so an embedder needs no extra path dependencies. They come from `db` and `query`, which `defra-node` already depends on