### PR TITLE
test(p2p): move sync state tests into the tests tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -692,10 +692,10 @@ jobs:
           "$CACHE_DIR/defradb" version --format json
 
       # Guards against silent drift between the committed Go-parity hex
-      # constants in `crates/p2p/src/**` and what upstream Go actually
+      # constants in `crates/p2p/**/*.rs` and what upstream Go actually
       # emits. Both generators print hex to stdout (no files written);
       # every `(N bytes): <hex>` or `(N): <hex>` line is checked against
-      # the Rust source tree. If upstream reorders a struct field the
+      # the Rust crate. If upstream reorders a struct field the
       # hex changes, the grep misses, and the job fails — instead of
       # Rust tests passing against stale constants.
       - name: Verify Go fixtures still match Rust constants
@@ -717,13 +717,13 @@ jobs:
           fi
           STALE=0
           while IFS= read -r H; do
-            if ! grep -qR --include='*.rs' -F "$H" crates/p2p/src/; then
-              echo "::error::Go fixture hex not found in crates/p2p/src/**: $H" >&2
+            if ! grep -qR --include='*.rs' -F "$H" crates/p2p/; then
+              echo "::error::Go fixture hex not found in crates/p2p/**/*.rs: $H" >&2
               STALE=1
             fi
           done <<< "$HEXES"
           if [ "$STALE" -ne 0 ]; then
-            echo "::error::Go fixture drift detected — regenerate Rust constants by running the generators locally and updating crates/p2p/src/message/pubsub.rs, crates/p2p/src/pubsub_rpc/envelope.rs, and crates/p2p/src/sync/coordinator/pubsub_services.rs" >&2
+            echo "::error::Go fixture drift detected — regenerate the Rust fixture constants under crates/p2p" >&2
             exit 1
           fi
 

--- a/crates/p2p/src/sync/broadcaster.rs
+++ b/crates/p2p/src/sync/broadcaster.rs
@@ -167,33 +167,3 @@ impl<T: P2PTransport> Broadcaster<T> {
         &self.transport
     }
 }
-
-#[cfg(all(test, feature = "libp2p-transport"))]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_create_broadcast() {
-        use std::str::FromStr;
-        let cid =
-            Cid::from_str("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi").unwrap();
-        let block = b"test block data";
-        let doc_id = "bae-123";
-        let collection_id = "users";
-        let creator = "12D3KooWPeer";
-
-        let broadcast = Broadcaster::<crate::host::Libp2pTransport>::create_broadcast(
-            &cid,
-            block,
-            doc_id,
-            collection_id,
-            creator,
-        );
-
-        assert_eq!(broadcast.doc_id, doc_id);
-        assert_eq!(broadcast.collection_id, collection_id);
-        assert_eq!(broadcast.creator, creator);
-        assert_eq!(broadcast.block, block.to_vec());
-        assert_eq!(broadcast.cid, cid.to_bytes());
-    }
-}

--- a/crates/p2p/src/sync/peer_state/tracker/mod.rs
+++ b/crates/p2p/src/sync/peer_state/tracker/mod.rs
@@ -7,8 +7,6 @@
 
 mod memory;
 mod operations;
-#[cfg(test)]
-pub mod tests;
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::time::{Duration, Instant};

--- a/crates/p2p/tests/sync/broadcaster.rs
+++ b/crates/p2p/tests/sync/broadcaster.rs
@@ -1,0 +1,27 @@
+use std::str::FromStr;
+
+use cid::Cid;
+use p2p::{Broadcaster, Libp2pTransport};
+
+#[test]
+fn test_create_broadcast() {
+    let cid = Cid::from_str("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi").unwrap();
+    let block = b"test block data";
+    let doc_id = "bae-123";
+    let collection_id = "users";
+    let creator = "12D3KooWPeer";
+
+    let broadcast = Broadcaster::<Libp2pTransport>::create_broadcast(
+        &cid,
+        block,
+        doc_id,
+        collection_id,
+        creator,
+    );
+
+    assert_eq!(broadcast.doc_id, doc_id);
+    assert_eq!(broadcast.collection_id, collection_id);
+    assert_eq!(broadcast.creator, creator);
+    assert_eq!(broadcast.block, block.to_vec());
+    assert_eq!(broadcast.cid, cid.to_bytes());
+}

--- a/crates/p2p/tests/sync/main.rs
+++ b/crates/p2p/tests/sync/main.rs
@@ -1,0 +1,3 @@
+#[cfg(feature = "libp2p-transport")]
+mod broadcaster;
+mod peer_state;

--- a/crates/p2p/tests/sync/peer_state.rs
+++ b/crates/p2p/tests/sync/peer_state.rs
@@ -1,7 +1,9 @@
-use super::*;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
+
+use cid::Cid;
+use p2p::{PeerStateTracker, DOC_SYNC_TOPIC};
 
 fn test_peer_id() -> String {
     static NEXT_PEER_ID: AtomicU64 = AtomicU64::new(0);
@@ -102,7 +104,7 @@ pub fn test_data_subscription_excludes_system_topics() {
     let tracker = PeerStateTracker::new();
     let peer = test_peer_id();
 
-    tracker.peer_subscribed(&peer, crate::topics::DOC_SYNC_TOPIC.to_string());
+    tracker.peer_subscribed(&peer, DOC_SYNC_TOPIC.to_string());
     assert!(!tracker.peer_has_data_subscription(&peer));
 
     tracker.peer_subscribed(&peer, "users".to_string());


### PR DESCRIPTION
## Context

This is 4/4 in the P2P test-compartment stack and depends on #1550. It moves sync tests that exercise exported behavior without exposing sync internals for test access.

## Changes

- moves peer-state tracking tests under `tests/sync`
- moves libp2p broadcaster construction coverage into the same feature-aware target
- preserves 18 no-default tests and all 19 tests with libp2p enabled
- leaves private queue and coordinator tests for a separate visibility-review layer

## Testing

- [x] `cargo test --profile super-dev -p p2p --test sync --no-default-features`
- [x] `cargo test --profile super-dev -p p2p --all-features`
- [x] `cargo clippy --profile super-dev -p p2p --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
