### PR TITLE
fix(ci): satisfy Rust 1.98 Clippy lints

### DIFF
--- a/crates/sourcehub/src/cosmos/event_subscriber.rs
+++ b/crates/sourcehub/src/cosmos/event_subscriber.rs
@@ -106,7 +106,7 @@ fn retry_delay_after_session(current: Duration, session_duration: Option<Duratio
 async fn consume<S>(
     socket: &mut tokio_tungstenite::WebSocketStream<S>,
     cache: &AccessCache,
-) -> Result<(), tokio_tungstenite::tungstenite::Error>
+) -> Result<(), Box<tokio_tungstenite::tungstenite::Error>>
 where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
 {


### PR DESCRIPTION
## Context

This is 1/4 in the P2P test-compartment stack. Rust 1.98 introduced new default Clippy diagnostics that caused the workspace lint job to fail before reaching the stack's own checks.

## Changes

- decode IVF-PQ and SSG values through fixed-size byte arrays
- box WebSocket errors at the SourceHub event-consumer boundary
- retain the direct P2P recovery outcome without an unnecessary allocation
- preserve existing runtime behavior and wire representations

## Testing

- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo clippy -p defra-wasm --target wasm32-unknown-unknown --all-targets -- -D warnings`
- [x] `cargo clippy -p defra-wasm --target wasm32-unknown-unknown --no-default-features --all-targets -- -D warnings`
- [x] `cargo test --profile super-dev -p db-index`
- [x] `cargo test -p sourcehub --lib`
- [x] `cargo test -p p2p --lib`
- [x] `cargo fmt --all -- --check`
