### PR TITLE
chore(benches): extract the shared runtime helpers

### DIFF
--- a/benches/benches/blockstore.rs
+++ b/benches/benches/blockstore.rs
@@ -1,5 +1,5 @@
 use std::num::NonZeroUsize;
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 
 use blockstore::{Blockstore, DefraBlockstore};
 use cid::Cid;
@@ -10,10 +10,7 @@ use sha2::{Digest, Sha256};
 use std::hint::black_box;
 use storage::backends::MemoryStore;
 
-fn runtime() -> &'static tokio::runtime::Runtime {
-    static RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
-    RUNTIME.get_or_init(|| tokio::runtime::Runtime::new().unwrap())
-}
+mod common;
 
 fn cid_from_data(data: &[u8]) -> Cid {
     let mut hasher = Sha256::new();
@@ -66,12 +63,12 @@ fn bench_txn_creation(c: &mut Criterion) {
     let payload = make_payload(1024, 43);
     let cid = cid_from_data(&payload);
 
-    runtime().block_on(async {
+    common::shared_runtime().block_on(async {
         blockstore.put(&cid, &payload).await.unwrap();
     });
 
     c.bench_function("txn_creation_only", |b| {
-        b.to_async(runtime()).iter(|| async {
+        b.to_async(common::shared_runtime()).iter(|| async {
             let txn = blockstore.new_store_txn(true).await.unwrap();
             black_box(txn);
         })
@@ -86,7 +83,7 @@ fn bench_blockstore(c: &mut Criterion) {
         ("put_4kb", make_payload(4096, 11)),
     ] {
         group.bench_function(BenchmarkId::from_parameter(name), |b| {
-            b.to_async(runtime()).iter_batched(
+            b.to_async(common::shared_runtime()).iter_batched(
                 || {
                     let blockstore = make_blockstore();
                     let cid = cid_from_data(&payload);
@@ -103,13 +100,13 @@ fn bench_blockstore(c: &mut Criterion) {
     let hit_payload = make_payload(1024, 19);
     let hit_blockstore = make_blockstore();
     let hit_cid = cid_from_data(&hit_payload);
-    runtime().block_on(async {
+    common::shared_runtime().block_on(async {
         hit_blockstore.put(&hit_cid, &hit_payload).await.unwrap();
         black_box(hit_blockstore.get(&hit_cid).await.unwrap());
     });
 
     group.bench_function(BenchmarkId::from_parameter("get_cache_hit"), |b| {
-        b.to_async(runtime()).iter(|| async {
+        b.to_async(common::shared_runtime()).iter(|| async {
             black_box(hit_blockstore.get(&hit_cid).await.unwrap());
         });
     });
@@ -118,13 +115,13 @@ fn bench_blockstore(c: &mut Criterion) {
     let miss_store = Arc::new(MemoryStore::new());
     let miss_writer = DefraBlockstore::new(miss_store.clone(), false);
     let miss_cid = cid_from_data(&miss_payload);
-    runtime().block_on(async {
+    common::shared_runtime().block_on(async {
         miss_writer.put(&miss_cid, &miss_payload).await.unwrap();
     });
 
     group.bench_function(BenchmarkId::from_parameter("get_cache_miss"), |b| {
         let miss_store = miss_store.clone();
-        b.to_async(runtime()).iter_batched(
+        b.to_async(common::shared_runtime()).iter_batched(
             || DefraBlockstore::new(miss_store.clone(), false),
             |blockstore| async move {
                 black_box(blockstore.get(&miss_cid).await.unwrap());
@@ -137,13 +134,13 @@ fn bench_blockstore(c: &mut Criterion) {
     let has_store = Arc::new(MemoryStore::new());
     let has_writer = DefraBlockstore::new(has_store.clone(), false);
     let has_cid = cid_from_data(&has_payload);
-    runtime().block_on(async {
+    common::shared_runtime().block_on(async {
         has_writer.put(&has_cid, &has_payload).await.unwrap();
     });
 
     group.bench_function(BenchmarkId::from_parameter("has_check"), |b| {
         let has_store = has_store.clone();
-        b.to_async(runtime()).iter_batched(
+        b.to_async(common::shared_runtime()).iter_batched(
             || DefraBlockstore::new(has_store.clone(), false),
             |blockstore| async move {
                 black_box(blockstore.has(&has_cid).await.unwrap());
@@ -160,7 +157,7 @@ fn bench_blockstore(c: &mut Criterion) {
             })
             .collect();
 
-        b.to_async(runtime()).iter_batched(
+        b.to_async(common::shared_runtime()).iter_batched(
             || (make_blockstore(), blocks.clone()),
             |(blockstore, blocks)| async move {
                 for (cid, payload) in &blocks {

--- a/benches/benches/common/mod.rs
+++ b/benches/benches/common/mod.rs
@@ -1,216 +1,29 @@
-//! Fixtures shared by the vector benchmarks.
+//! Helpers shared by more than one benchmark target.
+//!
+//! Only helpers that are byte-identical at every call site live here. A helper
+//! that differs between targets stays with its target: for tokio runtimes in
+//! particular, the builder configuration is part of what a benchmark measures,
+//! and four of the six variants in this suite are deliberately unique to their
+//! target.
 
 #![allow(dead_code)]
 
 pub mod sift;
+pub mod vector;
 
-use db::index::vector::core::Metric;
-use db::index::vector::engine::ann::VectorIndexEngine;
-use db::index::vector::engine::flat::Flat;
-use db::index::vector::engine::hnsw::Hnsw;
-use db::index::vector::engine::ivfpq::{IvfPq, IvfPqParams};
-use db::index::vector::engine::ssg::{Ssg, SsgParams};
-use db::index::vector::params::{Params, DEFAULT_M};
-use db::index::vector::store::{MemoryNodeStore, NodeId};
+use std::sync::OnceLock;
 
-pub const SEED: u64 = 0x0BE9_C4A1;
+use tokio::runtime::Runtime;
 
-/// Deterministic across machines and releases, which a random-number crate's
-/// stream is not.
-pub struct Corpus(u64);
-
-impl Corpus {
-    pub fn new(seed: u64) -> Self {
-        Self(seed)
-    }
-
-    fn next_u64(&mut self) -> u64 {
-        self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
-        let mut z = self.0;
-        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
-        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
-        z ^ (z >> 31)
-    }
-
-    fn unit(&mut self) -> f64 {
-        (self.next_u64() >> 11) as f64 / (1u64 << 53) as f64
-    }
-
-    fn gaussian(&mut self) -> f32 {
-        let u1 = self.unit().max(f64::MIN_POSITIVE);
-        let u2 = self.unit();
-        ((-2.0 * u1.ln()).sqrt() * (core::f64::consts::TAU * u2).cos()) as f32
-    }
-
-    pub fn vector(&mut self, dimensions: usize) -> Vec<f32> {
-        (0..dimensions)
-            .map(|_| (self.unit() * 2.0 - 1.0) as f32)
-            .collect()
-    }
-
-    pub fn vectors(&mut self, count: usize, dimensions: usize) -> Vec<Vec<f32>> {
-        (0..count).map(|_| self.vector(dimensions)).collect()
-    }
-
-    /// Clustered, which is the shape a real embedding corpus has. Uniform
-    /// vectors in high dimensions are all near-orthogonal and make every index
-    /// look the same.
-    pub fn clustered(
-        &mut self,
-        count: usize,
-        dimensions: usize,
-        clusters: usize,
-        spread: f32,
-    ) -> Vec<Vec<f32>> {
-        let centers: Vec<Vec<f32>> = (0..clusters).map(|_| self.vector(dimensions)).collect();
-        (0..count)
-            .map(|i| {
-                let center = &centers[i % clusters];
-                (0..dimensions)
-                    .map(|j| center[j] + self.gaussian() * spread)
-                    .collect()
-            })
-            .collect()
-    }
+/// Built once per process and reused. `Runtime::new()` is multi-threaded across
+/// all available cores.
+pub fn shared_runtime() -> &'static Runtime {
+    static RUNTIME: OnceLock<Runtime> = OnceLock::new();
+    RUNTIME.get_or_init(|| Runtime::new().unwrap())
 }
 
-/// Every kind, behind the one trait they all implement.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Kind {
-    Flat,
-    Hnsw,
-    IvfPq,
-    Ssg,
-}
-
-impl Kind {
-    pub fn name(self) -> &'static str {
-        match self {
-            Kind::Flat => "flat",
-            Kind::Hnsw => "hnsw",
-            Kind::IvfPq => "ivfpq",
-            Kind::Ssg => "ssg",
-        }
-    }
-
-    /// The kinds that build a structure after the fact, and therefore have a
-    /// second state to measure.
-    pub fn is_batch_built(self) -> bool {
-        matches!(self, Kind::IvfPq | Kind::Ssg)
-    }
-}
-
-pub const ALL_KINDS: [Kind; 4] = [Kind::Flat, Kind::Hnsw, Kind::IvfPq, Kind::Ssg];
-
-#[derive(Clone)]
-pub enum Index {
-    Flat(Flat<MemoryNodeStore>),
-    Hnsw(Hnsw<MemoryNodeStore>),
-    IvfPq(IvfPq<MemoryNodeStore>),
-    Ssg(Ssg<MemoryNodeStore>),
-}
-
-macro_rules! on_index {
-    ($self:ident, $index:ident => $call:expr) => {
-        match $self {
-            Index::Flat($index) => $call,
-            Index::Hnsw($index) => $call,
-            Index::IvfPq($index) => $call,
-            Index::Ssg($index) => $call,
-        }
-    };
-}
-
-impl Index {
-    pub fn new(kind: Kind) -> Self {
-        Self::with_metric(kind, Metric::Cosine)
-    }
-
-    /// SIFT's published ground truth is Euclidean, so a benchmark measured
-    /// against it must rank the same way or an exact scan does not score 1.0.
-    pub fn with_metric(kind: Kind, metric: Metric) -> Self {
-        let store = MemoryNodeStore::new();
-        match kind {
-            Kind::Flat => Index::Flat(Flat::new(store, metric)),
-            Kind::Hnsw => Index::Hnsw(Hnsw::new(store, metric, Params::new(DEFAULT_M), SEED)),
-            Kind::IvfPq => Index::IvfPq(
-                IvfPq::try_new(
-                    store,
-                    metric,
-                    // nlist derived as 4*sqrt(N): a hardcoded small nlist
-                    // makes nprobe probe a large fraction of the corpus, which
-                    // measures a misconfigured index rather than the kind.
-                    IvfPqParams::default(),
-                    SEED,
-                )
-                .expect("cosine is rankable by squared distance"),
-            ),
-            Kind::Ssg => Index::Ssg(
-                Ssg::try_new(
-                    store,
-                    metric,
-                    Params::new(DEFAULT_M),
-                    SsgParams::default(),
-                    SEED,
-                )
-                .expect("valid SSG parameters"),
-            ),
-        }
-    }
-
-    pub async fn insert(&mut self, id: NodeId, vector: &[f32]) {
-        on_index!(self, index => index.insert(id, vector).await.expect("insert"));
-    }
-
-    pub async fn delete(&mut self, id: NodeId) -> bool {
-        on_index!(self, index => index.delete(id).await.expect("delete"))
-    }
-
-    pub async fn search(&self, query: &[f32], k: usize) -> usize {
-        on_index!(self, index => index.search(query, k, None).await.expect("search").len())
-    }
-
-    pub async fn search_ids(&self, query: &[f32], k: usize) -> Vec<u64> {
-        on_index!(self, index => index
-            .search(query, k, None)
-            .await
-            .expect("search")
-            .into_iter()
-            .map(|n| n.id.0)
-            .collect())
-    }
-
-    /// Builds the structure a batch-built kind answers from. A no-op for the
-    /// kinds that have none, so a caller can treat every kind alike.
-    pub async fn build(&mut self) {
-        match self {
-            Index::IvfPq(index) => {
-                index.build().await.expect("ivf-pq build");
-            }
-            Index::Ssg(index) => {
-                index.build().await.expect("ssg build");
-            }
-            _ => {}
-        }
-    }
-
-    pub async fn filled(kind: Kind, vectors: &[Vec<f32>], built: bool) -> Self {
-        Self::filled_with(kind, Metric::Cosine, vectors, built).await
-    }
-
-    pub async fn filled_with(
-        kind: Kind,
-        metric: Metric,
-        vectors: &[Vec<f32>],
-        built: bool,
-    ) -> Self {
-        let mut index = Index::with_metric(kind, metric);
-        for (i, vector) in vectors.iter().enumerate() {
-            index.insert(NodeId(i as u64 + 1), vector).await;
-        }
-        if built {
-            index.build().await;
-        }
-        index
-    }
+/// A fresh multi-threaded runtime per call, for targets that build one outside
+/// the measured region and hand it to criterion.
+pub fn owned_runtime() -> Runtime {
+    Runtime::new().expect("a tokio runtime")
 }

--- a/benches/benches/common/vector.rs
+++ b/benches/benches/common/vector.rs
@@ -1,0 +1,214 @@
+//! Fixtures shared by the vector benchmarks.
+
+#![allow(dead_code)]
+
+use db::index::vector::core::Metric;
+use db::index::vector::engine::ann::VectorIndexEngine;
+use db::index::vector::engine::flat::Flat;
+use db::index::vector::engine::hnsw::Hnsw;
+use db::index::vector::engine::ivfpq::{IvfPq, IvfPqParams};
+use db::index::vector::engine::ssg::{Ssg, SsgParams};
+use db::index::vector::params::{Params, DEFAULT_M};
+use db::index::vector::store::{MemoryNodeStore, NodeId};
+
+pub const SEED: u64 = 0x0BE9_C4A1;
+
+/// Deterministic across machines and releases, which a random-number crate's
+/// stream is not.
+pub struct Corpus(u64);
+
+impl Corpus {
+    pub fn new(seed: u64) -> Self {
+        Self(seed)
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+
+    fn unit(&mut self) -> f64 {
+        (self.next_u64() >> 11) as f64 / (1u64 << 53) as f64
+    }
+
+    fn gaussian(&mut self) -> f32 {
+        let u1 = self.unit().max(f64::MIN_POSITIVE);
+        let u2 = self.unit();
+        ((-2.0 * u1.ln()).sqrt() * (core::f64::consts::TAU * u2).cos()) as f32
+    }
+
+    pub fn vector(&mut self, dimensions: usize) -> Vec<f32> {
+        (0..dimensions)
+            .map(|_| (self.unit() * 2.0 - 1.0) as f32)
+            .collect()
+    }
+
+    pub fn vectors(&mut self, count: usize, dimensions: usize) -> Vec<Vec<f32>> {
+        (0..count).map(|_| self.vector(dimensions)).collect()
+    }
+
+    /// Clustered, which is the shape a real embedding corpus has. Uniform
+    /// vectors in high dimensions are all near-orthogonal and make every index
+    /// look the same.
+    pub fn clustered(
+        &mut self,
+        count: usize,
+        dimensions: usize,
+        clusters: usize,
+        spread: f32,
+    ) -> Vec<Vec<f32>> {
+        let centers: Vec<Vec<f32>> = (0..clusters).map(|_| self.vector(dimensions)).collect();
+        (0..count)
+            .map(|i| {
+                let center = &centers[i % clusters];
+                (0..dimensions)
+                    .map(|j| center[j] + self.gaussian() * spread)
+                    .collect()
+            })
+            .collect()
+    }
+}
+
+/// Every kind, behind the one trait they all implement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Kind {
+    Flat,
+    Hnsw,
+    IvfPq,
+    Ssg,
+}
+
+impl Kind {
+    pub fn name(self) -> &'static str {
+        match self {
+            Kind::Flat => "flat",
+            Kind::Hnsw => "hnsw",
+            Kind::IvfPq => "ivfpq",
+            Kind::Ssg => "ssg",
+        }
+    }
+
+    /// The kinds that build a structure after the fact, and therefore have a
+    /// second state to measure.
+    pub fn is_batch_built(self) -> bool {
+        matches!(self, Kind::IvfPq | Kind::Ssg)
+    }
+}
+
+pub const ALL_KINDS: [Kind; 4] = [Kind::Flat, Kind::Hnsw, Kind::IvfPq, Kind::Ssg];
+
+#[derive(Clone)]
+pub enum Index {
+    Flat(Flat<MemoryNodeStore>),
+    Hnsw(Hnsw<MemoryNodeStore>),
+    IvfPq(IvfPq<MemoryNodeStore>),
+    Ssg(Ssg<MemoryNodeStore>),
+}
+
+macro_rules! on_index {
+    ($self:ident, $index:ident => $call:expr) => {
+        match $self {
+            Index::Flat($index) => $call,
+            Index::Hnsw($index) => $call,
+            Index::IvfPq($index) => $call,
+            Index::Ssg($index) => $call,
+        }
+    };
+}
+
+impl Index {
+    pub fn new(kind: Kind) -> Self {
+        Self::with_metric(kind, Metric::Cosine)
+    }
+
+    /// SIFT's published ground truth is Euclidean, so a benchmark measured
+    /// against it must rank the same way or an exact scan does not score 1.0.
+    pub fn with_metric(kind: Kind, metric: Metric) -> Self {
+        let store = MemoryNodeStore::new();
+        match kind {
+            Kind::Flat => Index::Flat(Flat::new(store, metric)),
+            Kind::Hnsw => Index::Hnsw(Hnsw::new(store, metric, Params::new(DEFAULT_M), SEED)),
+            Kind::IvfPq => Index::IvfPq(
+                IvfPq::try_new(
+                    store,
+                    metric,
+                    // nlist derived as 4*sqrt(N): a hardcoded small nlist
+                    // makes nprobe probe a large fraction of the corpus, which
+                    // measures a misconfigured index rather than the kind.
+                    IvfPqParams::default(),
+                    SEED,
+                )
+                .expect("cosine is rankable by squared distance"),
+            ),
+            Kind::Ssg => Index::Ssg(
+                Ssg::try_new(
+                    store,
+                    metric,
+                    Params::new(DEFAULT_M),
+                    SsgParams::default(),
+                    SEED,
+                )
+                .expect("valid SSG parameters"),
+            ),
+        }
+    }
+
+    pub async fn insert(&mut self, id: NodeId, vector: &[f32]) {
+        on_index!(self, index => index.insert(id, vector).await.expect("insert"));
+    }
+
+    pub async fn delete(&mut self, id: NodeId) -> bool {
+        on_index!(self, index => index.delete(id).await.expect("delete"))
+    }
+
+    pub async fn search(&self, query: &[f32], k: usize) -> usize {
+        on_index!(self, index => index.search(query, k, None).await.expect("search").len())
+    }
+
+    pub async fn search_ids(&self, query: &[f32], k: usize) -> Vec<u64> {
+        on_index!(self, index => index
+            .search(query, k, None)
+            .await
+            .expect("search")
+            .into_iter()
+            .map(|n| n.id.0)
+            .collect())
+    }
+
+    /// Builds the structure a batch-built kind answers from. A no-op for the
+    /// kinds that have none, so a caller can treat every kind alike.
+    pub async fn build(&mut self) {
+        match self {
+            Index::IvfPq(index) => {
+                index.build().await.expect("ivf-pq build");
+            }
+            Index::Ssg(index) => {
+                index.build().await.expect("ssg build");
+            }
+            _ => {}
+        }
+    }
+
+    pub async fn filled(kind: Kind, vectors: &[Vec<f32>], built: bool) -> Self {
+        Self::filled_with(kind, Metric::Cosine, vectors, built).await
+    }
+
+    pub async fn filled_with(
+        kind: Kind,
+        metric: Metric,
+        vectors: &[Vec<f32>],
+        built: bool,
+    ) -> Self {
+        let mut index = Index::with_metric(kind, metric);
+        for (i, vector) in vectors.iter().enumerate() {
+            index.insert(NodeId(i as u64 + 1), vector).await;
+        }
+        if built {
+            index.build().await;
+        }
+        index
+    }
+}

--- a/benches/benches/groupby.rs
+++ b/benches/benches/groupby.rs
@@ -1,5 +1,3 @@
-use std::sync::OnceLock;
-
 use async_trait::async_trait;
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
 use query::mapper::GroupBy;
@@ -8,12 +6,9 @@ use query::{Doc, DocumentMapping, PlanNode};
 use serde_json::Value as JsonValue;
 use std::hint::black_box;
 
-const GROUP_INDEX: usize = 4;
+mod common;
 
-fn runtime() -> &'static tokio::runtime::Runtime {
-    static RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
-    RUNTIME.get_or_init(|| tokio::runtime::Runtime::new().unwrap())
-}
+const GROUP_INDEX: usize = 4;
 
 #[derive(Clone)]
 struct GroupByCase {
@@ -185,7 +180,7 @@ impl PlanNode for VecPlanNode {
 }
 
 fn execute_groupby(node: &mut GroupByNode) {
-    runtime().block_on(async {
+    common::shared_runtime().block_on(async {
         node.init().await.unwrap();
         let mut yielded = 0usize;
         while node.next().await.unwrap() {

--- a/benches/benches/merge.rs
+++ b/benches/benches/merge.rs
@@ -1,6 +1,5 @@
 use std::future::Future;
 use std::pin::pin;
-use std::sync::OnceLock;
 use std::task::{Context as TaskContext, Poll, Waker};
 
 use crdt::composite::FieldDelta;
@@ -14,10 +13,7 @@ use defra_core::types::DocId;
 use std::hint::black_box;
 use storage::{MemoryStore, Store, Txn};
 
-fn runtime() -> &'static tokio::runtime::Runtime {
-    static RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
-    RUNTIME.get_or_init(|| tokio::runtime::Runtime::new().unwrap())
-}
+mod common;
 
 /// Single-poll executor for futures that never yield.
 ///
@@ -62,7 +58,7 @@ fn make_merge_setup(
     initial: LwwDelta,
     incoming: LwwDelta,
 ) -> (Box<dyn Txn>, Lww, Context, LwwDelta) {
-    runtime().block_on(async move {
+    common::shared_runtime().block_on(async move {
         let store = MemoryStore::new();
         let lww = Lww::new("v1".to_string(), b"doc1", "name".to_string()).unwrap();
         let ctx = make_context();
@@ -149,7 +145,7 @@ fn bench_merge_contaminated(c: &mut Criterion) {
         b.iter_batched(
             || make_merge_setup(clear_winner_initial.clone(), clear_winner_incoming.clone()),
             |(txn, lww, ctx, incoming)| {
-                runtime().block_on(async {
+                common::shared_runtime().block_on(async {
                     let mut txn = txn;
                     black_box(lww.merge(&mut *txn, &ctx, &incoming).await.unwrap());
                     black_box(lww.value(&*txn).await.unwrap());
@@ -166,7 +162,7 @@ fn bench_merge_contaminated(c: &mut Criterion) {
         b.iter_batched(
             || make_merge_setup(tiebreak_initial.clone(), tiebreak_incoming.clone()),
             |(txn, lww, ctx, incoming)| {
-                runtime().block_on(async {
+                common::shared_runtime().block_on(async {
                     let mut txn = txn;
                     black_box(lww.merge(&mut *txn, &ctx, &incoming).await.unwrap());
                     black_box(lww.value(&*txn).await.unwrap());
@@ -409,7 +405,7 @@ fn bench_overhead(c: &mut Criterion) {
     let mut group = c.benchmark_group("crdt_overhead");
 
     group.bench_function(BenchmarkId::from_parameter("tokio_block_on_ready"), |b| {
-        b.iter(|| runtime().block_on(async { black_box(1u64) }));
+        b.iter(|| common::shared_runtime().block_on(async { black_box(1u64) }));
     });
 
     group.bench_function(BenchmarkId::from_parameter("noop_block_on_ready"), |b| {

--- a/benches/benches/sift.rs
+++ b/benches/benches/sift.rs
@@ -13,22 +13,17 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use db::index::vector::store::NodeId;
 use std::hint::black_box;
-use tokio::runtime::Runtime;
 
 mod common;
 
 use common::sift::{skip_notice, SiftSmall};
-use common::{Index, ALL_KINDS};
+use common::vector::{Index, ALL_KINDS};
 use db::index::vector::core::Metric;
 
 /// SIFT's ground truth is Euclidean.
 const METRIC: Metric = Metric::Euclidean;
 
 const K: usize = 10;
-
-fn runtime() -> Runtime {
-    Runtime::new().expect("a tokio runtime")
-}
 
 /// Recall against the corpus's own ground truth, which is the whole reason to
 /// use it: every other number in this crate is measured against an oracle over
@@ -38,7 +33,7 @@ fn recall(c: &mut Criterion) {
         skip_notice("sift/recall");
         return;
     };
-    let rt = runtime();
+    let rt = common::owned_runtime();
 
     println!(
         "\nSIFT-small: {} base vectors, {} dimensions, {} queries, recall@{K} against published ground truth",
@@ -102,7 +97,7 @@ fn bulk_load(c: &mut Criterion) {
         skip_notice("sift/bulk_load");
         return;
     };
-    let rt = runtime();
+    let rt = common::owned_runtime();
 
     let mut group = c.benchmark_group("sift/bulk_load");
     group.sample_size(10);
@@ -128,7 +123,7 @@ fn insert(c: &mut Criterion) {
         skip_notice("sift/insert");
         return;
     };
-    let rt = runtime();
+    let rt = common::owned_runtime();
     let incoming = &sift.queries;
     let existing = sift.base.len();
 

--- a/benches/benches/transaction.rs
+++ b/benches/benches/transaction.rs
@@ -1,16 +1,12 @@
 use std::hint::black_box;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
-use std::sync::OnceLock;
 
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
 use storage::corekv::{IterOptions, Reader, Store, Writer};
 use tempfile::TempDir;
 
-fn runtime() -> &'static tokio::runtime::Runtime {
-    static RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
-    RUNTIME.get_or_init(|| tokio::runtime::Runtime::new().unwrap())
-}
+mod common;
 
 /// Fixture holding a seeded store plus the keys the benchmarks read against.
 ///
@@ -44,7 +40,7 @@ impl<S: Store> BenchStore<S> {
             .map(|index| format!("rand:{:04}", (index * 37) % 1000).into_bytes())
             .collect();
 
-        runtime().block_on(async {
+        common::shared_runtime().block_on(async {
             let mut txn = store.new_txn(false).await.unwrap();
             txn.set(&tree_key, b"tree-value").await.unwrap();
 
@@ -118,7 +114,7 @@ fn bench_backend<S: Store>(c: &mut Criterion, backend: &str, fixture: &BenchStor
     group.bench_function(BenchmarkId::from_parameter("get_from_tree"), |b| {
         b.iter_batched(
             || {
-                runtime().block_on(async {
+                common::shared_runtime().block_on(async {
                     (
                         fixture.store.new_txn(true).await.unwrap(),
                         fixture.tree_key.clone(),
@@ -126,7 +122,7 @@ fn bench_backend<S: Store>(c: &mut Criterion, backend: &str, fixture: &BenchStor
                 })
             },
             |(txn, key)| {
-                runtime().block_on(async {
+                common::shared_runtime().block_on(async {
                     let value = txn.get(&key).await.unwrap();
                     black_box(value);
                     txn.discard();
@@ -139,7 +135,7 @@ fn bench_backend<S: Store>(c: &mut Criterion, backend: &str, fixture: &BenchStor
     group.bench_function(BenchmarkId::from_parameter("get_from_pending"), |b| {
         b.iter_batched(
             || {
-                runtime().block_on(async {
+                common::shared_runtime().block_on(async {
                     let mut txn = fixture.store.new_txn(false).await.unwrap();
                     txn.set(&fixture.pending_key, &fixture.pending_value)
                         .await
@@ -148,7 +144,7 @@ fn bench_backend<S: Store>(c: &mut Criterion, backend: &str, fixture: &BenchStor
                 })
             },
             |(txn, key)| {
-                runtime().block_on(async {
+                common::shared_runtime().block_on(async {
                     let value = txn.get(&key).await.unwrap();
                     black_box(value);
                     txn.discard();
@@ -162,7 +158,7 @@ fn bench_backend<S: Store>(c: &mut Criterion, backend: &str, fixture: &BenchStor
         b.iter_batched(
             || fixture.next_set_payload(),
             |(key, value)| {
-                runtime().block_on(async {
+                common::shared_runtime().block_on(async {
                     let mut txn = fixture.store.new_txn(false).await.unwrap();
                     txn.set(&key, &value).await.unwrap();
                     txn.commit().await.unwrap();
@@ -174,9 +170,12 @@ fn bench_backend<S: Store>(c: &mut Criterion, backend: &str, fixture: &BenchStor
 
     group.bench_function(BenchmarkId::from_parameter("sequential_scan_100"), |b| {
         b.iter_batched(
-            || runtime().block_on(async { fixture.store.new_txn(true).await.unwrap() }),
+            || {
+                common::shared_runtime()
+                    .block_on(async { fixture.store.new_txn(true).await.unwrap() })
+            },
             |txn| {
-                runtime().block_on(async {
+                common::shared_runtime().block_on(async {
                     let mut iter = txn
                         .iterator(IterOptions::new().with_prefix(fixture.scan_prefix.clone()))
                         .await
@@ -200,9 +199,12 @@ fn bench_backend<S: Store>(c: &mut Criterion, backend: &str, fixture: &BenchStor
 
     group.bench_function(BenchmarkId::from_parameter("sequential_scan_1000"), |b| {
         b.iter_batched(
-            || runtime().block_on(async { fixture.store.new_txn(true).await.unwrap() }),
+            || {
+                common::shared_runtime()
+                    .block_on(async { fixture.store.new_txn(true).await.unwrap() })
+            },
             |txn| {
-                runtime().block_on(async {
+                common::shared_runtime().block_on(async {
                     let mut iter = txn
                         .iterator(IterOptions::new().with_prefix(fixture.scan_large_prefix.clone()))
                         .await
@@ -223,9 +225,12 @@ fn bench_backend<S: Store>(c: &mut Criterion, backend: &str, fixture: &BenchStor
 
     group.bench_function(BenchmarkId::from_parameter("keys_only_scan_1000"), |b| {
         b.iter_batched(
-            || runtime().block_on(async { fixture.store.new_txn(true).await.unwrap() }),
+            || {
+                common::shared_runtime()
+                    .block_on(async { fixture.store.new_txn(true).await.unwrap() })
+            },
             |txn| {
-                runtime().block_on(async {
+                common::shared_runtime().block_on(async {
                     let mut iter = txn
                         .iterator(
                             IterOptions::new()
@@ -250,9 +255,12 @@ fn bench_backend<S: Store>(c: &mut Criterion, backend: &str, fixture: &BenchStor
 
     group.bench_function(BenchmarkId::from_parameter("random_get_1000"), |b| {
         b.iter_batched(
-            || runtime().block_on(async { fixture.store.new_txn(true).await.unwrap() }),
+            || {
+                common::shared_runtime()
+                    .block_on(async { fixture.store.new_txn(true).await.unwrap() })
+            },
             |txn| {
-                runtime().block_on(async {
+                common::shared_runtime().block_on(async {
                     let mut hits = 0usize;
                     for key in &fixture.random_keys {
                         if txn.get(key).await.unwrap().is_some() {

--- a/benches/benches/vector_mutations.rs
+++ b/benches/benches/vector_mutations.rs
@@ -12,11 +12,10 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use db::index::vector::store::NodeId;
 use std::hint::black_box;
-use tokio::runtime::Runtime;
 
 mod common;
 
-use common::{Corpus, Index, Kind, ALL_KINDS, SEED};
+use common::vector::{Corpus, Index, Kind, ALL_KINDS, SEED};
 
 /// Every kind in every state a mutation can hit. A batch-built kind behaves
 /// like a flat scan until it is built, so measuring only that state would
@@ -36,14 +35,10 @@ const DIMENSIONS: usize = 128;
 const CORPUS: usize = 2_000;
 const BATCH: usize = 100;
 
-fn runtime() -> Runtime {
-    Runtime::new().expect("a tokio runtime")
-}
-
 /// Inserting into an index that already holds `CORPUS` vectors, which is what
 /// a write to a populated collection costs.
 fn insert(c: &mut Criterion) {
-    let rt = runtime();
+    let rt = common::owned_runtime();
     let mut corpus = Corpus::new(SEED);
     let existing = corpus.clustered(CORPUS, DIMENSIONS, 32, 0.2);
     let incoming = corpus.clustered(BATCH, DIMENSIONS, 32, 0.2);
@@ -78,7 +73,7 @@ fn insert(c: &mut Criterion) {
 /// is replaced and its own links rebuilt, while links pointing *at* it stay
 /// valid because the id is what they name.
 fn update(c: &mut Criterion) {
-    let rt = runtime();
+    let rt = common::owned_runtime();
     let mut corpus = Corpus::new(SEED ^ 0x11);
     let existing = corpus.clustered(CORPUS, DIMENSIONS, 32, 0.2);
     let replacements = corpus.clustered(BATCH, DIMENSIONS, 32, 0.2);
@@ -110,7 +105,7 @@ fn update(c: &mut Criterion) {
 /// Deletes are tombstones on every kind, so this measures the write and the
 /// read that precedes it, not a graph repair.
 fn delete(c: &mut Criterion) {
-    let rt = runtime();
+    let rt = common::owned_runtime();
     let mut corpus = Corpus::new(SEED ^ 0x22);
     let existing = corpus.clustered(CORPUS, DIMENSIONS, 32, 0.2);
 
@@ -138,7 +133,7 @@ fn delete(c: &mut Criterion) {
 /// Building the whole index from scratch: what creating an index on a
 /// populated collection costs.
 fn bulk_load(c: &mut Criterion) {
-    let rt = runtime();
+    let rt = common::owned_runtime();
     let mut corpus = Corpus::new(SEED ^ 0x33);
     let vectors = corpus.clustered(CORPUS, DIMENSIONS, 32, 0.2);
 
@@ -163,7 +158,7 @@ fn bulk_load(c: &mut Criterion) {
 /// enough. The graph kinds have no equivalent, so they are absent rather than
 /// reported as zero.
 fn build(c: &mut Criterion) {
-    let rt = runtime();
+    let rt = common::owned_runtime();
     let mut corpus = Corpus::new(SEED ^ 0x44);
     let vectors = corpus.clustered(CORPUS, DIMENSIONS, 32, 0.2);
 

--- a/benches/benches/vector_search.rs
+++ b/benches/benches/vector_search.rs
@@ -7,24 +7,19 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use db::index::vector::core::{dot, squared_euclidean, Metric, Tier};
 use std::hint::black_box;
-use tokio::runtime::Runtime;
 
 mod common;
 
-use common::{Corpus, Index, ALL_KINDS, SEED};
+use common::vector::{Corpus, Index, ALL_KINDS, SEED};
 
 const DIMENSIONS: usize = 128;
 const K: usize = 10;
-
-fn runtime() -> Runtime {
-    Runtime::new().expect("a tokio runtime")
-}
 
 /// The batch-built kinds are measured in their built state, which is the one a
 /// production query hits. Their untrained state is a flat scan and is already
 /// covered by the `flat` row.
 fn search(c: &mut Criterion) {
-    let rt = runtime();
+    let rt = common::owned_runtime();
     let mut corpus = Corpus::new(SEED);
     let vectors = corpus.clustered(5_000, DIMENSIONS, 50, 0.25);
     let query = corpus.vector(DIMENSIONS);
@@ -47,7 +42,7 @@ fn search(c: &mut Criterion) {
 /// How query cost grows with the corpus. The exhaustive kind is linear by
 /// construction; the point of the others is that they are not.
 fn search_by_corpus_size(c: &mut Criterion) {
-    let rt = runtime();
+    let rt = common::owned_runtime();
     let mut group = c.benchmark_group("search_by_corpus");
     group.sample_size(20);
 


### PR DESCRIPTION
## Context

With every target in one package the duplicated setup becomes visible. `runtime()` was defined in 11 of the bench files, but hashing the bodies shows it is six different functions, not one.

Only the two variants that are byte-identical across their call sites move into `common/`. The other four are deliberately unique and stay with their targets.

## What changed

- Add `common::shared_runtime()` (`&'static` OnceLock, four call sites) and `common::owned_runtime()` (owned, three call sites).
- Update seven targets to call them and delete the local `runtime()` from each.
- Split the vector corpus helpers out of `common/mod.rs` into `common/vector.rs`.

## Notes

- `common/` hosts only byte-identical helpers. http's runtime must be multi-threaded or the slow path deadlocks on `Handle::block_on` inside `spawn_blocking`, and crdt runs a custom single-poll executor alongside `Runtime::block_on` precisely so the gap can be measured.
- That rule is documented in `common/mod.rs` so a later cleanup does not undo it.
