### PR TITLE
chore(benches): suppress empty libtest harnesses and add bench recipes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,13 +206,14 @@ strip = true
 panic = "abort"
 overflow-checks = true
 
-[profile.bench]
-opt-level = 3
+# `bench` inherits `release`, including its lto/codegen-units/strip/
+# overflow-checks. It carried an `opt-level = 3` that release already sets.
 
+# Symbols for profiling bench targets: `just bench-profile`.
 [profile.profile]
 inherits = "release"
 strip = false
-debug = 1
+debug = "line-tables-only"
 lto = "thin"
 
 # Fast release iteration for CI/dev: measured 1m40s cold vs 6m44s fat LTO

--- a/benches/benches/retry_markers.rs
+++ b/benches/benches/retry_markers.rs
@@ -35,7 +35,6 @@ async fn fixture(replicators: usize) -> Peerstore<MemoryStore> {
 fn bench_retry_markers(c: &mut Criterion) {
     let rt = runtime();
     let mut group = c.benchmark_group("sender_marker_registration");
-    group.sample_size(10);
 
     for documents in DOCUMENT_COUNTS {
         for replicators in REPLICATOR_COUNTS {

--- a/crates/acp/Cargo.toml
+++ b/crates/acp/Cargo.toml
@@ -13,6 +13,9 @@ default = ["native"]
 native = []
 redb = ["storage/redb"]
 
+[lib]
+bench = false
+
 [dependencies]
 defra-core = { path = "../defra-core" }
 identity = { path = "../identity" }

--- a/crates/blockstore/Cargo.toml
+++ b/crates/blockstore/Cargo.toml
@@ -11,6 +11,9 @@ description = "IPFS-compatible blockstore with merge tracking for DefraDB"
 [package.metadata.cargo-machete]
 ignored = ["crypto", "defra-core"]
 
+[lib]
+bench = false
+
 [dependencies]
 # Internal dependencies
 storage = { path = "../storage" }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 ignored = ["anyhow", "bytes", "futures", "getrandom", "rand", "serde_bytes", "serde_ipld_dagcbor"]
 
 [lib]
+bench = false
 name = "cli"
 path = "src/lib.rs"
 

--- a/crates/crdt/Cargo.toml
+++ b/crates/crdt/Cargo.toml
@@ -10,6 +10,9 @@ repository.workspace = true
 [package.metadata.cargo-machete]
 ignored = ["serde_json", "thiserror"]
 
+[lib]
+bench = false
+
 [dependencies]
 defra-core = { path = "../defra-core" }
 storage = { path = "../storage" }

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -10,6 +10,9 @@ repository.workspace = true
 [package.metadata.cargo-machete]
 ignored = ["serde_bytes"]
 
+[lib]
+bench = false
+
 [dependencies]
 # Core dependencies
 defra-core = { path = "../defra-core" }

--- a/crates/cursor/Cargo.toml
+++ b/crates/cursor/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 description = "Opaque cursor token codec for GraphQL cursor pagination"
 license = "Apache-2.0 OR MIT"
 
+[lib]
+bench = false
+
 [dependencies]
 base64 = "0.22"
 serde = { version = "1", features = ["derive"] }

--- a/crates/datastore/Cargo.toml
+++ b/crates/datastore/Cargo.toml
@@ -11,6 +11,9 @@ description = "Transaction wrapper for DefraDB providing multistore access and c
 [package.metadata.cargo-machete]
 ignored = ["cid"]
 
+[lib]
+bench = false
+
 [dependencies]
 # Async runtime
 async-trait.workspace = true

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -20,6 +20,9 @@ rocksdb = ["storage/rocksdb"]
 fjall = ["storage/fjall"]
 wasmtime-runtime = ["lens/wasmtime-runtime"]
 
+[lib]
+bench = false
+
 [dependencies]
 web-time.workspace = true
 # Async runtime

--- a/crates/defra-core/Cargo.toml
+++ b/crates/defra-core/Cargo.toml
@@ -10,6 +10,9 @@ repository.workspace = true
 [package.metadata.cargo-machete]
 ignored = ["tracing"]
 
+[lib]
+bench = false
+
 [dependencies]
 # Error handling
 thiserror.workspace = true

--- a/crates/defra-node/Cargo.toml
+++ b/crates/defra-node/Cargo.toml
@@ -47,6 +47,9 @@ wasmtime-runtime = [
 # who want OTel must opt in.
 otel = ["telemetry/otlp"]
 
+[lib]
+bench = false
+
 [dependencies]
 db = { path = "../db", default-features = false }
 replication-filter = { path = "../replication-filter" }

--- a/crates/defra-version/Cargo.toml
+++ b/crates/defra-version/Cargo.toml
@@ -7,6 +7,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[lib]
+bench = false
+
 [dependencies]
 serde = { workspace = true }
 

--- a/crates/document/Cargo.toml
+++ b/crates/document/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 description = "Runtime document types for DefraDB"
 
+[lib]
+bench = false
+
 [dependencies]
 # Internal dependencies
 schema = { path = "../schema" }

--- a/crates/embedded/Cargo.toml
+++ b/crates/embedded/Cargo.toml
@@ -11,6 +11,9 @@ description = "Reusable embedded/mobile DefraDB node assembly"
 [package.metadata.cargo-machete]
 ignored = ["bytes", "document", "lens", "serde", "serde_bytes", "serde_ipld_dagcbor", "thiserror"]
 
+[lib]
+bench = false
+
 [dependencies]
 acp = { path = "../acp" }
 blockstore = { path = "../blockstore" }

--- a/crates/events/Cargo.toml
+++ b/crates/events/Cargo.toml
@@ -15,6 +15,9 @@ ignored = ["async-trait", "thiserror"]
 default = ["channel"]
 channel = ["dep:async-channel", "dep:parking_lot"]
 
+[lib]
+bench = false
+
 [dependencies]
 defra-core = { path = "../defra-core" }
 

--- a/crates/ffi/Cargo.toml
+++ b/crates/ffi/Cargo.toml
@@ -12,6 +12,7 @@ description = "FFI bindings for DefraDB Rust implementation"
 ignored = ["cid", "libp2p", "serde_bytes", "serde_ipld_dagcbor", "serde_yaml", "sha2", "thiserror"]
 
 [lib]
+bench = false
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [features]

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -14,6 +14,9 @@ ignored = ["futures", "hyper"]
 default = []
 test-utils = []
 
+[lib]
+bench = false
+
 [dependencies]
 # Internal crates
 query = { path = "../query" }

--- a/crates/identity/Cargo.toml
+++ b/crates/identity/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 description = "Identity types for DefraDB"
 
+[lib]
+bench = false
+
 [dependencies]
 defra-core = { path = "../defra-core" }
 crypto = { path = "../crypto" }

--- a/crates/keyring/Cargo.toml
+++ b/crates/keyring/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 description = "Keyring and key management for DefraDB"
 
+[lib]
+bench = false
+
 [dependencies]
 thiserror.workspace = true
 base64 = "0.22"

--- a/crates/kms/Cargo.toml
+++ b/crates/kms/Cargo.toml
@@ -24,6 +24,9 @@ threshold = ["dep:orbis"]
 # SourceHub-attested release policy. M4.
 sourcehub = ["dep:sourcehub"]
 
+[lib]
+bench = false
+
 [dependencies]
 ciborium.workspace = true
 defra-core = { path = "../defra-core" }

--- a/crates/lens/Cargo.toml
+++ b/crates/lens/Cargo.toml
@@ -12,6 +12,9 @@ description = "Lens schema migration support for DefraDB"
 default = ["wasmtime-runtime"]
 wasmtime-runtime = ["dep:wasmtime", "dep:tokio", "dep:parking_lot"]
 
+[lib]
+bench = false
+
 [dependencies]
 # Core
 async-trait.workspace = true

--- a/crates/orbis/Cargo.toml
+++ b/crates/orbis/Cargo.toml
@@ -10,6 +10,9 @@ repository.workspace = true
 [package.metadata.cargo-machete]
 ignored = ["prost", "tonic-prost"]
 
+[lib]
+bench = false
+
 [dependencies]
 defra-core = { path = "../defra-core" }
 identity = { path = "../identity" }

--- a/crates/p2p-adapter/Cargo.toml
+++ b/crates/p2p-adapter/Cargo.toml
@@ -11,6 +11,9 @@ description = "DefraDB P2P adapters for HTTP-facing operations"
 [package.metadata.cargo-machete]
 ignored = ["hex", "serde"]
 
+[lib]
+bench = false
+
 [dependencies]
 acp = { path = "../acp" }
 blockstore = { path = "../blockstore" }

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 description = "P2P networking for DefraDB using libp2p"
 
+[lib]
+bench = false
+
 [dependencies]
 # Internal crates
 defra-core = { path = "../defra-core" }

--- a/crates/pg-compat/Cargo.toml
+++ b/crates/pg-compat/Cargo.toml
@@ -10,6 +10,9 @@ repository.workspace = true
 [package.metadata.cargo-machete]
 ignored = ["thiserror"]
 
+[lib]
+bench = false
+
 [dependencies]
 # Internal crates
 query = { path = "../query" }

--- a/crates/query/Cargo.toml
+++ b/crates/query/Cargo.toml
@@ -7,6 +7,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[lib]
+bench = false
+
 [dependencies]
 web-time.workspace = true
 # Internal crates

--- a/crates/replication-filter/Cargo.toml
+++ b/crates/replication-filter/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 description = "Query-filter-backed replication filter matcher shared between cli and embedded"
 
+[lib]
+bench = false
+
 [dependencies]
 p2p = { path = "../p2p" }
 query = { path = "../query" }

--- a/crates/schema/Cargo.toml
+++ b/crates/schema/Cargo.toml
@@ -10,6 +10,9 @@ repository.workspace = true
 [package.metadata.cargo-machete]
 ignored = ["serde_ipld_dagcbor"]
 
+[lib]
+bench = false
+
 [dependencies]
 defra-core = { path = "../defra-core" }
 thiserror.workspace = true

--- a/crates/sourcehub/Cargo.toml
+++ b/crates/sourcehub/Cargo.toml
@@ -11,6 +11,9 @@ description = "SourceHub ACP client for DefraDB"
 [package.metadata.cargo-machete]
 ignored = ["alloy-rlp"]
 
+[lib]
+bench = false
+
 [dependencies]
 # HTTP client for REST/LCD and CometBFT JSON-RPC
 reqwest = { version = "0.12", default-features = false, features = [

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -7,6 +7,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[lib]
+bench = false
+
 [dependencies]
 web-time.workspace = true
 defra-core = { path = "../defra-core" }

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -36,6 +36,9 @@ otlp = [
     "opentelemetry_sdk/internal-logs",
     "opentelemetry-otlp/internal-logs",
 ]
+[lib]
+bench = false
+
 [dependencies]
 reqwest = { version = "0.13", default-features = false, features = ["blocking"], optional = true }
 tracing.workspace = true

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -12,6 +12,7 @@ description = "DefraDB browser client - WASM build for browser-based application
 ignored = ["async-trait", "getrandom", "sha2"]
 
 [lib]
+bench = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]

--- a/crates/zanzibar/Cargo.toml
+++ b/crates/zanzibar/Cargo.toml
@@ -11,6 +11,9 @@ description = "Standalone Zanzibar permission engine with pluggable KV backend"
 [package.metadata.cargo-machete]
 ignored = ["tracing"]
 
+[lib]
+bench = false
+
 [dependencies]
 identity = { path = "../identity" }
 async-trait.workspace = true

--- a/justfile
+++ b/justfile
@@ -292,6 +292,37 @@ bench-vector *args:
     cargo bench -p benches --bench sift --bench vector_search \
         --bench vector_mutations {{ args }}
 
+# criterion writes results to target/criterion/<group>/<function>, keyed by
+# group and function name and never by binary. Its uniquifier is per-process, so
+# two targets sharing a group *and* function name overwrite each other silently.
+# Group names are distinct today; this keeps them that way.
+[doc("Fail if two bench targets share a criterion group name.")]
+[group('check')]
+bench-groups:
+    #!/usr/bin/env bash
+    set -uo pipefail
+    dupes=""
+    for g in $(grep -ho 'benchmark_group("[^"]*")' benches/benches/*.rs | sort -u); do
+        n=$(grep -l -- "$g" benches/benches/*.rs | wc -l | tr -d ' ')
+        if [ "$n" -gt 1 ]; then dupes="$dupes  $g in $n targets"$'\n'; fi
+    done
+    if [ -n "$dupes" ]; then
+        echo "criterion group names collide across targets:" >&2
+        printf '%s' "$dupes" >&2
+        exit 1
+    fi
+    echo "criterion group names: no collisions across $(ls benches/benches/*.rs | wc -l | tr -d ' ') targets"
+
+# Profile one bench target with symbols. `[profile.bench]` inherits release's
+# `strip = true`, so a bench binary carries no symbols and a profiler resolves
+# nothing; `[profile.profile]` keeps them. criterion's own `--profile-time`
+# runs the benchmark without its sampling/analysis phases.
+[doc("Profile one bench target with symbols, under an external profiler.")]
+[group('test')]
+bench-profile target seconds="10" *args:
+    cargo bench --profile profile -p benches --bench {{ target }} -- \
+        --profile-time {{ seconds }} {{ args }}
+
 # Go, for the FFI compatibility harness and the Go-parity integration suites.
 [doc("Go, for the FFI harness and the Go-parity suites.")]
 [group('setup')]

--- a/proofs/Cargo.toml
+++ b/proofs/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 autotests = false
 
 [lib]
+bench = false
 path = "src/lib.rs"
 
 [[test]]


### PR DESCRIPTION
## Context

With the fold done, `cargo bench --no-run --workspace` still builds a bench binary for every `[lib]` and `[bin]` in the workspace. There are no `#[bench]` functions anywhere in this repo, so all of those harnesses are empty.

This PR is separable from 1/5-4/5 and can land or be reverted on its own. It changes no benchmark and no measurement.

## What changed

- Add `[lib] bench = false` to 33 manifests, removing 33 empty libtest harnesses per `cargo bench` run.
- Delete `[profile.bench] opt-level = 3`, a no-op since `bench` inherits `release`.
- Set `[profile.profile] debug = "line-tables-only"` and add `just bench-profile` to profile a target with symbols.
- Add `just bench-groups`, which fails if two targets share a criterion group name.
- Remove the `sample_size(10)` override in `retry_markers`; measured no criterion warning at 100 and no slowdown.

## Notes

- `[profile.bench]` inherits `release`'s `strip = true`, so bench binaries carry no symbols and a profiler resolves nothing; `[profile.profile]` keeps them, and criterion's `--profile-time` skips the sampling and analysis phases.
- `bench-groups` reads only literal `benchmark_group("…")`. Two call sites build the name with `format!()` and are not checked.
- Five `sample_size` overrides remain, on criterion's own recommendation for slow benchmarks.

