### PR TITLE
feat(ffi-test): pin the Go client checkout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,7 +246,8 @@ git log origin/develop --oneline --since="1 week ago"
 
 The Go repo has two remotes:
 - `origin` → `sourcenetwork/defradb` (upstream)
-- `fork` → `edjroz/defradb` (our fork; `jack/ffi-rust-compat` lives on `origin`)
+- `fork` → `edjroz/defradb` (our fork; the rustffi client branches
+  `edjroz/ffi-rust-compat` and `jack/ffi-rust-compat` both live on `origin`)
 
 `DEFRADB_GO_REPO` covers the shell commands above and `ffi-test`, which also
 accepts `--go-path <PATH>` to override it. Integration tests that consume Go

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,7 +246,7 @@ git log origin/develop --oneline --since="1 week ago"
 
 The Go repo has two remotes:
 - `origin` → `sourcenetwork/defradb` (upstream)
-- `fork` → `jackzampolin/defradb` (our fork, `jack/ffi-rust-compat` branch)
+- `fork` → `edjroz/defradb` (our fork; `jack/ffi-rust-compat` lives on `origin`)
 
 `DEFRADB_GO_REPO` covers the shell commands above and `ffi-test`, which also
 accepts `--go-path <PATH>` to override it. Integration tests that consume Go

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,8 +248,9 @@ The Go repo has two remotes:
 - `origin` → `sourcenetwork/defradb` (upstream)
 - `fork` → `jackzampolin/defradb` (our fork, `jack/ffi-rust-compat` branch)
 
-`DEFRADB_GO_REPO` covers the shell commands above only. Integration tests that
-consume Go build artifacts resolve them at compile time under
+`DEFRADB_GO_REPO` covers the shell commands above and `ffi-test`, which also
+accepts `--go-path <PATH>` to override it. Integration tests that consume Go
+build artifacts resolve them at compile time under
 `$HOME/go/src/github.com/sourcenetwork/defradb` — see `COPY_WASM_PATH` in
 `tools/integration-test/tests/p2p_iroh/sync/version.rs`. A checkout elsewhere
 needs a symlink at that path, or the `p2p_iroh` lens tests fail on a missing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4396,6 +4396,7 @@ dependencies = [
  "chrono",
  "clap",
  "colored",
+ "defra-version",
  "dirs",
  "serde",
  "serde_json",

--- a/crates/defra-version/src/lib.rs
+++ b/crates/defra-version/src/lib.rs
@@ -7,6 +7,16 @@ pub const GO_COMPAT_BRANCH: &str = "develop";
 /// Go release tag; empty when CI should build the pinned commit from source.
 pub const GO_COMPAT_TAG: &str = "";
 
+/// Go commit carrying the rustffi test client, which the FFI oracle checks out.
+///
+/// Deliberately independent of `GO_COMPAT_COMMIT`: that pin selects the Go
+/// binary the parity job measures against and tracks upstream drift, while this
+/// one fixes the Go *test corpus* the FFI oracle runs, so its pass rate stays
+/// comparable across baseline bumps. It lives on `jack/ffi-rust-compat`, a
+/// maintained chore branch upstream does not merge, and moves only when we
+/// retarget the parity claim or fix the client.
+pub const GO_FFI_CLIENT_COMMIT: &str = "029a3105";
+
 /// Go compatibility metadata.
 #[derive(Debug, Clone, Serialize)]
 pub struct GoCompat {
@@ -158,5 +168,6 @@ mod tests {
     fn go_compat_constants_are_set() {
         assert!(!GO_COMPAT_COMMIT.is_empty());
         assert!(!GO_COMPAT_BRANCH.is_empty());
+        assert!(!GO_FFI_CLIENT_COMMIT.is_empty());
     }
 }

--- a/crates/defra-version/src/lib.rs
+++ b/crates/defra-version/src/lib.rs
@@ -15,7 +15,7 @@ pub const GO_COMPAT_TAG: &str = "";
 /// comparable across baseline bumps. It lives on `jack/ffi-rust-compat`, a
 /// maintained chore branch upstream does not merge, and moves only when we
 /// retarget the parity claim or fix the client.
-pub const GO_FFI_CLIENT_COMMIT: &str = "029a3105";
+pub const GO_FFI_CLIENT_COMMIT: &str = "f2f532b2";
 
 /// Go compatibility metadata.
 #[derive(Debug, Clone, Serialize)]

--- a/tools/ffi-test/Cargo.toml
+++ b/tools/ffi-test/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 
 [dependencies]
 axum = { workspace = true }
+defra-version = { path = "../../crates/defra-version" }
 clap = { version = "4.5", features = ["derive"] }
 tokio = { version = "1.35", features = ["process", "fs", "net", "rt-multi-thread", "macros", "io-util"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/tools/ffi-test/README.md
+++ b/tools/ffi-test/README.md
@@ -1,6 +1,6 @@
 # ffi-test
 
-CLI tool for running Go integration tests against the Rust FFI implementation of DefraDB. Validates behavioral compatibility by building the Rust FFI library, copying it into the Go test harness, and running Go's integration test packages.
+CLI tool for running Go integration tests against the Rust FFI implementation of DefraDB. Validates behavioral compatibility by building the Rust FFI library into a Go checkout that already carries the Go-side test client, then running Go's integration test packages.
 
 ## Install
 
@@ -11,20 +11,43 @@ cargo install --path tools/ffi-test
 ## Architecture
 
 ```
-defradb.rs (Rust)                    defradb (Go)
-├── crates/ffi/                      ├── tests/integration/
-│   └── (FFI library)                │   └── (Go test packages)
-├── tools/ffi-test/                  └── tests/clients/rustffi/
-│   └── (this CLI tool)                  ├── libdefra_ffi.dylib
-                                         └── defra.h
+defradb.rs (Rust)                     defradb (Go) @ the client branch
+├── crates/ffi/                       ├── tests/integration/
+│   └── (FFI library)                 │   └── (Go test packages)
+└── tools/ffi-test/                   └── tests/clients/rustffi/
+    └── (this CLI tool)      ──────▶      ├── (the Go client, on the branch)
+                                          ├── defra.h        (generated)
+                                          └── libdefra_ffi.* (generated)
 ```
 
-FFI test requires **paired worktrees** — a Rust worktree and a corresponding Go worktree side by side:
+The Go tree is a checkout of `sourcenetwork/defradb` on the branch that carries
+the rustffi client — `jack/ffi-rust-compat`, or a branch based on it. That
+branch is a maintained chore branch, not something upstream intends to merge;
+it holds the client plus the harness seams the client needs.
 
-```
+`ffi-test` writes exactly two things into that checkout, both regenerated from
+`crates/ffi` on every run and neither ever committed:
+
+- **`defra.h`** — cbindgen output.
+- **the shared library** — `cargo build --release -p ffi`, copied in as
+  `libdefra_ffi.*`.
+
+Everything else in the Go tree belongs to the Go side. Changes to the client
+itself are commits on that branch, not edits here.
+
+## Resolving the Go checkout
+
+In order of precedence:
+
+1. `--go-path <PATH>`
+2. `DEFRADB_GO_REPO`
+3. **worktree pairing** — a Rust worktree and a Go worktree side by side,
+   sharing a suffix:
+
+```text
 sourcenetwork/
 ├── defradb.rs      ←→  defradb       (main)
-├── defradb.rs-foo  ←→  defradb-foo   (ffi/foo branch)
+├── defradb.rs-foo  ←→  defradb-foo   (feature branch)
 ```
 
 ## Commands

--- a/tools/ffi-test/README.md
+++ b/tools/ffi-test/README.md
@@ -21,7 +21,7 @@ defradb.rs (Rust)                     defradb (Go) @ the client branch
 ```
 
 The Go tree is a checkout of `sourcenetwork/defradb` on the branch that carries
-the rustffi client — `jack/ffi-rust-compat`, or a branch based on it. That
+the rustffi client — `edjroz/ffi-rust-compat`, or a branch based on it. That
 branch is a maintained chore branch, not something upstream intends to merge;
 it holds the client plus the harness seams the client needs.
 

--- a/tools/ffi-test/README.md
+++ b/tools/ffi-test/README.md
@@ -25,6 +25,11 @@ the rustffi client — `edjroz/ffi-rust-compat`, or a branch based on it. That
 branch is a maintained chore branch, not something upstream intends to merge;
 it holds the client plus the harness seams the client needs.
 
+The checkout must sit on the pinned client commit, `GO_FFI_CLIENT_COMMIT` in
+`crates/defra-version`, and `ffi-test run` fails fast when it does not. The pin
+keeps pass rates comparable: an unpinned checkout silently changes what the
+test corpus measures.
+
 `ffi-test` writes exactly two things into that checkout, both regenerated from
 `crates/ffi` on every run and neither ever committed:
 

--- a/tools/ffi-test/src/commands/diff.rs
+++ b/tools/ffi-test/src/commands/diff.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 use colored::Colorize;
 
@@ -8,8 +9,8 @@ use crate::runner::TestStatus;
 use crate::worktree::WorktreeContext;
 
 /// Show diff between two test runs
-pub async fn execute(package: &str) -> Result<()> {
-    let ctx = WorktreeContext::detect().await?;
+pub async fn execute(package: &str, go_path: Option<PathBuf>) -> Result<()> {
+    let ctx = WorktreeContext::detect_with(go_path).await?;
 
     println!(
         "{} {} - {}",

--- a/tools/ffi-test/src/commands/logs.rs
+++ b/tools/ffi-test/src/commands/logs.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use crate::error::{FfiTestError, Result};
 use crate::report::load_for_diff;
 use crate::runner::TestStatus;
@@ -9,8 +11,9 @@ pub async fn execute(
     test_filter: Option<&str>,
     failed_only: bool,
     all_output: bool,
+    go_path: Option<PathBuf>,
 ) -> Result<()> {
-    let ctx = WorktreeContext::detect().await?;
+    let ctx = WorktreeContext::detect_with(go_path).await?;
 
     // Load the most recent report for this package
     let reports = load_for_diff(&ctx.branch, package, 1).await?;

--- a/tools/ffi-test/src/commands/packages.rs
+++ b/tools/ffi-test/src/commands/packages.rs
@@ -1,10 +1,12 @@
+use std::path::PathBuf;
+
 use crate::error::Result;
 use crate::runner::{discover_subpackages, list_packages};
 use crate::worktree::WorktreeContext;
 
 /// List available test packages from the Go integration test directory
-pub async fn execute(filter: Option<&str>) -> Result<()> {
-    let ctx = WorktreeContext::detect().await?;
+pub async fn execute(filter: Option<&str>, go_path: Option<PathBuf>) -> Result<()> {
+    let ctx = WorktreeContext::detect_with(go_path).await?;
 
     let packages = match filter {
         Some(prefix) => discover_subpackages(&ctx.go_path, prefix).await?,

--- a/tools/ffi-test/src/commands/run.rs
+++ b/tools/ffi-test/src/commands/run.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use colored::Colorize;
 
 use crate::builder::build_ffi;
@@ -13,9 +15,10 @@ pub async fn execute(
     test_filter: Option<&str>,
     verbose: bool,
     skip_build: bool,
+    go_path: Option<PathBuf>,
 ) -> Result<()> {
     // Detect worktree context
-    let ctx = WorktreeContext::detect().await?;
+    let ctx = WorktreeContext::detect_with(go_path).await?;
 
     println!(
         "{} {} @ {}{}",

--- a/tools/ffi-test/src/commands/run.rs
+++ b/tools/ffi-test/src/commands/run.rs
@@ -7,7 +7,7 @@ use crate::embedding_fixture::EmbeddingFixture;
 use crate::error::Result;
 use crate::report::Report;
 use crate::runner::{discover_subpackages, run_tests, RunResult, TestStatus, TestSummary};
-use crate::worktree::WorktreeContext;
+use crate::worktree::{verify_go_pin, WorktreeContext};
 
 /// Run FFI tests for a package
 pub async fn execute(
@@ -33,6 +33,8 @@ pub async fn execute(
     );
     println!("  Rust: {}", ctx.rust_path.display());
     println!("  Go:   {}", ctx.go_path.display());
+
+    verify_go_pin(&ctx.go_path).await?;
     println!();
 
     // Discover all subpackages under this package

--- a/tools/ffi-test/src/commands/status.rs
+++ b/tools/ffi-test/src/commands/status.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, HashMap};
+use std::path::PathBuf;
 
 use colored::Colorize;
 
@@ -7,11 +8,16 @@ use crate::report::{load_all_for_branch, load_all_reports, Report};
 use crate::worktree::{list_rust_worktrees, WorktreeContext};
 
 /// Show status of FFI tests
-pub async fn execute(all: bool, depth: usize, filter: Option<&str>) -> Result<()> {
+pub async fn execute(
+    all: bool,
+    depth: usize,
+    filter: Option<&str>,
+    go_path: Option<PathBuf>,
+) -> Result<()> {
     if all {
         show_all_worktrees().await
     } else {
-        show_current_worktree(depth, filter).await
+        show_current_worktree(depth, filter, go_path).await
     }
 }
 
@@ -32,8 +38,12 @@ fn max_depth(packages: &[&String]) -> usize {
         .unwrap_or(1)
 }
 
-async fn show_current_worktree(depth: usize, filter: Option<&str>) -> Result<()> {
-    let ctx = WorktreeContext::detect().await?;
+async fn show_current_worktree(
+    depth: usize,
+    filter: Option<&str>,
+    go_path: Option<PathBuf>,
+) -> Result<()> {
+    let ctx = WorktreeContext::detect_with(go_path).await?;
 
     // Special case: if on main, show latest from ALL worktrees
     let is_main = ctx.branch == "main" || ctx.branch == "master";

--- a/tools/ffi-test/src/config.rs
+++ b/tools/ffi-test/src/config.rs
@@ -6,6 +6,9 @@ pub const RUST_WORKTREE_PREFIX: &str = "defradb.rs";
 /// Go worktree prefix
 pub const GO_WORKTREE_PREFIX: &str = "defradb";
 
+/// Environment variable naming the Go DefraDB checkout
+pub const GO_REPO_ENV: &str = "DEFRADB_GO_REPO";
+
 /// Report retention count per branch+package
 pub const REPORT_RETENTION_COUNT: usize = 10;
 

--- a/tools/ffi-test/src/error.rs
+++ b/tools/ffi-test/src/error.rs
@@ -9,7 +9,7 @@ pub enum FfiTestError {
     #[error(
         "Go checkout not found at {path}. It must be a checkout of \
          sourcenetwork/defradb carrying the rustffi client: the \
-         `jack/ffi-rust-compat` branch, or one based on it"
+         `edjroz/ffi-rust-compat` branch, or one based on it"
     )]
     GoWorktreeNotFound { path: String },
 

--- a/tools/ffi-test/src/error.rs
+++ b/tools/ffi-test/src/error.rs
@@ -7,9 +7,11 @@ pub enum FfiTestError {
     WorktreeDetection(String),
 
     #[error(
-        "Go worktree not found at {path}. Create it with: git worktree add {path} -b {branch}"
+        "Go checkout not found at {path}. It must be a checkout of \
+         sourcenetwork/defradb carrying the rustffi client: the \
+         `jack/ffi-rust-compat` branch, or one based on it"
     )]
-    GoWorktreeNotFound { path: String, branch: String },
+    GoWorktreeNotFound { path: String },
 
     #[error("FFI build failed: {0}")]
     FfiBuild(String),

--- a/tools/ffi-test/src/error.rs
+++ b/tools/ffi-test/src/error.rs
@@ -37,6 +37,13 @@ pub enum FfiTestError {
     #[error("cbindgen not found. Install with: cargo install cbindgen")]
     CbindgenNotFound,
 
+    #[error(
+        "Go checkout at {path} is on {found}, not the pinned client commit {}. \
+         Check it out at the pin, or update GO_FFI_CLIENT_COMMIT if the client moved",
+        defra_version::GO_FFI_CLIENT_COMMIT
+    )]
+    GoPinMismatch { path: String, found: String },
+
     #[error("Not in a defradb.rs worktree")]
     NotInWorktree,
 }

--- a/tools/ffi-test/src/main.rs
+++ b/tools/ffi-test/src/main.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use clap::{Parser, Subcommand};
 
 mod builder;
@@ -14,6 +16,10 @@ mod worktree;
 #[command(about = "FFI compatibility testing tool for defradb.rs")]
 #[command(version)]
 struct Cli {
+    /// Path to the Go DefraDB checkout (overrides DEFRADB_GO_REPO and worktree pairing)
+    #[arg(long, global = true, value_name = "PATH")]
+    go_path: Option<PathBuf>,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -117,32 +123,34 @@ enum WorktreeCommands {
 
 #[tokio::main]
 async fn main() {
-    let cli = Cli::parse();
+    let Cli { go_path, command } = Cli::parse();
 
-    let result = match cli.command {
+    let result = match command {
         Commands::Run {
             package,
             test,
             verbose,
             skip_build,
-        } => commands::run::execute(&package, test.as_deref(), verbose, skip_build).await,
+        } => commands::run::execute(&package, test.as_deref(), verbose, skip_build, go_path).await,
 
         Commands::Status {
             package,
             all,
             depth,
-        } => commands::status::execute(all, depth, package.as_deref()).await,
+        } => commands::status::execute(all, depth, package.as_deref(), go_path).await,
 
-        Commands::Diff { package } => commands::diff::execute(&package).await,
+        Commands::Diff { package } => commands::diff::execute(&package, go_path).await,
 
         Commands::Logs {
             package,
             test,
             failed,
             all,
-        } => commands::logs::execute(&package, test.as_deref(), failed, all).await,
+        } => commands::logs::execute(&package, test.as_deref(), failed, all, go_path).await,
 
-        Commands::Packages { package } => commands::packages::execute(package.as_deref()).await,
+        Commands::Packages { package } => {
+            commands::packages::execute(package.as_deref(), go_path).await
+        }
 
         Commands::Worktree { command } => match command {
             WorktreeCommands::List => commands::worktree::list().await,
@@ -158,5 +166,33 @@ async fn main() {
     if let Err(e) = result {
         eprintln!("\x1b[31mError:\x1b[0m {}", e);
         std::process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn go_path_of(args: &[&str]) -> Option<PathBuf> {
+        Cli::try_parse_from(args).map(|cli| cli.go_path).unwrap()
+    }
+
+    #[test]
+    fn go_path_is_accepted_before_and_after_the_subcommand() {
+        let expected = Some(PathBuf::from("/elsewhere/defradb"));
+
+        assert_eq!(
+            go_path_of(&["ffi-test", "--go-path", "/elsewhere/defradb", "packages"]),
+            expected
+        );
+        assert_eq!(
+            go_path_of(&["ffi-test", "packages", "--go-path", "/elsewhere/defradb"]),
+            expected
+        );
+    }
+
+    #[test]
+    fn go_path_is_absent_when_not_passed() {
+        assert_eq!(go_path_of(&["ffi-test", "packages"]), None);
     }
 }

--- a/tools/ffi-test/src/runner.rs
+++ b/tools/ffi-test/src/runner.rs
@@ -490,7 +490,6 @@ mod tests {
         let ctx = WorktreeContext {
             rust_path: std::path::PathBuf::from("/r/defradb.rs-ffi-port"),
             go_path: std::path::PathBuf::from("/r/defradb-ffi-port"),
-            suffix: "ffi-port".to_string(),
             branch: "edjroz/1395-rustffi-port".to_string(),
             commit: "0000000".to_string(),
             dirty: false,

--- a/tools/ffi-test/src/runner.rs
+++ b/tools/ffi-test/src/runner.rs
@@ -290,14 +290,20 @@ fn test_execution_error(package_output: &[String], stderr: &str) -> String {
 ///
 /// Without this every paired worktree shares one cgo cache and concurrent runs
 /// poison each other. Mirrors the Go Makefile's `gocache-$RUST_LIB-$PKG`.
+/// The digest keeps same-named checkouts under different parents isolated.
 fn gocache_dir(rust_path: &std::path::Path, package: &str) -> std::path::PathBuf {
+    use std::hash::{Hash, Hasher};
+
     let worktree = rust_path
         .file_name()
         .map(|name| name.to_string_lossy().into_owned())
         .unwrap_or_else(|| "unknown".to_string());
-    let package = package.replace('/', "-");
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    rust_path.hash(&mut hasher);
 
-    std::env::temp_dir().join(format!("gocache-{worktree}-{package}"))
+    std::env::temp_dir()
+        .join(format!("gocache-{worktree}-{:016x}", hasher.finish()))
+        .join(package)
 }
 
 /// Build environment variables for Go test
@@ -483,6 +489,23 @@ mod tests {
         );
         assert_ne!(here, other_package);
         assert!(here.to_string_lossy().contains("defradb.rs-ffi-port"));
+    }
+
+    #[test]
+    fn same_basename_worktrees_do_not_share_a_go_build_cache() {
+        assert_ne!(
+            gocache_dir(std::path::Path::new("/a/defradb.rs"), "query/simple"),
+            gocache_dir(std::path::Path::new("/b/defradb.rs"), "query/simple"),
+            "checkouts sharing a basename must not share a cgo cache"
+        );
+    }
+
+    #[test]
+    fn hyphenated_package_paths_do_not_collide() {
+        assert_ne!(
+            gocache_dir(std::path::Path::new("/r/defradb.rs-ffi-port"), "a/b-c"),
+            gocache_dir(std::path::Path::new("/r/defradb.rs-ffi-port"), "a-b/c"),
+        );
     }
 
     #[test]

--- a/tools/ffi-test/src/runner.rs
+++ b/tools/ffi-test/src/runner.rs
@@ -71,7 +71,7 @@ pub async fn run_tests(
     let start = Instant::now();
 
     // Build environment variables
-    let env = build_env(ctx);
+    let env = build_env(ctx, package);
 
     // Build the go test command
     let mut cmd = Command::new("go");
@@ -286,8 +286,22 @@ fn test_execution_error(package_output: &[String], stderr: &str) -> String {
     }
 }
 
+/// Per-worktree, per-package Go build cache.
+///
+/// Without this every paired worktree shares one cgo cache and concurrent runs
+/// poison each other. Mirrors the Go Makefile's `gocache-$RUST_LIB-$PKG`.
+fn gocache_dir(rust_path: &std::path::Path, package: &str) -> std::path::PathBuf {
+    let worktree = rust_path
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "unknown".to_string());
+    let package = package.replace('/', "-");
+
+    std::env::temp_dir().join(format!("gocache-{worktree}-{package}"))
+}
+
 /// Build environment variables for Go test
-fn build_env(ctx: &WorktreeContext) -> HashMap<String, String> {
+fn build_env(ctx: &WorktreeContext, package: &str) -> HashMap<String, String> {
     let mut env = HashMap::new();
 
     // CGO flags
@@ -320,6 +334,14 @@ fn build_env(ctx: &WorktreeContext) -> HashMap<String, String> {
 
     // Enable file-based database tests (Go env var name; Rust uses redb for persistence)
     env.insert("DEFRA_BADGER_FILE".to_string(), "true".to_string());
+
+    // Isolate the cgo build cache per worktree and package
+    env.insert(
+        "GOCACHE".to_string(),
+        gocache_dir(&ctx.rust_path, package)
+            .to_string_lossy()
+            .into_owned(),
+    );
 
     // Pass through Go test framework configuration from the environment.
     // These control the test matrix: which ACP type, mutation type, etc.
@@ -443,5 +465,42 @@ mod tests {
         let package_failure = &results["query/simple (go test)"];
         assert_eq!(package_failure.status, TestStatus::Fail);
         assert_eq!(package_failure.output, ["package setup failed"]);
+    }
+
+    #[test]
+    fn each_worktree_and_package_gets_its_own_go_build_cache() {
+        let here = gocache_dir(
+            std::path::Path::new("/r/defradb.rs-ffi-port"),
+            "query/simple",
+        );
+        let other_worktree =
+            gocache_dir(std::path::Path::new("/r/defradb.rs-index"), "query/simple");
+        let other_package = gocache_dir(std::path::Path::new("/r/defradb.rs-ffi-port"), "acp/nac");
+
+        assert_ne!(
+            here, other_worktree,
+            "concurrent worktrees must not share a cgo cache"
+        );
+        assert_ne!(here, other_package);
+        assert!(here.to_string_lossy().contains("defradb.rs-ffi-port"));
+    }
+
+    #[test]
+    fn the_go_child_process_is_told_which_build_cache_to_use() {
+        let ctx = WorktreeContext {
+            rust_path: std::path::PathBuf::from("/r/defradb.rs-ffi-port"),
+            go_path: std::path::PathBuf::from("/r/defradb-ffi-port"),
+            suffix: "ffi-port".to_string(),
+            branch: "edjroz/1395-rustffi-port".to_string(),
+            commit: "0000000".to_string(),
+            dirty: false,
+        };
+
+        let env = build_env(&ctx, "query/simple");
+
+        assert_eq!(
+            env.get("GOCACHE").map(String::as_str),
+            gocache_dir(&ctx.rust_path, "query/simple").to_str()
+        );
     }
 }

--- a/tools/ffi-test/src/worktree.rs
+++ b/tools/ffi-test/src/worktree.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 use tokio::process::Command;
 
-use crate::config::{GO_WORKTREE_PREFIX, RUST_WORKTREE_PREFIX};
+use crate::config::{GO_REPO_ENV, GO_WORKTREE_PREFIX, RUST_WORKTREE_PREFIX};
 use crate::error::{FfiTestError, Result};
 
 /// Information about the current worktree context
@@ -23,22 +23,31 @@ pub struct WorktreeContext {
 }
 
 impl WorktreeContext {
-    /// Detect the current worktree context from the current directory
-    pub async fn detect() -> Result<Self> {
+    /// Detect the current worktree context, preferring an explicitly supplied Go checkout
+    pub async fn detect_with(go_path_override: Option<PathBuf>) -> Result<Self> {
         let cwd = std::env::current_dir()?;
-        Self::from_path(&cwd).await
+        let from_env = std::env::var_os(GO_REPO_ENV).map(PathBuf::from);
+        Self::from_path_with(&cwd, go_path_override, from_env).await
     }
 
-    /// Detect worktree context from a given path
+    /// Detect worktree context from a given path, pairing it with the Go worktree beside it
     pub async fn from_path(path: &Path) -> Result<Self> {
+        Self::from_path_with(path, None, None).await
+    }
+
+    async fn from_path_with(
+        path: &Path,
+        explicit_go_path: Option<PathBuf>,
+        go_path_from_env: Option<PathBuf>,
+    ) -> Result<Self> {
         // Find the git root
         let rust_path = find_git_root(path).await?;
 
         // Extract suffix from path
         let suffix = extract_suffix(&rust_path)?;
 
-        // Derive Go worktree path
-        let go_path = derive_go_path(&rust_path, &suffix)?;
+        // Resolve the Go checkout: explicit path, then environment, then worktree pairing
+        let go_path = resolve_go_path(&rust_path, &suffix, explicit_go_path, go_path_from_env)?;
 
         // Validate Go worktree exists
         if !go_path.exists() {
@@ -110,6 +119,19 @@ fn extract_suffix(rust_path: &Path) -> Result<String> {
     };
 
     Ok(suffix)
+}
+
+/// Resolve the Go checkout: explicit path first, then `DEFRADB_GO_REPO`, then worktree pairing
+fn resolve_go_path(
+    rust_path: &Path,
+    suffix: &str,
+    explicit: Option<PathBuf>,
+    from_env: Option<PathBuf>,
+) -> Result<PathBuf> {
+    match explicit.or(from_env) {
+        Some(path) => Ok(path),
+        None => derive_go_path(rust_path, suffix),
+    }
 }
 
 /// Derive Go worktree path from suffix
@@ -376,6 +398,42 @@ pub async fn remove_worktree_pair(suffix: &str, force: bool, delete_branch: bool
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn an_explicit_go_path_beats_the_environment_and_the_pairing() {
+        let rust_path = Path::new("/home/user/source/defradb.rs-feature");
+
+        assert_eq!(
+            resolve_go_path(
+                rust_path,
+                "feature",
+                Some(PathBuf::from("/elsewhere/go-checkout")),
+                Some(PathBuf::from("/from/env")),
+            )
+            .unwrap(),
+            Path::new("/elsewhere/go-checkout")
+        );
+    }
+
+    #[test]
+    fn the_environment_beats_the_pairing_when_no_path_was_passed() {
+        let rust_path = Path::new("/home/user/source/defradb.rs-feature");
+
+        assert_eq!(
+            resolve_go_path(rust_path, "feature", None, Some(PathBuf::from("/from/env"))).unwrap(),
+            Path::new("/from/env")
+        );
+    }
+
+    #[test]
+    fn the_pairing_still_resolves_when_neither_is_set() {
+        let rust_path = Path::new("/home/user/source/defradb.rs-feature");
+
+        assert_eq!(
+            resolve_go_path(rust_path, "feature", None, None).unwrap(),
+            Path::new("/home/user/source/defradb-feature")
+        );
+    }
 
     #[test]
     fn derives_go_worktree_next_to_rust_worktree() {

--- a/tools/ffi-test/src/worktree.rs
+++ b/tools/ffi-test/src/worktree.rs
@@ -51,14 +51,8 @@ impl WorktreeContext {
 
         // Validate Go worktree exists
         if !go_path.exists() {
-            let branch = if suffix.is_empty() {
-                "jack/ffi-rust-compat".to_string()
-            } else {
-                format!("ffi/{}", suffix)
-            };
             return Err(FfiTestError::GoWorktreeNotFound {
                 path: go_path.display().to_string(),
-                branch,
             });
         }
 
@@ -442,6 +436,25 @@ mod tests {
         assert_eq!(
             derive_go_path(rust_path, "feature").unwrap(),
             Path::new("/home/user/source/defradb-feature")
+        );
+    }
+
+    #[test]
+    fn the_missing_go_worktree_hint_names_the_client_branch() {
+        let hint = FfiTestError::GoWorktreeNotFound {
+            path: "/r/defradb-ffi-port".to_string(),
+        }
+        .to_string();
+
+        assert!(
+            hint.contains("jack/ffi-rust-compat"),
+            "names the branch carrying the client: {hint}"
+        );
+        // the path may have come from --go-path or DEFRADB_GO_REPO, where
+        // `git worktree add` is the wrong mechanism entirely
+        assert!(
+            !hint.contains("worktree add"),
+            "must not prescribe a mechanism that only fits pairing: {hint}"
         );
     }
 }

--- a/tools/ffi-test/src/worktree.rs
+++ b/tools/ffi-test/src/worktree.rs
@@ -11,9 +11,6 @@ pub struct WorktreeContext {
     pub rust_path: PathBuf,
     /// Path to the paired Go worktree root
     pub go_path: PathBuf,
-    /// Worktree suffix (empty for main worktree)
-    #[allow(dead_code)]
-    pub suffix: String,
     /// Current git branch
     pub branch: String,
     /// Current git commit SHA (short)
@@ -44,7 +41,7 @@ impl WorktreeContext {
         let rust_path = find_git_root(path).await?;
 
         // Resolve the Go checkout: explicit path, then environment, then worktree pairing
-        let (go_path, suffix) = resolve_go_path(&rust_path, explicit_go_path, go_path_from_env)?;
+        let go_path = resolve_go_path(&rust_path, explicit_go_path, go_path_from_env)?;
 
         // Validate Go worktree exists
         if !go_path.exists() {
@@ -61,7 +58,6 @@ impl WorktreeContext {
         Ok(WorktreeContext {
             rust_path,
             go_path,
-            suffix,
             branch,
             commit,
             dirty,
@@ -117,16 +113,12 @@ fn resolve_go_path(
     rust_path: &Path,
     explicit: Option<PathBuf>,
     from_env: Option<PathBuf>,
-) -> Result<(PathBuf, String)> {
+) -> Result<PathBuf> {
     match explicit.or(from_env) {
         // An override names the Go checkout outright, so neither side has to
         // follow the paired naming convention.
-        Some(path) => Ok((path, String::new())),
-        None => {
-            let suffix = extract_suffix(rust_path)?;
-            let go_path = derive_go_path(rust_path, &suffix)?;
-            Ok((go_path, suffix))
-        }
+        Some(path) => Ok(path),
+        None => derive_go_path(rust_path, &extract_suffix(rust_path)?),
     }
 }
 
@@ -405,8 +397,7 @@ mod tests {
                 Some(PathBuf::from("/elsewhere/go-checkout")),
                 Some(PathBuf::from("/from/env")),
             )
-            .unwrap()
-            .0,
+            .unwrap(),
             Path::new("/elsewhere/go-checkout")
         );
     }
@@ -416,9 +407,7 @@ mod tests {
         let rust_path = Path::new("/home/user/source/defradb.rs-feature");
 
         assert_eq!(
-            resolve_go_path(rust_path, None, Some(PathBuf::from("/from/env")))
-                .unwrap()
-                .0,
+            resolve_go_path(rust_path, None, Some(PathBuf::from("/from/env"))).unwrap(),
             Path::new("/from/env")
         );
     }
@@ -428,7 +417,7 @@ mod tests {
         let rust_path = Path::new("/home/user/source/defradb.rs-feature");
 
         assert_eq!(
-            resolve_go_path(rust_path, None, None).unwrap().0,
+            resolve_go_path(rust_path, None, None).unwrap(),
             Path::new("/home/user/source/defradb-feature")
         );
     }
@@ -469,7 +458,7 @@ mod tests {
 
         // the suffix is only needed to derive a paired path; with an override
         // there is nothing to derive, so the name must not matter
-        let (path, _) = resolve_go_path(odd, explicit, None).unwrap();
+        let path = resolve_go_path(odd, explicit, None).unwrap();
 
         assert_eq!(path, PathBuf::from("/go/checkout"));
         assert!(

--- a/tools/ffi-test/src/worktree.rs
+++ b/tools/ffi-test/src/worktree.rs
@@ -43,11 +43,8 @@ impl WorktreeContext {
         // Find the git root
         let rust_path = find_git_root(path).await?;
 
-        // Extract suffix from path
-        let suffix = extract_suffix(&rust_path)?;
-
         // Resolve the Go checkout: explicit path, then environment, then worktree pairing
-        let go_path = resolve_go_path(&rust_path, &suffix, explicit_go_path, go_path_from_env)?;
+        let (go_path, suffix) = resolve_go_path(&rust_path, explicit_go_path, go_path_from_env)?;
 
         // Validate Go worktree exists
         if !go_path.exists() {
@@ -118,13 +115,18 @@ fn extract_suffix(rust_path: &Path) -> Result<String> {
 /// Resolve the Go checkout: explicit path first, then `DEFRADB_GO_REPO`, then worktree pairing
 fn resolve_go_path(
     rust_path: &Path,
-    suffix: &str,
     explicit: Option<PathBuf>,
     from_env: Option<PathBuf>,
-) -> Result<PathBuf> {
+) -> Result<(PathBuf, String)> {
     match explicit.or(from_env) {
-        Some(path) => Ok(path),
-        None => derive_go_path(rust_path, suffix),
+        // An override names the Go checkout outright, so neither side has to
+        // follow the paired naming convention.
+        Some(path) => Ok((path, String::new())),
+        None => {
+            let suffix = extract_suffix(rust_path)?;
+            let go_path = derive_go_path(rust_path, &suffix)?;
+            Ok((go_path, suffix))
+        }
     }
 }
 
@@ -400,11 +402,11 @@ mod tests {
         assert_eq!(
             resolve_go_path(
                 rust_path,
-                "feature",
                 Some(PathBuf::from("/elsewhere/go-checkout")),
                 Some(PathBuf::from("/from/env")),
             )
-            .unwrap(),
+            .unwrap()
+            .0,
             Path::new("/elsewhere/go-checkout")
         );
     }
@@ -414,7 +416,9 @@ mod tests {
         let rust_path = Path::new("/home/user/source/defradb.rs-feature");
 
         assert_eq!(
-            resolve_go_path(rust_path, "feature", None, Some(PathBuf::from("/from/env"))).unwrap(),
+            resolve_go_path(rust_path, None, Some(PathBuf::from("/from/env")))
+                .unwrap()
+                .0,
             Path::new("/from/env")
         );
     }
@@ -424,7 +428,7 @@ mod tests {
         let rust_path = Path::new("/home/user/source/defradb.rs-feature");
 
         assert_eq!(
-            resolve_go_path(rust_path, "feature", None, None).unwrap(),
+            resolve_go_path(rust_path, None, None).unwrap().0,
             Path::new("/home/user/source/defradb-feature")
         );
     }
@@ -455,6 +459,22 @@ mod tests {
         assert!(
             !hint.contains("worktree add"),
             "must not prescribe a mechanism that only fits pairing: {hint}"
+        );
+    }
+
+    #[test]
+    fn an_override_frees_the_rust_checkout_from_the_naming_convention() {
+        let odd = Path::new("/somewhere/my-fork-of-defradb-rs");
+        let explicit = Some(PathBuf::from("/go/checkout"));
+
+        // the suffix is only needed to derive a paired path; with an override
+        // there is nothing to derive, so the name must not matter
+        let (path, _) = resolve_go_path(odd, explicit, None).unwrap();
+
+        assert_eq!(path, PathBuf::from("/go/checkout"));
+        assert!(
+            resolve_go_path(odd, None, None).is_err(),
+            "without an override the pairing convention still applies"
         );
     }
 }

--- a/tools/ffi-test/src/worktree.rs
+++ b/tools/ffi-test/src/worktree.rs
@@ -474,7 +474,7 @@ mod tests {
         .to_string();
 
         assert!(
-            hint.contains("jack/ffi-rust-compat"),
+            hint.contains("edjroz/ffi-rust-compat"),
             "names the branch carrying the client: {hint}"
         );
         // the path may have come from --go-path or DEFRADB_GO_REPO, where

--- a/tools/ffi-test/src/worktree.rs
+++ b/tools/ffi-test/src/worktree.rs
@@ -188,6 +188,25 @@ async fn get_git_commit(path: &Path) -> Result<String> {
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
+/// Fail unless the Go checkout sits on the pinned client commit.
+///
+/// The oracle's result is only meaningful against a known Go tree: the test
+/// corpus and the harness seams both come from there, so an unpinned checkout
+/// silently changes what the pass rate means.
+pub async fn verify_go_pin(go_path: &Path) -> Result<()> {
+    let found = get_git_commit(go_path).await?;
+    let pin = defra_version::GO_FFI_CLIENT_COMMIT;
+
+    if found.starts_with(pin) || pin.starts_with(&found) {
+        return Ok(());
+    }
+
+    Err(FfiTestError::GoPinMismatch {
+        path: go_path.display().to_string(),
+        found,
+    })
+}
+
 /// Check if the worktree has uncommitted changes
 async fn is_git_dirty(path: &Path) -> Result<bool> {
     let output = Command::new("git")
@@ -430,6 +449,21 @@ mod tests {
             derive_go_path(rust_path, "feature").unwrap(),
             Path::new("/home/user/source/defradb-feature")
         );
+    }
+
+    #[test]
+    fn the_pin_mismatch_names_both_the_pin_and_what_was_found() {
+        let hint = FfiTestError::GoPinMismatch {
+            path: "/r/defradb-rustffi".to_string(),
+            found: "deadbeef".to_string(),
+        }
+        .to_string();
+
+        assert!(
+            hint.contains(defra_version::GO_FFI_CLIENT_COMMIT),
+            "names the pin: {hint}"
+        );
+        assert!(hint.contains("deadbeef"), "names what was found: {hint}");
     }
 
     #[test]


### PR DESCRIPTION
Closes #1395

## Problem

The Go client that lets Go's integration suite drive DefraDB through our C FFI lives on a branch of `sourcenetwork/defradb`, not here and not on Go's `develop`. Nothing in this repository recorded *which* commit of that branch the oracle was measured against, so a run's result could not be reproduced or compared over time.

An earlier iteration of this PR vendored the client and a patch series into `tools/ffi-test/goclient/`. **That approach was abandoned** after review: it made this repo the client's home, duplicated 6,000 lines that already exist upstream, and required regenerating patches on every baseline bump. The client's home is now a maintained branch, and this repo records a pin.

## What changed

- `GO_FFI_CLIENT_COMMIT` in `defra-version` names the Go commit carrying the client.
- `ffi-test run` verifies the checkout sits on that commit and refuses to run otherwise, naming both the pin and what it found.
- Deliberately independent of `GO_COMPAT_COMMIT`: that pin selects the Go **binary** the parity job measures against and tracks upstream drift; this one fixes the Go **test corpus** so the FFI pass rate stays comparable across baseline bumps.
- Checked on the run path only — `status`, `logs` and `diff` read reports and do not care which commit produced them.

## Verification

- [x] gate rejects a checkout on the wrong commit, naming both SHAs
- [x] gate passes on the pinned commit
- [x] `cargo test -p ffi-test` — 14 passed
- [x] clippy `-D warnings` exit 0, `fmt --check` clean

## Notes

- 8 files, +62 / −5.
- The pin is `f2f532b2` on `edjroz/ffi-rust-compat`, a branch we maintain. It is `jack/ffi-rust-compat` @ `57fefc55` plus five commits, fast-forward, nothing rewritten.
- **The gate has already earned itself.** When the client branch moved during development, it refused 20 consecutive runs rather than silently measuring a different tree.
- Superseded: this PR previously added 7,758 lines of vendored client and patches. None of that remains.