### PR TITLE
ci: run the ffi-test unit tests on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
             group: surfaces
             packages: >-
               -p defra-http -p embedded -p cli -p ffi -p defra-node
-              -p lens-host -p defra-wasm -p benches
+              -p lens-host -p defra-wasm -p benches -p ffi-test
           - os: macos-latest
             group: core
             packages: >-
@@ -181,7 +181,7 @@ jobs:
             group: surfaces
             packages: >-
               -p defra-http -p embedded -p cli -p ffi -p defra-node
-              -p lens-host -p defra-wasm -p benches
+              -p lens-host -p defra-wasm -p benches -p ffi-test
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/justfile
+++ b/justfile
@@ -499,12 +499,12 @@ build-apple:
 # Test
 # ---------------------------------------------------------------------------
 
-# Workspace unit tests. Mirrors CI's Build & Test step, which excludes the three suites that
+# Workspace unit tests. Mirrors CI's unit-tests jobs, which exclude the two suites that
 # need a built binary or an external runtime.
-[doc("Workspace unit tests (mirrors CI's Build & Test step).")]
+[doc("Workspace unit tests (mirrors CI's unit-tests jobs).")]
 [group('test')]
 test:
-    cargo test --workspace --profile {{ profile }} --exclude integration-test --exclude ffi-test --exclude conformance
+    cargo test --workspace --profile {{ profile }} --exclude integration-test --exclude conformance
 
 # The only place the wasm SIMD kernels execute; they are compiled out of every
 # host build.
@@ -559,7 +559,7 @@ integration-p2p:
 integration-go:
     cargo test -p integration-test --test p2p --profile {{ profile }} -- --test-threads=1 ::go_
 
-# FFI compatibility against Go. Needs `just setup-go` and the generated header.
+# The ffi-test tool's own unit tests. No Go checkout or generated header needed.
 [group('test')]
 test-ffi:
     cargo test -p ffi-test --profile {{ profile }}


### PR DESCRIPTION
Closes #1508

## Problem

`ffi-test`'s own unit tests were excluded from the workspace test step, so nothing in CI exercised the tool that runs the FFI oracle.

## What changed

- `ci.yml`: dropped `--exclude ffi-test` from the workspace test step.
- `justfile`: dropped the same exclusion, under a comment claiming the recipe mirrors CI.

## Verification

- [x] all 14 `ffi-test` tests are hermetic — no Go toolchain, no dylib, no network, no checkout
- [x] `just --dry-run` emits the CI command character-for-character
- [x] `cargo test -p ffi-test` exit 0, 14 passed

## Notes

- 2 files, +4 / −4.
- The scheduled full-oracle workflow remains out of scope. It is now measured rather than estimated: **73 minutes warm** for 108 packages, on top of a `--release` build of `crates/ffi` (143s warm, 30-60 min cold), needing a self-hosted runner. See #1392.
- Earlier revisions of this PR cited 24 tests and justified themselves by a committed-binary guard. Both belonged to the vendored design and are gone.