### PR TITLE
events crate test cleanup

### DIFF
--- a/crates/events/src/channel_bus.rs
+++ b/crates/events/src/channel_bus.rs
@@ -244,7 +244,3 @@ impl Bus for ChannelBus {
         self.closed.load(Ordering::Acquire)
     }
 }
-
-#[cfg(test)]
-#[path = "channel_bus_tests.rs"]
-mod tests;

--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -377,7 +377,3 @@ impl Message {
         }
     }
 }
-
-#[cfg(test)]
-#[path = "event_tests.rs"]
-mod tests;

--- a/crates/events/tests/channel_bus_tests.rs
+++ b/crates/events/tests/channel_bus_tests.rs
@@ -1,5 +1,6 @@
-use super::*;
-use crate::event::Update;
+//! Integration tests for the channel-backed event bus
+
+use events::{Bus, ChannelBus, ChannelBusConfig, EventName, MergeCompleteData, Message, Update};
 
 #[tokio::test]
 async fn test_channel_bus_publish_subscribe() {
@@ -35,7 +36,7 @@ async fn test_channel_bus_wildcard() {
 
     // Publish different events
     bus.publish(Message::merge());
-    bus.publish(Message::merge_complete(crate::MergeCompleteData {
+    bus.publish(Message::merge_complete(MergeCompleteData {
         doc_id: "test-doc".to_string(),
         subject_doc_id: None,
         cid: cid::Cid::default(),

--- a/crates/events/tests/event_tests.rs
+++ b/crates/events/tests/event_tests.rs
@@ -1,4 +1,7 @@
-use super::*;
+//! Integration tests for event types and messages
+
+use cid::Cid;
+use events::{EventName, MergeCompleteData, Message, PendingDagQuarantinedData, Update};
 
 #[test]
 fn test_event_name_matches() {


### PR DESCRIPTION
Move inline unit tests to crate-level /tests wherever possible.

Validation:
  cargo test -p events — 12 passing, 0 failures.
  cargo clippy -p events --all-targets -- -D warnings — clean.
  cargo fmt -p events applied.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>