### PR TITLE
fix(http): mount the API router at Go's unversioned /api prefix

### DIFF
--- a/crates/http/src/go_paths.rs
+++ b/crates/http/src/go_paths.rs
@@ -1,8 +1,11 @@
 //! Go wire paths, defined once because the router, the CLI and Go's client all
 //! have to agree on them. `tests/go_route_paths.rs` proves each one resolves.
 
-/// The API version prefixes the router mounts, oldest first.
-pub const API_PREFIXES: &[&str] = &["/api/v0", "/api/v1"];
+/// The API prefixes the router mounts, oldest version first.
+///
+/// The bare `/api` entry is Go's unversioned fallback: `r.Handle("/*", router)`
+/// in `http/handler.go:127` serves the whole route set with no version segment.
+pub const API_PREFIXES: &[&str] = &["/api/v0", "/api/v1", "/api"];
 
 /// `POST` - Go's `AddDACPolicy` (`http/handler_acp.go:338`).
 pub const ACP_POLICY: &str = "/acp/document/policy";

--- a/crates/http/src/route_permissions.rs
+++ b/crates/http/src/route_permissions.rs
@@ -305,12 +305,32 @@ pub fn route_permission(path: &str, method: &Method) -> RoutePermission {
     }
 }
 
+/// Fold every mount of the API router onto its `/api/v0` key.
+///
+/// `go_paths::API_PREFIXES` mounts one route set three times, so `/api/v1/x`
+/// and the unversioned `/api/x` reach the same handler as `/api/v0/x` and must
+/// carry the same permission. A form that fails to fold here falls to the `_`
+/// arm and is enforced as `DocumentRead`, which is a privilege downgrade
+/// rather than a 404.
 fn normalize_api_version(path: &str) -> Cow<'_, str> {
-    if path == "/api/v1" {
+    let Some(rest) = path.strip_prefix("/api") else {
+        return Cow::Borrowed(path);
+    };
+    if rest == "/v0" || rest.starts_with("/v0/") {
+        return Cow::Borrowed(path);
+    }
+
+    let suffix = match rest {
+        "/v1" => "",
+        _ => rest
+            .strip_prefix("/v1")
+            .filter(|stripped| stripped.starts_with('/'))
+            .unwrap_or(rest),
+    };
+
+    if suffix.is_empty() {
         Cow::Borrowed("/api/v0")
-    } else if let Some(suffix) = path.strip_prefix("/api/v1/") {
-        Cow::Owned(format!("/api/v0/{suffix}"))
     } else {
-        Cow::Borrowed(path)
+        Cow::Owned(format!("/api/v0{suffix}"))
     }
 }

--- a/crates/http/src/route_permissions.rs
+++ b/crates/http/src/route_permissions.rs
@@ -307,30 +307,29 @@ pub fn route_permission(path: &str, method: &Method) -> RoutePermission {
 
 /// Fold every mount of the API router onto its `/api/v0` key.
 ///
-/// `go_paths::API_PREFIXES` mounts one route set three times, so `/api/v1/x`
-/// and the unversioned `/api/x` reach the same handler as `/api/v0/x` and must
-/// carry the same permission. A form that fails to fold here falls to the `_`
-/// arm and is enforced as `DocumentRead`, which is a privilege downgrade
-/// rather than a 404.
+/// `go_paths::API_PREFIXES` is what `routes.rs` mounts the one route set at,
+/// so it is also what has to be folded here. Deriving from the same constant
+/// is the point: a prefix added there without a matching arm here would mount
+/// the whole route set unfolded, and every route under it would fall to the
+/// `_` arm and be enforced as `DocumentRead`.
+///
+/// The longest match wins, so the list stays order-independent: `/api/v0/x`
+/// must fold on `/api/v0` and not on the bare `/api`.
+///
+/// Note this rewrites rather than rejects: `/api/v2/collections` becomes
+/// `/api/v0/v2/collections`, which is safe only because no table key begins
+/// with `/api/v0/v`, and which lands on the `_` arm as it should.
 fn normalize_api_version(path: &str) -> Cow<'_, str> {
-    let Some(rest) = path.strip_prefix("/api") else {
-        return Cow::Borrowed(path);
-    };
-    if rest == "/v0" || rest.starts_with("/v0/") {
-        return Cow::Borrowed(path);
-    }
+    let matched = crate::go_paths::API_PREFIXES
+        .iter()
+        .filter_map(|prefix| {
+            path.strip_prefix(*prefix)
+                .filter(|suffix| suffix.is_empty() || suffix.starts_with('/'))
+        })
+        .max_by_key(|suffix| path.len() - suffix.len());
 
-    let suffix = match rest {
-        "/v1" => "",
-        _ => rest
-            .strip_prefix("/v1")
-            .filter(|stripped| stripped.starts_with('/'))
-            .unwrap_or(rest),
-    };
-
-    if suffix.is_empty() {
-        Cow::Borrowed("/api/v0")
-    } else {
-        Cow::Owned(format!("/api/v0{suffix}"))
+    match matched {
+        Some(suffix) => Cow::Owned(format!("/api/v0{suffix}")),
+        None => Cow::Borrowed(path),
     }
 }

--- a/crates/http/src/router/routes.rs
+++ b/crates/http/src/router/routes.rs
@@ -344,9 +344,11 @@ pub(crate) fn create_router_with_state_and_body_limits(
         .route("/node/identity", get(handlers::utility::get_node_identity))
         .with_state(state);
 
-    root_routes
-        .nest("/api/v0", api_routes.clone())
-        .nest("/api/v1", api_routes)
+    crate::go_paths::API_PREFIXES
+        .iter()
+        .fold(root_routes, |router, prefix| {
+            router.nest(prefix, api_routes.clone())
+        })
 }
 
 #[cfg(test)]

--- a/crates/http/tests/common/mod.rs
+++ b/crates/http/tests/common/mod.rs
@@ -16,7 +16,7 @@ use axum::{
     },
     Router,
 };
-use identity::{new_token, RawIdentity};
+use identity::{new_token, Identity, RawIdentity};
 use tower::ServiceExt;
 
 #[allow(unused_imports)]
@@ -81,6 +81,22 @@ pub fn bearer_token() -> String {
     )
     .unwrap();
     format!("Bearer {}", String::from_utf8(token).unwrap())
+}
+
+/// A NAC owner and a bearer token that authenticates as them, for tests that
+/// go through the real auth middleware rather than calling a handler direct.
+pub fn nac_owner() -> (identity::Did, String) {
+    let private_key = crypto::generate_ed25519().unwrap();
+    let identity = RawIdentity::from_private_key(private_key).unwrap();
+    let did = identity.did().expect("mock identity has a did");
+    let token = new_token(
+        &identity,
+        Duration::from_secs(3600),
+        Some(TEST_HOST.to_lowercase()),
+        None,
+    )
+    .unwrap();
+    (did, format!("Bearer {}", String::from_utf8(token).unwrap()))
 }
 
 pub struct Call {

--- a/crates/http/tests/route_permissions.rs
+++ b/crates/http/tests/route_permissions.rs
@@ -541,18 +541,34 @@ fn all_registered_routes_return_expected_permission() {
         ),
     ];
 
+    // Every mount in `API_PREFIXES` serves this same route set, so each form
+    // has to resolve to the same permission. Checking them here rather than
+    // hand-copying the list keeps the mounts from drifting apart.
     for (path, method, expected) in &routes {
-        let actual = route_permission(path, method);
-        assert_eq!(
-            actual, *expected,
-            "Mismatch for {} {}: expected {:?}, got {:?}",
-            method, path, expected, actual
-        );
+        for candidate in mount_forms(path) {
+            let actual = route_permission(&candidate, method);
+            assert_eq!(
+                actual, *expected,
+                "Mismatch for {} {}: expected {:?}, got {:?}",
+                method, candidate, expected, actual
+            );
+        }
     }
 }
 
+/// The same route as every prefix in `go_paths::API_PREFIXES` mounts it.
+fn mount_forms(v0_path: &str) -> Vec<String> {
+    let Some(suffix) = v0_path.strip_prefix("/api/v0") else {
+        return vec![v0_path.to_string()];
+    };
+    defra_http::go_paths::API_PREFIXES
+        .iter()
+        .map(|prefix| format!("{prefix}{suffix}"))
+        .collect()
+}
+
 #[test]
-fn v1_routes_use_same_permissions_as_v0() {
+fn every_mount_form_uses_the_same_permission_as_v0() {
     for (v0_path, method) in [
         ("/api/v0/version", Method::GET),
         ("/api/v0/graphql", Method::POST),
@@ -562,10 +578,25 @@ fn v1_routes_use_same_permissions_as_v0() {
         ("/api/v0/backup/export", Method::POST),
         ("/api/v0/block/signed", Method::GET),
     ] {
-        let v1_path = v0_path.replacen("/api/v0", "/api/v1", 1);
+        let expected = route_permission(v0_path, &method);
+        for candidate in mount_forms(v0_path) {
+            assert_eq!(
+                route_permission(&candidate, &method),
+                expected,
+                "{candidate} disagrees with {v0_path} for {method}"
+            );
+        }
+    }
+}
+
+/// A path that only looks versioned must not be rewritten into the table.
+#[test]
+fn near_miss_version_segments_are_not_folded() {
+    for path in ["/api/v10/collections", "/api/v2/collections"] {
         assert_eq!(
-            route_permission(&v1_path, &method),
-            route_permission(v0_path, &method)
+            route_permission(path, &Method::GET),
+            RoutePermission::Required(NodePermission::DocumentRead),
+            "{path} should fall to the safe default"
         );
     }
 }

--- a/crates/http/tests/unversioned_api_mount.rs
+++ b/crates/http/tests/unversioned_api_mount.rs
@@ -1,49 +1,111 @@
 //! Go mounts its whole router at `/api` with no version segment
-//! (`r.Handle("/*", router)`, `http/handler.go:127`), where Rust mounted only
+//! (`r.Handle("/*", router)`, `http/handler.go:126`), where Rust mounted only
 //! `/api/v0` and `/api/v1`, so every unversioned request 404'd.
 //!
 //! The mount is driven by `go_paths::API_PREFIXES`, and the permission table
-//! folds all three forms onto the v0 key: a form that resolves but does not
-//! fold is enforced as `DocumentRead`, a privilege downgrade rather than a 404.
+//! folds every prefix in that same list onto the v0 key: a form that resolves
+//! but does not fold is enforced as `DocumentRead`, a privilege downgrade
+//! rather than a 404.
+//!
+//! Parameterized routes are deliberately not asserted here. axum 0.8 yields a
+//! brace `MatchedPath` (`/api/collections/{name}`) while the table is keyed
+//! with colons, so those entries never match on any mount, versioned or not.
+//! That defect is #1497 and is not what this change is about; asserting it
+//! here would only certify the `_` arm.
 
 mod common;
 use common::*;
 
-/// The routes a hand-written client or a curl script is most likely to reach
-/// for, one per nesting style the router uses.
+use axum::{body::Body, http::Request, Router};
+use defra_http::router::{AppStateBuilder, NodeAcpOperations};
+use defra_http::{MockNodeAcpOperations, MockQueryExecutor};
+use std::sync::Arc;
+use tower::ServiceExt;
+
+/// One route per nesting style the router uses, all unparameterized.
 const PATHS: &[(&str, Method)] = &[
-    ("/graphql", Method::GET),
     ("/schema", Method::GET),
     ("/version", Method::GET),
     ("/collections", Method::GET),
-    ("/collections/Users", Method::GET),
     ("/p2p/replicators", Method::GET),
     ("/view/refresh", Method::POST),
+    ("/node/identity", Method::GET),
 ];
 
+/// Every prefix must answer a given request the same way, not merely resolve.
+/// `!= NOT_FOUND` would pass with the unversioned mount answering 405 while
+/// the versioned ones answer 400.
 #[tokio::test]
-async fn the_unversioned_mount_serves_the_same_routes_as_the_versioned_ones() {
+async fn every_mount_answers_a_request_identically() {
+    // Pinned literally: a test that only iterates the constant stops covering
+    // the unversioned mount the moment the constant loses it.
+    assert!(
+        defra_http::go_paths::API_PREFIXES.contains(&"/api"),
+        "the unversioned mount must stay in API_PREFIXES"
+    );
+
     for (path, method) in PATHS {
+        let mut answers = Vec::new();
         for prefix in defra_http::go_paths::API_PREFIXES {
-            let (status, body) = Call::post(&format!("{prefix}{path}"))
+            let answer = Call::post(&format!("{prefix}{path}"))
                 .method(method.clone())
                 .json("{}")
                 .authenticated()
                 .send()
                 .await;
             assert_ne!(
-                status,
+                answer.0,
                 StatusCode::NOT_FOUND,
-                "{prefix}{path} did not resolve: {body}"
+                "{prefix}{path} did not resolve: {}",
+                answer.1
+            );
+            answers.push((prefix, answer));
+        }
+        let (first_prefix, first) = &answers[0];
+        for (prefix, answer) in &answers[1..] {
+            assert_eq!(
+                answer, first,
+                "{prefix}{path} disagrees with {first_prefix}{path}"
             );
         }
     }
 }
 
-/// The regression itself: before this change these were 404s.
+/// The call this change exists to serve. Go advertises `POST /api/graphql`
+/// with a query body (`node/node_api.go`), and a GET without `query` is a 400
+/// on both, so asserting the GET proves nothing about the mount.
+#[tokio::test]
+async fn an_unversioned_graphql_post_is_served() {
+    let (status, body) = Call::post("/api/graphql")
+        .json(r#"{"query":"{ __typename }"}"#)
+        .authenticated()
+        .send()
+        .await;
+    assert_eq!(status, StatusCode::OK, "/api/graphql: {body}");
+
+    let mut answers = Vec::new();
+    for prefix in defra_http::go_paths::API_PREFIXES {
+        let (status, body) = Call::post(&format!("{prefix}/graphql"))
+            .json(r#"{"query":"{ __typename }"}"#)
+            .authenticated()
+            .send()
+            .await;
+        assert_eq!(status, StatusCode::OK, "{prefix}/graphql: {body}");
+        answers.push((prefix, status, body));
+    }
+    let (first_prefix, _, first_body) = &answers[0];
+    for (prefix, _, body) in &answers[1..] {
+        assert_eq!(
+            body, first_body,
+            "{prefix}/graphql disagrees with {first_prefix}/graphql"
+        );
+    }
+}
+
+/// The regression: this was a 404.
 #[tokio::test]
 async fn an_unversioned_request_is_not_a_404() {
-    let (status, body) = Call::post("/api/graphql")
+    let (status, body) = Call::post("/api/collections")
         .method(Method::GET)
         .authenticated()
         .send()
@@ -52,8 +114,8 @@ async fn an_unversioned_request_is_not_a_404() {
 }
 
 /// `MatchedPath` for the unversioned mount is `/api/collections`, not
-/// `/api/v0/collections`. Without the fold in `normalize_api_version` every
-/// unversioned route silently drops to the `DocumentRead` default.
+/// `/api/v0/collections`. Without the fold these drop to the `DocumentRead`
+/// default.
 #[test]
 fn the_unversioned_form_keeps_its_real_permission() {
     let cases = [
@@ -69,9 +131,9 @@ fn the_unversioned_form_keeps_its_real_permission() {
             NodePermission::DacPolicyAdd,
         ),
         (
-            "/collections/:name/truncate",
-            Method::DELETE,
-            NodePermission::CollectionTruncate,
+            "/backup/import",
+            Method::POST,
+            NodePermission::DocumentUpdate,
         ),
     ];
 
@@ -84,23 +146,93 @@ fn the_unversioned_form_keeps_its_real_permission() {
     }
 }
 
-/// The exemptions have to survive the fold too, or an unversioned health or
-/// version probe starts demanding a token.
+/// A prefix added to `API_PREFIXES` must fold without a second edit here, or
+/// it mounts the route set unenforced.
 #[test]
-fn the_unversioned_form_keeps_its_exemption() {
-    assert_eq!(
-        route_permission("/api/version", &Method::GET),
-        RoutePermission::Exempt
-    );
-    assert_eq!(
-        route_permission("/api/graphql/ws", &Method::GET),
-        RoutePermission::Exempt
-    );
+fn every_mounted_prefix_folds() {
+    for prefix in defra_http::go_paths::API_PREFIXES {
+        assert_eq!(
+            route_permission(&format!("{prefix}/purge"), &Method::POST),
+            RoutePermission::Required(NodePermission::DocumentUpdate),
+            "{prefix}/purge does not fold onto the v0 key"
+        );
+    }
 }
 
-/// The router mounts one route set three times; axum panics at construction on
-/// overlapping routes, so this is the proof the third mount is legal.
+/// The fold rewrites rather than rejects, so a near-miss has to land somewhere
+/// harmless: `/api/v2/collections` becomes `/api/v0/v2/collections`, which is
+/// no table key.
+#[test]
+fn near_miss_version_segments_land_on_the_safe_default() {
+    for path in ["/api/v10/collections", "/api/v2/collections", "/apifoo"] {
+        assert_eq!(
+            route_permission(path, &Method::GET),
+            RoutePermission::Required(NodePermission::DocumentRead),
+            "{path} should fall to the safe default"
+        );
+    }
+}
+
+/// Through the real middleware stack, which is what `server.rs:526-530`
+/// applies.
+///
+/// The same caller hits the same unversioned route twice, holding a different
+/// grant each time. That isolates which permission the route is enforced as:
+/// `/api/purge` folds to `DocumentUpdate`, so a `DocumentUpdate` holder gets
+/// through and a `DocumentRead` holder does not. An unfolded route would be
+/// enforced as `DocumentRead` and flip the first case.
 #[tokio::test]
-async fn the_router_builds_with_every_mount() {
-    let _ = router();
+async fn the_unversioned_mount_is_enforced_as_its_real_permission() {
+    async fn purge_as(granted: NodePermission) -> StatusCode {
+        let (owner, _) = nac_owner();
+        let (caller, bearer) = nac_owner();
+        let nac =
+            Arc::new(MockNodeAcpOperations::enabled_with_owner(owner).with_grant(caller, granted));
+        let state = AppStateBuilder::new(Arc::new(MockQueryExecutor::new()))
+            .with_nac(nac as Arc<dyn NodeAcpOperations>)
+            .build();
+        let router: Router = defra_http::create_router_with_state(state.clone()).route_layer(
+            axum::middleware::from_fn_with_state(
+                state,
+                defra_http::auth_middleware::auth_middleware,
+            ),
+        );
+
+        router
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/purge")
+                    .header(axum::http::header::HOST, TEST_HOST)
+                    .header(axum::http::header::AUTHORIZATION, bearer)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("router should respond")
+            .status()
+    }
+
+    let with_read = purge_as(NodePermission::DocumentRead).await;
+    let with_update = purge_as(NodePermission::DocumentUpdate).await;
+
+    // `require_permission` answers 401 on a denial (`nac_guard.rs:73-77`), so
+    // 401 means the middleware refused and anything else means it let the
+    // request reach the handler.
+    assert_ne!(
+        with_update,
+        StatusCode::NOT_FOUND,
+        "the route must be mounted unversioned"
+    );
+    assert_eq!(
+        with_read,
+        StatusCode::UNAUTHORIZED,
+        "a DocumentRead holder passed the unversioned purge gate, so it did \
+         not fold onto its real permission"
+    );
+    assert_ne!(
+        with_update,
+        StatusCode::UNAUTHORIZED,
+        "a DocumentUpdate holder must clear the purge gate, got {with_update}"
+    );
 }

--- a/crates/http/tests/unversioned_api_mount.rs
+++ b/crates/http/tests/unversioned_api_mount.rs
@@ -1,0 +1,106 @@
+//! Go mounts its whole router at `/api` with no version segment
+//! (`r.Handle("/*", router)`, `http/handler.go:127`), where Rust mounted only
+//! `/api/v0` and `/api/v1`, so every unversioned request 404'd.
+//!
+//! The mount is driven by `go_paths::API_PREFIXES`, and the permission table
+//! folds all three forms onto the v0 key: a form that resolves but does not
+//! fold is enforced as `DocumentRead`, a privilege downgrade rather than a 404.
+
+mod common;
+use common::*;
+
+/// The routes a hand-written client or a curl script is most likely to reach
+/// for, one per nesting style the router uses.
+const PATHS: &[(&str, Method)] = &[
+    ("/graphql", Method::GET),
+    ("/schema", Method::GET),
+    ("/version", Method::GET),
+    ("/collections", Method::GET),
+    ("/collections/Users", Method::GET),
+    ("/p2p/replicators", Method::GET),
+    ("/view/refresh", Method::POST),
+];
+
+#[tokio::test]
+async fn the_unversioned_mount_serves_the_same_routes_as_the_versioned_ones() {
+    for (path, method) in PATHS {
+        for prefix in defra_http::go_paths::API_PREFIXES {
+            let (status, body) = Call::post(&format!("{prefix}{path}"))
+                .method(method.clone())
+                .json("{}")
+                .authenticated()
+                .send()
+                .await;
+            assert_ne!(
+                status,
+                StatusCode::NOT_FOUND,
+                "{prefix}{path} did not resolve: {body}"
+            );
+        }
+    }
+}
+
+/// The regression itself: before this change these were 404s.
+#[tokio::test]
+async fn an_unversioned_request_is_not_a_404() {
+    let (status, body) = Call::post("/api/graphql")
+        .method(Method::GET)
+        .authenticated()
+        .send()
+        .await;
+    assert_ne!(status, StatusCode::NOT_FOUND, "{body}");
+}
+
+/// `MatchedPath` for the unversioned mount is `/api/collections`, not
+/// `/api/v0/collections`. Without the fold in `normalize_api_version` every
+/// unversioned route silently drops to the `DocumentRead` default.
+#[test]
+fn the_unversioned_form_keeps_its_real_permission() {
+    let cases = [
+        (
+            "/collections",
+            Method::POST,
+            NodePermission::CollectionPatch,
+        ),
+        ("/purge", Method::POST, NodePermission::DocumentUpdate),
+        (
+            "/acp/document/policy",
+            Method::POST,
+            NodePermission::DacPolicyAdd,
+        ),
+        (
+            "/collections/:name/truncate",
+            Method::DELETE,
+            NodePermission::CollectionTruncate,
+        ),
+    ];
+
+    for (path, method, expected) in cases {
+        assert_eq!(
+            route_permission(&format!("/api{path}"), &method),
+            RoutePermission::Required(expected),
+            "/api{path} lost its permission"
+        );
+    }
+}
+
+/// The exemptions have to survive the fold too, or an unversioned health or
+/// version probe starts demanding a token.
+#[test]
+fn the_unversioned_form_keeps_its_exemption() {
+    assert_eq!(
+        route_permission("/api/version", &Method::GET),
+        RoutePermission::Exempt
+    );
+    assert_eq!(
+        route_permission("/api/graphql/ws", &Method::GET),
+        RoutePermission::Exempt
+    );
+}
+
+/// The router mounts one route set three times; axum panics at construction on
+/// overlapping routes, so this is the proof the third mount is legal.
+#[tokio::test]
+async fn the_router_builds_with_every_mount() {
+    let _ = router();
+}


### PR DESCRIPTION
Closes #1495.

Go mounts its whole API router three times (`http/handler.go:116-128`): `/api/v0`, `/api/v1`, and an unversioned `r.Handle("/*", router)`. Rust mounted only the two versioned prefixes, so every unversioned `/api/...` request answered 404.

## What changed

**The mount list has one definition.** `go_paths::API_PREFIXES` already existed as the canonical prefix list, but `routes.rs` hardcoded its own two `.nest()` calls, so the two could drift. The router now folds over `API_PREFIXES`, and the constant gains the bare `/api` entry. Adding a prefix is now a one-line change in one place.

A side effect worth noting: `tests/go_route_paths.rs` iterates `API_PREFIXES`, so its `every_declared_go_path_resolves_under_every_api_version` test picked up coverage of the new mount for free.

**The permission table folds the unversioned form.** This is the part that mattered more than the mount. `route_permissions.rs` keys off axum's `MatchedPath`, and the unversioned mount produces `/api/collections`, not `/api/v0/collections`. `normalize_api_version` folded only `/api/v1/`, so every unversioned route would have fallen to the `_` arm and been enforced as `Required(DocumentRead)`: a privilege downgrade, not a 404. It now folds the bare `/api/` form too, and rejects near-misses (`/api/v10/...`, `/api/v2/...`) rather than rewriting them into the table.

## Tests

New `crates/http/tests/unversioned_api_mount.rs`:
- the unversioned mount serves the same routes as the versioned ones, across every nesting style the router uses
- the plain regression: `GET /api/graphql` is no longer a 404
- the unversioned form keeps its real permission (`CollectionPatch`, `DocumentUpdate`, `DacPolicyAdd`, `CollectionTruncate`) rather than dropping to the default
- exemptions survive the fold, so an unversioned version or ws probe does not start demanding a token
- the router builds, which is what proves the third mount does not trip axum's overlapping-route panic

`tests/route_permissions.rs`: rather than hand-copying an unversioned list into `all_registered_routes_return_expected_permission`, the loop now checks every entry against every prefix in `API_PREFIXES`. That cannot drift when a mount is added. Added `near_miss_version_segments_are_not_folded`.

## Verification

- `just fmt-check`: green
- `just lint`: green (exit 0)
- `just test`: green, 5201 tests passed, 0 failures
- `RUSTDOCFLAGS="-D warnings" cargo doc -p defra-http --no-deps`: green

`just doc` for the whole workspace is red on `main` already, from pre-existing rustdoc errors in `crates/storage` and `crates/datastore` (bare URLs, unclosed `<dyn>` HTML tags, unresolved intra-doc links). None of that is touched here, so the doc gate was run scoped to the crate this PR changes. The workspace doc build is worth its own cleanup PR.

---

## Review round: two assertions removed, four suggestions taken

**The truncate assertion was certifying the `_` arm, as flagged.** I probed axum 0.8 directly and `MatchedPath` is `/api/v0/collections/{name}/truncate` against a colon-keyed table, so no parameterized route matches on any mount. That is #1497 and not this change; the parameterized cases are gone and the file says why rather than re-asserting the default.

**`POST /api/graphql` with a real query is now tested**, across all three mounts, and pinned literally as `/api/graphql` as well. The GET was a 400 for a missing `query` on every mount, so it proved nothing.

Suggestions taken:

- `normalize_api_version` derives from `API_PREFIXES`. One deviation from the suggested form: it takes the **longest** match rather than the first, so the list stays order-independent. First-match rewrites `/api/v0/x` to `/api/v0/v0/x` if `"/api"` is ever ordered ahead of `"/api/v0"`. `/apifoo` is covered by a test.
- Mount parity uses `assert_eq!` across prefixes instead of `!= NOT_FOUND`.
- `the_router_builds_with_every_mount` deleted. Correct that `nest` inlines concatenated paths so there was no overlap panic to guard, and `go_route_paths.rs` already has that test.
- The exemption doc comment described something the harness could not produce. Replaced with a real `route_layer` + NAC test.

Also corrected in this description: the fold **rewrites** near-misses rather than rejecting them, so `/api/v2/collections` becomes `/api/v0/v2/collections` and is safe only because no table key starts with `/api/v0/v`. The earlier text had that backwards.

**Mutation-tested rather than assumed.** Two more tests turned out to have the same weakness the review identified: iterating `API_PREFIXES` means a test stops covering the unversioned mount the moment the constant loses it, so that form is pinned literally now. And the middleware test first written here passed with the fold deliberately broken, because refusing an anonymous caller does not distinguish `DocumentRead` from `DocumentUpdate`; it now runs one caller twice with different grants, so a `DocumentRead` holder must be refused where a `DocumentUpdate` holder is admitted.

Removing `"/api"` from `API_PREFIXES` fails 5 of 7 tests; breaking the fold fails 3.

Re-verified: `just fmt-check` green, `just lint` exit 0, `just test` 5203 passed 0 failed, `cargo doc -D warnings -p defra-http` green.
