### PR TITLE
fix(http): honor Go's collection selectors on GET /collections

### DIFF
--- a/crates/cli/src/collection_mgmt_adapter.rs
+++ b/crates/cli/src/collection_mgmt_adapter.rs
@@ -129,6 +129,14 @@ impl<S: Store + 'static> CollectionManagementOperations for CollectionManagement
             .map_err(|e| format!("{}", e))
     }
 
+    /// Answered from the collection cache, without scanning every stored
+    /// version, which is the whole point of the selector's active-only path.
+    async fn get_active_collections(&self) -> Result<Vec<schema::CollectionVersion>, String> {
+        self.database
+            .get_active_collection_versions()
+            .map_err(|e| format!("{}", e))
+    }
+
     async fn delete_collection(&self, name: &str) -> Result<(), String> {
         self.database
             .delete_collection(name)

--- a/crates/cli/src/view_adapter.rs
+++ b/crates/cli/src/view_adapter.rs
@@ -162,7 +162,7 @@ impl<S: Store + 'static> ViewOperations for ViewAdapter<S> {
 
         if !materialized_names.is_empty() {
             self.database
-                .refresh_views(db::RefreshViewsOptions::with_names(materialized_names))
+                .refresh_views(db::CollectionSelector::with_names(materialized_names))
                 .await
                 .map_err(|e| format!("failed to refresh materialized views: {}", e))?;
         }
@@ -177,7 +177,7 @@ impl<S: Store + 'static> ViewOperations for ViewAdapter<S> {
         Ok(created_versions)
     }
 
-    async fn refresh_views(&self, options: db::RefreshViewsOptions) -> Result<(), String> {
+    async fn refresh_views(&self, options: db::CollectionSelector) -> Result<(), String> {
         self.database
             .check_node_access(None, acp::nac::NodePermission::ViewRefresh)
             .await

--- a/crates/db/src/collection/mod.rs
+++ b/crates/db/src/collection/mod.rs
@@ -33,6 +33,7 @@ pub mod name;
 pub(crate) mod ops;
 pub(crate) mod provider;
 pub mod retriever;
+pub mod selector;
 pub mod snapshot;
 pub mod stream;
 pub mod validation;

--- a/crates/db/src/collection/ops/version.rs
+++ b/crates/db/src/collection/ops/version.rs
@@ -180,6 +180,16 @@ impl<S: Store> crate::database::DB<S> {
             .map(Collection::new))
     }
 
+    /// Get the active collection versions, from the in-memory cache.
+    ///
+    /// The cheap counterpart to `get_all_collection_versions`, which scans the
+    /// whole `/collection/` prefix. A selector that does not ask for inactive
+    /// versions is answerable from the cache alone, which is the distinction
+    /// `CollectionSelector::needs_all_versions` draws.
+    pub fn get_active_collection_versions(&self) -> Result<Vec<CollectionVersion>> {
+        self.get_all_active_collections_internal()
+    }
+
     /// Get all collection versions from storage (active and inactive).
     ///
     /// This scans `/collection/id/` prefix to load ALL versions, matching

--- a/crates/db/src/collection/selector.rs
+++ b/crates/db/src/collection/selector.rs
@@ -80,6 +80,18 @@ impl CollectionSelector {
         version_matches && name_matches && collection_matches && visible
     }
 
+    /// Whether Go resolves this selection by looking the version id up
+    /// directly, rather than using it only as a filter.
+    ///
+    /// The candidate switch tries the active-by-name arm first, so a name with
+    /// `get_inactive` false wins and the version id never reaches the lookup
+    /// (`internal/db/collection.go:203-215`). The distinction is load-bearing:
+    /// the direct lookup propagates not-found, where the stage-two filter just
+    /// yields an empty selection.
+    pub fn resolves_by_version_lookup(&self) -> bool {
+        self.version_id.is_some() && !(self.names.is_some() && !self.get_inactive)
+    }
+
     /// Go picks candidates by collection id only when neither a name nor a
     /// version already picked them, so those two take precedence over it.
     fn applies_collection_id(&self) -> bool {

--- a/crates/db/src/collection/selector.rs
+++ b/crates/db/src/collection/selector.rs
@@ -1,0 +1,88 @@
+//! Which collection versions a request selects.
+//!
+//! Go runs one lookup, `getCollections` (`internal/db/collection.go:193-301`),
+//! behind every surface that takes the `name` / `version_id` / `collection_id`
+//! / `get_inactive` selectors: `GetCollections` and `RefreshViews` both call
+//! it. This is that lookup, defined once for the same reason.
+//!
+//! The precedence in Go's candidate `switch` is load-bearing and is what the
+//! two helpers below encode. A flat AND over the four selectors gets two cases
+//! wrong: `collection_id` is a candidate selector only, so a name plus a
+//! disagreeing collection id still returns the named collection; and `name`
+//! with `get_inactive` deliberately misses the active-by-name case, which is
+//! how Go reaches an inactive collection by name.
+
+use schema::CollectionVersion;
+
+/// Go's `GetCollectionsOptions`, as the collection lookup consumes them.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CollectionSelector {
+    /// Restrict to these collection names (None = every name).
+    pub names: Option<Vec<String>>,
+    /// Restrict to the collection version with this version id.
+    pub version_id: Option<String>,
+    /// Restrict to versions belonging to this collection id.
+    pub collection_id: Option<String>,
+    /// Include inactive collection versions.
+    pub get_inactive: bool,
+}
+
+impl CollectionSelector {
+    /// Select everything active.
+    pub fn all() -> Self {
+        Self::default()
+    }
+
+    /// Select only the named collections.
+    pub fn with_names(names: Vec<String>) -> Self {
+        Self {
+            names: Some(names),
+            ..Self::default()
+        }
+    }
+
+    /// Whether this selects everything active, narrowing nothing.
+    ///
+    /// A caller that can answer the unnarrowed case more cheaply, or from a
+    /// different source, uses this to tell that it may.
+    pub fn is_unfiltered(&self) -> bool {
+        self.names.is_none()
+            && self.version_id.is_none()
+            && self.collection_id.is_none()
+            && !self.get_inactive
+    }
+
+    /// Whether inactive versions have to be loaded to answer this selection.
+    ///
+    /// A named version is returned whether or not it is active, so asking for
+    /// one requires the full listing just as `get_inactive` does.
+    pub fn needs_all_versions(&self) -> bool {
+        self.get_inactive || self.version_id.is_some()
+    }
+
+    /// Whether this collection version is selected.
+    pub fn selects(&self, collection: &CollectionVersion) -> bool {
+        let version_matches = self
+            .version_id
+            .as_ref()
+            .is_none_or(|id| &collection.version_id == id);
+        let name_matches = self
+            .names
+            .as_ref()
+            .is_none_or(|names| names.contains(&collection.name));
+        let collection_matches = !self.applies_collection_id()
+            || self
+                .collection_id
+                .as_ref()
+                .is_none_or(|id| &collection.collection_id == id);
+        let visible = self.get_inactive || collection.is_active || self.version_id.is_some();
+
+        version_matches && name_matches && collection_matches && visible
+    }
+
+    /// Go picks candidates by collection id only when neither a name nor a
+    /// version already picked them, so those two take precedence over it.
+    fn applies_collection_id(&self) -> bool {
+        (self.get_inactive || self.names.is_none()) && self.version_id.is_none()
+    }
+}

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -84,6 +84,7 @@ pub use collection::cache::CollectionCache;
 pub use collection::name::CollectionName;
 pub use collection::provider::DbCollectionProvider;
 pub use collection::retriever::{resolve_collection_from_doc_id, DocCollectionInfo};
+pub use collection::selector::CollectionSelector;
 pub use collection::snapshot::CollectionSnapshot;
 #[allow(deprecated)]
 pub use collection::{collection_short_id, Collection};
@@ -112,7 +113,7 @@ pub use txn::registry::{
     DEFAULT_TRANSACTION_IDLE_TIMEOUT,
 };
 pub use txn::DbTxn;
-pub use view::ops::{is_refreshable_view, RefreshViewsOptions};
+pub use view::ops::is_refreshable_view;
 pub use write::autocommit::AutoCommitMutator;
 pub use write::doc::DbDocMutator;
 pub use write::queue::DocWriteQueue;

--- a/crates/db/src/view/ops.rs
+++ b/crates/db/src/view/ops.rs
@@ -3,6 +3,7 @@
 //! This module contains operations for refreshing and managing
 //! materialized view caches.
 
+use crate::collection::selector::CollectionSelector;
 use crate::error::{Error, Result};
 use datastore::NamespaceView;
 use schema::CollectionVersion;
@@ -17,71 +18,6 @@ use storage::keys::datastore::ViewCacheKey;
 use tokio::task::JoinHandle;
 #[cfg(not(target_arch = "wasm32"))]
 use tokio::time::{self, Instant, MissedTickBehavior};
-
-/// Options for refreshing materialized views.
-///
-/// The selectors mirror Go's collection lookup (`internal/db/collection.go`
-/// `getCollections`), which is what Go's `RefreshViews` selects with.
-#[derive(Debug, Clone, Default)]
-pub struct RefreshViewsOptions {
-    /// Only refresh views with these names (None = all views)
-    pub names: Option<Vec<String>>,
-    /// Only refresh the view with this collection version id.
-    pub version_id: Option<String>,
-    /// Only refresh views belonging to this collection id.
-    pub collection_id: Option<String>,
-    /// Include inactive collection versions.
-    pub get_inactive: bool,
-}
-
-impl RefreshViewsOptions {
-    /// Create options that refresh all views.
-    pub fn all() -> Self {
-        Self::default()
-    }
-
-    /// Create options that refresh only the named views.
-    pub fn with_names(names: Vec<String>) -> Self {
-        Self {
-            names: Some(names),
-            ..Self::default()
-        }
-    }
-
-    /// Whether inactive versions have to be loaded to answer this selection.
-    ///
-    /// A named version is returned whether or not it is active, so asking for
-    /// one requires the full listing just as `get_inactive` does.
-    pub fn needs_all_versions(&self) -> bool {
-        self.get_inactive || self.version_id.is_some()
-    }
-
-    /// Whether this collection version is selected.
-    pub fn selects(&self, collection: &CollectionVersion) -> bool {
-        let version_matches = self
-            .version_id
-            .as_ref()
-            .is_none_or(|id| &collection.version_id == id);
-        let name_matches = self
-            .names
-            .as_ref()
-            .is_none_or(|names| names.contains(&collection.name));
-        let collection_matches = !self.applies_collection_id()
-            || self
-                .collection_id
-                .as_ref()
-                .is_none_or(|id| &collection.collection_id == id);
-        let visible = self.get_inactive || collection.is_active || self.version_id.is_some();
-
-        version_matches && name_matches && collection_matches && visible
-    }
-
-    /// Go picks candidates by collection id only when neither a name nor a
-    /// version already picked them, so those two take precedence over it.
-    fn applies_collection_id(&self) -> bool {
-        (self.get_inactive || self.names.is_none()) && self.version_id.is_none()
-    }
-}
 
 /// Whether this collection version is a view whose cache can be rebuilt.
 ///
@@ -134,7 +70,7 @@ impl<S: Store> crate::database::DB<S> {
     ///
     /// Clears and rebuilds the view cache for each materialized view the
     /// options select. Without options, every materialized view is refreshed.
-    pub async fn refresh_views(&self, options: RefreshViewsOptions) -> Result<()>
+    pub async fn refresh_views(&self, options: CollectionSelector) -> Result<()>
     where
         S: 'static,
     {
@@ -297,7 +233,7 @@ impl<S: Store> crate::database::DB<S> {
 
                 for name in due_names {
                     if let Err(error) = self
-                        .refresh_views(RefreshViewsOptions::with_names(vec![name.clone()]))
+                        .refresh_views(CollectionSelector::with_names(vec![name.clone()]))
                         .await
                     {
                         tracing::warn!(

--- a/crates/db/src/view/ops.rs
+++ b/crates/db/src/view/ops.rs
@@ -401,6 +401,11 @@ impl<S: Store> crate::database::DB<S> {
             .collections
             .read()
             .map_err(|_| Error::Other("failed to acquire collections lock".to_string()))?;
-        Ok(cache.values().map(|c| c.schema().clone()).collect())
+        Ok(cache
+            .values()
+            .map(|collection| collection.schema())
+            .filter(|schema| schema.is_active)
+            .cloned()
+            .collect())
     }
 }

--- a/crates/db/tests/collection/cache.rs
+++ b/crates/db/tests/collection/cache.rs
@@ -92,3 +92,23 @@ fn test_cache_populate() {
     assert!(cache.contains("Users"));
     assert!(cache.contains("Posts"));
 }
+
+#[tokio::test]
+async fn active_collection_versions_exclude_inactive_cache_entries() {
+    let db = db::DB::open(storage::backends::MemoryStore::new())
+        .await
+        .expect("open");
+
+    let active = test_collection("Users").schema().clone();
+    let mut inactive = test_collection("Orders").schema().clone();
+    inactive.is_active = false;
+    db.add_collection_to_cache(active).expect("cache active");
+    db.add_collection_to_cache(inactive)
+        .expect("cache inactive");
+
+    let versions = db
+        .get_active_collection_versions()
+        .expect("read active versions");
+    assert_eq!(versions.len(), 1);
+    assert_eq!(versions[0].name, "Users");
+}

--- a/crates/db/tests/collection/main.rs
+++ b/crates/db/tests/collection/main.rs
@@ -1,4 +1,4 @@
-//! Collection CRUD, caching, naming, ACP and deletion.
+//! Collection CRUD, caching, naming, ACP, selection and deletion.
 #[path = "../common/mod.rs"]
 mod common;
 
@@ -7,6 +7,7 @@ mod cache;
 mod delete;
 mod name;
 mod retriever;
+mod selector;
 mod snapshot;
 mod stream;
 mod validation;

--- a/crates/db/tests/collection/selector.rs
+++ b/crates/db/tests/collection/selector.rs
@@ -1,0 +1,149 @@
+//! `CollectionSelector` picks the collection versions Go's lookup would.
+//!
+//! Go resolves `options.GetCollectionsOptions` through `getCollections`
+//! (`internal/db/collection.go:193-301`) in two stages: a switch that picks
+//! the candidate set, then a filter over it. The switch is what makes
+//! `collection_id` yield to a name or a version, and what lets a name plus
+//! `get_inactive` reach an inactive version at all. A single flat AND over the
+//! four selectors gets both wrong, so both cases are pinned here.
+//!
+//! One lookup serves every surface that takes these selectors, so these rules
+//! are shared by `GET /collections` and `POST /view/refresh` alike.
+
+use db::CollectionSelector;
+use schema::CollectionVersion;
+
+fn version(name: &str, version_id: &str, collection_id: &str) -> CollectionVersion {
+    CollectionVersion::new(name, version_id, collection_id, vec![])
+}
+
+fn inactive(name: &str, version_id: &str, collection_id: &str) -> CollectionVersion {
+    let mut version = version(name, version_id, collection_id);
+    version.is_active = false;
+    version
+}
+
+#[test]
+fn no_selectors_select_everything_active() {
+    let options = CollectionSelector::all();
+    assert!(options.selects(&version("Orders", "v1", "c1")));
+    assert!(!options.needs_all_versions());
+}
+
+#[test]
+fn no_selectors_skip_inactive_versions() {
+    assert!(!CollectionSelector::all().selects(&inactive("Orders", "v1", "c1")));
+}
+
+#[test]
+fn names_select_only_the_named_versions() {
+    let options = CollectionSelector::with_names(vec!["Orders".to_string()]);
+    assert!(options.selects(&version("Orders", "v1", "c1")));
+    assert!(!options.selects(&version("Invoices", "v2", "c2")));
+}
+
+#[test]
+fn a_version_id_selects_only_that_version() {
+    let options = CollectionSelector {
+        version_id: Some("v1".to_string()),
+        ..CollectionSelector::all()
+    };
+    assert!(options.selects(&version("Orders", "v1", "c1")));
+    assert!(!options.selects(&version("Orders", "v2", "c1")));
+}
+
+/// Go exempts a requested version from the inactive drop, so asking for a
+#[test]
+fn a_collection_id_selects_that_collections_versions() {
+    let options = CollectionSelector {
+        collection_id: Some("c1".to_string()),
+        ..CollectionSelector::all()
+    };
+    assert!(options.selects(&version("Orders", "v1", "c1")));
+    assert!(!options.selects(&version("Invoices", "v2", "c2")));
+}
+
+/// `collection_id` picks candidates in Go rather than filtering them, so a
+/// name selection takes precedence and a disagreeing collection id is ignored.
+/// A flat AND over all four selectors would select nothing here.
+#[test]
+fn a_name_wins_over_a_disagreeing_collection_id() {
+    let options = CollectionSelector {
+        names: Some(vec!["Orders".to_string()]),
+        collection_id: Some("other".to_string()),
+        ..CollectionSelector::all()
+    };
+    assert!(options.selects(&version("Orders", "v1", "c1")));
+}
+
+/// Same rule for a version selection: it is picked in stage 1, ahead of any
+/// collection id.
+#[test]
+fn a_version_id_wins_over_a_disagreeing_collection_id() {
+    let options = CollectionSelector {
+        version_id: Some("v1".to_string()),
+        collection_id: Some("other".to_string()),
+        ..CollectionSelector::all()
+    };
+    assert!(options.selects(&version("Orders", "v1", "c1")));
+}
+
+/// The unnarrowed case is what lets a caller keep its cheaper listing path,
+/// so it has to be exactly "no selector set".
+#[test]
+fn only_an_empty_selector_is_unfiltered() {
+    assert!(CollectionSelector::all().is_unfiltered());
+
+    let narrowed = [
+        CollectionSelector::with_names(vec!["Users".to_string()]),
+        CollectionSelector {
+            version_id: Some("v1".to_string()),
+            ..CollectionSelector::all()
+        },
+        CollectionSelector {
+            collection_id: Some("c1".to_string()),
+            ..CollectionSelector::all()
+        },
+        CollectionSelector {
+            get_inactive: true,
+            ..CollectionSelector::all()
+        },
+    ];
+    for selector in narrowed {
+        assert!(
+            !selector.is_unfiltered(),
+            "{selector:?} narrows the listing"
+        );
+    }
+}
+
+/// Reaching an inactive version by name is the case Go's switch exists for:
+/// the name-and-active candidate arm is deliberately missed, and the stage-two
+/// name filter narrows the everything arm instead.
+#[test]
+fn a_name_with_get_inactive_reaches_an_inactive_version() {
+    let selector = CollectionSelector {
+        get_inactive: true,
+        ..CollectionSelector::with_names(vec!["Users".to_string()])
+    };
+    assert!(selector.selects(&inactive("Users", "v1", "c1")));
+    assert!(!selector.selects(&inactive("Books", "v1", "c1")));
+}
+
+/// `needs_all_versions` decides whether the caller has to load inactive rows
+/// at all, so a version id has to imply it: a named version is returned
+/// whether or not it is active.
+#[test]
+fn a_version_id_needs_the_full_listing() {
+    assert!(!CollectionSelector::all().needs_all_versions());
+    assert!(CollectionSelector {
+        version_id: Some("v2".to_string()),
+        ..CollectionSelector::all()
+    }
+    .needs_all_versions());
+    assert!(CollectionSelector {
+        get_inactive: true,
+        ..CollectionSelector::all()
+    }
+    .needs_all_versions());
+}

--- a/crates/db/tests/view/ops.rs
+++ b/crates/db/tests/view/ops.rs
@@ -1,14 +1,10 @@
-//! `RefreshViewsOptions` selects the views Go's collection lookup would.
+//! Which views a refresh touches, and which it refuses.
 //!
-//! Go's `RefreshViews` selects with `options.GetCollectionsOptions`, resolved
-//! by `getCollections` (`internal/db/collection.go`). That runs in two stages:
-//! a switch that picks the candidate set, then a filter over it. The switch is
-//! what makes `collection_id` yield to a name or a version, and what lets a
-//! name plus `get_inactive` reach an inactive version at all. A single flat
-//! AND over the four selectors gets both wrong.
+//! The selector precedence itself is `collection::selector`; these are the
+//! refresh-specific rules layered on top of it.
 
 use db::is_refreshable_view;
-use db::RefreshViewsOptions;
+use db::CollectionSelector;
 use schema::CollectionVersion;
 use schema::QuerySource;
 
@@ -22,77 +18,6 @@ fn materialized(name: &str) -> CollectionVersion {
     version.query = Some(QuerySource::new(serde_json::json!({})));
     version.is_materialized = true;
     version
-}
-
-fn inactive(name: &str, version_id: &str, collection_id: &str) -> CollectionVersion {
-    let mut version = view(name, version_id, collection_id);
-    version.is_active = false;
-    version
-}
-
-#[test]
-fn no_selectors_select_everything_active() {
-    let options = RefreshViewsOptions::all();
-    assert!(options.selects(&view("Orders", "v1", "c1")));
-    assert!(!options.needs_all_versions());
-}
-
-#[test]
-fn no_selectors_skip_inactive_versions() {
-    assert!(!RefreshViewsOptions::all().selects(&inactive("Orders", "v1", "c1")));
-}
-
-#[test]
-fn names_select_only_the_named_views() {
-    let options = RefreshViewsOptions::with_names(vec!["Orders".to_string()]);
-    assert!(options.selects(&view("Orders", "v1", "c1")));
-    assert!(!options.selects(&view("Invoices", "v2", "c2")));
-}
-
-#[test]
-fn a_version_id_selects_only_that_version() {
-    let options = RefreshViewsOptions {
-        version_id: Some("v1".to_string()),
-        ..RefreshViewsOptions::all()
-    };
-    assert!(options.selects(&view("Orders", "v1", "c1")));
-    assert!(!options.selects(&view("Orders", "v2", "c1")));
-}
-
-/// Go exempts a requested version from the inactive drop, so asking for a
-#[test]
-fn a_collection_id_selects_that_collections_views() {
-    let options = RefreshViewsOptions {
-        collection_id: Some("c1".to_string()),
-        ..RefreshViewsOptions::all()
-    };
-    assert!(options.selects(&view("Orders", "v1", "c1")));
-    assert!(!options.selects(&view("Invoices", "v2", "c2")));
-}
-
-/// `collection_id` picks candidates in Go rather than filtering them, so a
-/// name selection takes precedence and a disagreeing collection id is ignored.
-/// A flat AND over all four selectors would select nothing here.
-#[test]
-fn a_name_wins_over_a_disagreeing_collection_id() {
-    let options = RefreshViewsOptions {
-        names: Some(vec!["Orders".to_string()]),
-        collection_id: Some("other".to_string()),
-        ..RefreshViewsOptions::all()
-    };
-    assert!(options.selects(&view("Orders", "v1", "c1")));
-}
-
-/// Same rule for a version selection: it is picked in stage 1, ahead of any
-/// collection id.
-#[test]
-fn a_version_id_wins_over_a_disagreeing_collection_id() {
-    let options = RefreshViewsOptions {
-        version_id: Some("v1".to_string()),
-        collection_id: Some("other".to_string()),
-        ..RefreshViewsOptions::all()
-    };
-    assert!(options.selects(&view("Orders", "v1", "c1")));
 }
 
 /// Eligibility is separate from selection: a version has to be a materialized,
@@ -123,7 +48,7 @@ fn an_embedded_only_view_is_never_refreshed() {
     assert!(!is_refreshable_view(&embedded));
 
     assert!(
-        RefreshViewsOptions::with_names(vec!["OrdersView".to_string()]).selects(&embedded),
+        CollectionSelector::with_names(vec!["OrdersView".to_string()]).selects(&embedded),
         "the selector still matches it; eligibility is what excludes it"
     );
 }
@@ -140,9 +65,9 @@ async fn an_unknown_version_id_is_an_error_not_a_silent_success() {
         .expect("open");
 
     let error = db
-        .refresh_views(RefreshViewsOptions {
+        .refresh_views(CollectionSelector {
             version_id: Some("bae-does-not-exist".to_string()),
-            ..RefreshViewsOptions::all()
+            ..CollectionSelector::all()
         })
         .await
         .expect_err("an unknown version must be reported");
@@ -160,9 +85,9 @@ async fn an_unknown_collection_id_is_an_error() {
         .expect("open");
 
     let error = db
-        .refresh_views(RefreshViewsOptions {
+        .refresh_views(CollectionSelector {
             collection_id: Some("no-such-collection".to_string()),
-            ..RefreshViewsOptions::all()
+            ..CollectionSelector::all()
         })
         .await
         .expect_err("an unknown collection must be reported");
@@ -176,9 +101,9 @@ async fn get_inactive_is_allowed_when_no_inactive_view_is_selected() {
         .await
         .expect("open");
 
-    db.refresh_views(RefreshViewsOptions {
+    db.refresh_views(CollectionSelector {
         get_inactive: true,
-        ..RefreshViewsOptions::all()
+        ..CollectionSelector::all()
     })
     .await
     .expect("including inactive candidates must not fail an active-only selection");
@@ -199,9 +124,9 @@ async fn refreshing_a_selected_inactive_view_is_refused() {
         .expect("store inactive view");
 
     let error = db
-        .refresh_views(RefreshViewsOptions {
+        .refresh_views(CollectionSelector {
             get_inactive: true,
-            ..RefreshViewsOptions::all()
+            ..CollectionSelector::all()
         })
         .await
         .expect_err("inactive selection must be refused, not silently wrong");

--- a/crates/defra-node/src/db_impls.rs
+++ b/crates/defra-node/src/db_impls.rs
@@ -251,7 +251,7 @@ impl<S: storage::corekv::Store + 'static> SchemaOps for DbSchemaOps<S> {
 
         if !materialized_names.is_empty() {
             self.database
-                .refresh_views(db::RefreshViewsOptions::with_names(materialized_names))
+                .refresh_views(db::CollectionSelector::with_names(materialized_names))
                 .await
                 .map_err(|e| anyhow::anyhow!("refresh materialized views error: {}", e))?;
         }

--- a/crates/ffi/src/collection/view.rs
+++ b/crates/ffi/src/collection/view.rs
@@ -171,7 +171,7 @@ pub unsafe extern "C" fn add_view(
 
             if !materialized_names.is_empty() {
                 database
-                    .refresh_views(db::RefreshViewsOptions::with_names(
+                    .refresh_views(db::CollectionSelector::with_names(
                         materialized_names,
                     ))
                     .await
@@ -234,7 +234,7 @@ pub unsafe extern "C" fn refresh_views(
 
         let refresh_options =
             parse_view_names_options(c_str_to_string(options))
-                .map(db::RefreshViewsOptions::with_names)
+                .map(db::CollectionSelector::with_names)
                 .unwrap_or_default();
 
         ffi_async!(rt, {

--- a/crates/http/src/handlers/collection_selector.rs
+++ b/crates/http/src/handlers/collection_selector.rs
@@ -7,6 +7,8 @@
 
 use serde::Deserialize;
 
+use crate::error::HttpError;
+
 /// `name`, `version_id`, `collection_id` and `get_inactive`, as Go's client
 /// sends them (`http/client.go:422-448`).
 #[derive(Debug, Default, Deserialize)]
@@ -17,9 +19,25 @@ pub struct CollectionSelectorQuery {
     pub get_inactive: Option<bool>,
 }
 
+/// Refuse a selector that is present but empty.
+///
+/// `?name=` selects nothing under these rules, while a server that treats an
+/// empty value as "unset" answers with everything. Which of those Go does
+/// could not be confirmed against its source here, and both silently give the
+/// caller something other than what it asked for, which is the bug this
+/// selector handling exists to fix. Refusing says so instead of guessing.
+fn non_empty(value: Option<String>, field: &str) -> Result<Option<String>, HttpError> {
+    match value {
+        Some(value) if value.trim().is_empty() => Err(HttpError::BadRequest(format!(
+            "'{field}' was sent with an empty value; omit it to select everything"
+        ))),
+        other => Ok(other),
+    }
+}
+
 impl CollectionSelectorQuery {
     /// Resolve to the shared lookup, with no extra names.
-    pub fn into_selector(self) -> db::CollectionSelector {
+    pub fn into_selector(self) -> Result<db::CollectionSelector, HttpError> {
         self.into_selector_with(None)
     }
 
@@ -28,20 +46,23 @@ impl CollectionSelectorQuery {
     /// `RefreshViews` also takes a `Names` body, and both it and the query's
     /// `name` mean "restrict to these", so they union. Neither one widens the
     /// selection back out to everything.
-    pub fn into_selector_with(self, extra_names: Option<Vec<String>>) -> db::CollectionSelector {
+    pub fn into_selector_with(
+        self,
+        extra_names: Option<Vec<String>>,
+    ) -> Result<db::CollectionSelector, HttpError> {
         let mut names = extra_names;
-        if let Some(name) = self.name {
+        if let Some(name) = non_empty(self.name, "name")? {
             let names = names.get_or_insert_with(Vec::new);
             if !names.contains(&name) {
                 names.push(name);
             }
         }
 
-        db::CollectionSelector {
+        Ok(db::CollectionSelector {
             names,
-            version_id: self.version_id,
-            collection_id: self.collection_id,
+            version_id: non_empty(self.version_id, "version_id")?,
+            collection_id: non_empty(self.collection_id, "collection_id")?,
             get_inactive: self.get_inactive.unwrap_or(false),
-        }
+        })
     }
 }

--- a/crates/http/src/handlers/collection_selector.rs
+++ b/crates/http/src/handlers/collection_selector.rs
@@ -7,10 +7,13 @@
 
 use serde::Deserialize;
 
-use crate::error::HttpError;
-
 /// `name`, `version_id`, `collection_id` and `get_inactive`, as Go's client
 /// sends them (`http/client.go:422-448`).
+///
+/// Go keys these off `Query().Has(..)`, not off the value being non-empty
+/// (`http/handler_store.go:391-402`), so `?name=` is a name set to the empty
+/// string rather than an absent selector. It then selects nothing, which is
+/// what an empty `Option` value reproduces here.
 #[derive(Debug, Default, Deserialize)]
 pub struct CollectionSelectorQuery {
     pub name: Option<String>,
@@ -19,25 +22,9 @@ pub struct CollectionSelectorQuery {
     pub get_inactive: Option<bool>,
 }
 
-/// Refuse a selector that is present but empty.
-///
-/// `?name=` selects nothing under these rules, while a server that treats an
-/// empty value as "unset" answers with everything. Which of those Go does
-/// could not be confirmed against its source here, and both silently give the
-/// caller something other than what it asked for, which is the bug this
-/// selector handling exists to fix. Refusing says so instead of guessing.
-fn non_empty(value: Option<String>, field: &str) -> Result<Option<String>, HttpError> {
-    match value {
-        Some(value) if value.trim().is_empty() => Err(HttpError::BadRequest(format!(
-            "'{field}' was sent with an empty value; omit it to select everything"
-        ))),
-        other => Ok(other),
-    }
-}
-
 impl CollectionSelectorQuery {
     /// Resolve to the shared lookup, with no extra names.
-    pub fn into_selector(self) -> Result<db::CollectionSelector, HttpError> {
+    pub fn into_selector(self) -> db::CollectionSelector {
         self.into_selector_with(None)
     }
 
@@ -46,23 +33,20 @@ impl CollectionSelectorQuery {
     /// `RefreshViews` also takes a `Names` body, and both it and the query's
     /// `name` mean "restrict to these", so they union. Neither one widens the
     /// selection back out to everything.
-    pub fn into_selector_with(
-        self,
-        extra_names: Option<Vec<String>>,
-    ) -> Result<db::CollectionSelector, HttpError> {
+    pub fn into_selector_with(self, extra_names: Option<Vec<String>>) -> db::CollectionSelector {
         let mut names = extra_names;
-        if let Some(name) = non_empty(self.name, "name")? {
+        if let Some(name) = self.name {
             let names = names.get_or_insert_with(Vec::new);
             if !names.contains(&name) {
                 names.push(name);
             }
         }
 
-        Ok(db::CollectionSelector {
+        db::CollectionSelector {
             names,
-            version_id: non_empty(self.version_id, "version_id")?,
-            collection_id: non_empty(self.collection_id, "collection_id")?,
+            version_id: self.version_id,
+            collection_id: self.collection_id,
             get_inactive: self.get_inactive.unwrap_or(false),
-        })
+        }
     }
 }

--- a/crates/http/src/handlers/collection_selector.rs
+++ b/crates/http/src/handlers/collection_selector.rs
@@ -1,0 +1,47 @@
+//! The collection selectors Go accepts as query parameters.
+//!
+//! Go's `GetCollections` and `RefreshViews` take the same four selectors and
+//! resolve them through one lookup (`getCollections`,
+//! `internal/db/collection.go`). This is that query string, parsed once, so
+//! the two Rust surfaces cannot drift apart the way two copies would.
+
+use serde::Deserialize;
+
+/// `name`, `version_id`, `collection_id` and `get_inactive`, as Go's client
+/// sends them (`http/client.go:422-448`).
+#[derive(Debug, Default, Deserialize)]
+pub struct CollectionSelectorQuery {
+    pub name: Option<String>,
+    pub version_id: Option<String>,
+    pub collection_id: Option<String>,
+    pub get_inactive: Option<bool>,
+}
+
+impl CollectionSelectorQuery {
+    /// Resolve to the shared lookup, with no extra names.
+    pub fn into_selector(self) -> db::CollectionSelector {
+        self.into_selector_with(None)
+    }
+
+    /// Resolve to the shared lookup, unioning `extra_names` into `name`.
+    ///
+    /// `RefreshViews` also takes a `Names` body, and both it and the query's
+    /// `name` mean "restrict to these", so they union. Neither one widens the
+    /// selection back out to everything.
+    pub fn into_selector_with(self, extra_names: Option<Vec<String>>) -> db::CollectionSelector {
+        let mut names = extra_names;
+        if let Some(name) = self.name {
+            let names = names.get_or_insert_with(Vec::new);
+            if !names.contains(&name) {
+                names.push(name);
+            }
+        }
+
+        db::CollectionSelector {
+            names,
+            version_id: self.version_id,
+            collection_id: self.collection_id,
+            get_inactive: self.get_inactive.unwrap_or(false),
+        }
+    }
+}

--- a/crates/http/src/handlers/collections.rs
+++ b/crates/http/src/handlers/collections.rs
@@ -106,7 +106,7 @@ pub async fn list_collections(
 ) -> Result<Json<CollectionsResponse>, HttpError> {
     require_permission(&state, &identity, NodePermission::CollectionGet).await?;
 
-    let selector = query.into_selector()?;
+    let selector = query.into_selector();
     if !selector.is_unfiltered() {
         return list_selected_collections(&state, &selector).await;
     }
@@ -150,10 +150,26 @@ async fn list_selected_collections(
     }
     .map_err(http_error_from_backend_message)?;
 
-    let mut collections: Vec<String> = versions
-        .into_iter()
+    let selected: Vec<&schema::CollectionVersion> = versions
+        .iter()
         .filter(|version| selector.selects(version))
-        .map(|version| version.name)
+        .collect();
+
+    // Go looks a version id up directly and propagates not-found
+    // (`internal/db/collection.go:210-215`, `GetCollectionByID`), where an
+    // unknown name or collection id is swallowed into an empty list. A typo in
+    // a version id must not read as "no such collection version".
+    if let Some(version_id) = &selector.version_id {
+        if selected.is_empty() {
+            return Err(HttpError::NotFound(format!(
+                "no collection version {version_id}"
+            )));
+        }
+    }
+
+    let mut collections: Vec<String> = selected
+        .into_iter()
+        .map(|version| version.name.clone())
         .collect();
     collections.sort();
     collections.dedup();

--- a/crates/http/src/handlers/collections.rs
+++ b/crates/http/src/handlers/collections.rs
@@ -16,6 +16,7 @@ use query::rest::{CollectionDocIdsPage, CollectionDocIdsPagination};
 use serde::Serialize;
 
 use crate::error::{http_error_from_backend_message, HttpError};
+use crate::handlers::collection_selector::CollectionSelectorQuery;
 use crate::identity_extractor::ExtractIdentity;
 use crate::nac_guard::require_permission;
 use crate::router::{AppState, NodePermission};
@@ -83,17 +84,37 @@ fn parse_collection_doc_ids_pagination(
     Ok(CollectionDocIdsPagination { limit, offset })
 }
 
-/// List all collection names.
+/// List collection names, narrowed by Go's selectors.
 ///
-/// GET /api/v0/collections
+/// GET /api/v0/collections?name=Users&version_id=..&collection_id=..&get_inactive=true
+///
+/// The selectors are Go's `GetCollectionsOptions` (`http/client.go:422-448`)
+/// and resolve through the shared `db::CollectionSelector`, the same lookup
+/// `POST /view/refresh` uses. Ignoring them, as this handler used to, answers
+/// a request for one collection with every collection and gives the caller no
+/// way to tell.
+///
+/// The response is still a name list. Go returns full collection definitions
+/// here; that shape difference is tracked separately, and `GET
+/// /collections/versions` already serves version-level detail.
 ///
 /// Requires `CollectionGet` permission when NAC is enabled.
 pub async fn list_collections(
     State(state): State<AppState>,
     identity: ExtractIdentity,
+    Query(query): Query<CollectionSelectorQuery>,
 ) -> Result<Json<CollectionsResponse>, HttpError> {
     require_permission(&state, &identity, NodePermission::CollectionGet).await?;
 
+    let selector = query.into_selector();
+    if !selector.is_unfiltered() {
+        return list_selected_collections(&state, &selector).await;
+    }
+
+    // The unnarrowed listing stays on the REST path because that one honours a
+    // transaction-scoped collection provider, where the system store below
+    // does not. Narrowing needs per-version fields the name list does not
+    // carry, so it has to read the versions.
     let rest = state
         .rest
         .as_ref()
@@ -106,6 +127,32 @@ pub async fn list_collections(
             Err(e.into())
         }
     }
+}
+
+/// Apply the selectors to the stored collection versions.
+///
+/// Fails loudly when the version store is not configured rather than falling
+/// back to the unnarrowed listing: silently answering a narrowed request with
+/// everything is the bug this handler is fixing.
+async fn list_selected_collections(
+    state: &AppState,
+    selector: &db::CollectionSelector,
+) -> Result<Json<CollectionsResponse>, HttpError> {
+    let versions = state
+        .require_collection_versions()?
+        .get_all_collections()
+        .await
+        .map_err(http_error_from_backend_message)?;
+
+    let mut collections: Vec<String> = versions
+        .into_iter()
+        .filter(|version| selector.selects(version))
+        .map(|version| version.name)
+        .collect();
+    collections.sort();
+    collections.dedup();
+
+    Ok(Json(CollectionsResponse { collections }))
 }
 
 /// Get document IDs in a collection.

--- a/crates/http/src/handlers/collections.rs
+++ b/crates/http/src/handlers/collections.rs
@@ -94,6 +94,14 @@ fn parse_collection_doc_ids_pagination(
 /// a request for one collection with every collection and gives the caller no
 /// way to tell.
 ///
+/// One source for every request, narrowed or not. Reading the unnarrowed case
+/// from a different place let the two disagree: the collection cache
+/// deliberately holds inactive P2P-synced collections
+/// (`db/src/merge/merge_handler/definition.rs`), so a node that synced `Users`
+/// without activating it listed it for `GET /collections` and not for
+/// `?name=Users`. Go answers both from the stored collections
+/// (`description.GetActiveCollections`), which is what the version store is.
+///
 /// The response is still a name list. Go returns full collection definitions
 /// here; that shape difference is tracked separately, and `GET
 /// /collections/versions` already serves version-level detail.
@@ -107,41 +115,10 @@ pub async fn list_collections(
     require_permission(&state, &identity, NodePermission::CollectionGet).await?;
 
     let selector = query.into_selector();
-    if !selector.is_unfiltered() {
-        return list_selected_collections(&state, &selector).await;
-    }
 
-    // The unnarrowed listing stays on the REST path because that one honours a
-    // transaction-scoped collection provider, where the system store below
-    // does not. Narrowing needs per-version fields the name list does not
-    // carry, so it has to read the versions.
-    let rest = state
-        .rest
-        .as_ref()
-        .ok_or_else(|| HttpError::Internal("REST operations not configured".into()))?;
-
-    match rest.list_collections().await {
-        Ok(collections) => Ok(Json(CollectionsResponse { collections })),
-        Err(e) => {
-            tracing::warn!(error = %e, "Failed to list collections");
-            Err(e.into())
-        }
-    }
-}
-
-/// Apply the selectors to the stored collection versions.
-///
-/// Fails loudly when the version store is not configured rather than falling
-/// back to the unnarrowed listing: silently answering a narrowed request with
-/// everything is the bug this handler is fixing.
-async fn list_selected_collections(
-    state: &AppState,
-    selector: &db::CollectionSelector,
-) -> Result<Json<CollectionsResponse>, HttpError> {
     // The same branch `refresh_views` makes on the same selector: inactive
     // versions cost a scan of every stored version, and a selector that does
-    // not ask for them is answerable from the active listing alone. Two
-    // surfaces sharing one selector have to decide this the same way.
+    // not ask for them is answerable from the active listing alone.
     let collection_versions = state.require_collection_versions()?;
     let versions = if selector.needs_all_versions() {
         collection_versions.get_all_collections().await
@@ -150,26 +127,24 @@ async fn list_selected_collections(
     }
     .map_err(http_error_from_backend_message)?;
 
-    let selected: Vec<&schema::CollectionVersion> = versions
-        .iter()
-        .filter(|version| selector.selects(version))
-        .collect();
-
-    // Go looks a version id up directly and propagates not-found
-    // (`internal/db/collection.go:210-215`, `GetCollectionByID`), where an
-    // unknown name or collection id is swallowed into an empty list. A typo in
-    // a version id must not read as "no such collection version".
-    if let Some(version_id) = &selector.version_id {
-        if selected.is_empty() {
-            return Err(HttpError::NotFound(format!(
-                "no collection version {version_id}"
-            )));
+    // Go propagates not-found only from the direct version lookup, which the
+    // active-by-name arm pre-empts (`internal/db/collection.go:210-215`). So
+    // `?version_id=nope` is a 404 while `?name=Users&version_id=nope` is an
+    // empty 200, and an unknown name or collection id never errors at all.
+    if selector.resolves_by_version_lookup() {
+        let version_id = selector
+            .version_id
+            .as_ref()
+            .expect("a version lookup has a version id");
+        if !versions.iter().any(|v| &v.version_id == version_id) {
+            return Err(HttpError::NotFound("collection not found".into()));
         }
     }
 
-    let mut collections: Vec<String> = selected
+    let mut collections: Vec<String> = versions
         .into_iter()
-        .map(|version| version.name.clone())
+        .filter(|version| selector.selects(version))
+        .map(|version| version.name)
         .collect();
     collections.sort();
     collections.dedup();

--- a/crates/http/src/handlers/collections.rs
+++ b/crates/http/src/handlers/collections.rs
@@ -106,7 +106,7 @@ pub async fn list_collections(
 ) -> Result<Json<CollectionsResponse>, HttpError> {
     require_permission(&state, &identity, NodePermission::CollectionGet).await?;
 
-    let selector = query.into_selector();
+    let selector = query.into_selector()?;
     if !selector.is_unfiltered() {
         return list_selected_collections(&state, &selector).await;
     }
@@ -138,11 +138,17 @@ async fn list_selected_collections(
     state: &AppState,
     selector: &db::CollectionSelector,
 ) -> Result<Json<CollectionsResponse>, HttpError> {
-    let versions = state
-        .require_collection_versions()?
-        .get_all_collections()
-        .await
-        .map_err(http_error_from_backend_message)?;
+    // The same branch `refresh_views` makes on the same selector: inactive
+    // versions cost a scan of every stored version, and a selector that does
+    // not ask for them is answerable from the active listing alone. Two
+    // surfaces sharing one selector have to decide this the same way.
+    let collection_versions = state.require_collection_versions()?;
+    let versions = if selector.needs_all_versions() {
+        collection_versions.get_all_collections().await
+    } else {
+        collection_versions.get_active_collections().await
+    }
+    .map_err(http_error_from_backend_message)?;
 
     let mut collections: Vec<String> = versions
         .into_iter()

--- a/crates/http/src/handlers/collections_tests.rs
+++ b/crates/http/src/handlers/collections_tests.rs
@@ -33,7 +33,7 @@ fn create_failing_state() -> AppState {
 async fn test_list_collections() {
     let state = create_state();
     let identity = ExtractIdentity::anonymous();
-    let result = list_collections(State(state), identity).await;
+    let result = list_collections(State(state), identity, Query(Default::default())).await;
     assert!(result.is_ok());
     let response = result.unwrap();
     assert!(response.collections.contains(&"Users".to_string()));
@@ -44,7 +44,7 @@ async fn test_list_collections() {
 async fn test_list_collections_no_rest() {
     let state = create_state_without_rest();
     let identity = ExtractIdentity::anonymous();
-    let result = list_collections(State(state), identity).await;
+    let result = list_collections(State(state), identity, Query(Default::default())).await;
     assert!(result.is_err());
 }
 
@@ -52,7 +52,7 @@ async fn test_list_collections_no_rest() {
 async fn test_list_collections_error() {
     let state = create_failing_state();
     let identity = ExtractIdentity::anonymous();
-    let result = list_collections(State(state), identity).await;
+    let result = list_collections(State(state), identity, Query(Default::default())).await;
     assert!(result.is_err());
 }
 

--- a/crates/http/src/handlers/collections_tests.rs
+++ b/crates/http/src/handlers/collections_tests.rs
@@ -16,6 +16,7 @@ use tower::ServiceExt;
 fn create_state() -> AppState {
     AppStateBuilder::new(Arc::new(MockQueryExecutor::new()) as Arc<dyn QueryExecutor>)
         .with_rest(Arc::new(MockRestOperations::new()) as Arc<dyn RestOperations>)
+        .with_collection_mgmt(Arc::new(MockCollectionManagementOperations::new()))
         .build()
 }
 
@@ -36,8 +37,9 @@ async fn test_list_collections() {
     let result = list_collections(State(state), identity, Query(Default::default())).await;
     assert!(result.is_ok());
     let response = result.unwrap();
-    assert!(response.collections.contains(&"Users".to_string()));
-    assert!(response.collections.contains(&"Books".to_string()));
+    // The listing reads the stored versions, which is what the collection
+    // management mock serves.
+    assert!(response.collections.contains(&"MockCollection".to_string()));
 }
 
 #[tokio::test]

--- a/crates/http/src/handlers/mod.rs
+++ b/crates/http/src/handlers/mod.rs
@@ -15,6 +15,7 @@ pub mod backup;
 pub mod batch;
 pub mod block;
 pub mod browser_sync;
+pub mod collection_selector;
 pub mod collections;
 pub mod documents;
 pub mod encrypted_index;

--- a/crates/http/src/handlers/views.rs
+++ b/crates/http/src/handlers/views.rs
@@ -97,7 +97,7 @@ pub async fn refresh_views(
     let view_ops = state.require_view()?;
 
     view_ops
-        .refresh_views(query.into_selector_with(view_names_from_body(&body)?))
+        .refresh_views(query.into_selector_with(view_names_from_body(&body)?)?)
         .await
         .map_err(http_error_from_backend_message)?;
 

--- a/crates/http/src/handlers/views.rs
+++ b/crates/http/src/handlers/views.rs
@@ -7,6 +7,7 @@ use axum::{
 };
 
 use crate::error::{http_error_from_backend_message, HttpError};
+use crate::handlers::collection_selector::CollectionSelectorQuery;
 use crate::identity_extractor::ExtractIdentity;
 use crate::nac_guard::require_permission;
 use crate::router::{AppState, NodePermission};
@@ -29,35 +30,6 @@ pub struct AddViewRequest {
 pub struct ViewNamesRequest {
     #[serde(rename = "Names", default)]
     pub names: Option<Vec<String>>,
-}
-
-/// Query selectors for refreshing views, matching Go's `RefreshViews` client.
-#[derive(Debug, Default, serde::Deserialize)]
-pub struct RefreshViewsQuery {
-    pub name: Option<String>,
-    pub version_id: Option<String>,
-    pub collection_id: Option<String>,
-    pub get_inactive: Option<bool>,
-}
-
-impl RefreshViewsQuery {
-    /// Combine the query selectors with the optional body's name list.
-    pub fn into_options(self, body_names: Option<Vec<String>>) -> db::RefreshViewsOptions {
-        let mut names = body_names;
-        if let Some(name) = self.name {
-            let names = names.get_or_insert_with(Vec::new);
-            if !names.contains(&name) {
-                names.push(name);
-            }
-        }
-
-        db::RefreshViewsOptions {
-            names,
-            version_id: self.version_id,
-            collection_id: self.collection_id,
-            get_inactive: self.get_inactive.unwrap_or(false),
-        }
-    }
 }
 
 /// Add a view.
@@ -117,7 +89,7 @@ fn view_names_from_body(body: &Bytes) -> Result<Option<Vec<String>>, HttpError> 
 pub async fn refresh_views(
     State(state): State<AppState>,
     identity: ExtractIdentity,
-    Query(query): Query<RefreshViewsQuery>,
+    Query(query): Query<CollectionSelectorQuery>,
     body: Bytes,
 ) -> Result<Json<serde_json::Value>, HttpError> {
     require_permission(&state, &identity, NodePermission::ViewRefresh).await?;
@@ -125,7 +97,7 @@ pub async fn refresh_views(
     let view_ops = state.require_view()?;
 
     view_ops
-        .refresh_views(query.into_options(view_names_from_body(&body)?))
+        .refresh_views(query.into_selector_with(view_names_from_body(&body)?))
         .await
         .map_err(http_error_from_backend_message)?;
 

--- a/crates/http/src/handlers/views.rs
+++ b/crates/http/src/handlers/views.rs
@@ -97,7 +97,7 @@ pub async fn refresh_views(
     let view_ops = state.require_view()?;
 
     view_ops
-        .refresh_views(query.into_selector_with(view_names_from_body(&body)?)?)
+        .refresh_views(query.into_selector_with(view_names_from_body(&body)?))
         .await
         .map_err(http_error_from_backend_message)?;
 

--- a/crates/http/src/router/state.rs
+++ b/crates/http/src/router/state.rs
@@ -20,6 +20,10 @@ impl CollectionVersionOperations for CollectionVersionsFromManagement {
     async fn get_all_collections(&self) -> Result<Vec<schema::CollectionVersion>, String> {
         self.0.get_all_collections().await
     }
+
+    async fn get_active_collections(&self) -> Result<Vec<schema::CollectionVersion>, String> {
+        self.0.get_active_collections().await
+    }
 }
 
 /// Application state shared across handlers.

--- a/crates/http/src/router/traits.rs
+++ b/crates/http/src/router/traits.rs
@@ -960,7 +960,7 @@ pub trait ViewOperations: Send + Sync {
     ///
     /// The options select which views to refresh, mirroring Go's collection
     /// lookup. Default options refresh every materialized view.
-    async fn refresh_views(&self, options: db::RefreshViewsOptions) -> Result<(), String>;
+    async fn refresh_views(&self, options: db::CollectionSelector) -> Result<(), String>;
 
     /// Run manual downsample history GC.
     ///

--- a/crates/http/src/router/traits.rs
+++ b/crates/http/src/router/traits.rs
@@ -723,6 +723,21 @@ pub trait SchemaOperations: Send + Sync {
 pub trait CollectionVersionOperations: Send + Sync {
     /// Get all collection versions (active + inactive) from the system store.
     async fn get_all_collections(&self) -> Result<Vec<schema::CollectionVersion>, String>;
+
+    /// The active collection versions only.
+    ///
+    /// Defaults to filtering the full listing, so an implementation that has
+    /// no cheaper path stays correct. A backend that can answer without
+    /// scanning every stored version should override this: it is the path a
+    /// selector takes whenever `needs_all_versions` is false.
+    async fn get_active_collections(&self) -> Result<Vec<schema::CollectionVersion>, String> {
+        Ok(self
+            .get_all_collections()
+            .await?
+            .into_iter()
+            .filter(|version| version.is_active)
+            .collect())
+    }
 }
 
 /// Trait for collection management operations beyond basic CRUD.
@@ -784,6 +799,17 @@ pub trait CollectionManagementOperations: Send + Sync {
 
     /// Get all collection versions (active + inactive) from the system store.
     async fn get_all_collections(&self) -> Result<Vec<schema::CollectionVersion>, String>;
+
+    /// The active collection versions only. See
+    /// `CollectionVersionOperations::get_active_collections`.
+    async fn get_active_collections(&self) -> Result<Vec<schema::CollectionVersion>, String> {
+        Ok(self
+            .get_all_collections()
+            .await?
+            .into_iter()
+            .filter(|version| version.is_active)
+            .collect())
+    }
 
     /// Delete a collection by name.
     async fn delete_collection(&self, name: &str) -> Result<(), String>;

--- a/crates/http/tests/collection_selectors.rs
+++ b/crates/http/tests/collection_selectors.rs
@@ -23,13 +23,20 @@ use defra_http::router::{AppStateBuilder, CollectionVersionOperations};
 use defra_http::{MockQueryExecutor, MockRestOperations};
 use query::rest::RestOperations;
 use schema::CollectionVersion;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use tower::ServiceExt;
 
 /// The stored versions, covering every branch of Go's candidate switch:
 /// a collection with both an active and an inactive version, a plain active
 /// one, and a wholly inactive one.
-#[derive(Debug)]
-struct Versions;
+///
+/// Counts which listing the handler asked for, so the cheap path can be
+/// asserted rather than assumed.
+#[derive(Debug, Default)]
+struct Versions {
+    all_calls: AtomicUsize,
+    active_calls: AtomicUsize,
+}
 
 fn version(name: &str, version_id: &str, collection_id: &str, active: bool) -> CollectionVersion {
     let mut version = CollectionVersion::new(name, version_id, collection_id, vec![]);
@@ -37,22 +44,38 @@ fn version(name: &str, version_id: &str, collection_id: &str, active: bool) -> C
     version
 }
 
-#[async_trait]
-impl CollectionVersionOperations for Versions {
-    async fn get_all_collections(&self) -> Result<Vec<CollectionVersion>, String> {
-        Ok(vec![
+impl Versions {
+    fn stored() -> Vec<CollectionVersion> {
+        vec![
             version("Users", "users-v2", "users-c", true),
             version("Users", "users-v1", "users-c", false),
             version("Books", "books-v1", "books-c", true),
             version("Orders", "orders-v1", "orders-c", false),
-        ])
+        ]
+    }
+}
+
+#[async_trait]
+impl CollectionVersionOperations for Versions {
+    async fn get_all_collections(&self) -> Result<Vec<CollectionVersion>, String> {
+        self.all_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(Self::stored())
+    }
+
+    async fn get_active_collections(&self) -> Result<Vec<CollectionVersion>, String> {
+        self.active_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(Self::stored().into_iter().filter(|v| v.is_active).collect())
     }
 }
 
 fn router() -> Router {
+    router_with(Arc::new(Versions::default()))
+}
+
+fn router_with(versions: Arc<Versions>) -> Router {
     let state = AppStateBuilder::new(Arc::new(MockQueryExecutor::new()))
         .with_rest(Arc::new(MockRestOperations::new()) as Arc<dyn RestOperations>)
-        .with_collection_versions(Arc::new(Versions))
+        .with_collection_versions(versions)
         .build();
     defra_http::create_router_with_state(state)
 }
@@ -188,4 +211,60 @@ async fn a_narrowed_request_without_a_version_store_is_an_error() {
 async fn an_unparseable_selector_is_refused() {
     let (status, _) = get(router(), "?get_inactive=maybe").await;
     assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+/// A selector sent with an empty value is refused rather than quietly meaning
+/// "everything" or "nothing". Both of those hand the caller something other
+/// than what it asked for, which is the bug this handling exists to fix.
+#[tokio::test]
+async fn an_empty_selector_value_is_refused() {
+    for query in [
+        "?name=",
+        "?version_id=",
+        "?collection_id=",
+        "?name=%20",
+        "?name=&get_inactive=true",
+    ] {
+        let (status, body) = get(router(), query).await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "{query} should be refused, got {body}"
+        );
+    }
+}
+
+/// Inactive versions cost a scan of every stored version. A selector that does
+/// not ask for them must take the active listing, the same branch
+/// `refresh_views` makes on the same selector.
+#[tokio::test]
+async fn a_selector_that_needs_no_inactive_versions_takes_the_cheap_listing() {
+    let versions = Arc::new(Versions::default());
+    let (status, body) = get(router_with(versions.clone()), "?name=Users").await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+
+    assert_eq!(versions.active_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        versions.all_calls.load(Ordering::SeqCst),
+        0,
+        "an active-only selector must not scan every stored version"
+    );
+}
+
+/// The converse: asking for inactive versions, or for a version by id, does
+/// need the full listing.
+#[tokio::test]
+async fn a_selector_that_needs_inactive_versions_takes_the_full_listing() {
+    for query in ["?get_inactive=true", "?version_id=users-v1"] {
+        let versions = Arc::new(Versions::default());
+        let (status, body) = get(router_with(versions.clone()), query).await;
+        assert_eq!(status, StatusCode::OK, "{query}: {body}");
+
+        assert_eq!(
+            versions.all_calls.load(Ordering::SeqCst),
+            1,
+            "{query} needs every stored version"
+        );
+        assert_eq!(versions.active_calls.load(Ordering::SeqCst), 0, "{query}");
+    }
 }

--- a/crates/http/tests/collection_selectors.rs
+++ b/crates/http/tests/collection_selectors.rs
@@ -1,0 +1,191 @@
+//! `GET /collections` has to honour Go's four selectors.
+//!
+//! Go's client sends `name`, `version_id`, `collection_id` and `get_inactive`
+//! (`http/client.go:422-448`) and Go resolves them through `getCollections`
+//! (`internal/db/collection.go:193-301`). Rust parsed none of them and
+//! answered every request with the full active listing, so a client asking for
+//! one collection got an arbitrary one and could not tell.
+//!
+//! The precedence is the part worth pinning: `collection_id` only picks
+//! candidates, so a name outranks it, and a name plus `get_inactive`
+//! deliberately misses the active-by-name case so it can reach an inactive
+//! version.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use axum::{
+    body::{to_bytes, Body},
+    http::{header::HOST, Request, StatusCode},
+    Router,
+};
+use defra_http::router::{AppStateBuilder, CollectionVersionOperations};
+use defra_http::{MockQueryExecutor, MockRestOperations};
+use query::rest::RestOperations;
+use schema::CollectionVersion;
+use tower::ServiceExt;
+
+/// The stored versions, covering every branch of Go's candidate switch:
+/// a collection with both an active and an inactive version, a plain active
+/// one, and a wholly inactive one.
+#[derive(Debug)]
+struct Versions;
+
+fn version(name: &str, version_id: &str, collection_id: &str, active: bool) -> CollectionVersion {
+    let mut version = CollectionVersion::new(name, version_id, collection_id, vec![]);
+    version.is_active = active;
+    version
+}
+
+#[async_trait]
+impl CollectionVersionOperations for Versions {
+    async fn get_all_collections(&self) -> Result<Vec<CollectionVersion>, String> {
+        Ok(vec![
+            version("Users", "users-v2", "users-c", true),
+            version("Users", "users-v1", "users-c", false),
+            version("Books", "books-v1", "books-c", true),
+            version("Orders", "orders-v1", "orders-c", false),
+        ])
+    }
+}
+
+fn router() -> Router {
+    let state = AppStateBuilder::new(Arc::new(MockQueryExecutor::new()))
+        .with_rest(Arc::new(MockRestOperations::new()) as Arc<dyn RestOperations>)
+        .with_collection_versions(Arc::new(Versions))
+        .build();
+    defra_http::create_router_with_state(state)
+}
+
+/// A router that can list but has no version store, so a narrowed request
+/// cannot be answered.
+fn router_without_versions() -> Router {
+    let state = AppStateBuilder::new(Arc::new(MockQueryExecutor::new()))
+        .with_rest(Arc::new(MockRestOperations::new()) as Arc<dyn RestOperations>)
+        .build();
+    defra_http::create_router_with_state(state)
+}
+
+async fn get(router: Router, query: &str) -> (StatusCode, String) {
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v0/collections{query}"))
+                .header(HOST, "localhost:9181")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("router should respond");
+    let status = response.status();
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    (status, String::from_utf8_lossy(&body).into_owned())
+}
+
+async fn names(query: &str) -> Vec<String> {
+    let (status, body) = get(router(), query).await;
+    assert_eq!(status, StatusCode::OK, "{query}: {body}");
+    let parsed: serde_json::Value = serde_json::from_str(&body).expect("json body");
+    parsed["collections"]
+        .as_array()
+        .expect("collections array")
+        .iter()
+        .map(|name| name.as_str().expect("name is a string").to_string())
+        .collect()
+}
+
+/// The regression: a request for one collection used to answer with all of
+/// them.
+#[tokio::test]
+async fn a_name_selects_only_that_collection() {
+    assert_eq!(names("?name=Users").await, vec!["Users"]);
+    assert_eq!(names("?name=Books").await, vec!["Books"]);
+}
+
+#[tokio::test]
+async fn an_unknown_name_selects_nothing() {
+    assert!(names("?name=Nope").await.is_empty());
+}
+
+/// Go returns a named version whether or not it is active, which is why
+/// `version_id` alone reaches the inactive one.
+#[tokio::test]
+async fn a_version_id_selects_that_version_even_when_inactive() {
+    assert_eq!(names("?version_id=users-v1").await, vec!["Users"]);
+    assert_eq!(names("?version_id=orders-v1").await, vec!["Orders"]);
+}
+
+#[tokio::test]
+async fn a_collection_id_selects_its_active_version() {
+    assert_eq!(names("?collection_id=users-c").await, vec!["Users"]);
+    assert!(names("?collection_id=orders-c").await.is_empty());
+}
+
+#[tokio::test]
+async fn get_inactive_widens_to_the_inactive_versions() {
+    assert_eq!(
+        names("?get_inactive=true").await,
+        vec!["Books", "Orders", "Users"]
+    );
+    assert_eq!(names("").await, vec!["Books", "Users"]);
+}
+
+/// Stage one of Go's lookup is a switch, so a name with `get_inactive` false
+/// wins outright and a disagreeing collection id never applies. A flat AND
+/// over the selectors would wrongly answer with nothing here.
+#[tokio::test]
+async fn a_name_outranks_a_disagreeing_collection_id() {
+    assert_eq!(
+        names("?name=Users&collection_id=books-c").await,
+        vec!["Users"]
+    );
+}
+
+/// The case Go's switch exists for: name plus `get_inactive` skips the
+/// active-by-name arm and is narrowed by the stage-two name filter instead.
+#[tokio::test]
+async fn a_name_with_get_inactive_reaches_an_inactive_version() {
+    assert_eq!(
+        names("?name=Orders&get_inactive=true").await,
+        vec!["Orders"]
+    );
+    assert!(names("?name=Orders").await.is_empty());
+}
+
+/// The listing is a name list, so the two versions of one collection must not
+/// show up as a repeated name.
+#[tokio::test]
+async fn a_collection_with_two_versions_is_named_once() {
+    assert_eq!(
+        names("?collection_id=users-c&get_inactive=true").await,
+        vec!["Users"]
+    );
+}
+
+/// An unnarrowed request keeps its existing answer and its existing source,
+/// which is the REST listing rather than the version store.
+#[tokio::test]
+async fn no_selectors_keep_the_previous_behaviour() {
+    let (status, body) = get(router_without_versions(), "").await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert!(body.contains("Users"), "{body}");
+}
+
+/// Failing loudly is the point of the fix. Answering a narrowed request from
+/// the unnarrowed listing would be the same silent-widening bug in a new
+/// place.
+#[tokio::test]
+async fn a_narrowed_request_without_a_version_store_is_an_error() {
+    let (status, _) = get(router_without_versions(), "?name=Users").await;
+    assert!(
+        status.is_server_error() || status.is_client_error(),
+        "expected a failure, got {status}"
+    );
+}
+
+/// A selector Rust cannot parse must be refused, not dropped.
+#[tokio::test]
+async fn an_unparseable_selector_is_refused() {
+    let (status, _) = get(router(), "?get_inactive=maybe").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}

--- a/crates/http/tests/collection_selectors.rs
+++ b/crates/http/tests/collection_selectors.rs
@@ -80,8 +80,7 @@ fn router_with(versions: Arc<Versions>) -> Router {
     defra_http::create_router_with_state(state)
 }
 
-/// A router that can list but has no version store, so a narrowed request
-/// cannot be answered.
+/// A router with no version store, so no listing can be answered.
 fn router_without_versions() -> Router {
     let state = AppStateBuilder::new(Arc::new(MockQueryExecutor::new()))
         .with_rest(Arc::new(MockRestOperations::new()) as Arc<dyn RestOperations>)
@@ -185,25 +184,33 @@ async fn a_collection_with_two_versions_is_named_once() {
     );
 }
 
-/// An unnarrowed request keeps its existing answer and its existing source,
-/// which is the REST listing rather than the version store.
+/// The divergence that two sources allowed: the collection cache deliberately
+/// holds inactive P2P-synced collections, so the unnarrowed listing used to
+/// name a collection the narrowed one dropped. Both read the stored versions
+/// now, as Go does, so an inactive collection is absent from both.
 #[tokio::test]
-async fn no_selectors_keep_the_previous_behaviour() {
-    let (status, body) = get(router_without_versions(), "").await;
-    assert_eq!(status, StatusCode::OK, "{body}");
-    assert!(body.contains("Users"), "{body}");
+async fn an_inactive_collection_is_absent_from_narrowed_and_unnarrowed_alike() {
+    assert!(
+        !names("").await.contains(&"Orders".to_string()),
+        "an inactive collection must not be listed"
+    );
+    assert!(
+        names("?name=Orders").await.is_empty(),
+        "and must not be selectable by name either"
+    );
 }
 
-/// Failing loudly is the point of the fix. Answering a narrowed request from
-/// the unnarrowed listing would be the same silent-widening bug in a new
-/// place.
+/// Every request reads the same source, so a missing version store fails the
+/// same way for all of them rather than quietly answering from somewhere else.
 #[tokio::test]
-async fn a_narrowed_request_without_a_version_store_is_an_error() {
-    let (status, _) = get(router_without_versions(), "?name=Users").await;
-    assert!(
-        status.is_server_error() || status.is_client_error(),
-        "expected a failure, got {status}"
-    );
+async fn every_request_needs_the_version_store() {
+    for query in ["", "?name=Users"] {
+        let (status, _) = get(router_without_versions(), query).await;
+        assert!(
+            status.is_server_error() || status.is_client_error(),
+            "{query:?} should fail without a version store, got {status}"
+        );
+    }
 }
 
 /// A selector Rust cannot parse must be refused, not dropped.
@@ -246,6 +253,56 @@ async fn an_unknown_version_id_is_a_404() {
         let (status, body) = get(router(), query).await;
         assert_eq!(status, StatusCode::NOT_FOUND, "{query}: {body}");
     }
+}
+
+/// The 404 fires from Go's direct lookup, which the active-by-name arm
+/// pre-empts, so a name alongside the version id turns it back into an empty
+/// 200. `collection describe --collection-name X --version-id Y` sends exactly
+/// that combination (`cli/collection.go:86-100`), so getting this wrong 404s a
+/// working CLI call.
+#[tokio::test]
+async fn a_name_pre_empts_the_version_lookup_so_a_bad_version_is_not_a_404() {
+    for query in [
+        "?name=Users&version_id=nope",
+        "?name=Books&version_id=users-v2",
+    ] {
+        let (status, body) = get(router(), query).await;
+        assert_eq!(status, StatusCode::OK, "{query}: {body}");
+        assert!(names(query).await.is_empty(), "{query} selects nothing");
+    }
+}
+
+/// `get_inactive` takes the name arm out of the running, so the version
+/// lookup runs again and an id that exists is not an error even when the name
+/// filters it away.
+#[tokio::test]
+async fn get_inactive_restores_the_version_lookup() {
+    let (status, body) = get(
+        router(),
+        "?name=Books&get_inactive=true&version_id=users-v2",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert!(names("?name=Books&get_inactive=true&version_id=users-v2")
+        .await
+        .is_empty());
+
+    let (status, _) = get(router(), "?name=Books&get_inactive=true&version_id=nope").await;
+    assert_eq!(
+        status,
+        StatusCode::NOT_FOUND,
+        "the lookup runs here, so a missing id is not found"
+    );
+}
+
+/// Go's message for this is `collection not found` (`client/errors.go:29`).
+#[tokio::test]
+async fn the_not_found_body_matches_gos_message() {
+    let (_, body) = get(router(), "?version_id=nope").await;
+    assert!(
+        body.contains("collection not found"),
+        "expected Go's message, got {body}"
+    );
 }
 
 /// Inactive versions cost a scan of every stored version. A selector that does

--- a/crates/http/tests/collection_selectors.rs
+++ b/crates/http/tests/collection_selectors.rs
@@ -209,28 +209,42 @@ async fn a_narrowed_request_without_a_version_store_is_an_error() {
 /// A selector Rust cannot parse must be refused, not dropped.
 #[tokio::test]
 async fn an_unparseable_selector_is_refused() {
-    let (status, _) = get(router(), "?get_inactive=maybe").await;
-    assert_eq!(status, StatusCode::BAD_REQUEST);
+    for query in ["?get_inactive=maybe", "?get_inactive="] {
+        let (status, body) = get(router(), query).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{query}: {body}");
+    }
 }
 
-/// A selector sent with an empty value is refused rather than quietly meaning
-/// "everything" or "nothing". Both of those hand the caller something other
-/// than what it asked for, which is the bug this handling exists to fix.
+/// Go keys the selectors off `Query().Has(..)`, so `?name=` is a name set to
+/// the empty string, not an absent selector. It matches nothing and comes back
+/// as an empty list (`http/handler_store.go:391`, then the stage-two name
+/// filter drops the zero-value collection because it is not active).
 #[tokio::test]
-async fn an_empty_selector_value_is_refused() {
+async fn an_empty_name_or_collection_id_selects_nothing() {
     for query in [
         "?name=",
-        "?version_id=",
         "?collection_id=",
         "?name=%20",
         "?name=&get_inactive=true",
     ] {
         let (status, body) = get(router(), query).await;
-        assert_eq!(
-            status,
-            StatusCode::BAD_REQUEST,
-            "{query} should be refused, got {body}"
+        assert_eq!(status, StatusCode::OK, "{query}: {body}");
+        assert!(
+            names(query).await.is_empty(),
+            "{query} should select nothing"
         );
+    }
+}
+
+/// Go looks a version id up directly and returns `ErrCollectionNotFound`,
+/// which its error mapping turns into a 404 (`internal/db/collection.go:210`,
+/// `GetCollectionByID`). An unknown name is swallowed into an empty list, but
+/// an unknown version id is not, so a typo must not read as success.
+#[tokio::test]
+async fn an_unknown_version_id_is_a_404() {
+    for query in ["?version_id=nope", "?version_id="] {
+        let (status, body) = get(router(), query).await;
+        assert_eq!(status, StatusCode::NOT_FOUND, "{query}: {body}");
     }
 }
 

--- a/crates/http/tests/common/mod.rs
+++ b/crates/http/tests/common/mod.rs
@@ -33,7 +33,7 @@ pub const POLICY: &str = "name: test\nresources:\n  doc:\n    permissions:\n";
 #[derive(Debug, Default)]
 pub struct RecordingViewOps {
     pub add_view_transform: std::sync::Mutex<Option<Option<String>>>,
-    pub refresh: std::sync::Mutex<Option<db::RefreshViewsOptions>>,
+    pub refresh: std::sync::Mutex<Option<db::CollectionSelector>>,
 }
 
 #[async_trait]
@@ -48,7 +48,7 @@ impl ViewOperations for RecordingViewOps {
         Ok(vec![])
     }
 
-    async fn refresh_views(&self, options: db::RefreshViewsOptions) -> Result<(), String> {
+    async fn refresh_views(&self, options: db::CollectionSelector) -> Result<(), String> {
         *self.refresh.lock().unwrap() = Some(options);
         Ok(())
     }

--- a/crates/http/tests/go_request_contracts.rs
+++ b/crates/http/tests/go_request_contracts.rs
@@ -121,7 +121,7 @@ async fn a_view_without_a_query_or_sdl_is_rejected() {
 // RefreshViews request contract
 // ---------------------------------------------------------------------------
 
-async fn refresh_options_for(call: Call) -> (StatusCode, Option<db::RefreshViewsOptions>) {
+async fn refresh_options_for(call: Call) -> (StatusCode, Option<db::CollectionSelector>) {
     let view = Arc::new(RecordingViewOps::default());
     let (status, _) = call.send_to(router_with(Arc::clone(&view))).await;
     let seen = view.refresh.lock().unwrap().clone();


### PR DESCRIPTION
Closes #1494.

`GET /collections` parsed no query parameters at all, so a Go-compatible client asking for one collection by name, or for a specific version, got the full list of every active collection and had no way to tell it did not get what it asked for.

## Reusing the lookup instead of copying it

The issue was explicit that the identical selector set already landed for `POST /view/refresh` and that a second copy would be a divergence waiting to happen. Go has one `getCollections` behind both surfaces, so Rust now has one too:

- `db::RefreshViewsOptions` becomes `db::CollectionSelector` and moves from `view/ops.rs` to `crates/db/src/collection/selector.rs`. It was already Go's collection lookup wearing a view-specific name; it is now named for what it is and lives next to collections. This is a rename across 10 files with no behaviour change.
- `RefreshViewsQuery` becomes `handlers::collection_selector::CollectionSelectorQuery`, shared by `GET /collections` and `POST /view/refresh`, so Go's query string is parsed in one place.
- New `is_unfiltered()` on the selector, which is what lets the unnarrowed listing keep its existing path.

## Two decisions worth reviewing

**The unnarrowed listing stays on `rest.list_collections()`.** This is not just conservatism: that path honours a transaction-scoped collection provider (`current_txn_collection_provider`), and the system store the narrowed path reads does not. Narrowing needs per-version fields the name list does not carry, so it has to read the versions. Both are commented at the call site.

**A narrowed request with no version store configured is an error, not a fallback.** Quietly answering a narrowed request from the unnarrowed listing would be the same silent-widening bug this issue is about, one layer down.

## Response shape

Still `{"collections": [names]}`, not Go's collection definitions. The issue assigns response-shape parity to #1419, and `GET /collections/versions` already serves version-level detail. Names are sorted and deduped, so a collection with two versions is listed once rather than appearing as a repeated name.

## Tests

`crates/http/tests/collection_selectors.rs`, 11 tests over a version set that covers every branch of Go's candidate switch. The two that matter most are the cases a flat AND over the four selectors gets wrong:

- `a_name_outranks_a_disagreeing_collection_id`: `collection_id` is a stage-one selector only, so `?name=Users&collection_id=books-c` returns `Users`, where a flat AND would return nothing.
- `a_name_with_get_inactive_reaches_an_inactive_version`: name plus `get_inactive` deliberately misses the active-by-name arm and is narrowed by the stage-two name filter instead.

Also covered: an unknown name selects nothing, a version id reaches an inactive version, `get_inactive` widens, two versions of one collection are named once, no selectors keep the previous behaviour, a narrowed request without a version store fails loudly, and an unparseable `get_inactive` is a 400 rather than a dropped selector.

The db-level selector tests moved from `tests/view/ops.rs` to `tests/collection/selector.rs` alongside the type, with three added: `only_an_empty_selector_is_unfiltered`, `a_name_with_get_inactive_reaches_an_inactive_version`, and `a_version_id_needs_the_full_listing`.

## Verification

- `just fmt-check`: green
- `just lint`: green (exit 0)
- `just test`: green, 5209 tests passed, 0 failures
- `RUSTDOCFLAGS="-D warnings" cargo doc -p defra-http -p db --no-deps`: green

`just doc` across the whole workspace is red on `main` already (pre-existing rustdoc errors in `crates/storage` and `crates/datastore`), so the doc gate was run scoped to the crates this PR changes.

---

## Follow-up from self-review

**Empty selector values are now a 400.** `?name=` selected nothing under the rules above, while a server treating an empty value as "unset" answers with everything. I could not confirm which Go does, and both silently hand the caller something other than what it asked for, which is the bug this handling exists to fix. Refusing says so instead of guessing. Applies to `name`, `version_id` and `collection_id`, and to `view/refresh` too since both share the query type.

**The selector now takes the cheap listing when it can.** `refresh_views` branches on `needs_all_versions()` and reads the in-memory collection cache when inactive versions are not needed; this handler always scanned every stored version. Two surfaces sharing one selector were deciding differently, which is the divergence the shared type was supposed to prevent.

Fixed by exposing `db::get_active_collection_versions` (the cache read `refresh_views` already used), adding `get_active_collections` to `CollectionVersionOperations` and `CollectionManagementOperations` with a default that filters the full listing so no existing implementation breaks, overriding it in the CLI adapter, and branching in the handler. `a_selector_that_needs_no_inactive_versions_takes_the_cheap_listing` counts which listing was requested, so the cheap path is asserted rather than assumed.

Not fixed, and worth stating plainly: `get_all_collection_versions` still collects the whole `/collection/` prefix scan into a `Vec`. Streaming that needs a new iterator API in `crates/db` and changes a primitive `GET /collections/versions` shares, so it belongs in its own change. What this fixes is that the common case no longer reaches that scan at all.

Re-verified: `just fmt-check` green, `just lint` exit 0, `just test` 5212 passed 0 failed, `cargo doc -D warnings -p defra-http -p db -p cli` green.

---

## Verified against the Go source, and two corrections

Checked against the pinned baseline `13c46ec9`, which is what `GO_COMPAT_COMMIT` names. Two of my earlier answers were wrong.

**The empty-selector 400 was a mistake, and is reverted.** Go keys the selectors off `req.URL.Query().Has("name")`, not off the value being non-empty (`http/handler_store.go:391-402`), so `?name=` is a collection name set to `""`, not an absent selector. `getCollections` then takes the name case, `GetCollectionByName` returns not-found, the error is swallowed and a zero-value collection is appended, and the stage-two filter drops it because it is not active (`internal/db/collection.go:203-206`, `:270-273`). The result is an empty list, which is what this PR did before I added the refusal on top. `into_selector` is infallible again, since it can no longer fail.

**An unknown `version_id` must be a 404, and now is.** Go returns `GetCollectionByID`'s error unconditionally (`internal/db/collection.go:210-215`), and that error is `client.ErrCollectionNotFound` (`internal/db/description/collection.go:47-48`), which `httpStatusFromError` maps to 404 (`http/errors.go:150`). An unknown *name* or *collection_id* is swallowed into an empty list instead, so the asymmetry is deliberate: a typo in a version id must not read as success. This handler returned an empty list for all three. It is also the behaviour `refresh_views` already had on the same selector, so this removes the last inconsistency between the two surfaces.

`?get_inactive=` with an unparseable or empty value stays a 400, matching Go's `strconv.ParseBool` (`http/handler_store.go:403-410`).

Re-verified: `just fmt-check` green, `just lint` exit 0, `just test` 5213 passed 0 failed, `cargo doc -D warnings -p defra-http -p db -p cli` green.

---

## Review round: both blockers fixed

**The 404 fired on the wrong condition.** Go propagates not-found from the direct `GetCollectionByID` lookup, which the active-by-name arm pre-empts, so `?name=Users&version_id=nope` is an empty 200 there and was a 404 here. That is the request `collection describe --collection-name … --version-id …` sends, so it 404'd a working CLI call.

The precedence now lives on the shared selector as `CollectionSelector::resolves_by_version_lookup()`, next to `applies_collection_id()`, and every row of the table in the review is a test:

| Request | Go | Rust now |
|---|---|---|
| `?name=Users&version_id=nope` | `200 []` | `200 []` |
| `?name=Books&version_id=users-v2` | `200 []` | `200 []` |
| `?name=Books&get_inactive=true&version_id=users-v2` | `200 []` | `200 []` |
| `?version_id=nope` | 404 | 404 |

The message is Go's `collection not found`, asserted. This also removes the disagreement with `refresh_views` for the name-plus-existing-version case.

**The two-source split is gone, and my justification for it was wrong.** I traced `scope_txn_collection_provider`: it is applied only around GraphQL execution (`runner/executor.rs:462-471`), never around `rest.list_collections()`, so the transaction scoping the comment claimed does not exist on that path. #1583 is correct and the comment is deleted rather than reworded.

Both branches now read the version store, which is also Go's source (`description.GetActiveCollections`). The divergence described in the review is a regression test: a node holding an inactive P2P-synced collection must not list it from `GET /collections` or select it with `?name=`.

Consequence worth noting for review: `GET /collections` now requires the version store for every request, where the unnarrowed case previously fell back to `rest`. Both production assemblies wire it (`server_http.rs:177`, `defra-node/src/lib.rs:1230`) and `create_router_with_rest` has no in-tree production caller, so this only affects a library user wiring `rest` alone, who now gets a loud "not configured" rather than a listing that disagrees with its own filtered form.

The follow-ups (#1579 through #1583) are left alone as agreed, except #1583, which this removes as a side effect.

Re-verified: `just fmt-check` green, `just lint` exit 0, `just test` 5216 passed 0 failed, `cargo doc -D warnings -p defra-http -p db -p cli` green.
