### PR TITLE
fix(http): make DELETE /collections/{name} Go's filtered document delete

### DIFF
--- a/crates/http/src/handlers/collections.rs
+++ b/crates/http/src/handlers/collections.rs
@@ -437,30 +437,6 @@ pub async fn get_all_collections(
     Ok(Json(collections))
 }
 
-/// Delete a collection by name.
-///
-/// DELETE /api/v0/collections/{name}
-///
-/// Removes the collection and all its versions.
-///
-/// Requires `CollectionPatch` permission when NAC is enabled.
-pub async fn delete_collection(
-    State(state): State<AppState>,
-    identity: ExtractIdentity,
-    Path(name): Path<String>,
-) -> Result<Json<serde_json::Value>, HttpError> {
-    require_permission(&state, &identity, NodePermission::CollectionPatch).await?;
-
-    let collection_mgmt = state.require_collection_mgmt()?;
-
-    collection_mgmt
-        .delete_collection(&name)
-        .await
-        .map_err(http_error_from_backend_message)?;
-
-    Ok(Json(serde_json::json!({})))
-}
-
 /// Delete one or more collections by name (Go #4688 parity).
 ///
 /// DELETE /api/v0/collections?name=Users,Books&active-only=true

--- a/crates/http/src/handlers/documents.rs
+++ b/crates/http/src/handlers/documents.rs
@@ -9,10 +9,12 @@
 //! Go DefraDB behavior. Go returns only HTTP 200 status with no body.
 
 use axum::{
+    body::Bytes,
     extract::{Path, State},
     http::StatusCode,
     Json,
 };
+use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
 use crate::error::HttpError;
@@ -207,6 +209,96 @@ pub async fn delete_document(
                 doc_id = %doc_id,
                 error = %e,
                 "Failed to delete document"
+            );
+            Err(e.into())
+        }
+    }
+}
+
+/// Go's `DeleteCollectionRequest` (`http/handler_collection.go:32`).
+#[derive(Debug, Deserialize)]
+pub struct DeleteDocumentsRequest {
+    pub filter: Option<JsonValue>,
+}
+
+/// Go's `client.DeleteResult` / `client.UpdateResult` (`client/collection.go`).
+///
+/// Go's fields carry no json tags, so they marshal capitalised. A client
+/// reading `Count` off a lowercase `count` sees nothing.
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct DocumentsResult {
+    #[serde(rename = "Count")]
+    pub count: usize,
+    #[serde(rename = "DocIDs")]
+    pub doc_ids: Vec<String>,
+}
+
+impl From<Vec<String>> for DocumentsResult {
+    fn from(doc_ids: Vec<String>) -> Self {
+        Self {
+            count: doc_ids.len(),
+            doc_ids,
+        }
+    }
+}
+
+/// Read the `filter` a filtered mutation must have.
+///
+/// A missing or null filter is refused rather than treated as match-all. Go's
+/// behaviour for that case could not be confirmed against its source here, and
+/// the failure mode of guessing wrong is deleting or rewriting every document
+/// in the collection, which is exactly the silent-destruction bug this route
+/// is being fixed for. Refusing is recoverable; guessing is not.
+pub(crate) fn required_filter(body: &Bytes, field: &str) -> Result<JsonValue, HttpError> {
+    let parsed: JsonValue = serde_json::from_slice(body)
+        .map_err(|e| HttpError::BadRequest(format!("invalid request body: {e}")))?;
+
+    match parsed.get(field) {
+        Some(JsonValue::Null) | None => Err(HttpError::BadRequest(format!(
+            "'{field}' is required; send a filter object to select the documents to act on"
+        ))),
+        Some(filter) => Ok(filter.clone()),
+    }
+}
+
+/// Delete every document matching a filter.
+///
+/// DELETE /api/v0/collections/{name}
+///
+/// This is Go's `DeleteDocumentsWithFilter` (`http/handler_collection.go:511`),
+/// which its own client calls by `DELETE`ing this path with `{"filter": ...}`
+/// (`http/client_document.go:299-321`). Rust used to drop the collection and
+/// every one of its versions here, and answer success, so a Go-compatible
+/// client asking to delete a few documents destroyed the collection instead.
+///
+/// Dropping a collection lives on `DELETE /api/v0/collections?name=...`.
+///
+/// Requires `DocumentDelete` permission when NAC is enabled.
+pub async fn delete_documents_with_filter(
+    State(state): State<AppState>,
+    identity: ExtractIdentity,
+    Path(collection): Path<String>,
+    body: Bytes,
+) -> Result<Json<DocumentsResult>, HttpError> {
+    require_permission(&state, &identity, NodePermission::DocumentDelete).await?;
+
+    let filter = required_filter(&body, "filter")?;
+
+    let rest = state
+        .rest
+        .as_ref()
+        .ok_or_else(|| HttpError::Internal("REST operations not configured".into()))?;
+
+    match rest
+        .delete_documents_with_filter(&collection, &filter, identity.did())
+        .await
+    {
+        Ok(doc_ids) => Ok(Json(doc_ids.into())),
+        Err(e) => {
+            tracing::warn!(
+                collection = %collection,
+                error = %e,
+                "Failed to delete documents with filter"
             );
             Err(e.into())
         }

--- a/crates/http/src/handlers/documents.rs
+++ b/crates/http/src/handlers/documents.rs
@@ -242,22 +242,37 @@ impl From<Vec<String>> for DocumentsResult {
     }
 }
 
+/// Parse a filtered mutation's request body.
+fn request_body(body: &Bytes) -> Result<JsonValue, HttpError> {
+    serde_json::from_slice(body)
+        .map_err(|e| HttpError::BadRequest(format!("invalid request body: {e}")))
+}
+
 /// Read the `filter` a filtered mutation must have.
 ///
-/// A missing or null filter is refused rather than treated as match-all. Go's
-/// behaviour for that case could not be confirmed against its source here, and
-/// the failure mode of guessing wrong is deleting or rewriting every document
-/// in the collection, which is exactly the silent-destruction bug this route
-/// is being fixed for. Refusing is recoverable; guessing is not.
-pub(crate) fn required_filter(body: &Bytes, field: &str) -> Result<JsonValue, HttpError> {
-    let parsed: JsonValue = serde_json::from_slice(body)
-        .map_err(|e| HttpError::BadRequest(format!("invalid request body: {e}")))?;
-
-    match parsed.get(field) {
-        Some(JsonValue::Null) | None => Err(HttpError::BadRequest(format!(
-            "'{field}' is required; send a filter object to select the documents to act on"
-        ))),
-        Some(filter) => Ok(filter.clone()),
+/// Go types it as `any` and accepts three forms
+/// (`internal/db/document_update.go:163-183`): a `map`, GraphQL source as a
+/// `string`, and nothing else. Its own HTTP client marshals whatever the
+/// caller handed it (`http/client_document.go:299-321`), and the JS client
+/// always sends a string, so both forms arrive in practice.
+///
+/// A missing or null filter is refused, which is parity rather than caution:
+/// nil reaches Go's `default:` arm as `ErrUnsupportedFilterType`, a 400. An
+/// empty string is Go's `ErrEmptyFilter`, also a 400.
+///
+/// The string form is parsed into conditions rather than pasted into the
+/// mutation, so it is validated exactly like a filter that arrived as an
+/// object.
+fn required_filter(request: &JsonValue) -> Result<JsonValue, HttpError> {
+    match request.get("filter") {
+        Some(JsonValue::Object(conditions)) => Ok(JsonValue::Object(conditions.clone())),
+        Some(JsonValue::String(source)) => {
+            query::parse_filter_string(source).map_err(|e| HttpError::BadRequest(e.to_string()))
+        }
+        Some(JsonValue::Null) | None => Err(HttpError::BadRequest(
+            "'filter' is required; send a filter object to select the documents to act on".into(),
+        )),
+        Some(_) => Err(HttpError::BadRequest("unsupported filter type".into())),
     }
 }
 
@@ -282,7 +297,7 @@ pub async fn delete_documents_with_filter(
 ) -> Result<Json<DocumentsResult>, HttpError> {
     require_permission(&state, &identity, NodePermission::DocumentDelete).await?;
 
-    let filter = required_filter(&body, "filter")?;
+    let filter = required_filter(&request_body(&body)?)?;
 
     let rest = state
         .rest

--- a/crates/http/src/handlers/mod.rs
+++ b/crates/http/src/handlers/mod.rs
@@ -39,9 +39,12 @@ pub use graphql::{
 
 // Re-export REST handlers
 pub use collections::{
-    collection_exists, delete_collection, delete_collection_versions, delete_collections_by_names,
+    collection_exists, delete_collection_versions, delete_collections_by_names,
     describe_collection, find_collection_by_id, get_all_collections, get_collection_by_version_id,
     get_collection_doc_ids, list_collections, patch_collection, set_active, truncate_collection,
     CollectionDocIdsResponse, CollectionsResponse,
 };
-pub use documents::{create_document, delete_document, get_document, update_document};
+pub use documents::{
+    create_document, delete_document, delete_documents_with_filter, get_document, update_document,
+    DocumentsResult,
+};

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -26,6 +26,7 @@
 //! - `GET /api/v1/collections` - List all collections
 //! - `POST /api/v1/collections/{name}` - Create document(s)
 //! - `GET /api/v1/collections/{name}` - List collection document IDs
+//! - `DELETE /api/v1/collections/{name}` - Delete documents matching a filter
 //! - `GET /api/v1/collections/{name}/document/{docID}` - Get document
 //! - `PATCH /api/v1/collections/{name}/document/{docID}` - Update document
 //! - `DELETE /api/v1/collections/{name}/document/{docID}` - Delete document

--- a/crates/http/src/mock/collections.rs
+++ b/crates/http/src/mock/collections.rs
@@ -19,6 +19,10 @@ fn mock_collection_version(name: &str) -> schema::CollectionVersion {
 #[derive(Debug, Clone, Default)]
 pub struct MockCollectionManagementOperations {
     last_migration: Arc<Mutex<Option<lens::LensConfig>>>,
+    /// Names passed to `delete_collection`, so a test can tell a filtered
+    /// document delete from a collection drop. A no-op mock cannot: it lets a
+    /// route wired back to the drop keep every assertion green.
+    dropped_collections: Arc<Mutex<Vec<String>>>,
 }
 
 impl MockCollectionManagementOperations {
@@ -28,6 +32,11 @@ impl MockCollectionManagementOperations {
 
     pub fn last_migration(&self) -> Option<lens::LensConfig> {
         self.last_migration.lock().unwrap().clone()
+    }
+
+    /// Collections dropped through `delete_collection`.
+    pub fn dropped_collections(&self) -> Vec<String> {
+        self.dropped_collections.lock().unwrap().clone()
     }
 }
 
@@ -99,7 +108,11 @@ impl CollectionManagementOperations for MockCollectionManagementOperations {
         CollectionVersionOperations::get_all_collections(self).await
     }
 
-    async fn delete_collection(&self, _name: &str) -> Result<(), String> {
+    async fn delete_collection(&self, name: &str) -> Result<(), String> {
+        self.dropped_collections
+            .lock()
+            .unwrap()
+            .push(name.to_string());
         Ok(())
     }
 

--- a/crates/http/src/mock/rest.rs
+++ b/crates/http/src/mock/rest.rs
@@ -15,6 +15,16 @@ struct MockDocument {
     data: JsonValue,
 }
 
+/// Whether every key in `filter` equals the same key in `data`.
+fn matches_filter(data: &JsonValue, filter: &JsonValue) -> bool {
+    match filter.as_object() {
+        Some(fields) => fields
+            .iter()
+            .all(|(key, want)| data.get(key).is_some_and(|got| got == want)),
+        None => false,
+    }
+}
+
 /// Mock REST operations for testing collection and document handlers.
 #[derive(Debug)]
 pub struct MockRestOperations {
@@ -230,6 +240,28 @@ impl RestOperations for MockRestOperations {
             None => Err(RestError::collection_not_found(collection)),
         }
     }
+
+    /// Matches on equality of each filter key against the stored document,
+    /// which is enough to tell "the filter was applied" from "it was ignored".
+    async fn delete_documents_with_filter(
+        &self,
+        collection: &str,
+        filter: &JsonValue,
+        _identity: Option<&Did>,
+    ) -> RestResult<Vec<String>> {
+        let mut collections = self.collections.write().unwrap();
+        let docs = collections
+            .get_mut(collection)
+            .ok_or_else(|| RestError::collection_not_found(collection))?;
+
+        let matched: Vec<String> = docs
+            .iter()
+            .filter(|doc| matches_filter(&doc.data, filter))
+            .map(|doc| doc.doc_id.clone())
+            .collect();
+        docs.retain(|doc| !matched.contains(&doc.doc_id));
+        Ok(matched)
+    }
 }
 
 /// Mock REST operations that always fails (for error path testing).
@@ -332,6 +364,15 @@ impl RestOperations for FailingMockRestOperations {
         _doc_id: &str,
         _identity: Option<&Did>,
     ) -> RestResult<bool> {
+        Err(self.error.clone())
+    }
+
+    async fn delete_documents_with_filter(
+        &self,
+        _collection: &str,
+        _filter: &JsonValue,
+        _identity: Option<&Did>,
+    ) -> RestResult<Vec<String>> {
         Err(self.error.clone())
     }
 }

--- a/crates/http/src/mock/rest.rs
+++ b/crates/http/src/mock/rest.rs
@@ -15,14 +15,18 @@ struct MockDocument {
     data: JsonValue,
 }
 
-/// Whether every key in `filter` equals the same key in `data`.
-fn matches_filter(data: &JsonValue, filter: &JsonValue) -> bool {
-    match filter.as_object() {
-        Some(fields) => fields
-            .iter()
-            .all(|(key, want)| data.get(key).is_some_and(|got| got == want)),
-        None => false,
-    }
+/// Whether `filter` selects `data`, using the production filter engine.
+///
+/// Not a hand-rolled matcher: one that understood a different filter language
+/// than the server would make every test here green on requests the real path
+/// rejects, which is the whole hazard on a route that deletes documents.
+fn matches_filter(data: &JsonValue, filter: &JsonValue) -> RestResult<bool> {
+    let conditions = filter
+        .as_object()
+        .ok_or_else(|| RestError::invalid_input("filter must be an object"))?;
+    query::Filter::from_conditions(conditions.clone())
+        .matches_json_object(data)
+        .map_err(|e| RestError::invalid_input(e.to_string()))
 }
 
 /// Mock REST operations for testing collection and document handlers.
@@ -254,11 +258,12 @@ impl RestOperations for MockRestOperations {
             .get_mut(collection)
             .ok_or_else(|| RestError::collection_not_found(collection))?;
 
-        let matched: Vec<String> = docs
-            .iter()
-            .filter(|doc| matches_filter(&doc.data, filter))
-            .map(|doc| doc.doc_id.clone())
-            .collect();
+        let mut matched = Vec::new();
+        for doc in docs.iter() {
+            if matches_filter(&doc.data, filter)? {
+                matched.push(doc.doc_id.clone());
+            }
+        }
         docs.retain(|doc| !matched.contains(&doc.doc_id));
         Ok(matched)
     }

--- a/crates/http/src/route_permissions.rs
+++ b/crates/http/src/route_permissions.rs
@@ -78,6 +78,10 @@ pub fn route_permission(path: &str, method: &Method) -> RoutePermission {
             Method::GET => RoutePermission::Required(NodePermission::CollectionGet),
             Method::POST => RoutePermission::Required(NodePermission::CollectionPatch),
             Method::PATCH => RoutePermission::Required(NodePermission::CollectionPatch),
+            // Dropping collections by name. This fell to the read default
+            // while `delete_collections_by_names` enforced `CollectionPatch`
+            // itself, so the outer gate was weaker than the handler.
+            Method::DELETE => RoutePermission::Required(NodePermission::CollectionPatch),
             _ => RoutePermission::Required(NodePermission::CollectionGet),
         },
         "/api/v0/collections/default" => RoutePermission::Required(NodePermission::CollectionPatch),
@@ -92,10 +96,13 @@ pub fn route_permission(path: &str, method: &Method) -> RoutePermission {
             RoutePermission::Required(NodePermission::CollectionGet)
         }
         "/api/v0/collections/indexes" => RoutePermission::Required(NodePermission::IndexList),
+        // DELETE here is Go's filtered document delete, not a collection drop,
+        // so it is a document permission. Dropping a collection is
+        // `DELETE /collections?name=...`, which keeps `CollectionPatch`.
         "/api/v0/collections/:name" => match *method {
             Method::GET => RoutePermission::Required(NodePermission::CollectionGet),
             Method::POST => RoutePermission::Required(NodePermission::DocumentUpdate),
-            Method::DELETE => RoutePermission::Required(NodePermission::CollectionPatch),
+            Method::DELETE => RoutePermission::Required(NodePermission::DocumentDelete),
             _ => RoutePermission::Required(NodePermission::CollectionGet),
         },
         "/api/v0/collections/:name/describe" => {

--- a/crates/http/src/router/routes.rs
+++ b/crates/http/src/router/routes.rs
@@ -125,7 +125,7 @@ pub(crate) fn create_router_with_state_and_body_limits(
             "/{name}",
             get(handlers::get_collection_doc_ids)
                 .post(handlers::create_document)
-                .delete(handlers::delete_collection),
+                .delete(handlers::delete_documents_with_filter),
         )
         .route("/{name}/describe", get(handlers::describe_collection))
         .route("/{name}/exists", get(handlers::collection_exists))

--- a/crates/http/src/server.rs
+++ b/crates/http/src/server.rs
@@ -234,6 +234,7 @@ impl Server {
     /// - `GET /api/v1/collections` - List all collections
     /// - `POST /api/v1/collections/{name}` - Create document(s)
     /// - `GET /api/v1/collections/{name}` - List collection document IDs
+    /// - `DELETE /api/v1/collections/{name}` - Delete documents matching a filter
     /// - `GET /api/v1/collections/{name}/document/{docID}` - Get document
     /// - `PATCH /api/v1/collections/{name}/document/{docID}` - Update document
     /// - `DELETE /api/v1/collections/{name}/document/{docID}` - Delete document

--- a/crates/http/tests/filtered_document_delete.rs
+++ b/crates/http/tests/filtered_document_delete.rs
@@ -1,0 +1,193 @@
+//! `DELETE /collections/{name}` is Go's filtered document delete.
+//!
+//! Go serves `DeleteDocumentsWithFilter` here (`http/handler_collection.go:511`)
+//! and its own client posts `{"filter": ...}` to this path
+//! (`http/client_document.go:299-321`). Rust dropped the collection and every
+//! one of its versions instead, and answered success, so a Go-compatible
+//! client asking to delete two documents destroyed the collection and could
+//! not tell. That is worse than a 404: it succeeds, and does something far
+//! more destructive than what was asked.
+//!
+//! Dropping a collection keeps its own route, `DELETE /collections?name=...`,
+//! which is what the Rust CLI already calls.
+
+use std::sync::Arc;
+
+use axum::{
+    body::{to_bytes, Body},
+    http::{header::HOST, Method, Request, StatusCode},
+    Router,
+};
+use defra_http::route_permissions::{route_permission, RoutePermission};
+use defra_http::router::{AppStateBuilder, NodePermission};
+use defra_http::{MockCollectionManagementOperations, MockQueryExecutor, MockRestOperations};
+use query::rest::RestOperations;
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+fn router() -> Router {
+    let state = AppStateBuilder::new(Arc::new(MockQueryExecutor::new()))
+        .with_rest(Arc::new(MockRestOperations::new()) as Arc<dyn RestOperations>)
+        .with_collection_mgmt(Arc::new(MockCollectionManagementOperations::new()))
+        .build();
+    defra_http::create_router_with_state(state)
+}
+
+async fn send(router: Router, method: Method, uri: &str, body: &str) -> (StatusCode, String) {
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method(method)
+                .uri(uri)
+                .header(HOST, "localhost:9181")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .expect("router should respond");
+    let status = response.status();
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    (status, String::from_utf8_lossy(&body).into_owned())
+}
+
+async fn delete_with(router: Router, body: &str) -> (StatusCode, String) {
+    send(router, Method::DELETE, "/api/v0/collections/Users", body).await
+}
+
+async fn collection_names(router: Router) -> Vec<String> {
+    let (status, body) = send(router, Method::GET, "/api/v0/collections", "").await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    serde_json::from_str::<Value>(&body).unwrap()["collections"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|name| name.as_str().unwrap().to_string())
+        .collect()
+}
+
+async fn doc_ids(router: Router) -> Vec<String> {
+    let (status, body) = send(router, Method::GET, "/api/v0/collections/Users", "").await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    serde_json::from_str::<Value>(&body).unwrap()["doc_ids"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|id| id.as_str().unwrap().to_string())
+        .collect()
+}
+
+/// The filter selects, and only the matching documents go.
+#[tokio::test]
+async fn a_filter_deletes_only_the_matching_documents() {
+    let router = router();
+    let (status, body) = delete_with(router.clone(), r#"{"filter":{"name":"Alice"}}"#).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+
+    let result: Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(result["Count"], json!(1));
+    assert_eq!(result["DocIDs"], json!(["bae-123"]));
+
+    assert_eq!(doc_ids(router).await, vec!["bae-456"], "Bob must survive");
+}
+
+/// The bug itself: this route used to destroy the collection.
+#[tokio::test]
+async fn a_filtered_delete_leaves_the_collection_standing() {
+    let router = router();
+    let (status, body) = delete_with(router.clone(), r#"{"filter":{"name":"Alice"}}"#).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+
+    assert!(
+        collection_names(router)
+            .await
+            .contains(&"Users".to_string()),
+        "the collection must still exist after deleting a document from it"
+    );
+}
+
+/// Go's `DeleteResult` fields carry no json tags, so they marshal capitalised.
+/// A client reading `Count` off a lowercase `count` sees nothing.
+#[tokio::test]
+async fn the_response_uses_gos_field_names() {
+    let (_, body) = delete_with(router(), r#"{"filter":{"name":"Alice"}}"#).await;
+    let result: Value = serde_json::from_str(&body).unwrap();
+    assert!(result.get("Count").is_some(), "{body}");
+    assert!(result.get("DocIDs").is_some(), "{body}");
+}
+
+/// A filter matching nothing is a successful no-op, not an error.
+#[tokio::test]
+async fn a_filter_matching_nothing_deletes_nothing() {
+    let router = router();
+    let (status, body) = delete_with(router.clone(), r#"{"filter":{"name":"Nobody"}}"#).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+
+    let result: Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(result["Count"], json!(0));
+    assert_eq!(result["DocIDs"], json!([]));
+    assert_eq!(doc_ids(router).await.len(), 2);
+}
+
+/// A filter that cannot be read must not fall back to acting on everything.
+/// Go's behaviour for a null filter could not be confirmed from source here,
+/// and guessing "match all" would delete the whole collection's contents.
+#[tokio::test]
+async fn a_request_without_a_usable_filter_is_refused() {
+    for body in ["", "{}", r#"{"filter":null}"#, "not json"] {
+        let router = router();
+        let (status, response) = delete_with(router.clone(), body).await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "body {body:?} should be refused, got {response}"
+        );
+        assert_eq!(
+            doc_ids(router).await.len(),
+            2,
+            "body {body:?} must not have deleted anything"
+        );
+    }
+}
+
+#[tokio::test]
+async fn an_unknown_collection_is_not_a_success() {
+    let (status, _) = send(
+        router(),
+        Method::DELETE,
+        "/api/v0/collections/Nope",
+        r#"{"filter":{"name":"Alice"}}"#,
+    )
+    .await;
+    assert_ne!(status, StatusCode::OK);
+}
+
+/// Dropping a collection did not go away, it just stopped sharing a route with
+/// document deletion.
+#[tokio::test]
+async fn dropping_a_collection_still_has_its_own_route() {
+    let (status, body) = send(
+        router(),
+        Method::DELETE,
+        "/api/v0/collections?name=Users",
+        "",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+}
+
+/// The route changed meaning, so its permission had to change with it. Leaving
+/// it on `CollectionPatch` would gate document deletion behind a schema
+/// permission and let a `DocumentDelete` holder be refused.
+#[tokio::test]
+async fn the_route_is_gated_as_a_document_delete() {
+    assert_eq!(
+        route_permission("/api/v0/collections/:name", &Method::DELETE),
+        RoutePermission::Required(NodePermission::DocumentDelete)
+    );
+    assert_eq!(
+        route_permission("/api/v0/collections", &Method::DELETE),
+        RoutePermission::Required(NodePermission::CollectionPatch),
+        "dropping a collection stays a collection permission"
+    );
+}

--- a/crates/http/tests/filtered_document_delete.rs
+++ b/crates/http/tests/filtered_document_delete.rs
@@ -26,9 +26,13 @@ use serde_json::{json, Value};
 use tower::ServiceExt;
 
 fn router() -> Router {
+    router_with(Arc::new(MockCollectionManagementOperations::new()))
+}
+
+fn router_with(mgmt: Arc<MockCollectionManagementOperations>) -> Router {
     let state = AppStateBuilder::new(Arc::new(MockQueryExecutor::new()))
         .with_rest(Arc::new(MockRestOperations::new()) as Arc<dyn RestOperations>)
-        .with_collection_mgmt(Arc::new(MockCollectionManagementOperations::new()))
+        .with_collection_mgmt(mgmt)
         .build();
     defra_http::create_router_with_state(state)
 }
@@ -81,7 +85,8 @@ async fn doc_ids(router: Router) -> Vec<String> {
 #[tokio::test]
 async fn a_filter_deletes_only_the_matching_documents() {
     let router = router();
-    let (status, body) = delete_with(router.clone(), r#"{"filter":{"name":"Alice"}}"#).await;
+    let (status, body) =
+        delete_with(router.clone(), r#"{"filter":{"name":{"_eq":"Alice"}}}"#).await;
     assert_eq!(status, StatusCode::OK, "{body}");
 
     let result: Value = serde_json::from_str(&body).unwrap();
@@ -93,11 +98,21 @@ async fn a_filter_deletes_only_the_matching_documents() {
 
 /// The bug itself: this route used to destroy the collection.
 #[tokio::test]
-async fn a_filtered_delete_leaves_the_collection_standing() {
-    let router = router();
-    let (status, body) = delete_with(router.clone(), r#"{"filter":{"name":"Alice"}}"#).await;
+async fn a_filtered_delete_never_touches_collection_management() {
+    let mgmt = Arc::new(MockCollectionManagementOperations::new());
+    let router = router_with(mgmt.clone());
+    let (status, body) =
+        delete_with(router.clone(), r#"{"filter":{"name":{"_eq":"Alice"}}}"#).await;
     assert_eq!(status, StatusCode::OK, "{body}");
 
+    // The listing alone cannot detect a revert: it does not go through
+    // collection management, and the drop is a no-op against this mock. What
+    // pins the fix is that collection management is never reached.
+    assert!(
+        mgmt.dropped_collections().is_empty(),
+        "a filtered document delete dropped {:?}",
+        mgmt.dropped_collections()
+    );
     assert!(
         collection_names(router)
             .await
@@ -110,7 +125,7 @@ async fn a_filtered_delete_leaves_the_collection_standing() {
 /// A client reading `Count` off a lowercase `count` sees nothing.
 #[tokio::test]
 async fn the_response_uses_gos_field_names() {
-    let (_, body) = delete_with(router(), r#"{"filter":{"name":"Alice"}}"#).await;
+    let (_, body) = delete_with(router(), r#"{"filter":{"name":{"_eq":"Alice"}}}"#).await;
     let result: Value = serde_json::from_str(&body).unwrap();
     assert!(result.get("Count").is_some(), "{body}");
     assert!(result.get("DocIDs").is_some(), "{body}");
@@ -120,7 +135,8 @@ async fn the_response_uses_gos_field_names() {
 #[tokio::test]
 async fn a_filter_matching_nothing_deletes_nothing() {
     let router = router();
-    let (status, body) = delete_with(router.clone(), r#"{"filter":{"name":"Nobody"}}"#).await;
+    let (status, body) =
+        delete_with(router.clone(), r#"{"filter":{"name":{"_eq":"Nobody"}}}"#).await;
     assert_eq!(status, StatusCode::OK, "{body}");
 
     let result: Value = serde_json::from_str(&body).unwrap();
@@ -156,7 +172,7 @@ async fn an_unknown_collection_is_not_a_success() {
         router(),
         Method::DELETE,
         "/api/v0/collections/Nope",
-        r#"{"filter":{"name":"Alice"}}"#,
+        r#"{"filter":{"name":{"_eq":"Alice"}}}"#,
     )
     .await;
     assert_ne!(status, StatusCode::OK);
@@ -190,4 +206,61 @@ async fn the_route_is_gated_as_a_document_delete() {
         RoutePermission::Required(NodePermission::CollectionPatch),
         "dropping a collection stays a collection permission"
     );
+}
+
+/// Go's filter is `any` and a string is first-class, parsed with
+/// `NewFilterFromString` (`internal/db/document_update.go:168-176`). Its own
+/// client marshals whatever it was handed and the JS client always sends a
+/// string, so this is a payload Go-compatible clients really produce.
+#[tokio::test]
+async fn a_filter_sent_as_graphql_source_is_applied() {
+    let router = router();
+    let (status, body) =
+        delete_with(router.clone(), r#"{"filter":"{name: {_eq: \"Alice\"}}"}"#).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+
+    let result: Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(result["Count"], json!(1));
+    assert_eq!(doc_ids(router).await, vec!["bae-456"]);
+}
+
+/// An empty string filter is Go's `ErrEmptyFilter`, and a type Go's switch has
+/// no arm for is `ErrUnsupportedFilterType`. Both are 400s there.
+#[tokio::test]
+async fn an_unsupported_filter_type_is_refused() {
+    for body in [
+        r#"{"filter":""}"#,
+        r#"{"filter":"   "}"#,
+        r#"{"filter":[1,2]}"#,
+        r#"{"filter":7}"#,
+        r#"{"filter":true}"#,
+        r#"{"filter":"not graphql"}"#,
+    ] {
+        let router = router();
+        let (status, response) = delete_with(router.clone(), body).await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "body {body} should be refused, got {response}"
+        );
+        assert_eq!(
+            doc_ids(router).await.len(),
+            2,
+            "body {body} deleted something"
+        );
+    }
+}
+
+/// Go's connor reads a bare scalar as equality (`internal/connor/eq.go:63-76`),
+/// so `{"name":"Alice"}` and `{"name":{"_eq":"Alice"}}` are the same filter and
+/// a Go-compatible client may send either.
+#[tokio::test]
+async fn a_bare_scalar_condition_means_equality() {
+    let router = router();
+    let (status, body) = delete_with(router.clone(), r#"{"filter":{"name":"Alice"}}"#).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+
+    let result: Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(result["Count"], json!(1));
+    assert_eq!(doc_ids(router).await, vec!["bae-456"]);
 }

--- a/crates/http/tests/route_permissions.rs
+++ b/crates/http/tests/route_permissions.rs
@@ -104,7 +104,7 @@ fn collection_routes() {
     );
     assert_eq!(
         route_permission("/api/v0/collections/:name", &Method::DELETE),
-        RoutePermission::Required(NodePermission::CollectionPatch)
+        RoutePermission::Required(NodePermission::DocumentDelete)
     );
 }
 
@@ -281,6 +281,11 @@ fn all_registered_routes_return_expected_permission() {
             RoutePermission::Required(NodePermission::CollectionPatch),
         ),
         (
+            "/api/v0/collections",
+            Method::DELETE,
+            RoutePermission::Required(NodePermission::CollectionPatch),
+        ),
+        (
             "/api/v0/collections/default",
             Method::POST,
             RoutePermission::Required(NodePermission::CollectionPatch),
@@ -305,10 +310,11 @@ fn all_registered_routes_return_expected_permission() {
             Method::POST,
             RoutePermission::Required(NodePermission::DocumentUpdate),
         ),
+        // Go's filtered document delete, not a collection drop.
         (
             "/api/v0/collections/:name",
             Method::DELETE,
-            RoutePermission::Required(NodePermission::CollectionPatch),
+            RoutePermission::Required(NodePermission::DocumentDelete),
         ),
         (
             "/api/v0/collections/:name/truncate",

--- a/crates/query/src/lib.rs
+++ b/crates/query/src/lib.rs
@@ -64,8 +64,9 @@ pub use plan::{
 };
 pub use planner::{Doc, DocStatus, ExecInfo, PlanNode, Planner};
 pub use query_parse::{
-    parse_mutations, parse_mutations_with_limits, parse_query, parse_query_with_limits,
-    parse_request, parse_request_with_limits, ExplainType, ParsedOperation,
+    parse_filter_string, parse_mutations, parse_mutations_with_limits, parse_query,
+    parse_query_with_limits, parse_request, parse_request_with_limits, ExplainType,
+    ParsedOperation,
 };
 pub use rest::{
     CollectionDocIdsPage, CollectionDocIdsPagination, RestError, RestOperations,

--- a/crates/query/src/mapper/filter/eval_relation.rs
+++ b/crates/query/src/mapper/filter/eval_relation.rs
@@ -85,6 +85,7 @@ impl Filter {
             let field_missing = !obj.contains_key(key);
             let field_value = obj.get(key).cloned().unwrap_or(JsonValue::Null);
 
+            let value = super::op::normalize_field_condition(value);
             let ops = value
                 .as_object()
                 .ok_or_else(|| QueryError::invalid_filter("field condition must be object"))?;

--- a/crates/query/src/mapper/filter/filter_impl.rs
+++ b/crates/query/src/mapper/filter/filter_impl.rs
@@ -306,6 +306,8 @@ impl Filter {
                 continue;
             }
 
+            let value = super::op::normalize_field_condition(value);
+
             // Value should be an object with operator keys or nested field conditions
             let ops = value
                 .as_object()

--- a/crates/query/src/mapper/filter/op.rs
+++ b/crates/query/src/mapper/filter/op.rs
@@ -138,3 +138,25 @@ impl FilterOp {
         matches!(self, Self::Any | Self::All | Self::None)
     }
 }
+
+/// A field condition with a bare scalar normalized to `{_eq: value}`.
+///
+/// Go's connor treats a scalar directly as equality (`internal/connor/eq.go`),
+/// so `{name: "Alice"}` and `{name: {_eq: "Alice"}}` are the same filter and a
+/// Go-compatible client may send either. Arrays are deliberately left alone:
+/// connor gives them a meaning other than equality, and guessing it here would
+/// be worse than the caller getting an error.
+///
+/// Both field-condition sites run this, because a filter that matches on one
+/// path and errors on the other is the divergence this exists to prevent.
+pub(super) fn normalize_field_condition(
+    value: &serde_json::Value,
+) -> std::borrow::Cow<'_, serde_json::Value> {
+    if value.is_string() || value.is_number() || value.is_boolean() {
+        let mut ops = serde_json::Map::new();
+        ops.insert(FilterOp::Eq.as_str().to_string(), value.clone());
+        std::borrow::Cow::Owned(serde_json::Value::Object(ops))
+    } else {
+        std::borrow::Cow::Borrowed(value)
+    }
+}

--- a/crates/query/src/query_parse/filters.rs
+++ b/crates/query/src/query_parse/filters.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 use crate::error::{QueryError, Result};
 use crate::mapper::Filter;
 
-use super::values::graphql_value_to_json;
+use super::values::{graphql_value_to_json, graphql_value_to_json_no_vars};
 
 /// Parse a filter argument value into a Filter.
 pub(super) fn parse_filter_value(
@@ -53,4 +53,52 @@ pub(super) fn parse_filter_object(
     }
 
     Ok(conditions)
+}
+
+/// Parse Go's string filter form into filter conditions.
+///
+/// Go types a filter as `any` and accepts GraphQL source for it, which its own
+/// client and the JS client both send (`internal/db/document_update.go:168-176`
+/// via `NewFilterFromString`). An empty string is `ErrEmptyFilter` there, so it
+/// is an error here too rather than a match-all.
+///
+/// Parsed rather than pasted: the source is wrapped in a throwaway operation
+/// and run through the real parser, so what comes back is a JSON object that
+/// goes on to be validated like any other filter. Splicing the caller's text
+/// into the mutation would reopen exactly the hole key validation closes.
+pub fn parse_filter_string(source: &str) -> Result<JsonValue> {
+    if source.trim().is_empty() {
+        return Err(QueryError::parse("filter cannot be empty"));
+    }
+
+    let document = format!("query {{ probe(filter: {source}) {{ _docID }} }}");
+    let parsed = graphql_parser::parse_query::<String>(&document)
+        .map_err(|e| QueryError::parse(format!("invalid filter: {e}")))?;
+
+    let filter = parsed
+        .definitions
+        .iter()
+        .find_map(|definition| match definition {
+            graphql_parser::query::Definition::Operation(
+                graphql_parser::query::OperationDefinition::Query(query),
+            ) => query
+                .selection_set
+                .items
+                .iter()
+                .find_map(|item| match item {
+                    graphql_parser::query::Selection::Field(field) => field
+                        .arguments
+                        .iter()
+                        .find(|(name, _)| name == "filter")
+                        .map(|(_, value)| value),
+                    _ => None,
+                }),
+            _ => None,
+        })
+        .ok_or_else(|| QueryError::parse("invalid filter"))?;
+
+    match graphql_value_to_json_no_vars(filter)? {
+        JsonValue::Object(conditions) => Ok(JsonValue::Object(conditions)),
+        _ => Err(QueryError::parse("filter must be an object")),
+    }
 }

--- a/crates/query/src/query_parse/mod.rs
+++ b/crates/query/src/query_parse/mod.rs
@@ -22,6 +22,7 @@ mod values;
 mod variables;
 
 // Re-export everything from parser for backwards compatibility
+pub use filters::parse_filter_string;
 pub use limits::{MAX_QUERY_DEPTH, MAX_QUERY_WIDTH};
 pub use parser::{
     parse_mutations, parse_mutations_with_limits, parse_mutations_with_variables, parse_query,

--- a/crates/query/src/rest/gql.rs
+++ b/crates/query/src/rest/gql.rs
@@ -1,0 +1,148 @@
+//! Building the GraphQL documents the REST surface runs.
+//!
+//! Every REST operation is a GraphQL query or mutation underneath, so the
+//! document text is assembled here, in one place, rather than inline at each
+//! call site. Keeping it together is also what keeps the trust boundary in one
+//! place: `json_to_graphql_input` is where caller-supplied JSON becomes
+//! GraphQL syntax, and it is the only thing standing between a request body
+//! and the document that gets executed.
+
+use serde_json::Value as JsonValue;
+
+use super::error::{RestError, RestResult};
+use super::trait_def::CollectionDocIdsPagination;
+
+/// A GraphQL `Name`: `/[_A-Za-z][_0-9A-Za-z]*/` (GraphQL spec 2.1.9).
+fn is_graphql_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    chars
+        .next()
+        .is_some_and(|first| first == '_' || first.is_ascii_alphabetic())
+        && chars.all(|c| c == '_' || c.is_ascii_alphanumeric())
+}
+
+/// Convert a JSON value to GraphQL input syntax.
+///
+/// Object keys are bare identifiers (GraphQL input objects), not JSON-quoted keys.
+/// String leaves use JSON string encoding, which is a valid GraphQL `StringValue`
+/// and matches Go DefraDB's test harness (`valueToGQL` → `encoding/json.Marshal`),
+/// including `\b`, `\f`, and `\uXXXX` for other controls.
+///
+/// Keys are the trust boundary. They are written into the mutation unquoted, so
+/// a key carrying `)`, `{` or `}` would close the argument list and let the
+/// caller append operations of its own. Anything that is not a GraphQL `Name`
+/// is refused here rather than escaped: a key that is not a `Name` cannot
+/// address a schema field, so nothing legitimate is being turned away.
+pub(super) fn json_to_graphql_input(value: &JsonValue) -> RestResult<String> {
+    Ok(match value {
+        JsonValue::Null => "null".to_string(),
+        JsonValue::Bool(b) => b.to_string(),
+        JsonValue::Number(n) => n.to_string(),
+        JsonValue::String(s) => {
+            serde_json::to_string(s).expect("serializing a string to JSON cannot fail")
+        }
+        JsonValue::Array(arr) => {
+            let items = arr
+                .iter()
+                .map(json_to_graphql_input)
+                .collect::<RestResult<Vec<_>>>()?;
+            format!("[{}]", items.join(", "))
+        }
+        JsonValue::Object(obj) => {
+            let fields = obj
+                .iter()
+                .map(|(k, v)| {
+                    if !is_graphql_name(k) {
+                        return Err(RestError::invalid_input(format!(
+                            "'{k}' is not a valid field name"
+                        )));
+                    }
+                    Ok(format!("{}: {}", k, json_to_graphql_input(v)?))
+                })
+                .collect::<RestResult<Vec<_>>>()?;
+            format!("{{{}}}", fields.join(", "))
+        }
+    })
+}
+
+pub(super) fn build_list_ids_query(
+    collection: &str,
+    pagination: Option<CollectionDocIdsPagination>,
+) -> String {
+    match pagination {
+        Some(pagination) => format!(
+            r#"{{ {collection}(limit: {limit}, offset: {offset}) {{ _docID }} }}"#,
+            collection = collection,
+            limit = pagination.limit,
+            offset = pagination.offset
+        ),
+        None => format!(
+            r#"{{ {collection} {{ _docID }} }}"#,
+            collection = collection
+        ),
+    }
+}
+
+pub(super) fn build_count_query(collection: &str) -> String {
+    format!(
+        r#"{{ total: COUNT({collection}: {{}}) }}"#,
+        collection = collection
+    )
+}
+
+pub(super) fn build_create_mutation(collection: &str, data: &JsonValue) -> RestResult<String> {
+    let graphql_data = json_to_graphql_input(data)?;
+    Ok(format!(
+        r#"mutation {{ add_{collection}(input: [{graphql_data}]) {{ _docID }} }}"#,
+        collection = collection,
+        graphql_data = graphql_data
+    ))
+}
+
+pub(super) fn build_create_many_mutation(
+    collection: &str,
+    docs: &[JsonValue],
+) -> RestResult<String> {
+    let inputs = docs
+        .iter()
+        .map(json_to_graphql_input)
+        .collect::<RestResult<Vec<_>>>()?;
+    Ok(format!(
+        r#"mutation {{ add_{collection}(input: [{inputs}]) {{ _docID }} }}"#,
+        collection = collection,
+        inputs = inputs.join(", ")
+    ))
+}
+
+pub(super) fn build_update_mutation(
+    collection: &str,
+    doc_id: &str,
+    patch: &JsonValue,
+) -> RestResult<String> {
+    let graphql_patch = json_to_graphql_input(patch)?;
+    Ok(format!(
+        r#"mutation {{ update_{collection}(docIDs: ["{doc_id}"], input: {graphql_patch}) {{ _docID }} }}"#,
+        collection = collection,
+        doc_id = doc_id,
+        graphql_patch = graphql_patch
+    ))
+}
+
+pub(super) fn build_delete_mutation(collection: &str, doc_id: &str) -> String {
+    format!(
+        r#"mutation {{ delete_{collection}(docIDs: ["{doc_id}"]) {{ _docID }} }}"#,
+        collection = collection,
+        doc_id = doc_id
+    )
+}
+
+pub(super) fn build_filtered_delete_mutation(
+    collection: &str,
+    filter: &JsonValue,
+) -> RestResult<String> {
+    Ok(format!(
+        r#"mutation {{ delete_{collection}(filter: {filter}) {{ _docID }} }}"#,
+        collection = collection,
+        filter = json_to_graphql_input(filter)?
+    ))
+}

--- a/crates/query/src/rest/mod.rs
+++ b/crates/query/src/rest/mod.rs
@@ -4,6 +4,7 @@
 //! It provides collection listing and document CRUD operations separate from GraphQL.
 
 mod error;
+mod gql;
 mod operations;
 mod trait_def;
 

--- a/crates/query/src/rest/operations.rs
+++ b/crates/query/src/rest/operations.rs
@@ -116,6 +116,60 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> RestOperationsImpl<F, R> {
         )
     }
 
+    fn build_filtered_delete_mutation(&self, collection: &str, filter: &JsonValue) -> String {
+        format!(
+            r#"mutation {{ delete_{collection}(filter: {filter}) {{ _docID }} }}"#,
+            collection = collection,
+            filter = json_to_graphql_input(filter)
+        )
+    }
+
+    /// Pull the `_docID` list out of a `<op>_<Collection>` mutation result.
+    ///
+    /// One extractor rather than one per call site: the single-document and
+    /// filtered paths have to agree on the result shape, and two copies of
+    /// this would drift.
+    fn mutation_doc_ids(
+        &self,
+        result: &JsonValue,
+        collection: &str,
+        op: &str,
+    ) -> RestResult<Vec<String>> {
+        let key = format!("{op}_{collection}");
+        let docs = result
+            .get(&key)
+            .or_else(|| result.get(collection))
+            .ok_or_else(|| {
+                tracing::warn!(
+                    collection = %collection,
+                    op = %op,
+                    result = ?result,
+                    "Mutation returned unexpected result structure"
+                );
+                RestError::internal(format!(
+                    "unexpected {op} mutation result: missing key '{key}'"
+                ))
+            })?;
+
+        let docs = docs.as_array().ok_or_else(|| {
+            tracing::warn!(
+                collection = %collection,
+                op = %op,
+                result = ?result,
+                "Mutation result is not an array"
+            );
+            RestError::internal(format!(
+                "unexpected {op} mutation result format: expected array"
+            ))
+        })?;
+
+        Ok(docs
+            .iter()
+            .filter_map(|doc| doc.get("_docID").and_then(|id| id.as_str()))
+            .map(String::from)
+            .collect())
+    }
+
     fn extract_doc_ids(&self, result: &JsonValue, collection: &str) -> RestResult<Vec<String>> {
         let docs = result.get(collection).ok_or_else(|| {
             tracing::warn!(
@@ -439,37 +493,34 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> RestOperations for RestOpe
             .execute_mutation_with_identity(&mutation, identity.cloned())
             .await?;
 
-        let delete_key = format!("delete_{}", collection);
-        let delete_result = result.get(&delete_key).or_else(|| result.get(collection));
-
-        let deleted = match delete_result {
-            Some(v) => match v.as_array() {
-                Some(arr) => !arr.is_empty(),
-                None => {
-                    tracing::warn!(
-                        collection = %collection,
-                        doc_id = %doc_id,
-                        result = ?result,
-                        "Delete mutation result is not an array"
-                    );
-                    return Err(RestError::internal(
-                        "unexpected delete mutation result format: expected array",
-                    ));
-                }
-            },
-            None => {
-                tracing::warn!(
-                    collection = %collection,
-                    doc_id = %doc_id,
-                    result = ?result,
-                    "Delete mutation returned unexpected result structure"
-                );
-                return Err(RestError::internal(
-                    "unexpected delete mutation result: missing expected key",
-                ));
-            }
-        };
+        let deleted = !self
+            .mutation_doc_ids(&result, collection, "delete")?
+            .is_empty();
 
         Ok(deleted)
+    }
+
+    async fn delete_documents_with_filter(
+        &self,
+        collection: &str,
+        filter: &JsonValue,
+        identity: Option<&Did>,
+    ) -> RestResult<Vec<String>> {
+        if !self
+            .runner
+            .has_collection(collection)
+            .await
+            .map_err(|e| RestError::internal(e.to_string()))?
+        {
+            return Err(RestError::collection_not_found(collection));
+        }
+
+        let mutation = self.build_filtered_delete_mutation(collection, filter);
+        let result = self
+            .runner
+            .execute_mutation_with_identity(&mutation, identity.cloned())
+            .await?;
+
+        self.mutation_doc_ids(&result, collection, "delete")
     }
 }

--- a/crates/query/src/rest/operations.rs
+++ b/crates/query/src/rest/operations.rs
@@ -11,35 +11,8 @@ use crate::runner::QueryRunner;
 use crate::txn::TransactionRegistry;
 
 use super::error::{RestError, RestResult};
+use super::gql;
 use super::trait_def::{CollectionDocIdsPage, CollectionDocIdsPagination, RestOperations};
-
-/// Convert a JSON value to GraphQL input syntax.
-///
-/// Object keys are bare identifiers (GraphQL input objects), not JSON-quoted keys.
-/// String leaves use JSON string encoding, which is a valid GraphQL `StringValue`
-/// and matches Go DefraDB's test harness (`valueToGQL` → `encoding/json.Marshal`),
-/// including `\b`, `\f`, and `\uXXXX` for other controls.
-pub(super) fn json_to_graphql_input(value: &JsonValue) -> String {
-    match value {
-        JsonValue::Null => "null".to_string(),
-        JsonValue::Bool(b) => b.to_string(),
-        JsonValue::Number(n) => n.to_string(),
-        JsonValue::String(s) => {
-            serde_json::to_string(s).expect("serializing a string to JSON cannot fail")
-        }
-        JsonValue::Array(arr) => {
-            let items: Vec<String> = arr.iter().map(json_to_graphql_input).collect();
-            format!("[{}]", items.join(", "))
-        }
-        JsonValue::Object(obj) => {
-            let fields: Vec<String> = obj
-                .iter()
-                .map(|(k, v)| format!("{}: {}", k, json_to_graphql_input(v)))
-                .collect();
-            format!("{{{}}}", fields.join(", "))
-        }
-    }
-}
 
 /// Production implementation of REST operations using QueryRunner.
 ///
@@ -52,76 +25,6 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> RestOperationsImpl<F, R> {
     /// Create a new REST operations implementation.
     pub fn new(runner: Arc<QueryRunner<F, R>>) -> Self {
         Self { runner }
-    }
-
-    fn build_list_ids_query(
-        &self,
-        collection: &str,
-        pagination: Option<CollectionDocIdsPagination>,
-    ) -> String {
-        match pagination {
-            Some(pagination) => format!(
-                r#"{{ {collection}(limit: {limit}, offset: {offset}) {{ _docID }} }}"#,
-                collection = collection,
-                limit = pagination.limit,
-                offset = pagination.offset
-            ),
-            None => format!(
-                r#"{{ {collection} {{ _docID }} }}"#,
-                collection = collection
-            ),
-        }
-    }
-
-    fn build_count_query(&self, collection: &str) -> String {
-        format!(
-            r#"{{ total: COUNT({collection}: {{}}) }}"#,
-            collection = collection
-        )
-    }
-
-    fn build_create_mutation(&self, collection: &str, data: &JsonValue) -> String {
-        let graphql_data = json_to_graphql_input(data);
-        format!(
-            r#"mutation {{ add_{collection}(input: [{graphql_data}]) {{ _docID }} }}"#,
-            collection = collection,
-            graphql_data = graphql_data
-        )
-    }
-
-    fn build_create_many_mutation(&self, collection: &str, docs: &[JsonValue]) -> String {
-        let inputs: Vec<String> = docs.iter().map(json_to_graphql_input).collect();
-        format!(
-            r#"mutation {{ add_{collection}(input: [{inputs}]) {{ _docID }} }}"#,
-            collection = collection,
-            inputs = inputs.join(", ")
-        )
-    }
-
-    fn build_update_mutation(&self, collection: &str, doc_id: &str, patch: &JsonValue) -> String {
-        let graphql_patch = json_to_graphql_input(patch);
-        format!(
-            r#"mutation {{ update_{collection}(docIDs: ["{doc_id}"], input: {graphql_patch}) {{ _docID }} }}"#,
-            collection = collection,
-            doc_id = doc_id,
-            graphql_patch = graphql_patch
-        )
-    }
-
-    fn build_delete_mutation(&self, collection: &str, doc_id: &str) -> String {
-        format!(
-            r#"mutation {{ delete_{collection}(docIDs: ["{doc_id}"]) {{ _docID }} }}"#,
-            collection = collection,
-            doc_id = doc_id
-        )
-    }
-
-    fn build_filtered_delete_mutation(&self, collection: &str, filter: &JsonValue) -> String {
-        format!(
-            r#"mutation {{ delete_{collection}(filter: {filter}) {{ _docID }} }}"#,
-            collection = collection,
-            filter = json_to_graphql_input(filter)
-        )
     }
 
     /// Pull the `_docID` list out of a `<op>_<Collection>` mutation result.
@@ -299,7 +202,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> RestOperations for RestOpe
             return Err(RestError::collection_not_found(collection));
         }
 
-        let query = self.build_list_ids_query(collection, None);
+        let query = gql::build_list_ids_query(collection, None);
         let result = self
             .runner
             .execute_query_with_identity(&query, identity.cloned())
@@ -322,7 +225,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> RestOperations for RestOpe
             return Err(RestError::collection_not_found(collection));
         }
 
-        let count_query = self.build_count_query(collection);
+        let count_query = gql::build_count_query(collection);
         let count_result = self
             .runner
             .execute_query_with_identity(&count_query, identity.cloned())
@@ -338,7 +241,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> RestOperations for RestOpe
             });
         }
 
-        let query = self.build_list_ids_query(collection, Some(pagination));
+        let query = gql::build_list_ids_query(collection, Some(pagination));
         let result = self
             .runner
             .execute_query_with_identity(&query, identity.cloned())
@@ -386,7 +289,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> RestOperations for RestOpe
             return Err(RestError::collection_not_found(collection));
         }
 
-        let mutation = self.build_create_mutation(collection, &data);
+        let mutation = gql::build_create_mutation(collection, &data)?;
         let result = self
             .runner
             .execute_mutation_with_identity(&mutation, identity.cloned())
@@ -417,7 +320,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> RestOperations for RestOpe
             return Err(RestError::collection_not_found(collection));
         }
 
-        let mutation = self.build_create_many_mutation(collection, &data);
+        let mutation = gql::build_create_many_mutation(collection, &data)?;
         let result = self
             .runner
             .execute_mutation_with_identity(&mutation, identity.cloned())
@@ -455,7 +358,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> RestOperations for RestOpe
             return Err(RestError::document_not_found(doc_id));
         }
 
-        let mutation = self.build_update_mutation(collection, doc_id, &patch);
+        let mutation = gql::build_update_mutation(collection, doc_id, &patch)?;
         self.runner
             .execute_mutation_with_identity(&mutation, identity.cloned())
             .await?;
@@ -487,7 +390,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> RestOperations for RestOpe
             return Ok(false);
         }
 
-        let mutation = self.build_delete_mutation(collection, doc_id);
+        let mutation = gql::build_delete_mutation(collection, doc_id);
         let result = self
             .runner
             .execute_mutation_with_identity(&mutation, identity.cloned())
@@ -515,7 +418,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> RestOperations for RestOpe
             return Err(RestError::collection_not_found(collection));
         }
 
-        let mutation = self.build_filtered_delete_mutation(collection, filter);
+        let mutation = gql::build_filtered_delete_mutation(collection, filter)?;
         let result = self
             .runner
             .execute_mutation_with_identity(&mutation, identity.cloned())

--- a/crates/query/src/rest/tests.rs
+++ b/crates/query/src/rest/tests.rs
@@ -1,36 +1,36 @@
-use super::operations::json_to_graphql_input;
+use super::gql::{build_filtered_delete_mutation, json_to_graphql_input};
 use super::*;
 use crate::error::QueryError;
 use serde_json::json;
 
 #[test]
 fn test_json_to_graphql_null() {
-    assert_eq!(json_to_graphql_input(&json!(null)), "null");
+    assert_eq!(json_to_graphql_input(&json!(null)).unwrap(), "null");
 }
 
 #[test]
 fn test_json_to_graphql_bool() {
-    assert_eq!(json_to_graphql_input(&json!(true)), "true");
-    assert_eq!(json_to_graphql_input(&json!(false)), "false");
+    assert_eq!(json_to_graphql_input(&json!(true)).unwrap(), "true");
+    assert_eq!(json_to_graphql_input(&json!(false)).unwrap(), "false");
 }
 
 #[test]
 fn test_json_to_graphql_number() {
-    assert_eq!(json_to_graphql_input(&json!(42)), "42");
-    assert_eq!(json_to_graphql_input(&json!(-17)), "-17");
-    assert_eq!(json_to_graphql_input(&json!(3.15)), "3.15");
+    assert_eq!(json_to_graphql_input(&json!(42)).unwrap(), "42");
+    assert_eq!(json_to_graphql_input(&json!(-17)).unwrap(), "-17");
+    assert_eq!(json_to_graphql_input(&json!(3.15)).unwrap(), "3.15");
 }
 
 #[test]
 fn test_json_to_graphql_simple_string() {
-    assert_eq!(json_to_graphql_input(&json!("hello")), "\"hello\"");
-    assert_eq!(json_to_graphql_input(&json!("")), "\"\"");
+    assert_eq!(json_to_graphql_input(&json!("hello")).unwrap(), "\"hello\"");
+    assert_eq!(json_to_graphql_input(&json!("")).unwrap(), "\"\"");
 }
 
 #[test]
 fn test_json_to_graphql_string_with_quotes() {
     assert_eq!(
-        json_to_graphql_input(&json!("Hello \"World\"")),
+        json_to_graphql_input(&json!("Hello \"World\"")).unwrap(),
         "\"Hello \\\"World\\\"\""
     );
 }
@@ -38,7 +38,7 @@ fn test_json_to_graphql_string_with_quotes() {
 #[test]
 fn test_json_to_graphql_string_with_backslashes() {
     assert_eq!(
-        json_to_graphql_input(&json!("path\\to\\file")),
+        json_to_graphql_input(&json!("path\\to\\file")).unwrap(),
         "\"path\\\\to\\\\file\""
     );
 }
@@ -46,7 +46,7 @@ fn test_json_to_graphql_string_with_backslashes() {
 #[test]
 fn test_json_to_graphql_string_with_newlines() {
     assert_eq!(
-        json_to_graphql_input(&json!("line1\nline2")),
+        json_to_graphql_input(&json!("line1\nline2")).unwrap(),
         "\"line1\\nline2\""
     );
 }
@@ -54,7 +54,7 @@ fn test_json_to_graphql_string_with_newlines() {
 #[test]
 fn test_json_to_graphql_string_with_carriage_return() {
     assert_eq!(
-        json_to_graphql_input(&json!("line1\rline2")),
+        json_to_graphql_input(&json!("line1\rline2")).unwrap(),
         "\"line1\\rline2\""
     );
 }
@@ -62,50 +62,65 @@ fn test_json_to_graphql_string_with_carriage_return() {
 #[test]
 fn test_json_to_graphql_string_with_tabs() {
     assert_eq!(
-        json_to_graphql_input(&json!("col1\tcol2")),
+        json_to_graphql_input(&json!("col1\tcol2")).unwrap(),
         "\"col1\\tcol2\""
     );
 }
 
 #[test]
 fn test_json_to_graphql_string_with_backspace() {
-    assert_eq!(json_to_graphql_input(&json!("a\u{0008}b")), "\"a\\bb\"");
+    assert_eq!(
+        json_to_graphql_input(&json!("a\u{0008}b")).unwrap(),
+        "\"a\\bb\""
+    );
 }
 
 #[test]
 fn test_json_to_graphql_string_with_form_feed() {
-    assert_eq!(json_to_graphql_input(&json!("a\u{000c}b")), "\"a\\fb\"");
+    assert_eq!(
+        json_to_graphql_input(&json!("a\u{000c}b")).unwrap(),
+        "\"a\\fb\""
+    );
 }
 
 #[test]
 fn test_json_to_graphql_string_with_other_controls() {
     // JSON (and Go valueToGQL) use \uXXXX for controls without a short escape.
-    assert_eq!(json_to_graphql_input(&json!("a\u{0000}b")), "\"a\\u0000b\"");
-    assert_eq!(json_to_graphql_input(&json!("a\u{0007}b")), "\"a\\u0007b\"");
+    assert_eq!(
+        json_to_graphql_input(&json!("a\u{0000}b")).unwrap(),
+        "\"a\\u0000b\""
+    );
+    assert_eq!(
+        json_to_graphql_input(&json!("a\u{0007}b")).unwrap(),
+        "\"a\\u0007b\""
+    );
 }
 
 #[test]
 fn test_json_to_graphql_string_with_mixed_escapes() {
     assert_eq!(
-        json_to_graphql_input(&json!("line1\nline2\t\"quoted\"\r\\end")),
+        json_to_graphql_input(&json!("line1\nline2\t\"quoted\"\r\\end")).unwrap(),
         "\"line1\\nline2\\t\\\"quoted\\\"\\r\\\\end\""
     );
 }
 
 #[test]
 fn test_json_to_graphql_array_empty() {
-    assert_eq!(json_to_graphql_input(&json!([])), "[]");
+    assert_eq!(json_to_graphql_input(&json!([])).unwrap(), "[]");
 }
 
 #[test]
 fn test_json_to_graphql_array_simple() {
-    assert_eq!(json_to_graphql_input(&json!([1, 2, 3])), "[1, 2, 3]");
+    assert_eq!(
+        json_to_graphql_input(&json!([1, 2, 3])).unwrap(),
+        "[1, 2, 3]"
+    );
 }
 
 #[test]
 fn test_json_to_graphql_array_mixed() {
     assert_eq!(
-        json_to_graphql_input(&json!(["hello", 42, true, null])),
+        json_to_graphql_input(&json!(["hello", 42, true, null])).unwrap(),
         "[\"hello\", 42, true, null]"
     );
 }
@@ -113,14 +128,14 @@ fn test_json_to_graphql_array_mixed() {
 #[test]
 fn test_json_to_graphql_array_nested() {
     assert_eq!(
-        json_to_graphql_input(&json!([[1, 2], [3, 4]])),
+        json_to_graphql_input(&json!([[1, 2], [3, 4]])).unwrap(),
         "[[1, 2], [3, 4]]"
     );
 }
 
 #[test]
 fn test_json_to_graphql_object_simple() {
-    let result = json_to_graphql_input(&json!({"name": "Alice", "age": 30}));
+    let result = json_to_graphql_input(&json!({"name": "Alice", "age": 30})).unwrap();
     assert!(
         result == "{name: \"Alice\", age: 30}" || result == "{age: 30, name: \"Alice\"}",
         "Unexpected result: {}",
@@ -130,13 +145,13 @@ fn test_json_to_graphql_object_simple() {
 
 #[test]
 fn test_json_to_graphql_object_nested() {
-    let result = json_to_graphql_input(&json!({"user": {"name": "Bob"}}));
+    let result = json_to_graphql_input(&json!({"user": {"name": "Bob"}})).unwrap();
     assert_eq!(result, "{user: {name: \"Bob\"}}");
 }
 
 #[test]
 fn test_json_to_graphql_object_with_array() {
-    let result = json_to_graphql_input(&json!({"tags": ["a", "b"]}));
+    let result = json_to_graphql_input(&json!({"tags": ["a", "b"]})).unwrap();
     assert_eq!(result, "{tags: [\"a\", \"b\"]}");
 }
 
@@ -149,7 +164,7 @@ fn test_json_to_graphql_complex_nested() {
             "active": true
         }
     });
-    let result = json_to_graphql_input(&value);
+    let result = json_to_graphql_input(&value).unwrap();
     assert!(result.contains("name: \"Alice\\nSmith\""));
     assert!(result.contains("tags: [\"admin\", \"user\"]"));
     assert!(result.contains("active: true"));
@@ -158,7 +173,7 @@ fn test_json_to_graphql_complex_nested() {
 #[test]
 fn test_json_to_graphql_unicode() {
     assert_eq!(
-        json_to_graphql_input(&json!("héllo 世界")),
+        json_to_graphql_input(&json!("héllo 世界")).unwrap(),
         "\"héllo 世界\""
     );
 }
@@ -230,4 +245,83 @@ fn test_rest_error_from_query_error() {
     let rest_err: RestError = err.into();
     assert!(matches!(rest_err, RestError::PermissionDenied(_)));
     assert!(rest_err.to_string().contains("ACP registration failed"));
+}
+
+// ---------------------------------------------------------------------------
+// Object keys are the trust boundary
+// ---------------------------------------------------------------------------
+
+/// Keys are written into the mutation unquoted, so a key carrying GraphQL
+/// punctuation would close the argument list and let a caller append
+/// operations of its own. This is the check that it cannot.
+#[test]
+fn a_key_that_could_escape_the_document_is_refused() {
+    let hostile = [
+        json!({"a) { _docID } } mutation { delete_Other(filter: {": 1}),
+        json!({"name\"": 1}),
+        json!({"na me": 1}),
+        json!({"": 1}),
+        json!({"1name": 1}),
+        json!({"name#comment": 1}),
+        json!({"a$b": 1}),
+    ];
+    for value in hostile {
+        assert!(
+            json_to_graphql_input(&value).is_err(),
+            "{value} should be refused"
+        );
+    }
+}
+
+/// The refusal has to reach nested keys too, or a filter one level down is
+/// still an open door.
+#[test]
+fn a_hostile_key_is_refused_at_any_depth() {
+    assert!(json_to_graphql_input(&json!({"user": {"na)me": 1}})).is_err());
+    assert!(json_to_graphql_input(&json!({"users": [{"na)me": 1}]})).is_err());
+    assert!(json_to_graphql_input(&json!([[{"na)me": 1}]])).is_err());
+}
+
+/// Nothing legitimate is turned away: a key that is not a GraphQL Name cannot
+/// address a schema field in the first place.
+#[test]
+fn real_field_names_still_encode() {
+    for value in [
+        json!({"name": "Alice"}),
+        json!({"_docID": "bae-1"}),
+        json!({"age_2": 1}),
+        json!({"_": 1}),
+        json!({"A1": 1}),
+        json!({"user": {"address": {"city": "Berlin"}}}),
+    ] {
+        assert!(
+            json_to_graphql_input(&value).is_ok(),
+            "{value} should encode"
+        );
+    }
+}
+
+/// String *values* are still free-form; only keys are constrained.
+#[test]
+fn hostile_text_in_a_value_is_escaped_not_refused() {
+    let encoded = json_to_graphql_input(&json!({"name": "a) { _docID } } mutation {"})).unwrap();
+    assert_eq!(
+        encoded, r#"{name: "a) { _docID } } mutation {"}"#,
+        "a value is a quoted StringValue, so it cannot escape"
+    );
+}
+
+/// The filter reaches the document builder verbatim, so the refusal has to
+/// hold at the builder the real REST implementation calls, not only at the
+/// encoder underneath it.
+#[test]
+fn a_filtered_delete_refuses_a_hostile_filter_key() {
+    let hostile = json!({"a) { _docID } } mutation { delete_Other(filter: {": 1});
+    assert!(build_filtered_delete_mutation("Users", &hostile).is_err());
+
+    let ordinary = json!({"name": {"_eq": "Alice"}});
+    assert_eq!(
+        build_filtered_delete_mutation("Users", &ordinary).unwrap(),
+        r#"mutation { delete_Users(filter: {name: {_eq: "Alice"}}) { _docID } }"#
+    );
 }

--- a/crates/query/src/rest/trait_def.rs
+++ b/crates/query/src/rest/trait_def.rs
@@ -114,4 +114,16 @@ pub trait RestOperations: MaybeSendSync {
         doc_id: &str,
         identity: Option<&Did>,
     ) -> RestResult<bool>;
+
+    /// Delete every document matching a filter.
+    ///
+    /// This is Go's `DeleteDocumentsWithFilter`. The filter is a GraphQL
+    /// filter object, as the `filter` argument of a `delete_<Collection>`
+    /// mutation takes it, and the returned ids are the documents deleted.
+    async fn delete_documents_with_filter(
+        &self,
+        collection: &str,
+        filter: &JsonValue,
+        identity: Option<&Did>,
+    ) -> RestResult<Vec<String>>;
 }

--- a/tools/integration-test/tests/basic/document_lifecycle.rs
+++ b/tools/integration-test/tests/basic/document_lifecycle.rs
@@ -245,3 +245,55 @@ async fn rust_filter_mutations_return_post_update_docs() {
     let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
     filter_mutations_return_post_update_docs(cluster).await;
 }
+
+async fn filtered_document_delete_http_contract(cluster: TestCluster) {
+    let client = cluster.client(0);
+    client
+        .schema_add("type HttpDeleteUser { name: String }")
+        .expect("failed to add schema");
+
+    let alice = client
+        .query(r#"mutation { add_HttpDeleteUser(input: {name: "Alice"}) { _docID } }"#)
+        .expect("create Alice");
+    let alice_id = alice["add_HttpDeleteUser"][0]["_docID"]
+        .as_str()
+        .expect("Alice has a document ID");
+    client
+        .query(r#"mutation { add_HttpDeleteUser(input: {name: "Bob"}) { _docID } }"#)
+        .expect("create Bob");
+
+    let response = reqwest::Client::new()
+        .delete(format!(
+            "{}/api/v0/collections/HttpDeleteUser",
+            cluster.api_url(0)
+        ))
+        .json(&serde_json::json!({
+            "filter": r#"{name: {_eq: "Alice"}}"#,
+        }))
+        .send()
+        .await
+        .expect("filtered delete request");
+    let status = response.status();
+    let body = response.text().await.expect("filtered delete response");
+    assert!(
+        status.is_success(),
+        "filtered delete failed: {status} {body}"
+    );
+
+    let result: Value = serde_json::from_str(&body).expect("filtered delete JSON");
+    assert_eq!(result["Count"], 1);
+    assert_eq!(result["DocIDs"], serde_json::json!([alice_id]));
+
+    let stored = client
+        .query("query { HttpDeleteUser { name } }")
+        .expect("query remaining documents");
+    assert_eq!(
+        stored["HttpDeleteUser"],
+        serde_json::json!([{"name": "Bob"}])
+    );
+}
+
+for_each_runtime!(
+    filtered_document_delete_http_contract,
+    filtered_document_delete_http_contract
+);


### PR DESCRIPTION
Closes #1492.

Go serves `DeleteDocumentsWithFilter` at `DELETE /collections/{name}` (`http/handler_collection.go:511`) and its own client posts `{"filter": ...}` to exactly that path (`http/client_document.go:299-321`). Rust dropped the collection and every one of its versions there, and answered success.

So a Go-compatible client asking to delete two documents destroyed the collection, got a 200, and had no way to tell. That is worse than a 404: it succeeds, and does something far more destructive than what was asked.

## What changed

`DELETE /collections/{name}` now deletes the documents matching the filter and returns Go's `{"Count": n, "DocIDs": [...]}`. Dropping a collection keeps its existing route, `DELETE /collections?name=Users&active-only=true`, which is already what the Rust CLI calls; nothing in the workspace called the parameterized form over HTTP.

New `RestOperations::delete_documents_with_filter`, implemented as a `delete_<Collection>(filter: ...)` mutation, which is the same path the single-document delete already took.

**One result extractor, not two.** `delete_document` had its `_docID` extraction written inline. The filtered path needs the same shape, so that logic moved into a shared `mutation_doc_ids(result, collection, op)` and both call it. Two copies would have drifted the moment either result shape changed.

## An absent filter is refused, not treated as match-all

A missing, null, or unparseable `filter` returns 400 and deletes nothing.

I could not confirm Go's behaviour for a null filter: there is no Go checkout available in this environment, so this is stated as an open question rather than as verified parity. The asymmetry decided it. If Go refuses too, refusing costs a client one clear error message. If Go treats nil as match-all, guessing that way here deletes every document in the collection, which is the same silent-destruction class this issue is about. Refusing is recoverable; guessing is not.

This is the one thing worth checking on the Go side before merge, and the reason is recorded at `required_filter` in `handlers/documents.rs`.

## Permission changes

**`DELETE /collections/:name` moves from `CollectionPatch` to `DocumentDelete`**, because the route no longer patches a collection. Leaving it would gate document deletion behind a schema permission and refuse a legitimate `DocumentDelete` holder.

**`DELETE /collections` gains an explicit `CollectionPatch` arm.** This one is a pre-existing gap that a test in this PR caught: the route had no `Method::DELETE` arm and fell to the `_` default, so the outer gate read it as `CollectionGet`, a read permission, while `delete_collections_by_names` independently enforced `CollectionPatch`. Not exploitable, since the handler re-checks, but the table was weaker than the handler it fronts. Fixed here because this PR is re-splitting exactly this pair of delete routes; happy to lift it into its own PR if you would rather.

## Tests

`crates/http/tests/filtered_document_delete.rs`, 8 tests:

- a filter deletes only the matching documents, and the non-matching one survives
- **the regression itself**: the collection is still standing after a filtered delete
- the response uses Go's capitalised `Count` / `DocIDs`, since Go's result fields carry no json tags and a client reading `Count` off a lowercase `count` sees nothing
- a filter matching nothing is a successful no-op, not an error
- an empty body, `{}`, a null filter and non-JSON are each refused, and each is asserted to have deleted nothing
- an unknown collection is not a success
- dropping a collection still works on its own route
- both delete routes carry the permission they should

## Verification

- `just fmt-check`: green
- `just lint`: green (exit 0)
- `just test`: green, 5203 tests passed, 0 failures
- `RUSTDOCFLAGS="-D warnings" cargo doc -p defra-http -p query --no-deps`: green

`just doc` across the workspace is red on `main` already (pre-existing rustdoc errors in `crates/storage` and `crates/datastore`), so the doc gate was run scoped to the crates this PR changes.

#1493 adds `PATCH` on this same route entry and is stacked on this branch to avoid a merge conflict on the same lines.

---

## Follow-up from self-review: a GraphQL injection, and the file split

**`json_to_graphql_input` wrote JSON object keys into the mutation raw.** Probed, not reasoned about:

```
input : {"a) { _docID } } mutation { delete_Other(filter: {": 1}
output: {a) { _docID } } mutation { delete_Other(filter: {: 1}
```

A key carrying `)`, `{` or `}` closes the argument list and lets the caller append operations of its own. This is pre-existing, since `create_document` and `update_document` already fed request-body JSON through the same encoder, but this PR adds a new untrusted path to it (the `filter`) from a new route, so it is fixed here.

Keys must now be GraphQL `Name`s (`[_A-Za-z][_0-9A-Za-z]*`) or the request is refused. Refused rather than escaped: a key that is not a `Name` cannot address a schema field, so nothing legitimate is turned away. `json_to_graphql_input` and every builder became fallible.

Covered by: hostile keys at any nesting depth and inside arrays, `build_filtered_delete_mutation` refusing them at the builder the real implementation calls, ordinary field names still encoding, and string *values* staying free-form because a quoted `StringValue` cannot escape.

One test did not survive its own review. I first wrote this as an HTTP-level test, and it failed: `MockRestOperations` does its own filter matching and never builds a GraphQL document, so the encoder is never reached through the mock. A passing version would have been asserting mock behaviour while looking like it proved the boundary. It was replaced with tests against the real builder and encoder.

**`operations.rs` was 565 lines, over the 400-line guideline.** GraphQL document construction moved to `crates/query/src/rest/gql.rs`, which is also what puts the trust boundary in one file. The builders never used `self`, so they became free functions. `operations.rs` is now 429 lines, `gql.rs` 148. `mutation_doc_ids` stayed behind: it parses results rather than building documents.

Re-verified: `just fmt-check` green, `just lint` exit 0, `just test` 5208 passed 0 failed, `cargo doc -D warnings -p defra-http -p query` green.

---

## The nil-filter question is now answered from the Go source

Checked against the pinned baseline `13c46ec9`.

**Refusing a nil filter is what Go does**, so this is verified parity rather than the safe guess described above. `DeleteDocumentsWithFilter` passes `request.Filter` straight through (`http/handler_collection.go:40-61`), and `makeSelectionPlan` type-switches on it (`internal/db/document_update.go:161-183`): `string`, `immutable.Option[request.Filter]` and `map[string]any` are handled, and everything else, `nil` included, hits `default:` and returns `NewErrUnsupportedFilterType`. `httpStatusFromError` has no arm for it, so it falls through to the 400 default (`http/errors.go:196`). An absent or null filter is a 400 on both runtimes.

An empty *string* filter is `ErrEmptyFilter` on Go, also a 400.

The `{Count, DocIDs}` response shape is confirmed too: `client.DeleteResult` and `client.UpdateResult` carry no json tags (`client/collection.go:189-204`), so they marshal capitalised.

**One divergence found and not closed.** Go's switch also accepts a filter given as a *string*, parsed with `NewFilterFromString`. Rust encodes a string filter as a GraphQL string literal, so it fails rather than filtering. Supporting it would mean splicing caller-supplied text directly into the mutation, which is the injection hole this PR closes, so it wants a deliberate decision rather than a quiet passthrough. Filed as a known gap: it fails loudly, so it is a capability difference, not a silent wrong answer.

---

## Review round: the tests were green on a language the server rejects

All three blockers fixed. The filter-language one was the important catch and both halves of it were real.

**The mock and production disagreed, so every test here certified a rejected request.** Confirmed: `filter_impl.rs:312` requires an operator object, so `{"name":"Alice"}` was a 400 on the live path, while Go's connor reads a bare scalar as equality (`internal/connor/eq.go:63-76`) and deletes Alice.

Fixed on both sides:

- The mock now calls `query::Filter::from_conditions(..).matches_json_object(..)`, the production engine, so the two cannot diverge by construction.
- Implicit-eq now matches connor. `{name: "Alice"}` and `{name: {_eq: "Alice"}}` are one filter, as on Go. The change is purely additive: it only accepts input that previously errored.
- That normalization is **one** function used by both field-condition sites (`filter_impl.rs` and `eval_relation.rs`). Two copies is how the mock and production drifted apart in the first place.
- Arrays are deliberately still refused: connor gives them a meaning other than equality, and guessing it is worse than an error.

**String filters work.** Parsed by a new `query::parse_filter_string`, which wraps the source in a throwaway operation and runs the real parser, so the result is a JSON object validated like any other filter. Not interpolated, as asked. An empty string is Go's `ErrEmptyFilter`, and an unsupported type is Go's `ErrUnsupportedFilterType`; both 400.

**The guard test could not detect its own regression.** Correct: the listing does not go through collection management, and the mock's drop was a no-op. `MockCollectionManagementOperations` now records dropped names and the test asserts management is never reached. Verified by actually re-wiring the route back to the destructive handler: **9 of 11 tests fail**, including the guard.

Also done: dropped the single-call-site `field` parameter and the `pub(crate)` on `required_filter`.

**Not done, and worth its own decision.** No test here runs `RestOperationsImpl`, so the failure mode described on #1577 (renaming the `input` argument would 500 the route with the suite still green) remains uncovered. Pointing the mock at the production filter engine closes the filter-language divergence but not this. One test through a real node would cover this route and the PATCH together, and `tools/integration-test/` has no coverage of either today. Flagged rather than folded in, since it is a new integration binary rather than a change to this one.

Re-verified: `just fmt-check` green, `just lint` exit 0, `just test` 5211 passed 0 failed, `cargo doc -D warnings -p defra-http -p query` green.
