### PR TITLE
fix(http): serve Go's filtered document update on PATCH /collections/{name}

### DIFF
--- a/crates/http/src/handlers/documents.rs
+++ b/crates/http/src/handlers/documents.rs
@@ -276,6 +276,36 @@ fn required_filter(request: &JsonValue) -> Result<JsonValue, HttpError> {
     }
 }
 
+/// Read the `updater` patch.
+///
+/// Go types this as a `string` holding JSON (`UpdateCollectionRequest`,
+/// `http/handler_collection.go:36-39`), so a string is parsed as JSON. An
+/// object is accepted as-is because a hand-written client is likelier to send
+/// one than to double-encode, and refusing it would buy nothing.
+fn required_updater(request: &JsonValue) -> Result<JsonValue, HttpError> {
+    let updater = match request.get("updater") {
+        Some(JsonValue::Null) | None => {
+            return Err(HttpError::BadRequest(
+                "'updater' is required; send the update to apply".into(),
+            ))
+        }
+        Some(updater) => updater,
+    };
+
+    let parsed = match updater {
+        JsonValue::String(encoded) => serde_json::from_str(encoded)
+            .map_err(|e| HttpError::BadRequest(format!("'updater' is not valid JSON: {e}")))?,
+        other => other.clone(),
+    };
+
+    if !parsed.is_object() {
+        return Err(HttpError::BadRequest(
+            "'updater' must be a JSON object of fields to update".into(),
+        ));
+    }
+    Ok(parsed)
+}
+
 /// Delete every document matching a filter.
 ///
 /// DELETE /api/v0/collections/{name}
@@ -314,6 +344,50 @@ pub async fn delete_documents_with_filter(
                 collection = %collection,
                 error = %e,
                 "Failed to delete documents with filter"
+            );
+            Err(e.into())
+        }
+    }
+}
+
+/// Apply an update to every document matching a filter.
+///
+/// PATCH /api/v0/collections/{name}
+///
+/// This is Go's `UpdateDocumentsWithFilter` (`http/handler_collection.go:510`),
+/// which its own client reaches by `PATCH`ing this path with
+/// `{"filter": ..., "updater": "..."}` (`http/client_document.go:263-296`).
+/// Rust registered no `PATCH` here, so the request answered 405 and filtered
+/// update had no HTTP-level equivalent at all.
+///
+/// Requires `DocumentUpdate` permission when NAC is enabled.
+pub async fn update_documents_with_filter(
+    State(state): State<AppState>,
+    identity: ExtractIdentity,
+    Path(collection): Path<String>,
+    body: Bytes,
+) -> Result<Json<DocumentsResult>, HttpError> {
+    require_permission(&state, &identity, NodePermission::DocumentUpdate).await?;
+
+    let request = request_body(&body)?;
+    let filter = required_filter(&request)?;
+    let updater = required_updater(&request)?;
+
+    let rest = state
+        .rest
+        .as_ref()
+        .ok_or_else(|| HttpError::Internal("REST operations not configured".into()))?;
+
+    match rest
+        .update_documents_with_filter(&collection, &filter, &updater, identity.did())
+        .await
+    {
+        Ok(doc_ids) => Ok(Json(doc_ids.into())),
+        Err(e) => {
+            tracing::warn!(
+                collection = %collection,
+                error = %e,
+                "Failed to update documents with filter"
             );
             Err(e.into())
         }

--- a/crates/http/src/handlers/mod.rs
+++ b/crates/http/src/handlers/mod.rs
@@ -46,5 +46,5 @@ pub use collections::{
 };
 pub use documents::{
     create_document, delete_document, delete_documents_with_filter, get_document, update_document,
-    DocumentsResult,
+    update_documents_with_filter, DocumentsResult,
 };

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -26,6 +26,7 @@
 //! - `GET /api/v1/collections` - List all collections
 //! - `POST /api/v1/collections/{name}` - Create document(s)
 //! - `GET /api/v1/collections/{name}` - List collection document IDs
+//! - `PATCH /api/v1/collections/{name}` - Update documents matching a filter
 //! - `DELETE /api/v1/collections/{name}` - Delete documents matching a filter
 //! - `GET /api/v1/collections/{name}/document/{docID}` - Get document
 //! - `PATCH /api/v1/collections/{name}/document/{docID}` - Update document

--- a/crates/http/src/mock/rest.rs
+++ b/crates/http/src/mock/rest.rs
@@ -267,6 +267,33 @@ impl RestOperations for MockRestOperations {
         docs.retain(|doc| !matched.contains(&doc.doc_id));
         Ok(matched)
     }
+
+    async fn update_documents_with_filter(
+        &self,
+        collection: &str,
+        filter: &JsonValue,
+        updater: &JsonValue,
+        _identity: Option<&Did>,
+    ) -> RestResult<Vec<String>> {
+        let mut collections = self.collections.write().unwrap();
+        let docs = collections
+            .get_mut(collection)
+            .ok_or_else(|| RestError::collection_not_found(collection))?;
+
+        let mut updated = Vec::new();
+        for doc in docs.iter_mut() {
+            if !matches_filter(&doc.data, filter)? {
+                continue;
+            }
+            if let (Some(data), Some(patch)) = (doc.data.as_object_mut(), updater.as_object()) {
+                for (key, value) in patch {
+                    data.insert(key.clone(), value.clone());
+                }
+            }
+            updated.push(doc.doc_id.clone());
+        }
+        Ok(updated)
+    }
 }
 
 /// Mock REST operations that always fails (for error path testing).
@@ -376,6 +403,16 @@ impl RestOperations for FailingMockRestOperations {
         &self,
         _collection: &str,
         _filter: &JsonValue,
+        _identity: Option<&Did>,
+    ) -> RestResult<Vec<String>> {
+        Err(self.error.clone())
+    }
+
+    async fn update_documents_with_filter(
+        &self,
+        _collection: &str,
+        _filter: &JsonValue,
+        _updater: &JsonValue,
         _identity: Option<&Did>,
     ) -> RestResult<Vec<String>> {
         Err(self.error.clone())

--- a/crates/http/src/route_permissions.rs
+++ b/crates/http/src/route_permissions.rs
@@ -96,12 +96,14 @@ pub fn route_permission(path: &str, method: &Method) -> RoutePermission {
             RoutePermission::Required(NodePermission::CollectionGet)
         }
         "/api/v0/collections/indexes" => RoutePermission::Required(NodePermission::IndexList),
-        // DELETE here is Go's filtered document delete, not a collection drop,
-        // so it is a document permission. Dropping a collection is
-        // `DELETE /collections?name=...`, which keeps `CollectionPatch`.
+        // PATCH and DELETE here are Go's filtered document operations, not
+        // collection ones, so they are document permissions. Dropping a
+        // collection is `DELETE /collections?name=...`, which keeps
+        // `CollectionPatch`.
         "/api/v0/collections/:name" => match *method {
             Method::GET => RoutePermission::Required(NodePermission::CollectionGet),
             Method::POST => RoutePermission::Required(NodePermission::DocumentUpdate),
+            Method::PATCH => RoutePermission::Required(NodePermission::DocumentUpdate),
             Method::DELETE => RoutePermission::Required(NodePermission::DocumentDelete),
             _ => RoutePermission::Required(NodePermission::CollectionGet),
         },

--- a/crates/http/src/router/routes.rs
+++ b/crates/http/src/router/routes.rs
@@ -125,6 +125,7 @@ pub(crate) fn create_router_with_state_and_body_limits(
             "/{name}",
             get(handlers::get_collection_doc_ids)
                 .post(handlers::create_document)
+                .patch(handlers::update_documents_with_filter)
                 .delete(handlers::delete_documents_with_filter),
         )
         .route("/{name}/describe", get(handlers::describe_collection))

--- a/crates/http/src/server.rs
+++ b/crates/http/src/server.rs
@@ -234,6 +234,7 @@ impl Server {
     /// - `GET /api/v1/collections` - List all collections
     /// - `POST /api/v1/collections/{name}` - Create document(s)
     /// - `GET /api/v1/collections/{name}` - List collection document IDs
+    /// - `PATCH /api/v1/collections/{name}` - Update documents matching a filter
     /// - `DELETE /api/v1/collections/{name}` - Delete documents matching a filter
     /// - `GET /api/v1/collections/{name}/document/{docID}` - Get document
     /// - `PATCH /api/v1/collections/{name}/document/{docID}` - Update document

--- a/crates/http/tests/filtered_document_update.rs
+++ b/crates/http/tests/filtered_document_update.rs
@@ -1,0 +1,247 @@
+//! `PATCH /collections/{name}` is Go's filtered document update.
+//!
+//! Go registers `UpdateDocumentsWithFilter` here
+//! (`http/handler_collection.go:510`), back to back with the filtered delete,
+//! and its client sends `{"filter": ..., "updater": "..."}` to this path
+//! (`http/client_document.go:263-296`). Rust registered `GET`, `POST` and
+//! `DELETE` on this path but no `PATCH`, so the request answered 405 and
+//! filtered update was reachable only through a GraphQL mutation.
+//!
+//! Unlike the filtered delete this failed loudly, so it was a capability gap
+//! rather than a correctness hazard.
+
+use std::sync::Arc;
+
+use axum::{
+    body::{to_bytes, Body},
+    http::{header::HOST, Method, Request, StatusCode},
+    Router,
+};
+use defra_http::route_permissions::{route_permission, RoutePermission};
+use defra_http::router::{AppStateBuilder, NodePermission};
+use defra_http::{MockQueryExecutor, MockRestOperations};
+use query::rest::RestOperations;
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+fn router() -> Router {
+    let state = AppStateBuilder::new(Arc::new(MockQueryExecutor::new()))
+        .with_rest(Arc::new(MockRestOperations::new()) as Arc<dyn RestOperations>)
+        .build();
+    defra_http::create_router_with_state(state)
+}
+
+async fn send(router: Router, method: Method, uri: &str, body: &str) -> (StatusCode, String) {
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method(method)
+                .uri(uri)
+                .header(HOST, "localhost:9181")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .expect("router should respond");
+    let status = response.status();
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    (status, String::from_utf8_lossy(&body).into_owned())
+}
+
+async fn patch_with(router: Router, body: &str) -> (StatusCode, String) {
+    send(router, Method::PATCH, "/api/v0/collections/Users", body).await
+}
+
+async fn document(router: Router, doc_id: &str) -> Value {
+    let (status, body) = send(
+        router,
+        Method::GET,
+        &format!("/api/v0/collections/Users/document/{doc_id}"),
+        "",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    serde_json::from_str(&body).unwrap()
+}
+
+/// The gap itself: this used to be a 405.
+#[tokio::test]
+async fn the_route_is_no_longer_a_405() {
+    let (status, body) = patch_with(
+        router(),
+        r#"{"filter":{"name":{"_eq":"Alice"}},"updater":"{\"age\":31}"}"#,
+    )
+    .await;
+    assert_ne!(status, StatusCode::METHOD_NOT_ALLOWED, "{body}");
+    assert_eq!(status, StatusCode::OK, "{body}");
+}
+
+/// Go types `updater` as a string holding JSON, which is what its client
+/// sends, so that encoding has to work.
+#[tokio::test]
+async fn an_updater_sent_as_a_json_string_is_applied() {
+    let router = router();
+    let (status, body) = patch_with(
+        router.clone(),
+        r#"{"filter":{"name":{"_eq":"Alice"}},"updater":"{\"age\":31}"}"#,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+
+    let result: Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(result["Count"], json!(1));
+    assert_eq!(result["DocIDs"], json!(["bae-123"]));
+
+    assert_eq!(document(router.clone(), "bae-123").await["age"], json!(31));
+    assert_eq!(
+        document(router, "bae-456").await["age"],
+        json!(25),
+        "a non-matching document must not be touched"
+    );
+}
+
+/// A hand-written client is likelier to send an object than to double-encode.
+#[tokio::test]
+async fn an_updater_sent_as_an_object_is_applied() {
+    let router = router();
+    let (status, body) = patch_with(
+        router.clone(),
+        r#"{"filter":{"name":{"_eq":"Alice"}},"updater":{"age":31}}"#,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(document(router, "bae-123").await["age"], json!(31));
+}
+
+/// Go's `UpdateResult` fields carry no json tags, so they marshal capitalised.
+#[tokio::test]
+async fn the_response_uses_gos_field_names() {
+    let (_, body) = patch_with(
+        router(),
+        r#"{"filter":{"name":{"_eq":"Alice"}},"updater":"{\"age\":31}"}"#,
+    )
+    .await;
+    let result: Value = serde_json::from_str(&body).unwrap();
+    assert!(result.get("Count").is_some(), "{body}");
+    assert!(result.get("DocIDs").is_some(), "{body}");
+}
+
+#[tokio::test]
+async fn a_filter_matching_nothing_updates_nothing() {
+    let router = router();
+    let (status, body) = patch_with(
+        router.clone(),
+        r#"{"filter":{"name":{"_eq":"Nobody"}},"updater":"{\"age\":31}"}"#,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+
+    let result: Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(result["Count"], json!(0));
+    assert_eq!(document(router, "bae-123").await["age"], json!(30));
+}
+
+/// Neither half may be guessed. A missing filter would rewrite the whole
+/// collection; a missing updater would claim an update that never happened.
+#[tokio::test]
+async fn an_incomplete_request_is_refused() {
+    let bodies = [
+        "",
+        "{}",
+        "not json",
+        r#"{"updater":"{\"age\":31}"}"#,
+        r#"{"filter":null,"updater":"{\"age\":31}"}"#,
+        r#"{"filter":{"name":{"_eq":"Alice"}}}"#,
+        r#"{"filter":{"name":{"_eq":"Alice"}},"updater":null}"#,
+        r#"{"filter":{"name":{"_eq":"Alice"}},"updater":"not json"}"#,
+    ];
+    for body in bodies {
+        let router = router();
+        let (status, response) = patch_with(router.clone(), body).await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "body {body:?} should be refused, got {response}"
+        );
+        assert_eq!(
+            document(router, "bae-123").await["age"],
+            json!(30),
+            "body {body:?} must not have changed anything"
+        );
+    }
+}
+
+#[tokio::test]
+async fn an_unknown_collection_is_not_a_success() {
+    let (status, _) = send(
+        router(),
+        Method::PATCH,
+        "/api/v0/collections/Nope",
+        r#"{"filter":{"name":{"_eq":"Alice"}},"updater":"{\"age\":31}"}"#,
+    )
+    .await;
+    assert_ne!(status, StatusCode::OK);
+}
+
+/// A new verb on an existing path needs its own permission entry, or it falls
+/// to the safe default and is gated as a read.
+#[tokio::test]
+async fn the_route_is_gated_as_a_document_update() {
+    assert_eq!(
+        route_permission("/api/v0/collections/:name", &Method::PATCH),
+        RoutePermission::Required(NodePermission::DocumentUpdate)
+    );
+}
+
+/// A JSON Patch updater is refused, deliberately.
+///
+/// Go accepts the array and answers 200 with a non-zero `Count`, but changes
+/// nothing: the patch branch is an empty `// todo` and the loop still calls
+/// `c.update` and increments the count (`internal/db/document_update.go:135-152`,
+/// and its own `TestUpdateWithPatch_DoesNothing`). Reporting documents as
+/// updated while leaving them untouched is a lie to the caller, so this route
+/// says it cannot do it instead of copying the behaviour. That is a known
+/// divergence from Go, in the direction of refusing a no-op.
+#[tokio::test]
+async fn a_json_patch_updater_is_refused_rather_than_silently_doing_nothing() {
+    let router = router();
+    let (status, body) = patch_with(
+        router.clone(),
+        r#"{"filter":{"name":{"_eq":"Alice"}},"updater":"[{\"name\":\"Eric\"}]"}"#,
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    assert_eq!(
+        document(router, "bae-123").await["name"],
+        json!("Alice"),
+        "and nothing may have changed"
+    );
+}
+
+/// Go's filter is `any`, and a string is first-class; the JS client always
+/// sends one (`internal/db/document_update.go:168-176`).
+#[tokio::test]
+async fn a_filter_sent_as_graphql_source_is_applied() {
+    let router = router();
+    let (status, body) = patch_with(
+        router.clone(),
+        r#"{"filter":"{name: {_eq: \"Alice\"}}","updater":"{\"age\":31}"}"#,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(document(router, "bae-123").await["age"], json!(31));
+}
+
+/// A bare scalar condition is equality, as Go's connor reads it.
+#[tokio::test]
+async fn a_bare_scalar_condition_means_equality() {
+    let router = router();
+    let (status, body) = patch_with(
+        router.clone(),
+        r#"{"filter":{"name":"Alice"},"updater":"{\"age\":31}"}"#,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(document(router, "bae-123").await["age"], json!(31));
+}

--- a/crates/http/tests/route_permissions.rs
+++ b/crates/http/tests/route_permissions.rs
@@ -310,7 +310,12 @@ fn all_registered_routes_return_expected_permission() {
             Method::POST,
             RoutePermission::Required(NodePermission::DocumentUpdate),
         ),
-        // Go's filtered document delete, not a collection drop.
+        // Go's filtered document operations, not collection ones.
+        (
+            "/api/v0/collections/:name",
+            Method::PATCH,
+            RoutePermission::Required(NodePermission::DocumentUpdate),
+        ),
         (
             "/api/v0/collections/:name",
             Method::DELETE,

--- a/crates/query/src/rest/gql.rs
+++ b/crates/query/src/rest/gql.rs
@@ -146,3 +146,16 @@ pub(super) fn build_filtered_delete_mutation(
         filter = json_to_graphql_input(filter)?
     ))
 }
+
+pub(super) fn build_filtered_update_mutation(
+    collection: &str,
+    filter: &JsonValue,
+    updater: &JsonValue,
+) -> RestResult<String> {
+    Ok(format!(
+        r#"mutation {{ update_{collection}(filter: {filter}, input: {updater}) {{ _docID }} }}"#,
+        collection = collection,
+        filter = json_to_graphql_input(filter)?,
+        updater = json_to_graphql_input(updater)?
+    ))
+}

--- a/crates/query/src/rest/operations.rs
+++ b/crates/query/src/rest/operations.rs
@@ -426,4 +426,29 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> RestOperations for RestOpe
 
         self.mutation_doc_ids(&result, collection, "delete")
     }
+
+    async fn update_documents_with_filter(
+        &self,
+        collection: &str,
+        filter: &JsonValue,
+        updater: &JsonValue,
+        identity: Option<&Did>,
+    ) -> RestResult<Vec<String>> {
+        if !self
+            .runner
+            .has_collection(collection)
+            .await
+            .map_err(|e| RestError::internal(e.to_string()))?
+        {
+            return Err(RestError::collection_not_found(collection));
+        }
+
+        let mutation = gql::build_filtered_update_mutation(collection, filter, updater)?;
+        let result = self
+            .runner
+            .execute_mutation_with_identity(&mutation, identity.cloned())
+            .await?;
+
+        self.mutation_doc_ids(&result, collection, "update")
+    }
 }

--- a/crates/query/src/rest/tests.rs
+++ b/crates/query/src/rest/tests.rs
@@ -1,4 +1,6 @@
-use super::gql::{build_filtered_delete_mutation, json_to_graphql_input};
+use super::gql::{
+    build_filtered_delete_mutation, build_filtered_update_mutation, json_to_graphql_input,
+};
 use super::*;
 use crate::error::QueryError;
 use serde_json::json;
@@ -323,5 +325,21 @@ fn a_filtered_delete_refuses_a_hostile_filter_key() {
     assert_eq!(
         build_filtered_delete_mutation("Users", &ordinary).unwrap(),
         r#"mutation { delete_Users(filter: {name: {_eq: "Alice"}}) { _docID } }"#
+    );
+}
+
+/// The update carries two caller-supplied objects, so both the filter and the
+/// updater have to be refused when they could escape the document.
+#[test]
+fn a_filtered_update_refuses_a_hostile_key_in_either_half() {
+    let hostile = json!({"a) { _docID } } mutation { delete_Other(filter: {": 1});
+    let ordinary = json!({"name": {"_eq": "Alice"}});
+    let patch = json!({"age": 31});
+
+    assert!(build_filtered_update_mutation("Users", &hostile, &patch).is_err());
+    assert!(build_filtered_update_mutation("Users", &ordinary, &hostile).is_err());
+    assert_eq!(
+        build_filtered_update_mutation("Users", &ordinary, &patch).unwrap(),
+        r#"mutation { update_Users(filter: {name: {_eq: "Alice"}}, input: {age: 31}) { _docID } }"#
     );
 }

--- a/crates/query/src/rest/trait_def.rs
+++ b/crates/query/src/rest/trait_def.rs
@@ -126,4 +126,17 @@ pub trait RestOperations: MaybeSendSync {
         filter: &JsonValue,
         identity: Option<&Did>,
     ) -> RestResult<Vec<String>>;
+
+    /// Apply an update to every document matching a filter.
+    ///
+    /// This is Go's `UpdateDocumentsWithFilter`. `updater` is the patch to
+    /// apply, as the `input` argument of an `update_<Collection>` mutation
+    /// takes it, and the returned ids are the documents updated.
+    async fn update_documents_with_filter(
+        &self,
+        collection: &str,
+        filter: &JsonValue,
+        updater: &JsonValue,
+        identity: Option<&Did>,
+    ) -> RestResult<Vec<String>>;
 }

--- a/tools/integration-test/tests/basic/document_lifecycle.rs
+++ b/tools/integration-test/tests/basic/document_lifecycle.rs
@@ -158,6 +158,70 @@ async fn document_lifecycle_test(cluster: TestCluster) {
 
 for_each_runtime!(document_lifecycle, document_lifecycle_test);
 
+async fn filtered_document_update_http_contract(cluster: TestCluster) {
+    let client = cluster.client(0);
+    client
+        .schema_add("type HttpFilterUser { name: String  age: Int }")
+        .expect("failed to add schema");
+
+    let alice = client
+        .query(r#"mutation { add_HttpFilterUser(input: {name: "Alice", age: 30}) { _docID } }"#)
+        .expect("create Alice");
+    let alice_id = alice["add_HttpFilterUser"][0]["_docID"]
+        .as_str()
+        .expect("Alice has a document ID");
+    client
+        .query(r#"mutation { add_HttpFilterUser(input: {name: "Bob", age: 25}) { _docID } }"#)
+        .expect("create Bob");
+
+    let response = reqwest::Client::new()
+        .patch(format!(
+            "{}/api/v0/collections/HttpFilterUser",
+            cluster.api_url(0)
+        ))
+        .json(&serde_json::json!({
+            "filter": r#"{name: {_eq: "Alice"}}"#,
+            "updater": r#"{"age":31}"#,
+        }))
+        .send()
+        .await
+        .expect("filtered update request");
+    let status = response.status();
+    let body = response.text().await.expect("filtered update response");
+    assert!(
+        status.is_success(),
+        "filtered update failed: {status} {body}"
+    );
+
+    let result: Value = serde_json::from_str(&body).expect("filtered update JSON");
+    assert_eq!(result["Count"], 1);
+    assert_eq!(result["DocIDs"], serde_json::json!([alice_id]));
+
+    let stored = client
+        .query("query { HttpFilterUser { name age } }")
+        .expect("query updated documents");
+    let users = stored["HttpFilterUser"]
+        .as_array()
+        .expect("HttpFilterUser result is an array");
+    assert!(
+        users
+            .iter()
+            .any(|user| user["name"] == "Alice" && user["age"] == 31),
+        "Alice was not updated: {users:?}"
+    );
+    assert!(
+        users
+            .iter()
+            .any(|user| user["name"] == "Bob" && user["age"] == 25),
+        "Bob was unexpectedly updated: {users:?}"
+    );
+}
+
+for_each_runtime!(
+    filtered_document_update_http_contract,
+    filtered_document_update_http_contract
+);
+
 async fn filter_mutations_return_post_update_docs(cluster: TestCluster) {
     let client = cluster.client(0);
 


### PR DESCRIPTION
Closes #1493.

**Stacked on #1576 (issue #1492).** Both issues land on the same route entry and the same handler file, so independent branches would conflict on merge. Review only the last commit; the base retargets to `main` once #1576 lands.

Go registers `UpdateDocumentsWithFilter` at `PATCH /collections/{name}` (`http/handler_collection.go:510`), back to back with the filtered delete. Rust registered `GET`, `POST` and `DELETE` on that path but no `PATCH`, so the request answered 405 and filtered update had no HTTP-level equivalent at all: it was reachable only through a GraphQL mutation.

Unlike #1492 this failed loudly, so it is a capability gap rather than a correctness hazard.

## What changed

`PATCH /collections/{name}` takes `{"filter": ..., "updater": "..."}` and returns Go's `{"Count": n, "DocIDs": [...]}`.

New `RestOperations::update_documents_with_filter`, built as an `update_<Collection>(filter: ..., input: ...)` mutation. It reuses the `mutation_doc_ids` extractor that #1576 factored out, so all four document-mutation paths agree on the result shape by construction.

## The `updater` encoding

Go types this as a `string` holding JSON (`UpdateCollectionRequest`, `http/handler_collection.go:36-39`), which is what its client sends, so that is the primary path and it is tested directly.

A plain JSON object is also accepted. A hand-written client is likelier to send one than to double-encode, and refusing it would buy nothing. The leniency does not widen into accepting nonsense: a non-object updater such as `"[1,2]"` is refused.

## Neither half may be guessed

A missing or null `filter` and a missing or null `updater` are both 400s. A missing filter would rewrite every document in the collection, and a missing updater would report an update that never happened. Same reasoning as the filter handling in #1576, and the shared `required_filter` helper is the same function.

## Permission

`PATCH /collections/:name` is registered as `DocumentUpdate`, matching the `POST` on the same path. A new verb on an existing path gets its own `MatchedPath` arm, and without an entry it would fall to the `_` default and be gated as a read.

## Tests

`crates/http/tests/filtered_document_update.rs`, 8 tests:

- **the gap itself**: the route is no longer a 405
- an updater sent as a JSON string is applied, only to matching documents, and a non-matching document is asserted untouched
- an updater sent as an object is applied
- the response uses Go's capitalised `Count` / `DocIDs`
- a filter matching nothing updates nothing and reports `Count: 0`
- nine malformed bodies are each refused, and each is asserted to have changed nothing
- an unknown collection is not a success
- the route is gated as `DocumentUpdate`

## Verification

- `just fmt-check`: green
- `just lint`: green (exit 0)
- `just test`: green, 5211 tests passed, 0 failures
- `RUSTDOCFLAGS="-D warnings" cargo doc -p defra-http -p query --no-deps`: green

`just doc` across the workspace is red on `main` already (pre-existing rustdoc errors in `crates/storage` and `crates/datastore`), so the doc gate was run scoped to the crates this PR changes.

---

## Follow-up from self-review

Rebased onto the hardened base in #1576. `build_filtered_update_mutation` moved into `crates/query/src/rest/gql.rs` with the other builders and became fallible, so both caller-supplied objects on this route, the filter and the updater, are refused when a key could escape the GraphQL document. `a_filtered_update_refuses_a_hostile_key_in_either_half` pins both halves and the ordinary encoding.

Re-verified after the rebase: `just lint` exit 0, `just test` 5217 passed 0 failed.

---

## Verified against the Go source

Checked against the pinned baseline `13c46ec9`. `updater` really is a `string` holding JSON (`http/handler_collection.go:36-39`, passed to `col.UpdateDocumentsWithFilter(ctx, request.Filter, request.Updater, ...)` at `:81`), so the primary encoding this PR implements is correct, and a nil filter is a 400 on Go as well (see #1576).

**One divergence found and not closed.** Go runs `fastjson.Parse(updater)` and branches on the parsed type (`internal/db/document_update.go:73-87`): an **array** is a JSON Patch update, an **object** is a merge, anything else is `client.ErrInvalidUpdater`. Rust has no JSON Patch path, so this handler refuses arrays with a 400 where Go would apply a patch.

That is a capability gap that fails loudly rather than a silent wrong answer, but it is not full parity and is called out here rather than papered over. Object updaters, which is what a merge update sends and what Go's own client produces from a `map`, work.

---

## Review round: the patch claim was wrong, and the 400 is now deliberate

**Correcting this description first, because it was the actual error.** It said this is where "Go would apply a patch". At `13c46ec9` Go does no such thing: `if isPatch { // todo }` is empty, and the loop still calls `c.update` and increments the count (`internal/db/document_update.go:135-152`). Go answers 200 with a non-zero `Count` and no field change, which is what its own `TestUpdateWithPatch_DoesNothing` is named for.

**The 400 stays, now as a stated choice rather than mistaken parity.** Matching Go would mean telling a caller that N documents were updated while touching none of them. Reporting work that did not happen is worse than refusing, so this route says it cannot apply a JSON Patch instead of copying a no-op that lies about its result. The test carries that reasoning and asserts nothing changed.

**String filters** are resolved by the rebase onto #1576: `required_filter` parses them before the builder is reached, so nothing is interpolated. Covered here for PATCH as well, alongside the bare-scalar form.

**The mock filter language** is fixed in #1576, and the tests in this file moved to the real syntax in the same rebase, as requested.

**The unfalsifiable-tests point stands and is not fixed here.** Nothing in this file executes `RestOperationsImpl`, so the `input`-argument-rename failure mode remains uncovered. That needs one test through a real node covering this route and the DELETE together; raised on #1576 as a shared follow-up rather than duplicated into two mock suites.

Re-verified after the rebase: `just fmt-check` green, `just lint` exit 0, `just test` 5223 passed 0 failed, `cargo doc -D warnings -p defra-http -p query` green.
