### PR TITLE
fix(schema): enforce relation integrity

### DIFF
--- a/crates/db/src/collection/ops/create.rs
+++ b/crates/db/src/collection/ops/create.rs
@@ -291,6 +291,13 @@ impl<S: Store> crate::database::DB<S> {
     ) -> Result<CollectionVersion> {
         self.check_node_access(None, acp::nac::NodePermission::CollectionPatch)
             .await?;
+        let existing = self.get_all_collection_versions().await?;
+        schema::definition_validation::validate_new_collections_with_existing(
+            std::slice::from_ref(&schema),
+            &existing,
+        )
+        .map_err(Error::Other)?;
+
         let name = schema.name.clone();
         let mut txn = self.new_txn(false).await?;
 
@@ -351,6 +358,10 @@ impl<S: Store> crate::database::DB<S> {
     ) -> Result<Vec<CollectionVersion>> {
         self.check_node_access(None, acp::nac::NodePermission::CollectionPatch)
             .await?;
+        let existing = self.get_all_collection_versions().await?;
+        schema::definition_validation::validate_new_collections_with_existing(&schemas, &existing)
+            .map_err(Error::Other)?;
+
         // Track old collection_id -> new collection_id mappings.
         // When views are created, create_collection_with_txn regenerates CIDs to include
         // query source data. Sibling schemas' relation fields may reference the old CIDs

--- a/crates/db/src/txn/registry/schemas.rs
+++ b/crates/db/src/txn/registry/schemas.rs
@@ -149,6 +149,12 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
 
         schema::definition_validation::validate_new_collections(&collections)
             .map_err(|e| Error::Other(format!("failed to validate schema: {}", e)))?;
+        let existing = self.db.get_all_collection_versions().await?;
+        schema::definition_validation::validate_new_collections_with_existing(
+            &collections,
+            &existing,
+        )
+        .map_err(|e| Error::Other(format!("failed to validate schema: {}", e)))?;
 
         let mut finalized = Vec::new();
         for collection in collections {

--- a/crates/db/tests/collection/validation.rs
+++ b/crates/db/tests/collection/validation.rs
@@ -72,3 +72,23 @@ fn non_nillable_field_rejects_null_and_missing_values() {
         .to_string();
     assert!(error.contains("value not provided for non-nillable field. Name: createdAt"));
 }
+
+#[tokio::test]
+async fn atomic_creation_rejects_an_unknown_relation_target() {
+    let database = db::DB::open(storage::backends::MemoryStore::new())
+        .await
+        .unwrap();
+    let author = FieldDescription::new("1", "author", FieldKind::named("Missing", false))
+        .with_relation_name("missing_posts")
+        .as_primary();
+    let posts = CollectionVersion::new("Post", "v-post", "c-post", vec![author]);
+
+    let error = database
+        .create_collections_atomic(vec![posts])
+        .await
+        .unwrap_err();
+
+    assert!(error
+        .to_string()
+        .contains("no type found for given name. Field: author, Kind: Missing"));
+}

--- a/crates/db/tests/txn/registry_suite.rs
+++ b/crates/db/tests/txn/registry_suite.rs
@@ -102,6 +102,36 @@ async fn test_begin_readwrite_transaction() {
 }
 
 #[tokio::test]
+async fn add_schema_in_txn_rejects_an_unpaired_relation() {
+    let db = Arc::new(DB::new(MemoryStore::new()).unwrap());
+    let registry = DbTransactionRegistry::new(db);
+    let txn_id = registry.begin(false).await.unwrap();
+
+    let error = registry
+        .add_schema_in_txn(
+            txn_id.as_str(),
+            r#"
+                type User {
+                    posts: [Post] @relation(name: "user_posts")
+                }
+
+                type Post {
+                    title: String
+                }
+            "#,
+        )
+        .await
+        .unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("relation missing field. Object: Post, RelationName: user_posts"),
+        "unexpected error: {error}"
+    );
+}
+
+#[tokio::test]
 async fn test_transaction_id_matches() {
     let db = test_db_with_collections().await;
     let registry = DbTransactionRegistry::new(db);

--- a/crates/http/tests/filtered_document_delete.rs
+++ b/crates/http/tests/filtered_document_delete.rs
@@ -59,17 +59,6 @@ async fn delete_with(router: Router, body: &str) -> (StatusCode, String) {
     send(router, Method::DELETE, "/api/v0/collections/Users", body).await
 }
 
-async fn collection_names(router: Router) -> Vec<String> {
-    let (status, body) = send(router, Method::GET, "/api/v0/collections", "").await;
-    assert_eq!(status, StatusCode::OK, "{body}");
-    serde_json::from_str::<Value>(&body).unwrap()["collections"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .map(|name| name.as_str().unwrap().to_string())
-        .collect()
-}
-
 async fn doc_ids(router: Router) -> Vec<String> {
     let (status, body) = send(router, Method::GET, "/api/v0/collections/Users", "").await;
     assert_eq!(status, StatusCode::OK, "{body}");
@@ -105,19 +94,15 @@ async fn a_filtered_delete_never_touches_collection_management() {
         delete_with(router.clone(), r#"{"filter":{"name":{"_eq":"Alice"}}}"#).await;
     assert_eq!(status, StatusCode::OK, "{body}");
 
-    // The listing alone cannot detect a revert: it does not go through
-    // collection management, and the drop is a no-op against this mock. What
-    // pins the fix is that collection management is never reached.
     assert!(
         mgmt.dropped_collections().is_empty(),
         "a filtered document delete dropped {:?}",
         mgmt.dropped_collections()
     );
-    assert!(
-        collection_names(router)
-            .await
-            .contains(&"Users".to_string()),
-        "the collection must still exist after deleting a document from it"
+    assert_eq!(
+        doc_ids(router).await,
+        vec!["bae-456"],
+        "the collection and its unmatched document must survive"
     );
 }
 

--- a/crates/schema/src/collection.rs
+++ b/crates/schema/src/collection.rs
@@ -364,6 +364,7 @@ impl CollectionVersion {
     }
 
     fn validate_relation_id_field_kinds(&self) -> Result<()> {
+        // Matches Go's validateRelationalFieldIDType.
         for field in self
             .relation_fields()
             .filter(|field| !field.kind.is_array())

--- a/crates/schema/src/definition_validation/global_validators.rs
+++ b/crates/schema/src/definition_validation/global_validators.rs
@@ -4,6 +4,160 @@ use super::helpers::*;
 use super::DefinitionState;
 use crate::{FieldKind, ScalarKind, ORPHAN_COLLECTION_ID};
 
+fn format_relation_kind(kind: &FieldKind) -> String {
+    let (name, is_array) = match kind {
+        FieldKind::Named { name, is_array } => (name.clone(), *is_array),
+        FieldKind::Relation {
+            collection_id,
+            is_array,
+        } => (collection_id.clone(), *is_array),
+        FieldKind::SelfRef {
+            relative_id,
+            is_array,
+        } => {
+            let name = if relative_id.is_empty() {
+                "Self".to_string()
+            } else {
+                format!("Self-{relative_id}")
+            };
+            (name, *is_array)
+        }
+        _ => return format_field_kind(kind),
+    };
+
+    if is_array {
+        format!("[{name}]")
+    } else {
+        name
+    }
+}
+
+/// Matches Go's validateRelationPointsToValidKind.
+pub(super) fn validate_relation_points_to_valid_kind(
+    new_state: &DefinitionState,
+    old_state: &DefinitionState,
+) -> Vec<String> {
+    let mut errs = Vec::new();
+    for collection in &new_state.collections {
+        for field in collection.relation_fields() {
+            if new_state
+                .collection_for_kind(collection, &field.kind)
+                .is_some()
+            {
+                continue;
+            }
+
+            if let Some(removed) = old_state.collection_for_kind(collection, &field.kind) {
+                errs.push(format!(
+                    "cannot remove a collection while another field references it. Removed: {}, ReferencedBy: {}, Field: {}",
+                    removed.name, collection.name, field.name
+                ));
+            } else {
+                errs.push(format!(
+                    "no type found for given name. Field: {}, Kind: {}",
+                    field.name,
+                    format_relation_kind(&field.kind)
+                ));
+            }
+        }
+    }
+    errs
+}
+
+/// Matches Go's validateSecondaryFieldsPairUp.
+pub(super) fn validate_secondary_fields_pair_up(
+    new_state: &DefinitionState,
+    _old_state: &DefinitionState,
+) -> Vec<String> {
+    let mut errs = Vec::new();
+    for collection in &new_state.collections {
+        if collection.query.is_some() {
+            continue;
+        }
+
+        for field in collection
+            .relation_fields()
+            .filter(|field| !field.is_primary)
+        {
+            let Some(relation_name) = field.relation_name.as_deref() else {
+                continue;
+            };
+            let Some(target) = new_state.collection_for_kind(collection, &field.kind) else {
+                continue;
+            };
+            if target.is_embedded_only {
+                continue;
+            }
+
+            let paired = target
+                .field_by_relation(relation_name, &collection.name, &field.name)
+                .is_some_and(|other| other.is_primary);
+            if !paired {
+                errs.push(format!(
+                    "relation missing field. Object: {}, RelationName: {}",
+                    target.name, relation_name
+                ));
+            }
+        }
+    }
+    errs
+}
+
+/// Matches Go's validateSingleSidePrimary.
+pub(super) fn validate_single_side_primary(
+    new_state: &DefinitionState,
+    _old_state: &DefinitionState,
+) -> Vec<String> {
+    let mut errs = Vec::new();
+    for collection in &new_state.collections {
+        for field in collection
+            .relation_fields()
+            .filter(|field| field.is_primary)
+        {
+            let Some(relation_name) = field.relation_name.as_deref() else {
+                continue;
+            };
+            let Some(target) = new_state.collection_for_kind(collection, &field.kind) else {
+                continue;
+            };
+            if target
+                .field_by_relation(relation_name, &collection.name, &field.name)
+                .is_some_and(|other| other.is_primary)
+            {
+                errs.push("relation can only have a single field set as primary".to_string());
+            }
+        }
+    }
+    errs
+}
+
+/// Matches Go's validateSelfReferences.
+pub(super) fn validate_self_references(
+    new_state: &DefinitionState,
+    _old_state: &DefinitionState,
+) -> Vec<String> {
+    let mut errs = Vec::new();
+    for collection in &new_state.collections {
+        for field in collection.relation_fields() {
+            if matches!(field.kind, FieldKind::SelfRef { .. }) {
+                continue;
+            }
+            let Some(target) = new_state.collection_for_kind(collection, &field.kind) else {
+                continue;
+            };
+            if target.collection_id == collection.collection_id
+                || target.collection_id == collection.version_id
+            {
+                errs.push(format!(
+                    "must specify 'Self' kind for self referencing relations. Field: {}",
+                    field.name
+                ));
+            }
+        }
+    }
+    errs
+}
+
 /// Matches Go's validateCollectionNameUnique.
 pub(super) fn validate_collection_name_unique(
     new_state: &DefinitionState,

--- a/crates/schema/src/definition_validation/mod.rs
+++ b/crates/schema/src/definition_validation/mod.rs
@@ -10,7 +10,7 @@ mod update_validators;
 use global_validators::*;
 use update_validators::*;
 
-use crate::CollectionVersion;
+use crate::{CollectionVersion, FieldKind};
 use std::collections::HashMap;
 
 /// Snapshot of all collection versions for validation.
@@ -42,6 +42,34 @@ impl DefinitionState {
             active_by_collection_id,
         }
     }
+
+    fn collection_for_kind<'a>(
+        &'a self,
+        host: &'a CollectionVersion,
+        kind: &FieldKind,
+    ) -> Option<&'a CollectionVersion> {
+        match kind {
+            FieldKind::Named { name, .. } => self
+                .active_by_name
+                .get(name)
+                .or_else(|| self.collections.iter().find(|col| col.name == *name)),
+            FieldKind::Relation { collection_id, .. } => self
+                .active_by_collection_id
+                .get(collection_id)
+                .or_else(|| self.collections_by_id.get(collection_id)),
+            FieldKind::SelfRef { relative_id, .. } if relative_id.is_empty() => Some(host),
+            FieldKind::SelfRef { relative_id, .. } => {
+                let host_set = host.collection_set.as_ref()?;
+                self.collections.iter().find(|col| {
+                    col.collection_set.as_ref().is_some_and(|set| {
+                        set.collection_set_id == host_set.collection_set_id
+                            && set.relative_id.to_string() == *relative_id
+                    })
+                })
+            }
+            _ => None,
+        }
+    }
 }
 
 type Validator = fn(new_state: &DefinitionState, old_state: &DefinitionState) -> Vec<String>;
@@ -68,6 +96,10 @@ const UPDATE_VALIDATORS: &[Validator] = &[
 /// Validators that run on both create and update.
 const GLOBAL_VALIDATORS: &[Validator] = &[
     validate_collection_name_unique,
+    validate_relation_points_to_valid_kind,
+    validate_secondary_fields_pair_up,
+    validate_single_side_primary,
+    validate_self_references,
     validate_collection_name_not_empty,
     validate_type_supported,
     validate_type_and_kind_compatible,
@@ -79,6 +111,13 @@ const GLOBAL_VALIDATORS: &[Validator] = &[
     validate_embedding_fields_for_generation,
     validate_vector_index_metrics,
     validate_embedding_provider_and_model,
+];
+
+const RELATION_VALIDATORS: &[Validator] = &[
+    validate_relation_points_to_valid_kind,
+    validate_secondary_fields_pair_up,
+    validate_single_side_primary,
+    validate_self_references,
 ];
 
 /// Validates embedding definitions on newly created collections.
@@ -100,6 +139,31 @@ pub fn validate_new_collections(new_collections: &[CollectionVersion]) -> Result
 
     let mut errors = Vec::new();
     for validator in validators {
+        errors.extend(validator(&new_state, &old_state));
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors.join("\n"))
+    }
+}
+
+/// Validates relation integrity for new collections alongside persisted definitions.
+pub fn validate_new_collections_with_existing(
+    new_collections: &[CollectionVersion],
+    existing_collections: &[CollectionVersion],
+) -> Result<(), String> {
+    let collections = new_collections
+        .iter()
+        .chain(existing_collections)
+        .cloned()
+        .collect::<Vec<_>>();
+    let new_state = DefinitionState::new(&collections);
+    let old_state = DefinitionState::new(existing_collections);
+
+    let mut errors = Vec::new();
+    for validator in RELATION_VALIDATORS {
         errors.extend(validator(&new_state, &old_state));
     }
 

--- a/crates/schema/src/field.rs
+++ b/crates/schema/src/field.rs
@@ -165,6 +165,7 @@ impl FieldDescription {
             );
         }
 
+        // Matches Go's validateRelationNameSet.
         if self.kind.is_relation() && self.relation_name.is_none() {
             return Err(SchemaError::MissingRequiredField(format!(
                 "relation name cannot be empty. Field: {}",

--- a/crates/schema/tests/validation_tests.rs
+++ b/crates/schema/tests/validation_tests.rs
@@ -181,3 +181,80 @@ fn test_single_sided_relation_no_primary_check() {
     // Should fail because relation points to nonexistent "users" collection
     assert!(result.is_err());
 }
+
+#[test]
+fn new_relation_can_target_an_existing_collection() {
+    let author = FieldDescription::new("3", "author", FieldKind::named("users", false))
+        .with_relation_name("user_posts")
+        .as_primary();
+    let posts = CollectionVersion::new("posts", "v-posts", "coll-posts", vec![author]);
+
+    schema::definition_validation::validate_new_collections_with_existing(
+        &[posts],
+        &[user_collection()],
+    )
+    .unwrap();
+}
+
+#[test]
+fn new_relation_must_target_a_known_collection() {
+    let author = FieldDescription::new("3", "author", FieldKind::named("missing", true))
+        .with_relation_name("user_posts")
+        .as_primary();
+    let posts = CollectionVersion::new("posts", "v-posts", "coll-posts", vec![author]);
+
+    let error =
+        schema::definition_validation::validate_new_collections_with_existing(&[posts], &[])
+            .unwrap_err();
+
+    assert!(error.contains("no type found for given name. Field: author, Kind: [missing]"));
+}
+
+#[test]
+fn secondary_relation_requires_a_primary_counterpart() {
+    let author = FieldDescription::new("3", "author", FieldKind::named("users", false))
+        .with_relation_name("user_posts");
+    let posts = CollectionVersion::new("posts", "v-posts", "coll-posts", vec![author]);
+
+    let error = schema::definition_validation::validate_new_collections_with_existing(
+        &[posts],
+        &[user_collection()],
+    )
+    .unwrap_err();
+
+    assert!(error.contains("relation missing field. Object: users, RelationName: user_posts"));
+}
+
+#[test]
+fn paired_relation_cannot_have_two_primary_fields() {
+    let posts_field = FieldDescription::new("3", "posts", FieldKind::named("posts", true))
+        .with_relation_name("user_posts")
+        .as_primary();
+    let users = CollectionVersion::new("users", "v-users", "coll-users", vec![posts_field]);
+    let author = FieldDescription::new("3", "author", FieldKind::named("users", false))
+        .with_relation_name("user_posts")
+        .as_primary();
+    let posts = CollectionVersion::new("posts", "v-posts", "coll-posts", vec![author]);
+
+    let error =
+        schema::definition_validation::validate_new_collections_with_existing(&[users, posts], &[])
+            .unwrap_err();
+
+    assert!(error.contains("relation can only have a single field set as primary"));
+}
+
+#[test]
+fn self_relation_must_use_self_kind() {
+    let manager = FieldDescription::new("3", "manager", FieldKind::named("users", false))
+        .with_relation_name("user_manager")
+        .as_primary();
+    let users = CollectionVersion::new("users", "v-users", "coll-users", vec![manager]);
+
+    let error =
+        schema::definition_validation::validate_new_collections_with_existing(&[users], &[])
+            .unwrap_err();
+
+    assert!(
+        error.contains("must specify 'Self' kind for self referencing relations. Field: manager")
+    );
+}


### PR DESCRIPTION
## Context

This is 1/3 in the schema-definition validation stack and addresses relation-integrity gaps identified in #1404. Rust accepted invalid relation definitions through collection creation paths that Go rejects.

## Changes

- resolve named, collection-ID, `Self`, and relative-`Self` relation targets against new and persisted definitions
- reject unknown or removed targets, missing counterparts, dual-primary relations, and self-relations declared without `Self`
- enforce the checks across regular, atomic, and explicit-transaction schema creation
- add focused schema and database boundary regressions

## Testing

- [x] `cargo test -p schema`
- [x] `cargo test -p db --test collection`
- [x] `cargo test -p db --test txn`
- [x] `cargo clippy -p schema -p db --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
