### PR TITLE
fix(schema): validate field defaults

### DIFF
--- a/crates/db/src/collection/ops/create.rs
+++ b/crates/db/src/collection/ops/create.rs
@@ -31,6 +31,7 @@ impl<S: Store> crate::database::DB<S> {
 
         // Validate schema (includes policy validation for path traversal prevention)
         schema.validate()?;
+        Collection::validate_default_values(&schema)?;
         let name = collection_name.as_str().to_string();
 
         // For views, regenerate version_id to include query_select in the CID

--- a/crates/db/src/collection/validation.rs
+++ b/crates/db/src/collection/validation.rs
@@ -1,6 +1,31 @@
 use super::*;
 
 impl Collection {
+    /// Matches Go's validateCollectionFieldDefaultValue.
+    pub(crate) fn validate_default_values(schema: &CollectionVersion) -> Result<()> {
+        for field in &schema.fields {
+            let Some(default) = &field.default_value else {
+                continue;
+            };
+            let value =
+                query::plan::mutation::json_to_normal_value_with_kind(default, Some(&field.kind));
+            let value = value.map_err(|error| {
+                Error::Other(format!(
+                    "default field value is invalid. Collection: {}, Inner: {}",
+                    schema.name, error
+                ))
+            })?;
+
+            if !is_value_compatible_with_kind(&value, &field.kind) {
+                return Err(Error::Other(format!(
+                    "default field value is invalid. Collection: {}, Inner: Field '{}' has incompatible type",
+                    schema.name, field.name
+                )));
+            }
+        }
+        Ok(())
+    }
+
     /// Validate a document against this collection's schema.
     ///
     /// Returns an error if the document contains fields with incorrect types.

--- a/crates/db/src/definition/patch/validate.rs
+++ b/crates/db/src/definition/patch/validate.rs
@@ -224,6 +224,8 @@ impl<S: Store> crate::database::DB<S> {
             }
         }
 
+        Collection::validate_default_values(&new_schema)?;
+
         Ok(new_schema)
     }
 }

--- a/crates/db/tests/collection/validation.rs
+++ b/crates/db/tests/collection/validation.rs
@@ -92,3 +92,45 @@ async fn atomic_creation_rejects_an_unknown_relation_target() {
         .to_string()
         .contains("no type found for given name. Field: author, Kind: Missing"));
 }
+
+#[tokio::test]
+async fn creation_rejects_an_invalid_default_value() {
+    let database = db::DB::open(storage::backends::MemoryStore::new())
+        .await
+        .unwrap();
+    let count = FieldDescription::new("1", "count", FieldKind::int())
+        .with_default(serde_json::json!("not-an-int"));
+    let collection = CollectionVersion::new("Counter", "v-counter", "c-counter", vec![count]);
+
+    let error = database.create_collection(collection).await.unwrap_err();
+
+    assert!(error.to_string().contains(
+        "default field value is invalid. Collection: Counter, Inner: Field 'count' has incompatible type"
+    ));
+}
+
+#[tokio::test]
+async fn creation_accepts_supported_scalar_defaults() {
+    let database = db::DB::open(storage::backends::MemoryStore::new())
+        .await
+        .unwrap();
+    let collections = query::parse_sdl(
+        r#"
+        type Defaults {
+            active: Boolean @default(value: true)
+            created: DateTime @default(value: "2000-07-23T03:00:00Z")
+            name: String @default(value: "Bob")
+            age: Int @default(value: 40)
+            points: Float @default(value: 10)
+            metadata: JSON @default(value: "{\"one\":1}")
+            image: Blob @default(value: "ff0099")
+        }
+        "#,
+    )
+    .unwrap();
+
+    database
+        .create_collections_atomic(collections)
+        .await
+        .unwrap();
+}

--- a/crates/db/tests/definition/patch.rs
+++ b/crates/db/tests/definition/patch.rs
@@ -30,6 +30,22 @@ async fn users_db() -> DB<MemoryStore> {
     db
 }
 
+#[tokio::test]
+async fn patch_rejects_an_invalid_default_value() {
+    let db = users_db().await;
+    let patch = r#"[{
+        "op": "add",
+        "path": "/Users/Fields/-",
+        "value": {"Name": "age", "Kind": "Int", "DefaultValue": "unknown"}
+    }]"#;
+
+    let error = db.patch_collection("Users", patch, None).await.unwrap_err();
+
+    assert!(error.to_string().contains(
+        "default field value is invalid. Collection: Users, Inner: Field 'age' has incompatible type"
+    ));
+}
+
 const ADD_AGE_PATCH: &str = r#"
     [{
         "op": "add",

--- a/crates/query/src/plan/mutation/create_conversions.rs
+++ b/crates/query/src/plan/mutation/create_conversions.rs
@@ -116,7 +116,6 @@ pub fn json_to_normal_value(value: &JsonValue) -> Result<document::NormalValue> 
 }
 
 /// Convert a JSON value to a document NormalValue with schema-aware type coercion.
-#[allow(dead_code)]
 pub fn json_to_normal_value_with_kind(
     value: &JsonValue,
     field_kind: Option<&FieldKind>,

--- a/crates/query/src/plan/mutation/mod.rs
+++ b/crates/query/src/plan/mutation/mod.rs
@@ -7,7 +7,9 @@ mod update;
 mod upsert;
 
 pub use create::{CreateInput, CreateNode};
-pub use create_conversions::{json_to_normal_value, normal_value_to_json};
+pub use create_conversions::{
+    json_to_normal_value, json_to_normal_value_with_kind, normal_value_to_json,
+};
 pub use delete::DeleteNode;
 pub use update::{UpdateInput, UpdateNode};
 pub use upsert::{UpsertAction, UpsertInput, UpsertNode};


### PR DESCRIPTION
## Context

This is 2/3 in the schema-definition validation stack and depends on #1584. Invalid field defaults could be accepted with a schema and fail only when a document attempted to use them.

## Changes

- validate defaults with the same schema-aware JSON conversion used by document creation
- reject malformed or type-incompatible defaults during collection creation
- apply the same validation after JSON schema patches
- cover supported scalar defaults and invalid create/patch cases

## Testing

- [x] `cargo test -p db --test collection`
- [x] `cargo test -p db --test definition`
- [x] `cargo test -p query`
- [x] `cargo clippy -p query -p db --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
