### PR TITLE
fix(view): protect populated cache on dematerialize

### DIFF
--- a/crates/db/src/definition/patch/mod.rs
+++ b/crates/db/src/definition/patch/mod.rs
@@ -168,6 +168,17 @@ impl<S: Store> crate::database::DB<S> {
         // same index/head/cache namespace as the rest of the collection history.
         new_schema.root_id = old_schema.root_id;
 
+        // Matches Go's validateDematerializedViewHasNoData.
+        if old_schema.is_materialized
+            && !new_schema.is_materialized
+            && self.collection_has_data(&old_schema).await?
+        {
+            return Err(Error::InvalidPatch(format!(
+                "cannot dematerialize a materialized view that has data, first truncate it and then try again. Name: {}, VersionID: {}",
+                old_schema.name, old_schema.version_id
+            )));
+        }
+
         // Handle in-place updates (deactivation, IsActive-only, or PreviousVersion/Transform-only).
         // These don't create a new schema version - they update the existing one.
         let is_isactive_only_change = is_active_explicitly_set

--- a/crates/db/tests/definition/patch.rs
+++ b/crates/db/tests/definition/patch.rs
@@ -6,6 +6,7 @@ use schema::FieldKind;
 use schema::ScalarArrayKind;
 use storage::backends::MemoryStore;
 use storage::corekv::Key;
+use storage::keys::datastore::ViewCacheKey;
 use storage::keys::systemstore::LensConfigKey;
 
 async fn agent_response_db() -> DB<MemoryStore> {
@@ -288,6 +289,72 @@ async fn patch_view_query_creates_new_version() {
         Some(original.version_id())
     );
     assert_eq!(db.get_all_collection_versions().await.unwrap().len(), 3);
+}
+
+#[tokio::test]
+async fn patch_dematerialization_requires_an_empty_view() {
+    let db = DB::new(MemoryStore::new()).unwrap();
+    let users = query::parse_sdl("type Users { name: String }").unwrap();
+    db.create_collections_atomic(users).await.unwrap();
+
+    let mut views = query::parse_sdl("type UserView { name: String }").unwrap();
+    let select = query::parse_query("query { Users { name } }").unwrap();
+    views[0].query = Some(schema::QuerySource::new(query::select_to_go_json(
+        &select[0],
+    )));
+    views[0].is_materialized = true;
+    db.create_collections_atomic(views).await.unwrap();
+    let dematerialized = db
+        .patch_collection(
+            "UserView",
+            r#"[{"op":"replace","path":"/UserView/IsMaterialized","value":false}]"#,
+            None,
+        )
+        .await
+        .unwrap();
+    assert!(!dematerialized.is_materialized);
+
+    let view = db
+        .patch_collection(
+            "UserView",
+            r#"[{"op":"replace","path":"/UserView/IsMaterialized","value":true}]"#,
+            None,
+        )
+        .await
+        .unwrap();
+    assert!(view.is_materialized);
+
+    let txn = db.new_txn(false).await.unwrap();
+    let cache_key = ViewCacheKey::new(view.root_id, 0).bytes();
+    txn.datastore()
+        .unwrap()
+        .set(&cache_key, b"cached")
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+
+    let txn = db.new_txn(true).await.unwrap();
+    assert!(txn
+        .datastore()
+        .unwrap()
+        .get(&cache_key)
+        .await
+        .unwrap()
+        .is_some());
+    txn.force_discard().unwrap();
+
+    let error = db
+        .patch_collection(
+            "UserView",
+            r#"[{"op":"replace","path":"/UserView/IsMaterialized","value":false}]"#,
+            None,
+        )
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains(
+        "cannot dematerialize a materialized view that has data, first truncate it and then try again"
+    ));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Context

This is 3/3 in the schema-definition validation stack and depends on #1585. A metadata-only patch could dematerialize a populated view while leaving its cache data behind.

## Changes

- reject materialized-to-embedded transitions while the view cache contains data
- reuse the existing collection-data check at the shared patch decision point
- continue allowing empty views to dematerialize and embedded views to rematerialize
- add a regression covering the populated-cache transition

## Testing

- [x] `cargo test -p db --test definition`
- [x] `cargo test -p db`
- [x] `cargo test -p schema -p query`
- [x] `cargo clippy -p schema -p query -p db --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`

Closes #1404
