### PR TITLE
fix(db): preserve active name selector precedence

### DIFF
--- a/crates/db/src/collection/selector.rs
+++ b/crates/db/src/collection/selector.rs
@@ -55,9 +55,11 @@ impl CollectionSelector {
     /// Whether inactive versions have to be loaded to answer this selection.
     ///
     /// A named version is returned whether or not it is active, so asking for
-    /// one requires the full listing just as `get_inactive` does.
+    /// one directly requires the full listing just as `get_inactive` does.
+    /// When an active name selected the candidate first, the version id only
+    /// filters that candidate and does not widen the lookup.
     pub fn needs_all_versions(&self) -> bool {
-        self.get_inactive || self.version_id.is_some()
+        self.get_inactive || self.resolves_by_version_lookup()
     }
 
     /// Whether this collection version is selected.
@@ -75,7 +77,8 @@ impl CollectionSelector {
                 .collection_id
                 .as_ref()
                 .is_none_or(|id| &collection.collection_id == id);
-        let visible = self.get_inactive || collection.is_active || self.version_id.is_some();
+        let visible =
+            self.get_inactive || collection.is_active || self.resolves_by_version_lookup();
 
         version_matches && name_matches && collection_matches && visible
     }
@@ -89,7 +92,7 @@ impl CollectionSelector {
     /// the direct lookup propagates not-found, where the stage-two filter just
     /// yields an empty selection.
     pub fn resolves_by_version_lookup(&self) -> bool {
-        self.version_id.is_some() && !(self.names.is_some() && !self.get_inactive)
+        self.version_id.is_some() && (self.get_inactive || self.names.is_none())
     }
 
     /// Go picks candidates by collection id only when neither a name nor a

--- a/crates/db/src/view/ops.rs
+++ b/crates/db/src/view/ops.rs
@@ -80,10 +80,12 @@ impl<S: Store> crate::database::DB<S> {
             self.get_all_active_collections_internal()?
         };
 
-        // A selector that matches nothing is a caller mistake, not an empty
-        // refresh. Go looks a version up directly and propagates not-found
-        // (`internal/db/collection.go:211`), so a typo must not read as success.
-        if let Some(version_id) = &options.version_id {
+        // A direct version lookup that matches nothing is a caller mistake, not
+        // an empty refresh. Go propagates that not-found error
+        // (`internal/db/collection.go:211`).
+        if let (true, Some(version_id)) =
+            (options.resolves_by_version_lookup(), &options.version_id)
+        {
             if !collections.iter().any(|col| &col.version_id == version_id) {
                 return Err(Error::Other(format!(
                     "no active collection version {version_id}"

--- a/crates/db/tests/collection/selector.rs
+++ b/crates/db/tests/collection/selector.rs
@@ -52,7 +52,6 @@ fn a_version_id_selects_only_that_version() {
     assert!(!options.selects(&version("Orders", "v2", "c1")));
 }
 
-/// Go exempts a requested version from the inactive drop, so asking for a
 #[test]
 fn a_collection_id_selects_that_collections_versions() {
     let options = CollectionSelector {
@@ -130,6 +129,24 @@ fn a_name_with_get_inactive_reaches_an_inactive_version() {
     assert!(!selector.selects(&inactive("Books", "v1", "c1")));
 }
 
+/// A name selects from Go's active-by-name index before the version id is
+/// applied, so a matching inactive version cannot replace that candidate.
+#[test]
+fn a_name_with_a_version_id_stays_active_only() {
+    let selector = CollectionSelector {
+        version_id: Some("v1".to_string()),
+        ..CollectionSelector::with_names(vec!["Users".to_string()])
+    };
+    assert!(selector.selects(&version("Users", "v1", "c1")));
+    assert!(!selector.selects(&inactive("Users", "v1", "c1")));
+
+    let selector = CollectionSelector {
+        get_inactive: true,
+        ..selector
+    };
+    assert!(selector.selects(&inactive("Users", "v1", "c1")));
+}
+
 /// `needs_all_versions` decides whether the caller has to load inactive rows
 /// at all, so a version id has to imply it: a named version is returned
 /// whether or not it is active.
@@ -144,6 +161,11 @@ fn a_version_id_needs_the_full_listing() {
     assert!(CollectionSelector {
         get_inactive: true,
         ..CollectionSelector::all()
+    }
+    .needs_all_versions());
+    assert!(!CollectionSelector {
+        version_id: Some("v2".to_string()),
+        ..CollectionSelector::with_names(vec!["Users".to_string()])
     }
     .needs_all_versions());
 }

--- a/crates/db/tests/view/ops.rs
+++ b/crates/db/tests/view/ops.rs
@@ -79,6 +79,24 @@ async fn an_unknown_version_id_is_an_error_not_a_silent_success() {
 }
 
 #[tokio::test]
+async fn a_name_precedes_an_unknown_version_id() {
+    let db = db::DB::open(storage::backends::MemoryStore::new())
+        .await
+        .expect("open");
+    db.create_collection(materialized("OrdersView"))
+        .await
+        .expect("store view");
+
+    db.refresh_views(CollectionSelector {
+        names: Some(vec!["OrdersView".to_string()]),
+        version_id: Some("bae-does-not-exist".to_string()),
+        ..CollectionSelector::all()
+    })
+    .await
+    .expect("the version id only filters the active name candidate");
+}
+
+#[tokio::test]
 async fn an_unknown_collection_id_is_an_error() {
     let db = db::DB::open(storage::backends::MemoryStore::new())
         .await

--- a/crates/http/tests/collection_selectors.rs
+++ b/crates/http/tests/collection_selectors.rs
@@ -272,6 +272,17 @@ async fn a_name_pre_empts_the_version_lookup_so_a_bad_version_is_not_a_404() {
     }
 }
 
+/// The name arm selects the active version before the version id filters it.
+/// A matching active id survives, while an inactive id cannot replace it.
+#[tokio::test]
+async fn a_name_filters_its_active_candidate_by_version_id() {
+    assert_eq!(
+        names("?name=Users&version_id=users-v2").await,
+        vec!["Users"]
+    );
+    assert!(names("?name=Users&version_id=users-v1").await.is_empty());
+}
+
 /// `get_inactive` takes the name arm out of the running, so the version
 /// lookup runs again and an id that exists is not an error even when the name
 /// filters it away.
@@ -310,16 +321,18 @@ async fn the_not_found_body_matches_gos_message() {
 /// `refresh_views` makes on the same selector.
 #[tokio::test]
 async fn a_selector_that_needs_no_inactive_versions_takes_the_cheap_listing() {
-    let versions = Arc::new(Versions::default());
-    let (status, body) = get(router_with(versions.clone()), "?name=Users").await;
-    assert_eq!(status, StatusCode::OK, "{body}");
+    for query in ["?name=Users", "?name=Users&version_id=users-v2"] {
+        let versions = Arc::new(Versions::default());
+        let (status, body) = get(router_with(versions.clone()), query).await;
+        assert_eq!(status, StatusCode::OK, "{query}: {body}");
 
-    assert_eq!(versions.active_calls.load(Ordering::SeqCst), 1);
-    assert_eq!(
-        versions.all_calls.load(Ordering::SeqCst),
-        0,
-        "an active-only selector must not scan every stored version"
-    );
+        assert_eq!(versions.active_calls.load(Ordering::SeqCst), 1, "{query}");
+        assert_eq!(
+            versions.all_calls.load(Ordering::SeqCst),
+            0,
+            "{query} must not scan every stored version"
+        );
+    }
 }
 
 /// The converse: asking for inactive versions, or for a version by id, does


### PR DESCRIPTION
## Context

This is 1/3 in the collection selector parity stack. Combined name and version selectors could expose an inactive collection version even when inactive versions were not requested.

## Changes

- preserve active-by-name candidate precedence before applying `version_id`
- avoid loading inactive versions unless the selector explicitly requests them
- cover active, inactive, matching, and unknown mixed-selector cases through DB and HTTP tests

## Testing

- [x] `cargo test -p db --test collection selector`
- [x] `cargo test -p defra-http --test collection_selectors`
- [x] `cargo clippy -p db --test collection --no-deps -- -D warnings`
- [x] `cargo fmt --all -- --check`

Closes #1579
Closes #1582