### PR TITLE
fix(http): align collection selector query parsing

### DIFF
--- a/crates/http/src/handlers/collection_selector.rs
+++ b/crates/http/src/handlers/collection_selector.rs
@@ -5,7 +5,30 @@
 //! `internal/db/collection.go`). This is that query string, parsed once, so
 //! the two Rust surfaces cannot drift apart the way two copies would.
 
-use serde::Deserialize;
+use axum::{
+    extract::{FromRequestParts, Query},
+    http::request::Parts,
+};
+use serde::{de::Error as _, Deserialize, Deserializer};
+
+use crate::error::HttpError;
+
+fn deserialize_go_bool<'de, D>(deserializer: D) -> Result<Option<bool>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let Some(value) = Option::<String>::deserialize(deserializer)? else {
+        return Ok(None);
+    };
+
+    match value.as_str() {
+        "1" | "t" | "T" | "true" | "TRUE" | "True" => Ok(Some(true)),
+        "0" | "f" | "F" | "false" | "FALSE" | "False" => Ok(Some(false)),
+        _ => Err(D::Error::custom(format!(
+            "strconv.ParseBool: parsing \"{value}\": invalid syntax"
+        ))),
+    }
+}
 
 /// `name`, `version_id`, `collection_id` and `get_inactive`, as Go's client
 /// sends them (`http/client.go:422-448`).
@@ -19,7 +42,22 @@ pub struct CollectionSelectorQuery {
     pub name: Option<String>,
     pub version_id: Option<String>,
     pub collection_id: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_go_bool")]
     pub get_inactive: Option<bool>,
+}
+
+impl<S> FromRequestParts<S> for CollectionSelectorQuery
+where
+    S: Send + Sync,
+{
+    type Rejection = HttpError;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let Query(query) = Query::<Self>::from_request_parts(parts, state)
+            .await
+            .map_err(|rejection| HttpError::BadRequest(rejection.body_text()))?;
+        Ok(query)
+    }
 }
 
 impl CollectionSelectorQuery {

--- a/crates/http/src/handlers/collections.rs
+++ b/crates/http/src/handlers/collections.rs
@@ -110,7 +110,7 @@ fn parse_collection_doc_ids_pagination(
 pub async fn list_collections(
     State(state): State<AppState>,
     identity: ExtractIdentity,
-    Query(query): Query<CollectionSelectorQuery>,
+    query: CollectionSelectorQuery,
 ) -> Result<Json<CollectionsResponse>, HttpError> {
     require_permission(&state, &identity, NodePermission::CollectionGet).await?;
 

--- a/crates/http/src/handlers/collections_tests.rs
+++ b/crates/http/src/handlers/collections_tests.rs
@@ -34,7 +34,7 @@ fn create_failing_state() -> AppState {
 async fn test_list_collections() {
     let state = create_state();
     let identity = ExtractIdentity::anonymous();
-    let result = list_collections(State(state), identity, Query(Default::default())).await;
+    let result = list_collections(State(state), identity, CollectionSelectorQuery::default()).await;
     assert!(result.is_ok());
     let response = result.unwrap();
     // The listing reads the stored versions, which is what the collection
@@ -46,7 +46,7 @@ async fn test_list_collections() {
 async fn test_list_collections_no_rest() {
     let state = create_state_without_rest();
     let identity = ExtractIdentity::anonymous();
-    let result = list_collections(State(state), identity, Query(Default::default())).await;
+    let result = list_collections(State(state), identity, CollectionSelectorQuery::default()).await;
     assert!(result.is_err());
 }
 
@@ -54,7 +54,7 @@ async fn test_list_collections_no_rest() {
 async fn test_list_collections_error() {
     let state = create_failing_state();
     let identity = ExtractIdentity::anonymous();
-    let result = list_collections(State(state), identity, Query(Default::default())).await;
+    let result = list_collections(State(state), identity, CollectionSelectorQuery::default()).await;
     assert!(result.is_err());
 }
 

--- a/crates/http/src/handlers/views.rs
+++ b/crates/http/src/handlers/views.rs
@@ -1,10 +1,6 @@
 //! View endpoint handlers.
 
-use axum::{
-    body::Bytes,
-    extract::{Query, State},
-    Json,
-};
+use axum::{body::Bytes, extract::State, Json};
 
 use crate::error::{http_error_from_backend_message, HttpError};
 use crate::handlers::collection_selector::CollectionSelectorQuery;
@@ -89,7 +85,7 @@ fn view_names_from_body(body: &Bytes) -> Result<Option<Vec<String>>, HttpError> 
 pub async fn refresh_views(
     State(state): State<AppState>,
     identity: ExtractIdentity,
-    Query(query): Query<CollectionSelectorQuery>,
+    query: CollectionSelectorQuery,
     body: Bytes,
 ) -> Result<Json<serde_json::Value>, HttpError> {
     require_permission(&state, &identity, NodePermission::ViewRefresh).await?;

--- a/crates/http/tests/collection_selectors.rs
+++ b/crates/http/tests/collection_selectors.rs
@@ -16,7 +16,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use axum::{
     body::{to_bytes, Body},
-    http::{header::HOST, Request, StatusCode},
+    http::{header::HOST, Method, Request, StatusCode},
+    response::Response,
     Router,
 };
 use defra_http::router::{AppStateBuilder, CollectionVersionOperations};
@@ -88,8 +89,8 @@ fn router_without_versions() -> Router {
     defra_http::create_router_with_state(state)
 }
 
-async fn get(router: Router, query: &str) -> (StatusCode, String) {
-    let response = router
+async fn get_response(router: Router, query: &str) -> Response {
+    router
         .oneshot(
             Request::builder()
                 .uri(format!("/api/v0/collections{query}"))
@@ -98,7 +99,11 @@ async fn get(router: Router, query: &str) -> (StatusCode, String) {
                 .unwrap(),
         )
         .await
-        .expect("router should respond");
+        .expect("router should respond")
+}
+
+async fn get(router: Router, query: &str) -> (StatusCode, String) {
+    let response = get_response(router, query).await;
     let status = response.status();
     let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
     (status, String::from_utf8_lossy(&body).into_owned())
@@ -217,9 +222,56 @@ async fn every_request_needs_the_version_store() {
 #[tokio::test]
 async fn an_unparseable_selector_is_refused() {
     for query in ["?get_inactive=maybe", "?get_inactive="] {
-        let (status, body) = get(router(), query).await;
-        assert_eq!(status, StatusCode::BAD_REQUEST, "{query}: {body}");
+        let response = get_response(router(), query).await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{query}");
+        assert_eq!(
+            response.headers()["content-type"],
+            "application/json",
+            "{query} must use the Go error envelope"
+        );
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let error: serde_json::Value = serde_json::from_slice(&body).expect("JSON error body");
+        assert!(error["error"].as_str().is_some(), "{query}: {error}");
     }
+}
+
+#[tokio::test]
+async fn get_inactive_accepts_every_go_boolean_form() {
+    for value in ["1", "t", "T", "true", "TRUE", "True"] {
+        assert_eq!(
+            names(&format!("?get_inactive={value}")).await,
+            vec!["Books", "Orders", "Users"],
+            "{value} should be true"
+        );
+    }
+    for value in ["0", "f", "F", "false", "FALSE", "False"] {
+        assert_eq!(
+            names(&format!("?get_inactive={value}")).await,
+            vec!["Books", "Users"],
+            "{value} should be false"
+        );
+    }
+}
+
+#[tokio::test]
+async fn view_refresh_uses_the_same_json_selector_error() {
+    let response = router()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/v0/view/refresh?get_inactive=maybe")
+                .header(HOST, "localhost:9181")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("router should respond");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(response.headers()["content-type"], "application/json");
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let error: serde_json::Value = serde_json::from_slice(&body).expect("JSON error body");
+    assert!(error["error"].as_str().is_some(), "{error}");
 }
 
 /// Go keys the selectors off `Query().Has(..)`, so `?name=` is a name set to


### PR DESCRIPTION
## Context

This is 2/3 in the collection selector parity stack and depends on #1588. HTTP selector query parsing accepted fewer boolean forms than Go and returned non-JSON extractor errors for invalid values.

## Changes

- accept every boolean spelling supported by Go `strconv.ParseBool`
- route collection and view selector parse failures through the shared JSON HTTP error envelope
- cover valid boolean forms and invalid selector responses on both endpoints

## Testing

- [x] `cargo test -p defra-http --test collection_selectors`
- [x] `cargo clippy -p defra-http --all-targets --no-deps -- -D warnings`
- [x] `cargo fmt --all -- --check`

Closes #1580
Closes #1581