### PR TITLE
fix(http): list transaction-scoped collections

### DIFF
--- a/crates/http/src/handlers/collections.rs
+++ b/crates/http/src/handlers/collections.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 
 use axum::{
     extract::{Path, Query, State},
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
     Json,
 };
 use query::rest::{CollectionDocIdsPage, CollectionDocIdsPagination};
@@ -17,6 +17,7 @@ use serde::Serialize;
 
 use crate::error::{http_error_from_backend_message, HttpError};
 use crate::handlers::collection_selector::CollectionSelectorQuery;
+use crate::handlers::txn_header::txn_id_from_headers;
 use crate::identity_extractor::ExtractIdentity;
 use crate::nac_guard::require_permission;
 use crate::router::{AppState, NodePermission};
@@ -110,20 +111,28 @@ fn parse_collection_doc_ids_pagination(
 pub async fn list_collections(
     State(state): State<AppState>,
     identity: ExtractIdentity,
+    headers: HeaderMap,
     query: CollectionSelectorQuery,
 ) -> Result<Json<CollectionsResponse>, HttpError> {
     require_permission(&state, &identity, NodePermission::CollectionGet).await?;
 
     let selector = query.into_selector();
 
-    // The same branch `refresh_views` makes on the same selector: inactive
-    // versions cost a scan of every stored version, and a selector that does
-    // not ask for them is answerable from the active listing alone.
-    let collection_versions = state.require_collection_versions()?;
-    let versions = if selector.needs_all_versions() {
-        collection_versions.get_all_collections().await
+    let versions = if let Some(txn_id) = txn_id_from_headers(&headers)? {
+        state
+            .require_txn_ops()?
+            .get_collections_in_txn(txn_id)
+            .await
     } else {
-        collection_versions.get_active_collections().await
+        // The same branch `refresh_views` makes on the same selector: inactive
+        // versions cost a scan of every stored version, and a selector that
+        // does not ask for them is answerable from the active listing alone.
+        let collection_versions = state.require_collection_versions()?;
+        if selector.needs_all_versions() {
+            collection_versions.get_all_collections().await
+        } else {
+            collection_versions.get_active_collections().await
+        }
     }
     .map_err(http_error_from_backend_message)?;
 

--- a/crates/http/src/handlers/collections_tests.rs
+++ b/crates/http/src/handlers/collections_tests.rs
@@ -34,7 +34,13 @@ fn create_failing_state() -> AppState {
 async fn test_list_collections() {
     let state = create_state();
     let identity = ExtractIdentity::anonymous();
-    let result = list_collections(State(state), identity, CollectionSelectorQuery::default()).await;
+    let result = list_collections(
+        State(state),
+        identity,
+        HeaderMap::new(),
+        CollectionSelectorQuery::default(),
+    )
+    .await;
     assert!(result.is_ok());
     let response = result.unwrap();
     // The listing reads the stored versions, which is what the collection
@@ -46,7 +52,13 @@ async fn test_list_collections() {
 async fn test_list_collections_no_rest() {
     let state = create_state_without_rest();
     let identity = ExtractIdentity::anonymous();
-    let result = list_collections(State(state), identity, CollectionSelectorQuery::default()).await;
+    let result = list_collections(
+        State(state),
+        identity,
+        HeaderMap::new(),
+        CollectionSelectorQuery::default(),
+    )
+    .await;
     assert!(result.is_err());
 }
 
@@ -54,7 +66,13 @@ async fn test_list_collections_no_rest() {
 async fn test_list_collections_error() {
     let state = create_failing_state();
     let identity = ExtractIdentity::anonymous();
-    let result = list_collections(State(state), identity, CollectionSelectorQuery::default()).await;
+    let result = list_collections(
+        State(state),
+        identity,
+        HeaderMap::new(),
+        CollectionSelectorQuery::default(),
+    )
+    .await;
     assert!(result.is_err());
 }
 

--- a/crates/http/tests/collection_selectors.rs
+++ b/crates/http/tests/collection_selectors.rs
@@ -21,7 +21,7 @@ use axum::{
     Router,
 };
 use defra_http::router::{AppStateBuilder, CollectionVersionOperations};
-use defra_http::{MockQueryExecutor, MockRestOperations};
+use defra_http::{MockQueryExecutor, MockRestOperations, MockTransactionOperations};
 use query::rest::RestOperations;
 use schema::CollectionVersion;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -77,6 +77,7 @@ fn router_with(versions: Arc<Versions>) -> Router {
     let state = AppStateBuilder::new(Arc::new(MockQueryExecutor::new()))
         .with_rest(Arc::new(MockRestOperations::new()) as Arc<dyn RestOperations>)
         .with_collection_versions(versions)
+        .with_txn_ops(Arc::new(MockTransactionOperations::new()))
         .build();
     defra_http::create_router_with_state(state)
 }
@@ -90,14 +91,19 @@ fn router_without_versions() -> Router {
 }
 
 async fn get_response(router: Router, query: &str) -> Response {
+    get_response_with_txn(router, query, None).await
+}
+
+async fn get_response_with_txn(router: Router, query: &str, txn_id: Option<&str>) -> Response {
+    let mut request = Request::builder()
+        .uri(format!("/api/v0/collections{query}"))
+        .header(HOST, "localhost:9181");
+    if let Some(txn_id) = txn_id {
+        request = request.header("x-defradb-tx", txn_id);
+    }
+
     router
-        .oneshot(
-            Request::builder()
-                .uri(format!("/api/v0/collections{query}"))
-                .header(HOST, "localhost:9181")
-                .body(Body::empty())
-                .unwrap(),
-        )
+        .oneshot(request.body(Body::empty()).unwrap())
         .await
         .expect("router should respond")
 }
@@ -272,6 +278,18 @@ async fn view_refresh_uses_the_same_json_selector_error() {
     let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
     let error: serde_json::Value = serde_json::from_slice(&body).expect("JSON error body");
     assert!(error["error"].as_str().is_some(), "{error}");
+}
+
+#[tokio::test]
+async fn a_transaction_header_reads_transaction_visible_collections() {
+    assert!(names("?name=MockCollection").await.is_empty());
+
+    let response =
+        get_response_with_txn(router(), "?name=MockCollection", Some("transaction-id")).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&body).expect("JSON body");
+    assert_eq!(body["collections"], serde_json::json!(["MockCollection"]));
 }
 
 /// Go keys the selectors off `Query().Has(..)`, so `?name=` is a name set to

--- a/tools/integration-test/tests/basic/transactions.rs
+++ b/tools/integration-test/tests/basic/transactions.rs
@@ -126,6 +126,58 @@ async fn rust_txn_schema_add_via_header_is_scoped() {
     txn_schema_add_via_header_is_scoped(cluster).await;
 }
 
+async fn txn_collection_listing_via_header_is_scoped(cluster: TestCluster) {
+    let client = cluster.client(0);
+    let api_url = cluster.api_url(0);
+    let tx_id = client.tx_create().expect("tx_create failed");
+    let http_client = reqwest::Client::new();
+
+    let response = http_client
+        .post(format!("{}/api/v0/collections", api_url))
+        .header("x-defradb-tx", &tx_id)
+        .body("type ListedInTxn { name: String }")
+        .send()
+        .await
+        .expect("schema add request failed");
+    assert!(
+        response.status().is_success(),
+        "schema add failed: {}",
+        response.text().await.unwrap_or_default()
+    );
+
+    let in_tx = http_client
+        .get(format!("{}/api/v0/collections?name=ListedInTxn", api_url))
+        .header("x-defradb-tx", &tx_id)
+        .send()
+        .await
+        .expect("transaction collection listing failed");
+    assert!(in_tx.status().is_success());
+    assert!(in_tx
+        .text()
+        .await
+        .expect("transaction collection body")
+        .contains("ListedInTxn"));
+
+    let outside = http_client
+        .get(format!("{}/api/v0/collections?name=ListedInTxn", api_url))
+        .send()
+        .await
+        .expect("outside collection listing failed");
+    assert!(outside.status().is_success());
+    assert!(!outside
+        .text()
+        .await
+        .expect("outside collection body")
+        .contains("ListedInTxn"));
+
+    client.tx_discard(&tx_id).expect("tx_discard failed");
+}
+
+for_each_runtime!(
+    txn_collection_listing_via_header_is_scoped,
+    txn_collection_listing_via_header_is_scoped
+);
+
 async fn concurrent_txn_endpoint_is_not_exposed(cluster: TestCluster) {
     let api_url = cluster.api_url(0);
     let response = reqwest::Client::new()


### PR DESCRIPTION
## Context

This is 3/3 in the collection selector parity stack and depends on #1589. `GET /collections` ignored the transaction header, so collection versions created inside a transaction were not visible through the transaction-scoped API.

## Changes

- honor `x-defradb-tx` when listing collections
- read collection versions through existing transaction operations before applying shared selector rules
- cover transaction-visible collection listing in routed and cross-runtime tests

## Testing

- [x] `cargo test -p defra-http --test collection_selectors`
- [x] `cargo test -p defra-http --lib test_list_collections`
- [x] `cargo clippy -p integration-test --test basic --no-deps -- -D warnings`
- [x] `cargo fmt --all -- --check`

Closes #1583