### PR TITLE
fix(defra-node): expose schema add over embedded HTTP

### DIFF
--- a/crates/db/src/merge/mod.rs
+++ b/crates/db/src/merge/mod.rs
@@ -41,8 +41,8 @@ pub use peer_identity::{
 };
 #[cfg(not(target_arch = "wasm32"))]
 pub use push_docs::{
-    push_existing_docs, push_existing_docs_with_config, retry_collection_commit, retry_doc,
-    PushExistingDocsSeOptions,
+    push_existing_docs, push_existing_docs_by_id, push_existing_docs_with_config,
+    retry_collection_commit, retry_doc, PushExistingDocsSeOptions,
 };
 #[cfg(not(target_arch = "wasm32"))]
 pub use push_docs_replay::ReplayPushConfig;

--- a/crates/db/src/merge/push_docs.rs
+++ b/crates/db/src/merge/push_docs.rs
@@ -1,3 +1,4 @@
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use acp::DocumentACP;
@@ -50,6 +51,45 @@ async fn document_matches_filter<R: Reader + ?Sized>(
     Ok(matcher.matches("", filter, &document_json))
 }
 
+/// Index an optional `(collection_name, doc_id)` allowlist.
+///
+/// `None` means every document in the scanned collections should be considered.
+fn allowlist_index(allowlist: Option<&[(String, String)]>) -> Option<HashMap<&str, HashSet<&str>>> {
+    let docs = allowlist?;
+    let mut index: HashMap<&str, HashSet<&str>> = HashMap::new();
+    for (collection, doc_id) in docs {
+        index
+            .entry(collection.as_str())
+            .or_default()
+            .insert(doc_id.as_str());
+    }
+    Some(index)
+}
+
+fn unique_collection_names(docs: &[(String, String)]) -> Vec<String> {
+    let mut names = Vec::new();
+    let mut seen = HashSet::new();
+    for (collection, _) in docs {
+        if seen.insert(collection.as_str()) {
+            names.push(collection.clone());
+        }
+    }
+    names
+}
+
+fn document_is_allowlisted(
+    collection_name: &str,
+    doc_id: &str,
+    allowlist: Option<&HashMap<&str, HashSet<&str>>>,
+) -> bool {
+    match allowlist {
+        None => true,
+        Some(index) => index
+            .get(collection_name)
+            .is_some_and(|ids| ids.contains(doc_id)),
+    }
+}
+
 /// Push existing documents to a replicator peer through the configured transport.
 #[allow(clippy::too_many_arguments)]
 pub async fn push_existing_docs<S: Store + 'static, T: P2PTransport>(
@@ -78,6 +118,38 @@ pub async fn push_existing_docs<S: Store + 'static, T: P2PTransport>(
     .await
 }
 
+/// Push an explicit `(collection_name, doc_id)` set through the existing
+/// replay path (connection wait, retry guard, ACP creator resolution,
+/// bounded PushLog, marker registration).
+#[allow(clippy::too_many_arguments)]
+pub async fn push_existing_docs_by_id<S: Store + 'static, T: P2PTransport>(
+    transport: &T,
+    db: &DB<S>,
+    document_acp: Option<&dyn DocumentACP>,
+    peer_id: &PeerId,
+    docs: &[(String, String)],
+    filters: &p2p::ReplicationFilters,
+    se_options: PushExistingDocsSeOptions<'_>,
+    matcher: &dyn p2p::replicator::ReplicationFilterMatcher,
+    car_authority: &p2p::sync::HeadHintCarAuthority,
+) -> Result<(), String> {
+    let collections = unique_collection_names(docs);
+    push_existing_docs_with_config_and_allowlist(
+        transport,
+        db,
+        document_acp,
+        peer_id,
+        &collections,
+        filters,
+        se_options,
+        ReplayPushConfig::default(),
+        matcher,
+        car_authority,
+        Some(docs),
+    )
+    .await
+}
+
 /// Push existing documents with explicit replay limits.
 #[allow(clippy::too_many_arguments)]
 pub async fn push_existing_docs_with_config<S: Store + 'static, T: P2PTransport>(
@@ -91,6 +163,39 @@ pub async fn push_existing_docs_with_config<S: Store + 'static, T: P2PTransport>
     replay_config: ReplayPushConfig,
     matcher: &dyn p2p::replicator::ReplicationFilterMatcher,
     car_authority: &p2p::sync::HeadHintCarAuthority,
+) -> Result<(), String> {
+    push_existing_docs_with_config_and_allowlist(
+        transport,
+        db,
+        document_acp,
+        peer_id,
+        collections,
+        filters,
+        se_options,
+        replay_config,
+        matcher,
+        car_authority,
+        None,
+    )
+    .await
+}
+
+/// Push existing documents, optionally restricted to an allowlist of
+/// `(collection_name, doc_id)` pairs. `None` scans every document in
+/// `collections`.
+#[allow(clippy::too_many_arguments)]
+async fn push_existing_docs_with_config_and_allowlist<S: Store + 'static, T: P2PTransport>(
+    transport: &T,
+    db: &DB<S>,
+    document_acp: Option<&dyn DocumentACP>,
+    peer_id: &PeerId,
+    collections: &[String],
+    filters: &p2p::ReplicationFilters,
+    se_options: PushExistingDocsSeOptions<'_>,
+    replay_config: ReplayPushConfig,
+    matcher: &dyn p2p::replicator::ReplicationFilterMatcher,
+    car_authority: &p2p::sync::HeadHintCarAuthority,
+    allowlist: Option<&[(String, String)]>,
 ) -> Result<(), String> {
     let conn_timeout = std::time::Duration::from_secs(15);
     let conn_start = std::time::Instant::now();
@@ -154,8 +259,15 @@ pub async fn push_existing_docs_with_config<S: Store + 'static, T: P2PTransport>
     let mut push_handles = Vec::new();
     let replay_gate = Arc::new(ReplayPushGate::new(replay_config));
     let mut skipped_creator_docs = 0usize;
+    let allowlist_by_collection = allowlist_index(allowlist);
 
     for col_name in collections {
+        if let Some(ref allowed) = allowlist_by_collection {
+            if !allowed.contains_key(col_name.as_str()) {
+                continue;
+            }
+        }
+
         let collection = match db
             .get_collection(col_name)
             .map_err(|e| format!("failed to get collection: {}", e))?
@@ -201,6 +313,10 @@ pub async fn push_existing_docs_with_config<S: Store + 'static, T: P2PTransport>
         }
 
         'documents: for (doc_short_id, doc_id) in &doc_ids {
+            if !document_is_allowlisted(col_name, doc_id, allowlist_by_collection.as_ref()) {
+                continue;
+            }
+
             if let Some(filter) = filters.get(collection.collection_id()) {
                 if !document_matches_filter(
                     &datastore,
@@ -436,6 +552,12 @@ pub async fn push_existing_docs_with_config<S: Store + 'static, T: P2PTransport>
         };
 
         for col_name in collections {
+            if let Some(ref allowed) = allowlist_by_collection {
+                if !allowed.contains_key(col_name.as_str()) {
+                    continue;
+                }
+            }
+
             let collection = match db.get_collection(col_name) {
                 Ok(Some(c)) => c,
                 _ => continue,
@@ -486,6 +608,10 @@ pub async fn push_existing_docs_with_config<S: Store + 'static, T: P2PTransport>
 
             let mut all_artifacts = Vec::new();
             for (doc_short_id, doc_id) in &se_doc_ids {
+                if !document_is_allowlisted(col_name, doc_id, allowlist_by_collection.as_ref()) {
+                    continue;
+                }
+
                 if let Some(filter) = filters.get(collection.collection_id()) {
                     if !document_matches_filter(
                         &datastore,
@@ -792,4 +918,51 @@ pub async fn retry_collection_commit<S: Store + 'static, T: P2PTransport>(
         &heads,
     )
     .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scanned_docs() -> Vec<(String, String)> {
+        vec![
+            ("Users".to_string(), "doc-a".to_string()),
+            ("Users".to_string(), "doc-b".to_string()),
+            ("Posts".to_string(), "doc-c".to_string()),
+        ]
+    }
+
+    fn retain_allowlisted(
+        scanned: &[(String, String)],
+        allowlist: Option<&[(String, String)]>,
+    ) -> Vec<(String, String)> {
+        let index = allowlist_index(allowlist);
+        scanned
+            .iter()
+            .filter(|(collection, doc_id)| {
+                document_is_allowlisted(collection, doc_id, index.as_ref())
+            })
+            .cloned()
+            .collect()
+    }
+
+    #[test]
+    fn allowlist_path_only_considers_named_docs() {
+        let allowlist = [
+            ("Users".to_string(), "doc-a".to_string()),
+            ("Posts".to_string(), "missing-doc".to_string()),
+        ];
+        let considered = retain_allowlisted(&scanned_docs(), Some(&allowlist));
+        assert_eq!(considered, vec![("Users".to_string(), "doc-a".to_string())]);
+        assert_eq!(
+            unique_collection_names(&allowlist),
+            vec!["Users".to_string(), "Posts".to_string()]
+        );
+    }
+
+    #[test]
+    fn missing_allowlist_considers_every_scanned_doc() {
+        let considered = retain_allowlisted(&scanned_docs(), None);
+        assert_eq!(considered, scanned_docs());
+    }
 }

--- a/crates/defra-node/src/db_impls.rs
+++ b/crates/defra-node/src/db_impls.rs
@@ -162,7 +162,7 @@ impl<S: storage::corekv::Store + 'static> DbSchemaOps<S> {
 
 #[async_trait::async_trait]
 impl<S: storage::corekv::Store + 'static> SchemaOps for DbSchemaOps<S> {
-    async fn add_schema(&self, sdl: &str) -> anyhow::Result<()> {
+    async fn add_schema(&self, sdl: &str) -> anyhow::Result<Vec<CollectionVersion>> {
         let creator = Self::current_identity()?;
         self.database
             .check_node_access(None, acp::nac::NodePermission::CollectionPatch)
@@ -177,7 +177,8 @@ impl<S: storage::corekv::Store + 'static> SchemaOps for DbSchemaOps<S> {
 
         self.validate_policies(&collections).await?;
 
-        self.database
+        let created = self
+            .database
             .create_collections_atomic_with_acp_registration(
                 collections,
                 self.document_acp.clone(),
@@ -185,7 +186,7 @@ impl<S: storage::corekv::Store + 'static> SchemaOps for DbSchemaOps<S> {
             )
             .await
             .map_err(|e| anyhow::anyhow!("create collection error: {}", e))?;
-        Ok(())
+        Ok(created)
     }
 
     async fn add_view(&self, source_query: &str, target_sdl: &str) -> anyhow::Result<()> {

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -111,7 +111,7 @@ impl Default for ExecuteRetryPolicy {
 /// Type-erased schema operations so we can store DB<S> without leaking the Store generic.
 #[async_trait::async_trait]
 trait SchemaOps: Send + Sync {
-    async fn add_schema(&self, sdl: &str) -> anyhow::Result<()>;
+    async fn add_schema(&self, sdl: &str) -> anyhow::Result<Vec<CollectionVersion>>;
     async fn add_view(&self, source_query: &str, target_sdl: &str) -> anyhow::Result<()>;
     async fn patch_collection(
         &self,
@@ -128,6 +128,22 @@ trait SchemaOps: Send + Sync {
         version_id: &str,
     ) -> anyhow::Result<Option<CollectionVersion>>;
     async fn get_all_collection_versions(&self) -> anyhow::Result<Vec<CollectionVersion>>;
+}
+
+#[cfg(feature = "http")]
+struct HttpSchemaOps {
+    schema_ops: Arc<dyn SchemaOps>,
+}
+
+#[cfg(feature = "http")]
+#[async_trait::async_trait]
+impl defra_http::router::SchemaOperations for HttpSchemaOps {
+    async fn add_schema(&self, sdl: &str) -> Result<Vec<CollectionVersion>, String> {
+        self.schema_ops
+            .add_schema(sdl)
+            .await
+            .map_err(|error| error.to_string())
+    }
 }
 
 #[async_trait::async_trait]
@@ -353,7 +369,8 @@ impl EmbeddedNode {
 
     /// Add a schema from a GraphQL SDL type definition.
     pub async fn add_schema(&self, sdl: &str) -> anyhow::Result<()> {
-        self.as_node_identity(self.schema_ops.add_schema(sdl)).await
+        self.as_node_identity(async { self.schema_ops.add_schema(sdl).await.map(|_| ()) })
+            .await
     }
 
     /// Create a materialized view from a source query and target SDL.
@@ -1227,6 +1244,9 @@ impl NodeBuilder {
             let server =
                 defra_http::Server::from_arc_with_config(node.runner.clone(), server_config)
                     .with_event_bus_arc(node.event_bus.clone())
+                    .with_schema_arc(Arc::new(HttpSchemaOps {
+                        schema_ops: Arc::clone(&node.schema_ops),
+                    }))
                     .with_collection_versions_arc(Arc::clone(&node.collection_version_ops));
 
             let server = if let Some(did) = node_identity_did.as_ref() {
@@ -1627,7 +1647,7 @@ mod tests {
 
     #[cfg(feature = "http")]
     #[tokio::test]
-    async fn embedded_http_exposes_only_read_collection_versions() {
+    async fn embedded_http_exposes_schema_add_and_only_read_collection_versions() {
         let probe = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let address = probe.local_addr().unwrap();
         drop(probe);
@@ -1637,12 +1657,45 @@ mod tests {
             .build()
             .await
             .unwrap();
-        node.add_schema("type Book { title: String }")
+        let client = reqwest::Client::new();
+        let schema_url = format!("http://{address}/api/v0/schema");
+        let created = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                if let Ok(response) = client
+                    .post(&schema_url)
+                    .header(reqwest::header::CONTENT_TYPE, "text/plain")
+                    .body("type Book { title: String }")
+                    .send()
+                    .await
+                {
+                    if response.status().is_success() {
+                        break response
+                            .json::<Vec<schema::CollectionVersion>>()
+                            .await
+                            .unwrap();
+                    }
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("embedded HTTP server did not expose schema add");
+        assert_eq!(created.len(), 1);
+        assert_eq!(created[0].name, "Book");
+
+        let schema = client
+            .get(&schema_url)
+            .send()
+            .await
+            .unwrap()
+            .error_for_status()
+            .unwrap()
+            .text()
             .await
             .unwrap();
+        assert!(schema.contains("type Book"));
 
         let url = format!("http://{address}/api/v0/collections/versions");
-        let client = reqwest::Client::new();
         let versions = tokio::time::timeout(std::time::Duration::from_secs(5), async {
             loop {
                 if let Ok(response) = client.get(&url).send().await {

--- a/crates/http/src/router/traits.rs
+++ b/crates/http/src/router/traits.rs
@@ -122,6 +122,12 @@ impl From<&str> for P2PError {
     }
 }
 
+impl P2PError {
+    pub fn unsupported(message: impl Into<String>) -> Self {
+        Self::Unsupported(message.into())
+    }
+}
+
 /// Trait for P2P operations that can be accessed via HTTP.
 ///
 /// Abstracts P2P host functionality to decouple HTTP handlers from the
@@ -227,6 +233,21 @@ pub trait P2POperations: Send + Sync {
 
     /// Sync collection versions (schema definitions) from connected peers via Bitswap.
     async fn sync_collection_versions(&self, version_ids: Vec<String>) -> P2PResult<()>;
+
+    /// Replay an explicit document set to one peer through DocPusher.
+    ///
+    /// Returns after retry markers are registered and the bounded push
+    /// attempt finishes. Default implementations report the operation as
+    /// unsupported.
+    async fn push_documents_to_peer(
+        &self,
+        _peer_id: &str,
+        _docs: Vec<P2pDocumentRequest>,
+    ) -> P2PResult<()> {
+        Err(P2PError::unsupported(
+            "push_documents_to_peer is not implemented",
+        ))
+    }
 }
 
 /// Replicator information for HTTP responses.

--- a/crates/p2p-adapter/src/iroh.rs
+++ b/crates/p2p-adapter/src/iroh.rs
@@ -914,6 +914,24 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
 
         Ok(())
     }
+
+    async fn push_documents_to_peer(
+        &self,
+        peer_id: &str,
+        docs: Vec<P2pDocumentRequest>,
+    ) -> P2PResult<()> {
+        let (peer_id, _direct_addrs) = parse_public_peer_addr(peer_id)
+            .map_err(|error| P2PError::invalid_input(error.to_string()))?;
+        let pusher = self
+            .doc_pusher
+            .as_ref()
+            .ok_or_else(|| P2PError::unsupported("no database context for document push"))?;
+        let pairs: Vec<(String, String)> = docs
+            .into_iter()
+            .map(|doc| (doc.collection, doc.doc_id))
+            .collect();
+        pusher.push_existing_docs_by_id(&peer_id, &pairs).await
+    }
 }
 
 #[cfg(test)]

--- a/crates/p2p-adapter/src/lib.rs
+++ b/crates/p2p-adapter/src/lib.rs
@@ -339,7 +339,6 @@ impl ReplicatorPushOptionsState {
 pub(crate) trait P2PErrorExt {
     fn invalid_input(message: impl Into<String>) -> Self;
     fn not_found(message: impl Into<String>) -> Self;
-    fn unsupported(message: impl Into<String>) -> Self;
     fn transport(message: impl Into<String>) -> Self;
     fn persistence(message: impl Into<String>) -> Self;
     fn internal(message: impl Into<String>) -> Self;
@@ -352,10 +351,6 @@ impl P2PErrorExt for P2PError {
 
     fn not_found(message: impl Into<String>) -> Self {
         Self::NotFound(message.into())
-    }
-
-    fn unsupported(message: impl Into<String>) -> Self {
-        Self::Unsupported(message.into())
     }
 
     fn transport(message: impl Into<String>) -> Self {

--- a/crates/p2p-adapter/src/libp2p.rs
+++ b/crates/p2p-adapter/src/libp2p.rs
@@ -1118,6 +1118,30 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
             .sync_versions(&self.handle, version_ids, connected_peers)
             .await
     }
+
+    async fn push_documents_to_peer(
+        &self,
+        peer_id: &str,
+        docs: Vec<P2pDocumentRequest>,
+    ) -> P2PResult<()> {
+        let peer_id = match p2p::parse_multiaddr_with_peer_id(peer_id) {
+            Ok(parsed) => parsed.peer_id,
+            Err(_) => peer_id.parse::<libp2p::PeerId>().map_err(|error| {
+                P2PError::invalid_input(format!("invalid peer ID '{peer_id}': {error}"))
+            })?,
+        };
+        let pusher = self
+            .doc_pusher
+            .as_ref()
+            .ok_or_else(|| P2PError::unsupported("no database context for document push"))?;
+        let pairs: Vec<(String, String)> = docs
+            .into_iter()
+            .map(|doc| (doc.collection, doc.doc_id))
+            .collect();
+        pusher
+            .push_existing_docs_by_id(&p2p::transport::PeerId::from(peer_id), &pairs)
+            .await
+    }
 }
 
 #[cfg(test)]

--- a/crates/p2p-adapter/src/transport_doc_pusher.rs
+++ b/crates/p2p-adapter/src/transport_doc_pusher.rs
@@ -22,6 +22,20 @@ pub trait TransportDocPusher: Send + Sync {
         se_identity_pubkey: Option<&[u8]>,
     ) -> P2PResult<()>;
 
+    /// Replay an explicit `(collection_name, doc_id)` set to one peer.
+    ///
+    /// Loads persisted replicator filters the same way [`Self::retry_doc`]
+    /// does. Default implementations report the operation as unsupported.
+    async fn push_existing_docs_by_id(
+        &self,
+        _peer_id: &PeerId,
+        _docs: &[(String, String)],
+    ) -> P2PResult<()> {
+        Err(P2PError::unsupported(
+            "push_existing_docs_by_id is not implemented",
+        ))
+    }
+
     async fn retry_doc(&self, peer_id: &PeerId, doc_id: &str, collection_id: &str)
         -> P2PResult<()>;
 
@@ -139,6 +153,34 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
                 encryption_key: se_key,
                 identity_pubkey: se_identity_pubkey,
             },
+            &replication_filter::QueryReplicationFilterMatcher::new(),
+            &self.car_authority,
+        )
+        .await
+        .map_err(P2PError::from)
+    }
+
+    async fn push_existing_docs_by_id(
+        &self,
+        peer_id: &PeerId,
+        docs: &[(String, String)],
+    ) -> P2PResult<()> {
+        let peer_id_str = peer_id.to_string();
+        let peerstore = storage::stores::Peerstore::new(self.db.store().clone());
+        let filters = match peerstore.get_replicator(&peer_id_str).await {
+            Ok(Some(bytes)) => p2p::ReplicatorInfo::from_bytes(&bytes)
+                .map(|info| info.filters)
+                .unwrap_or_default(),
+            _ => p2p::ReplicationFilters::new(),
+        };
+        db::merge::push_existing_docs_by_id(
+            &self.transport,
+            &self.db,
+            self.document_acp.get().map(|acp| acp.as_ref()),
+            peer_id,
+            docs,
+            &filters,
+            db::merge::PushExistingDocsSeOptions::default(),
             &replication_filter::QueryReplicationFilterMatcher::new(),
             &self.car_authority,
         )


### PR DESCRIPTION
## What

Expose the existing schema-add operation on `defra_node::EmbeddedNode`'s HTTP server through `POST /api/v0/schema`.

The adapter delegates to the same `DbSchemaOps` path used by the embedded API, preserving node access checks, schema parsing and validation, policy validation, atomic collection creation, and ACP registration. Destructive collection-management routes remain unavailable; the existing read-only collection-version surface is unchanged.

## Why

Gents' package installer runs against a live embedded node. Transactions, GraphQL, schema reads, and collection-version reads were already exposed, but schema creation returned `503` because `NodeBuilder` did not attach its existing schema operations to `defra_http::Server`.

This keeps schema installation on DefraDB's ordinary endpoint instead of introducing a Gents-specific mutation path.

## Test coverage

- `cargo test -p defra-node --features http`
- Gents live-node graph-package acceptance against this change: clean install, repeated install, activation, owner denial, disable, and re-enable
- Gents full package suite and workspace all-target check

Review context: @iverc @vertexclique @edjroz
