### PR TITLE
fix(query): scope cid: queries to the queried collection (#1604)

### DIFF
--- a/crates/db/src/read/autocommit/mod.rs
+++ b/crates/db/src/read/autocommit/mod.rs
@@ -384,7 +384,7 @@ impl<S: Store + 'static> DocFetcher for AutoCommitFetcher<S> {
 
     async fn get_documents_at_cid(
         &self,
-        collection_name: &str,
+        collection_short_id: u32,
         cid: &str,
         expected_doc_id: Option<&str>,
         caller_identity: Option<&identity::Did>,
@@ -395,25 +395,12 @@ impl<S: Store + 'static> DocFetcher for AutoCommitFetcher<S> {
 
         let txn_holder: Arc<TokioMutex<Option<DbTxn<S>>>> = Arc::new(TokioMutex::new(Some(txn)));
 
-        let collection =
-            crate::collection::loader::get_collection_with_lazy_load(&txn_holder, collection_name)
-                .await
-                .map(|(collection, _, _)| collection);
-
-        let result = match collection {
-            Ok(collection) => {
-                let versioned_fetcher = VersionedFetcher::with_kms(
-                    txn_holder.clone(),
-                    self.db.kms(),
-                    caller_identity.cloned(),
-                );
-                versioned_fetcher
-                    .get_documents_at_cid(cid, expected_doc_id, Some(collection.resolved_root_id()))
-                    .await
-                    .map_err(|e| query::error::QueryError::execution(e.to_string()))
-            }
-            Err(e) => Err(e),
-        };
+        let versioned_fetcher =
+            VersionedFetcher::with_kms(txn_holder.clone(), self.db.kms(), caller_identity.cloned());
+        let result = versioned_fetcher
+            .get_documents_at_cid(cid, expected_doc_id, Some(collection_short_id))
+            .await
+            .map_err(|e| query::error::QueryError::execution(e.to_string()));
 
         if let Some(txn) = txn_holder.lock().await.take() {
             let _ = txn.discard();

--- a/crates/db/src/read/autocommit/mod.rs
+++ b/crates/db/src/read/autocommit/mod.rs
@@ -384,6 +384,7 @@ impl<S: Store + 'static> DocFetcher for AutoCommitFetcher<S> {
 
     async fn get_documents_at_cid(
         &self,
+        collection_name: &str,
         cid: &str,
         expected_doc_id: Option<&str>,
         caller_identity: Option<&identity::Did>,
@@ -394,12 +395,25 @@ impl<S: Store + 'static> DocFetcher for AutoCommitFetcher<S> {
 
         let txn_holder: Arc<TokioMutex<Option<DbTxn<S>>>> = Arc::new(TokioMutex::new(Some(txn)));
 
-        let versioned_fetcher =
-            VersionedFetcher::with_kms(txn_holder.clone(), self.db.kms(), caller_identity.cloned());
-        let result = versioned_fetcher
-            .get_documents_at_cid(cid, expected_doc_id)
-            .await
-            .map_err(|e| query::error::QueryError::execution(e.to_string()));
+        let collection =
+            crate::collection::loader::get_collection_with_lazy_load(&txn_holder, collection_name)
+                .await
+                .map(|(collection, _, _)| collection);
+
+        let result = match collection {
+            Ok(collection) => {
+                let versioned_fetcher = VersionedFetcher::with_kms(
+                    txn_holder.clone(),
+                    self.db.kms(),
+                    caller_identity.cloned(),
+                );
+                versioned_fetcher
+                    .get_documents_at_cid(cid, expected_doc_id, Some(collection.resolved_root_id()))
+                    .await
+                    .map_err(|e| query::error::QueryError::execution(e.to_string()))
+            }
+            Err(e) => Err(e),
+        };
 
         if let Some(txn) = txn_holder.lock().await.take() {
             let _ = txn.discard();

--- a/crates/db/src/read/doc.rs
+++ b/crates/db/src/read/doc.rs
@@ -542,15 +542,14 @@ impl<S: Store + 'static> DocFetcher for DbDocFetcher<S> {
 
     async fn get_documents_at_cid(
         &self,
-        collection_name: &str,
+        collection_short_id: u32,
         cid: &str,
         expected_doc_id: Option<&str>,
         _caller_identity: Option<&identity::Did>,
     ) -> query::error::Result<Vec<Document>> {
-        let (collection, _, _) = get_collection_with_lazy_load(&self.txn, collection_name).await?;
         let versioned_fetcher = VersionedFetcher::new(self.txn.clone());
         versioned_fetcher
-            .get_documents_at_cid(cid, expected_doc_id, Some(collection.resolved_root_id()))
+            .get_documents_at_cid(cid, expected_doc_id, Some(collection_short_id))
             .await
             .map_err(|e| query::error::QueryError::execution(e.to_string()))
     }

--- a/crates/db/src/read/doc.rs
+++ b/crates/db/src/read/doc.rs
@@ -542,13 +542,15 @@ impl<S: Store + 'static> DocFetcher for DbDocFetcher<S> {
 
     async fn get_documents_at_cid(
         &self,
+        collection_name: &str,
         cid: &str,
         expected_doc_id: Option<&str>,
         _caller_identity: Option<&identity::Did>,
     ) -> query::error::Result<Vec<Document>> {
+        let (collection, _, _) = get_collection_with_lazy_load(&self.txn, collection_name).await?;
         let versioned_fetcher = VersionedFetcher::new(self.txn.clone());
         versioned_fetcher
-            .get_documents_at_cid(cid, expected_doc_id)
+            .get_documents_at_cid(cid, expected_doc_id, Some(collection.resolved_root_id()))
             .await
             .map_err(|e| query::error::QueryError::execution(e.to_string()))
     }

--- a/crates/db/src/read/lensed/autocommit/fetch.rs
+++ b/crates/db/src/read/lensed/autocommit/fetch.rs
@@ -411,6 +411,7 @@ impl<S: Store + 'static> LensedAutoCommitFetcher<S> {
 
     pub(super) async fn get_documents_at_cid_impl(
         &self,
+        collection_name: &str,
         cid: &str,
         expected_doc_id: Option<&str>,
         caller_identity: Option<&identity::Did>,
@@ -422,12 +423,25 @@ impl<S: Store + 'static> LensedAutoCommitFetcher<S> {
         let txn_holder: std::sync::Arc<TokioMutex<Option<DbTxn<S>>>> =
             std::sync::Arc::new(TokioMutex::new(Some(txn)));
 
-        let versioned_fetcher =
-            VersionedFetcher::with_kms(txn_holder.clone(), self.db.kms(), caller_identity.cloned());
-        let result = versioned_fetcher
-            .get_documents_at_cid(cid, expected_doc_id)
-            .await
-            .map_err(|e| query::error::QueryError::execution(e.to_string()));
+        let collection =
+            crate::collection::loader::get_collection_with_lazy_load(&txn_holder, collection_name)
+                .await
+                .map(|(collection, _, _)| collection);
+
+        let result = match collection {
+            Ok(collection) => {
+                let versioned_fetcher = VersionedFetcher::with_kms(
+                    txn_holder.clone(),
+                    self.db.kms(),
+                    caller_identity.cloned(),
+                );
+                versioned_fetcher
+                    .get_documents_at_cid(cid, expected_doc_id, Some(collection.resolved_root_id()))
+                    .await
+                    .map_err(|e| query::error::QueryError::execution(e.to_string()))
+            }
+            Err(e) => Err(e),
+        };
 
         if let Some(txn) = txn_holder.lock().await.take() {
             let _ = txn.discard();

--- a/crates/db/src/read/lensed/autocommit/fetch.rs
+++ b/crates/db/src/read/lensed/autocommit/fetch.rs
@@ -411,7 +411,7 @@ impl<S: Store + 'static> LensedAutoCommitFetcher<S> {
 
     pub(super) async fn get_documents_at_cid_impl(
         &self,
-        collection_name: &str,
+        collection_short_id: u32,
         cid: &str,
         expected_doc_id: Option<&str>,
         caller_identity: Option<&identity::Did>,
@@ -423,25 +423,12 @@ impl<S: Store + 'static> LensedAutoCommitFetcher<S> {
         let txn_holder: std::sync::Arc<TokioMutex<Option<DbTxn<S>>>> =
             std::sync::Arc::new(TokioMutex::new(Some(txn)));
 
-        let collection =
-            crate::collection::loader::get_collection_with_lazy_load(&txn_holder, collection_name)
-                .await
-                .map(|(collection, _, _)| collection);
-
-        let result = match collection {
-            Ok(collection) => {
-                let versioned_fetcher = VersionedFetcher::with_kms(
-                    txn_holder.clone(),
-                    self.db.kms(),
-                    caller_identity.cloned(),
-                );
-                versioned_fetcher
-                    .get_documents_at_cid(cid, expected_doc_id, Some(collection.resolved_root_id()))
-                    .await
-                    .map_err(|e| query::error::QueryError::execution(e.to_string()))
-            }
-            Err(e) => Err(e),
-        };
+        let versioned_fetcher =
+            VersionedFetcher::with_kms(txn_holder.clone(), self.db.kms(), caller_identity.cloned());
+        let result = versioned_fetcher
+            .get_documents_at_cid(cid, expected_doc_id, Some(collection_short_id))
+            .await
+            .map_err(|e| query::error::QueryError::execution(e.to_string()));
 
         if let Some(txn) = txn_holder.lock().await.take() {
             let _ = txn.discard();

--- a/crates/db/src/read/lensed/autocommit/mod.rs
+++ b/crates/db/src/read/lensed/autocommit/mod.rs
@@ -182,12 +182,12 @@ impl<S: Store + 'static> DocFetcher for LensedAutoCommitFetcher<S> {
 
     async fn get_documents_at_cid(
         &self,
-        collection_name: &str,
+        collection_short_id: u32,
         cid: &str,
         expected_doc_id: Option<&str>,
         caller_identity: Option<&identity::Did>,
     ) -> query::error::Result<Vec<Document>> {
-        self.get_documents_at_cid_impl(collection_name, cid, expected_doc_id, caller_identity)
+        self.get_documents_at_cid_impl(collection_short_id, cid, expected_doc_id, caller_identity)
             .await
     }
 

--- a/crates/db/src/read/lensed/autocommit/mod.rs
+++ b/crates/db/src/read/lensed/autocommit/mod.rs
@@ -182,11 +182,12 @@ impl<S: Store + 'static> DocFetcher for LensedAutoCommitFetcher<S> {
 
     async fn get_documents_at_cid(
         &self,
+        collection_name: &str,
         cid: &str,
         expected_doc_id: Option<&str>,
         caller_identity: Option<&identity::Did>,
     ) -> query::error::Result<Vec<Document>> {
-        self.get_documents_at_cid_impl(cid, expected_doc_id, caller_identity)
+        self.get_documents_at_cid_impl(collection_name, cid, expected_doc_id, caller_identity)
             .await
     }
 

--- a/crates/db/src/read/lensed/fetcher/mod.rs
+++ b/crates/db/src/read/lensed/fetcher/mod.rs
@@ -351,16 +351,20 @@ impl<S: Store + 'static> DocFetcher for LensedDocFetcher<S> {
 
     async fn get_documents_at_cid(
         &self,
+        collection_name: &str,
         cid: &str,
         expected_doc_id: Option<&str>,
         caller_identity: Option<&identity::Did>,
     ) -> query::error::Result<Vec<Document>> {
         use crate::read::versioned::VersionedFetcher;
 
+        let (collection, _, _) =
+            crate::collection::loader::get_collection_with_lazy_load(&self.txn, collection_name)
+                .await?;
         let versioned_fetcher =
             VersionedFetcher::with_kms(self.txn.clone(), self.db.kms(), caller_identity.cloned());
         versioned_fetcher
-            .get_documents_at_cid(cid, expected_doc_id)
+            .get_documents_at_cid(cid, expected_doc_id, Some(collection.resolved_root_id()))
             .await
             .map_err(|e| query::error::QueryError::execution(e.to_string()))
     }

--- a/crates/db/src/read/lensed/fetcher/mod.rs
+++ b/crates/db/src/read/lensed/fetcher/mod.rs
@@ -351,20 +351,17 @@ impl<S: Store + 'static> DocFetcher for LensedDocFetcher<S> {
 
     async fn get_documents_at_cid(
         &self,
-        collection_name: &str,
+        collection_short_id: u32,
         cid: &str,
         expected_doc_id: Option<&str>,
         caller_identity: Option<&identity::Did>,
     ) -> query::error::Result<Vec<Document>> {
         use crate::read::versioned::VersionedFetcher;
 
-        let (collection, _, _) =
-            crate::collection::loader::get_collection_with_lazy_load(&self.txn, collection_name)
-                .await?;
         let versioned_fetcher =
             VersionedFetcher::with_kms(self.txn.clone(), self.db.kms(), caller_identity.cloned());
         versioned_fetcher
-            .get_documents_at_cid(cid, expected_doc_id, Some(collection.resolved_root_id()))
+            .get_documents_at_cid(cid, expected_doc_id, Some(collection_short_id))
             .await
             .map_err(|e| query::error::QueryError::execution(e.to_string()))
     }

--- a/crates/db/src/read/versioned.rs
+++ b/crates/db/src/read/versioned.rs
@@ -60,7 +60,9 @@ impl<S: Store> VersionedFetcher<S> {
         cid_str: &str,
         expected_doc_id: Option<&str>,
     ) -> Result<Document> {
-        let docs = self.get_documents_at_cid(cid_str, expected_doc_id).await?;
+        let docs = self
+            .get_documents_at_cid(cid_str, expected_doc_id, None)
+            .await?;
         docs.into_iter().next().ok_or_else(|| {
             Error::Serialization("cid either does not exist or belong to document".to_string())
         })
@@ -71,10 +73,15 @@ impl<S: Store> VersionedFetcher<S> {
     /// For document-level CIDs, returns a single document.
     /// For collection-level CIDs (branchable collections), walks the collection DAG
     /// and returns all documents visible at that collection state.
+    ///
+    /// If `collection_short_id` is provided, documents belonging to another
+    /// collection are dropped before reconstruction (Go parity: a foreign
+    /// collection's commit CID yields an empty result, never a foreign row).
     pub async fn get_documents_at_cid(
         &self,
         cid_str: &str,
         expected_doc_id: Option<&str>,
+        collection_short_id: Option<u32>,
     ) -> Result<Vec<Document>> {
         let mut guard = self.txn.lock().await;
         let txn = guard.as_mut().ok_or(Error::TxnNotActive)?;
@@ -88,7 +95,12 @@ impl<S: Store> VersionedFetcher<S> {
         // Check if this is a collection block (branchable collection CID)
         if matches!(&target_block.delta, CrdtDelta::Collection(_)) {
             return self
-                .get_documents_at_collection_cid(txn, &target_cid, &target_block)
+                .get_documents_at_collection_cid(
+                    txn,
+                    &target_cid,
+                    &target_block,
+                    collection_short_id,
+                )
                 .await;
         }
 
@@ -113,6 +125,28 @@ impl<S: Store> VersionedFetcher<S> {
             ));
         } else {
             owners
+        };
+
+        // Collection membership gate, before ACP and reconstruction
+        // (Go parity: GetDocShortID + noResults in planner/select.go).
+        let selected_owners = match collection_short_id {
+            Some(col_short_id) => {
+                let systemstore = txn.systemstore()?;
+                let mut members = Vec::with_capacity(selected_owners.len());
+                for owner in selected_owners {
+                    if crate::docid::map::get_doc_short_id(&systemstore, col_short_id, &owner)
+                        .await?
+                        .is_some()
+                    {
+                        members.push(owner);
+                    }
+                }
+                if members.is_empty() {
+                    return Ok(Vec::new());
+                }
+                members
+            }
+            None => selected_owners,
         };
 
         // Collect all blocks from target CID back to genesis
@@ -140,6 +174,7 @@ impl<S: Store> VersionedFetcher<S> {
         txn: &mut DbTxn<S>,
         start_cid: &Cid,
         start_block: &Block,
+        collection_short_id: Option<u32>,
     ) -> Result<Vec<Document>> {
         // Walk the collection DAG backwards to find all document composite CIDs.
         // Each collection block links to one document composite block.
@@ -163,6 +198,19 @@ impl<S: Store> VersionedFetcher<S> {
                             .await?
                             .and_then(|owners| owners.into_iter().next())
                         {
+                            if let Some(col_short_id) = collection_short_id {
+                                let systemstore = txn.systemstore()?;
+                                if crate::docid::map::get_doc_short_id(
+                                    &systemstore,
+                                    col_short_id,
+                                    &doc_id,
+                                )
+                                .await?
+                                .is_none()
+                                {
+                                    continue;
+                                }
+                            }
                             let priority = doc_block.delta.priority();
                             match doc_composites.get(&doc_id) {
                                 None => {
@@ -227,10 +275,14 @@ impl<S: Store> VersionedFetcher<S> {
     /// Parse a CID string, returning appropriate errors for invalid/unknown CIDs.
     fn parse_cid(cid_str: &str) -> Result<Cid> {
         Cid::from_str(cid_str).map_err(|_e| {
-            // Go's CID library is more lenient. If it looks like a valid CIDv1
-            // format, treat as "not found" rather than "invalid".
+            // Go's CID library is more lenient: a CIDv1-shaped string decodes
+            // and then misses in the blockstore, so surface the blockstore
+            // miss (an error the runner propagates) rather than the
+            // does-not-exist string it swallows as an empty result.
             if Self::looks_like_cidv1(cid_str) {
-                Error::Serialization("cid either does not exist or belong to document".to_string())
+                Error::Serialization(
+                    "seek failed: (version fetcher) failed to get block in blockstore: ipld: could not find".to_string(),
+                )
             } else {
                 Error::Serialization("invalid cid: selected encoding not supported".to_string())
             }

--- a/crates/db/src/read/versioned.rs
+++ b/crates/db/src/read/versioned.rs
@@ -17,6 +17,9 @@ use storage::corekv::Store;
 use crate::error::{Error, Result};
 use crate::txn::DbTxn;
 
+const BLOCK_NOT_FOUND: &str =
+    "seek failed: (version fetcher) failed to get block in blockstore: ipld: could not find";
+
 /// Fetcher for reconstructing documents at specific historical versions.
 ///
 /// Given a CID, this fetcher walks backwards through the merkle DAG,
@@ -74,9 +77,8 @@ impl<S: Store> VersionedFetcher<S> {
     /// For collection-level CIDs (branchable collections), walks the collection DAG
     /// and returns all documents visible at that collection state.
     ///
-    /// If `collection_short_id` is provided, documents belonging to another
-    /// collection are dropped before reconstruction (Go parity: a foreign
-    /// collection's commit CID yields an empty result, never a foreign row).
+    /// `collection_short_id` gates membership: documents of another collection
+    /// are dropped before ACP and reconstruction.
     pub async fn get_documents_at_cid(
         &self,
         cid_str: &str,
@@ -94,12 +96,17 @@ impl<S: Store> VersionedFetcher<S> {
 
         // Check if this is a collection block (branchable collection CID)
         if matches!(&target_block.delta, CrdtDelta::Collection(_)) {
+            let expected = match expected_doc_id {
+                Some(expected) => Some(self.canonical_doc_id(txn, expected).await?),
+                None => None,
+            };
             return self
                 .get_documents_at_collection_cid(
                     txn,
                     &target_cid,
                     &target_block,
                     collection_short_id,
+                    expected,
                 )
                 .await;
         }
@@ -127,27 +134,16 @@ impl<S: Store> VersionedFetcher<S> {
             owners
         };
 
-        // Collection membership gate, before ACP and reconstruction
-        // (Go parity: GetDocShortID + noResults in planner/select.go).
-        let selected_owners = match collection_short_id {
-            Some(col_short_id) => {
-                let systemstore = txn.systemstore()?;
-                let mut members = Vec::with_capacity(selected_owners.len());
-                for owner in selected_owners {
-                    if crate::docid::map::get_doc_short_id(&systemstore, col_short_id, &owner)
-                        .await?
-                        .is_some()
-                    {
-                        members.push(owner);
-                    }
-                }
-                if members.is_empty() {
-                    return Ok(Vec::new());
-                }
-                members
+        // Membership gate, before ACP and the DAG walk.
+        let mut members = Vec::with_capacity(selected_owners.len());
+        for owner in selected_owners {
+            if self.is_member(txn, collection_short_id, &owner).await? {
+                members.push(owner);
             }
-            None => selected_owners,
-        };
+        }
+        if members.is_empty() {
+            return Ok(Vec::new());
+        }
 
         // Collect all blocks from target CID back to genesis
         let blocks = self
@@ -158,10 +154,28 @@ impl<S: Store> VersionedFetcher<S> {
         let mut sorted_blocks: Vec<(Cid, Block)> = blocks.into_iter().collect();
         sorted_blocks.sort_by_key(|(_, block)| block.delta.priority());
 
-        selected_owners
+        members
             .into_iter()
             .map(|doc_id| self.replay_deltas(&sorted_blocks, &doc_id))
             .collect()
+    }
+
+    /// Whether `doc_id` belongs to `collection_short_id` (`None` skips the gate).
+    async fn is_member(
+        &self,
+        txn: &mut DbTxn<S>,
+        collection_short_id: Option<u32>,
+        doc_id: &str,
+    ) -> Result<bool> {
+        let Some(col_short_id) = collection_short_id else {
+            return Ok(true);
+        };
+        let systemstore = txn.systemstore()?;
+        Ok(
+            crate::docid::map::get_doc_short_id(&systemstore, col_short_id, doc_id)
+                .await?
+                .is_some(),
+        )
     }
 
     /// Reconstruct documents from a collection-level CID.
@@ -175,6 +189,7 @@ impl<S: Store> VersionedFetcher<S> {
         start_cid: &Cid,
         start_block: &Block,
         collection_short_id: Option<u32>,
+        expected_doc_id: Option<String>,
     ) -> Result<Vec<Document>> {
         // Walk the collection DAG backwards to find all document composite CIDs.
         // Each collection block links to one document composite block.
@@ -198,18 +213,13 @@ impl<S: Store> VersionedFetcher<S> {
                             .await?
                             .and_then(|owners| owners.into_iter().next())
                         {
-                            if let Some(col_short_id) = collection_short_id {
-                                let systemstore = txn.systemstore()?;
-                                if crate::docid::map::get_doc_short_id(
-                                    &systemstore,
-                                    col_short_id,
-                                    &doc_id,
-                                )
-                                .await?
-                                .is_none()
-                                {
-                                    continue;
-                                }
+                            // Membership and docID gates; a mismatch is a skip.
+                            if !self.is_member(txn, collection_short_id, &doc_id).await?
+                                || expected_doc_id
+                                    .as_deref()
+                                    .is_some_and(|expected| expected != doc_id)
+                            {
+                                continue;
                             }
                             let priority = doc_block.delta.priority();
                             match doc_composites.get(&doc_id) {
@@ -280,9 +290,7 @@ impl<S: Store> VersionedFetcher<S> {
             // miss (an error the runner propagates) rather than the
             // does-not-exist string it swallows as an empty result.
             if Self::looks_like_cidv1(cid_str) {
-                Error::Serialization(
-                    "seek failed: (version fetcher) failed to get block in blockstore: ipld: could not find".to_string(),
-                )
+                Error::Serialization(BLOCK_NOT_FOUND.to_string())
             } else {
                 Error::Serialization("invalid cid: selected encoding not supported".to_string())
             }
@@ -406,11 +414,7 @@ impl<S: Store> VersionedFetcher<S> {
             .get(&key)
             .await
             .map_err(Error::Storage)?
-            .ok_or_else(|| {
-                Error::Serialization(
-                    "seek failed: (version fetcher) failed to get block in blockstore: ipld: could not find".to_string(),
-                )
-            })?;
+            .ok_or_else(|| Error::Serialization(BLOCK_NOT_FOUND.to_string()))?;
 
         let mut block = Block::from_dag_cbor(&data)
             .map_err(|e| Error::Serialization(format!("Failed to decode block: {}", e)))?;

--- a/crates/db/tests/read/commits_suite.rs
+++ b/crates/db/tests/read/commits_suite.rs
@@ -148,7 +148,7 @@ mod shared_owner_tests {
 
         let version_txn = db.new_txn(true).await.unwrap();
         let documents = VersionedFetcher::new(Arc::new(Mutex::new(Some(version_txn))))
-            .get_documents_at_cid(&cid.to_string(), None)
+            .get_documents_at_cid(&cid.to_string(), None, None)
             .await
             .unwrap();
         let document_owners: HashSet<_> = documents

--- a/crates/db/tests/read/versioned.rs
+++ b/crates/db/tests/read/versioned.rs
@@ -48,7 +48,7 @@ async fn kms_identity_prefers_caller_then_task_then_thread() {
 #[tokio::test]
 async fn collection_cid_doc_id_filter_accepts_an_alias() {
     use defra_core::{Block, CollectionDeltaPayload, CompositeDeltaPayload, CrdtDelta, DAGLink};
-    use storage::backends::MemoryStore;
+    use storage::RegolithStore;
 
     const COLLECTION_SHORT_ID: u32 = 7;
 
@@ -87,7 +87,7 @@ async fn collection_cid_doc_id_filter_accepts_an_alias() {
     )
     .to_string();
 
-    let db = db::DB::new(MemoryStore::new()).unwrap();
+    let db = db::DB::new(RegolithStore::in_memory().unwrap()).unwrap();
     let txn = db.new_txn(false).await.unwrap();
     {
         let blockstore = txn.blockstore().unwrap();

--- a/crates/db/tests/read/versioned.rs
+++ b/crates/db/tests/read/versioned.rs
@@ -44,3 +44,91 @@ async fn kms_identity_prefers_caller_then_task_then_thread() {
         Some(&identity::Did::new("did:key:thread").unwrap())
     );
 }
+
+#[tokio::test]
+async fn collection_cid_doc_id_filter_accepts_an_alias() {
+    use defra_core::{Block, CollectionDeltaPayload, CompositeDeltaPayload, CrdtDelta, DAGLink};
+    use storage::backends::MemoryStore;
+
+    const COLLECTION_SHORT_ID: u32 = 7;
+
+    let genesis = |priority| {
+        Block::new(
+            CrdtDelta::Composite(CompositeDeltaPayload {
+                schema_version_id: format!("v{priority}"),
+                priority: 1,
+                status: 1,
+            }),
+            vec![],
+            vec![],
+        )
+    };
+    let (wanted, other) = (genesis(1), genesis(2));
+    let (wanted_cid, other_cid) = (
+        wanted.generate_cid().unwrap(),
+        other.generate_cid().unwrap(),
+    );
+    let collection = Block::new(
+        CrdtDelta::Collection(CollectionDeltaPayload {
+            schema_version_id: "v1".to_string(),
+            priority: 1,
+        }),
+        vec![],
+        vec![
+            DAGLink::new("_C", wanted_cid),
+            DAGLink::new("_C", other_cid),
+        ],
+    );
+    let collection_cid = collection.generate_cid().unwrap();
+
+    let wanted_doc_id = document::DocID::new_v0(wanted_cid).to_string();
+    let alias = document::DocID::new_v0(
+        defra_core::block::generate_cid_from_bytes(b"legacy-short-id").unwrap(),
+    )
+    .to_string();
+
+    let db = db::DB::new(MemoryStore::new()).unwrap();
+    let txn = db.new_txn(false).await.unwrap();
+    {
+        let blockstore = txn.blockstore().unwrap();
+        let systemstore = txn.systemstore().unwrap();
+        for (cid, block) in [
+            (wanted_cid, &wanted),
+            (other_cid, &other),
+            (collection_cid, &collection),
+        ] {
+            blockstore
+                .set(&cid.to_bytes(), &block.to_dag_cbor().unwrap())
+                .await
+                .unwrap();
+        }
+        for (short_id, doc_id) in [
+            (1u64, &wanted_doc_id),
+            (2, &document::DocID::new_v0(other_cid).to_string()),
+        ] {
+            db::docid::map::set_doc_id_mapping(&systemstore, COLLECTION_SHORT_ID, short_id, doc_id)
+                .await
+                .unwrap();
+        }
+        db::docid::map::set_doc_id_alias(&systemstore, COLLECTION_SHORT_ID, 1, &alias)
+            .await
+            .unwrap();
+    }
+    txn.commit().await.unwrap();
+
+    let version_txn = db.new_txn(true).await.unwrap();
+    let documents = VersionedFetcher::new(Arc::new(TokioMutex::new(Some(version_txn))))
+        .get_documents_at_cid(
+            &collection_cid.to_string(),
+            Some(&alias),
+            Some(COLLECTION_SHORT_ID),
+        )
+        .await
+        .unwrap();
+
+    let ids: Vec<_> = documents
+        .iter()
+        .filter_map(|document| document.id().map(|id| id.to_string()))
+        .collect();
+    assert_eq!(ids, vec![wanted_doc_id]);
+}

--- a/crates/query/src/fetcher.rs
+++ b/crates/query/src/fetcher.rs
@@ -347,6 +347,12 @@ pub trait DocFetcher: MaybeSendSync {
     /// `collection_short_id` is the queried collection: documents belonging to
     /// another collection are excluded, so a foreign collection's commit CID
     /// yields an empty result (Go parity).
+    ///
+    /// Defaulted to an error rather than to a delegation to
+    /// [`get_document_at_cid`](Self::get_document_at_cid): that method takes no
+    /// collection, so delegating would return a document the caller then
+    /// ACP-checks against the wrong collection. A fetcher supporting CID-based
+    /// queries must scope them itself.
     async fn get_documents_at_cid(
         &self,
         collection_short_id: u32,
@@ -354,12 +360,10 @@ pub trait DocFetcher: MaybeSendSync {
         expected_doc_id: Option<&str>,
         caller_identity: Option<&Did>,
     ) -> Result<Vec<Document>> {
-        let _ = collection_short_id;
-        // Default: delegate to single-document method
-        let doc = self
-            .get_document_at_cid(cid, expected_doc_id, caller_identity)
-            .await?;
-        Ok(vec![doc])
+        let _ = (collection_short_id, cid, expected_doc_id, caller_identity);
+        Err(crate::error::QueryError::execution(
+            "CID-based time-travel queries are not supported by this fetcher".to_string(),
+        ))
     }
 
     /// Get all cached view items for a materialized view.
@@ -418,3 +422,75 @@ pub struct CommitsQueryOptions {
 ///
 /// This trait abstracts collection resolution, allowing the QueryRunner to
 pub use crate::collection_provider::{CollectionProvider, StaticCollectionProvider};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Overrides only the single-document CID method, as an out-of-tree fetcher
+    /// reasonably might.
+    struct SingleDocOnlyFetcher;
+
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    impl DocFetcher for SingleDocOnlyFetcher {
+        async fn get_all(&self, _collection_name: &str) -> Result<Vec<Document>> {
+            unreachable!()
+        }
+
+        async fn stream_by_doc_short_ids(
+            &self,
+            _collection_name: &str,
+            _doc_short_ids: &[u64],
+            _show_deleted: bool,
+        ) -> Result<Box<dyn DocStream>> {
+            unreachable!()
+        }
+
+        async fn stream_all_with_deleted(
+            &self,
+            _collection_name: &str,
+            _show_deleted: bool,
+        ) -> Result<Box<dyn DocStream>> {
+            unreachable!()
+        }
+
+        async fn get_by_ids(
+            &self,
+            _collection_name: &str,
+            _doc_ids: &[String],
+        ) -> Result<FetchByIdsResult> {
+            unreachable!()
+        }
+
+        async fn get_by_field_value(
+            &self,
+            _collection_name: &str,
+            _field_name: &str,
+            _value: &str,
+        ) -> Result<Vec<Document>> {
+            unreachable!()
+        }
+
+        async fn get_document_at_cid(
+            &self,
+            _cid: &str,
+            _expected_doc_id: Option<&str>,
+            _caller_identity: Option<&Did>,
+        ) -> Result<Document> {
+            Ok(Document::new())
+        }
+    }
+
+    /// The defaulted collection-scoped fetch cannot honour `collection_short_id`,
+    /// so it must refuse rather than hand back a document the query runner would
+    /// then ACP-check against the wrong collection.
+    #[tokio::test]
+    async fn defaulted_documents_at_cid_does_not_return_unscoped_documents() {
+        let result = SingleDocOnlyFetcher
+            .get_documents_at_cid(1, "bafy", None, None)
+            .await;
+
+        assert!(result.is_err(), "expected refusal, got {result:?}");
+    }
+}

--- a/crates/query/src/fetcher.rs
+++ b/crates/query/src/fetcher.rs
@@ -344,17 +344,17 @@ pub trait DocFetcher: MaybeSendSync {
     /// For collection-level CIDs (branchable collections), returns all
     /// documents visible at that collection state.
     ///
-    /// `collection_name` is the queried collection: documents belonging to
+    /// `collection_short_id` is the queried collection: documents belonging to
     /// another collection are excluded, so a foreign collection's commit CID
     /// yields an empty result (Go parity).
     async fn get_documents_at_cid(
         &self,
-        collection_name: &str,
+        collection_short_id: u32,
         cid: &str,
         expected_doc_id: Option<&str>,
         caller_identity: Option<&Did>,
     ) -> Result<Vec<Document>> {
-        let _ = collection_name;
+        let _ = collection_short_id;
         // Default: delegate to single-document method
         let doc = self
             .get_document_at_cid(cid, expected_doc_id, caller_identity)

--- a/crates/query/src/fetcher.rs
+++ b/crates/query/src/fetcher.rs
@@ -338,17 +338,23 @@ pub trait DocFetcher: MaybeSendSync {
         ))
     }
 
-    /// Reconstruct documents at the specified CID.
+    /// Reconstruct documents at the specified CID, scoped to a collection.
     ///
     /// For document-level CIDs, returns a single document.
     /// For collection-level CIDs (branchable collections), returns all
     /// documents visible at that collection state.
+    ///
+    /// `collection_name` is the queried collection: documents belonging to
+    /// another collection are excluded, so a foreign collection's commit CID
+    /// yields an empty result (Go parity).
     async fn get_documents_at_cid(
         &self,
+        collection_name: &str,
         cid: &str,
         expected_doc_id: Option<&str>,
         caller_identity: Option<&Did>,
     ) -> Result<Vec<Document>> {
+        let _ = collection_name;
         // Default: delegate to single-document method
         let doc = self
             .get_document_at_cid(cid, expected_doc_id, caller_identity)

--- a/crates/query/src/runner/fetcher.rs
+++ b/crates/query/src/runner/fetcher.rs
@@ -242,13 +242,13 @@ impl DocFetcher for FetcherWrapper {
 
     async fn get_documents_at_cid(
         &self,
-        collection_name: &str,
+        collection_short_id: u32,
         cid: &str,
         expected_doc_id: Option<&str>,
         caller_identity: Option<&identity::Did>,
     ) -> Result<Vec<Document>> {
         self.get_fetcher()
-            .get_documents_at_cid(collection_name, cid, expected_doc_id, caller_identity)
+            .get_documents_at_cid(collection_short_id, cid, expected_doc_id, caller_identity)
             .await
     }
 

--- a/crates/query/src/runner/fetcher.rs
+++ b/crates/query/src/runner/fetcher.rs
@@ -242,12 +242,13 @@ impl DocFetcher for FetcherWrapper {
 
     async fn get_documents_at_cid(
         &self,
+        collection_name: &str,
         cid: &str,
         expected_doc_id: Option<&str>,
         caller_identity: Option<&identity::Did>,
     ) -> Result<Vec<Document>> {
         self.get_fetcher()
-            .get_documents_at_cid(cid, expected_doc_id, caller_identity)
+            .get_documents_at_cid(collection_name, cid, expected_doc_id, caller_identity)
             .await
     }
 

--- a/crates/query/src/runner/version.rs
+++ b/crates/query/src/runner/version.rs
@@ -60,6 +60,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
 
             match fetcher
                 .get_documents_at_cid(
+                    &select.collection_name,
                     cid,
                     expected_doc_id.map(|s| s.as_str()),
                     caller_identity.as_ref(),
@@ -80,6 +81,21 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                 }
             }
         }
+
+        // docID is a post-filter when cid is set, for every CID kind
+        // (Go parity: selectNode.Next). Mismatch is a skip, not an error.
+        let documents = if let Some(ref doc_ids) = select.doc_ids {
+            documents
+                .into_iter()
+                .filter(|(doc, _)| {
+                    doc.id()
+                        .map(|id| doc_ids.iter().any(|expected| *expected == id.to_string()))
+                        .unwrap_or(false)
+                })
+                .collect()
+        } else {
+            documents
+        };
 
         // Get collection schema for building the mapping
         let collection = self.get_collection(&select.collection_name).await?;

--- a/crates/query/src/runner/version.rs
+++ b/crates/query/src/runner/version.rs
@@ -48,6 +48,9 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         // Get expected docID from select.doc_ids (optional validation)
         let expected_doc_id = select.doc_ids.as_ref().and_then(|ids| ids.first());
 
+        // Collection schema: scopes the fetch below, then builds the mapping.
+        let collection = self.get_collection(&select.collection_name).await?;
+
         // Fetch document(s) at the specified CIDs.
         // For collection-level CIDs (branchable), this returns multiple documents.
         // For document-level CIDs, this returns a single document.
@@ -60,7 +63,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
 
             match fetcher
                 .get_documents_at_cid(
-                    &select.collection_name,
+                    collection.resolved_root_id(),
                     cid,
                     expected_doc_id.map(|s| s.as_str()),
                     caller_identity.as_ref(),
@@ -81,24 +84,6 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                 }
             }
         }
-
-        // docID is a post-filter when cid is set, for every CID kind
-        // (Go parity: selectNode.Next). Mismatch is a skip, not an error.
-        let documents = if let Some(ref doc_ids) = select.doc_ids {
-            documents
-                .into_iter()
-                .filter(|(doc, _)| {
-                    doc.id()
-                        .map(|id| doc_ids.iter().any(|expected| *expected == id.to_string()))
-                        .unwrap_or(false)
-                })
-                .collect()
-        } else {
-            documents
-        };
-
-        // Get collection schema for building the mapping
-        let collection = self.get_collection(&select.collection_name).await?;
 
         // Apply ACP filtering: check read permission for each reconstructed document.
         // CID-based time-travel queries must enforce the same ACP rules as regular queries.

--- a/tools/integration-test/tests/query.rs
+++ b/tools/integration-test/tests/query.rs
@@ -1,5 +1,7 @@
 #[path = "query/aggregate_groupby_1595.rs"]
 mod aggregate_groupby_1595;
+#[path = "query/cid_scoping_1604.rs"]
+mod cid_scoping_1604;
 #[path = "query/commits_aggregate.rs"]
 mod commits_aggregate;
 #[path = "query/commits_collection_id.rs"]

--- a/tools/integration-test/tests/query/cid_scoping_1604.rs
+++ b/tools/integration-test/tests/query/cid_scoping_1604.rs
@@ -1,0 +1,155 @@
+//! CID query collection scoping (#1604). Mirrors Go's
+//! TestQuerySimple_WithCidFromAnotherCollection_ReturnsEmpty,
+//! TestQuerySimpleWithCidOfBranchableCollectionAndDocID, and
+//! TestQuerySimple_UnknownCid.
+
+use integration_test::{for_each_runtime, DefraClient, TestCluster};
+use serde_json::Value;
+
+fn extract_doc_id(data: &Value, mutation_name: &str) -> String {
+    data[mutation_name]
+        .as_array()
+        .and_then(|arr| arr.first())
+        .and_then(|value| value["_docID"].as_str())
+        .or_else(|| data[mutation_name]["_docID"].as_str())
+        .unwrap_or_else(|| panic!("missing _docID in {data}"))
+        .to_string()
+}
+
+fn create_commit_cid_for_doc(node: &DefraClient, doc_id: &str) -> String {
+    let result = node
+        .query(&format!(
+            r#"query {{
+                _commits(docID: ["{doc_id}"], filter: {{fieldName: {{_eq: "_C"}}}}) {{
+                    cid
+                    height
+                }}
+            }}"#
+        ))
+        .expect("query doc commit cid");
+    result["_commits"]
+        .as_array()
+        .and_then(|commits| {
+            commits
+                .iter()
+                .find(|commit| commit["height"].as_u64() == Some(1))
+        })
+        .and_then(|commit| commit["cid"].as_str())
+        .unwrap_or_else(|| panic!("missing create commit cid in {result}"))
+        .to_string()
+}
+
+fn collection_commit_cid_at_height(node: &DefraClient, height: u64) -> String {
+    let result = node
+        .query("query { _commits { cid height docID } }")
+        .expect("query collection commits");
+    result["_commits"]
+        .as_array()
+        .and_then(|commits| {
+            commits.iter().find(|commit| {
+                commit["docID"].is_null() && commit["height"].as_u64() == Some(height)
+            })
+        })
+        .and_then(|commit| commit["cid"].as_str())
+        .unwrap_or_else(|| panic!("missing collection commit at height {height} in {result}"))
+        .to_string()
+}
+
+async fn cid_from_another_collection_returns_empty_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    node.schema_add("type Users { name: String }  type Pets { name: String }")
+        .expect("add schema");
+
+    let created = node
+        .query(r#"mutation { add_Users(input: {name: "John"}) { _docID name } }"#)
+        .expect("add John");
+    let john_id = extract_doc_id(&created, "add_Users");
+    let john_cid = create_commit_cid_for_doc(&node, &john_id);
+
+    let result = node
+        .query(&format!(
+            r#"query {{ Pets(cid: "{john_cid}") {{ name }} }}"#
+        ))
+        .expect("query Pets by Users CID");
+
+    assert_eq!(
+        result["Pets"],
+        Value::Array(vec![]),
+        "a Users commit CID queried as Pets must yield an empty result: {result}"
+    );
+}
+
+async fn cid_of_branchable_collection_with_doc_id_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    node.schema_add("type Users @branchable { name: String }")
+        .expect("add schema");
+
+    let created = node
+        .query(r#"mutation { add_Users(input: {name: "Fred"}) { _docID name } }"#)
+        .expect("add Fred");
+    let fred_id = extract_doc_id(&created, "add_Users");
+    node.query(r#"mutation { add_Users(input: {name: "John"}) { _docID name } }"#)
+        .expect("add John");
+    node.query(&format!(
+        r#"mutation {{ update_Users(docID: "{fred_id}", input: {{name: "Freddddd"}}) {{ _docID name }} }}"#
+    ))
+    .expect("update Fred");
+
+    // Collection commit created when John was added (Go: CollectionCID0_1).
+    let collection_cid = collection_commit_cid_at_height(&node, 2);
+
+    let result = node
+        .query(&format!(
+            r#"query {{ Users(cid: "{collection_cid}", docID: "{fred_id}") {{ name }} }}"#
+        ))
+        .expect("query Users by collection CID and docID");
+
+    let users = result["Users"]
+        .as_array()
+        .unwrap_or_else(|| panic!("Users array missing from response: {result}"));
+    assert_eq!(
+        users.len(),
+        1,
+        "docID must post-filter the collection snapshot to one document: {result}"
+    );
+    assert_eq!(
+        users[0]["name"], "Fred",
+        "expected Fred's historical value at that collection state: {result}"
+    );
+}
+
+async fn unknown_cid_errors_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    node.schema_add("type Users { name: String }")
+        .expect("add schema");
+
+    let result = node.query(
+        r#"query { Users(cid: "bafybeid57gpbwi4i6bg7g35hhhhhhhhhhhhhhhhhhhhhhhdoesnotexist") { name } }"#,
+    );
+
+    let error_text = match result {
+        Err(err) => format!("{err:#}"),
+        Ok(value) => {
+            let errors = value["errors"].as_array().cloned().unwrap_or_default();
+            assert!(
+                !errors.is_empty(),
+                "unknown CID must error, got success: {value}"
+            );
+            Value::Array(errors).to_string()
+        }
+    };
+    assert!(
+        error_text.contains("failed to get block in blockstore: ipld: could not find"),
+        "unknown CID must surface the blockstore miss, got: {error_text}"
+    );
+}
+
+for_each_runtime!(
+    cid_from_another_collection_returns_empty,
+    cid_from_another_collection_returns_empty_test
+);
+for_each_runtime!(
+    cid_of_branchable_collection_with_doc_id,
+    cid_of_branchable_collection_with_doc_id_test
+);
+for_each_runtime!(unknown_cid_errors, unknown_cid_errors_test);

--- a/tools/integration-test/tests/query/cid_scoping_1604.rs
+++ b/tools/integration-test/tests/query/cid_scoping_1604.rs
@@ -123,21 +123,11 @@ async fn unknown_cid_errors_test(cluster: TestCluster) {
     node.schema_add("type Users { name: String }")
         .expect("add schema");
 
-    let result = node.query(
-        r#"query { Users(cid: "bafybeid57gpbwi4i6bg7g35hhhhhhhhhhhhhhhhhhhhhhhdoesnotexist") { name } }"#,
-    );
-
-    let error_text = match result {
-        Err(err) => format!("{err:#}"),
-        Ok(value) => {
-            let errors = value["errors"].as_array().cloned().unwrap_or_default();
-            assert!(
-                !errors.is_empty(),
-                "unknown CID must error, got success: {value}"
-            );
-            Value::Array(errors).to_string()
-        }
-    };
+    let error_text = node
+        .query_expect_error(
+            r#"query { Users(cid: "bafybeid57gpbwi4i6bg7g35hhhhhhhhhhhhhhhhhhhhhhhdoesnotexist") { name } }"#,
+        )
+        .expect("unknown CID must error");
     assert!(
         error_text.contains("failed to get block in blockstore: ipld: could not find"),
         "unknown CID must surface the blockstore miss, got: {error_text}"


### PR DESCRIPTION
Closes #1604.

User-document `cid:` queries returned documents from other collections. Three sub-fixes, mirroring Go:

- **Collection membership**: `VersionedFetcher::get_documents_at_cid` takes the queried collection's short ID and drops non-member documents (via the existing `docid::map::get_doc_short_id`) before ACP and reconstruction — a foreign collection's commit CID now yields `[]` instead of leaking the row. This also removes a path where a foreign document was ACP-checked against the wrong collection's policy.
- **docID filter**: applied inside the fetcher for every CID kind, canonicalizing the requested docID first so alias docIDs (backup restore, legacy short-ID migration) still match; a branchable-collection CID plus `docID` returns 1 document. Mismatch is a skip, not an error.
- **Unknown CID**: a CIDv1-shaped but unresolvable CID surfaces the blockstore-miss error (`failed to get block in blockstore: ipld: could not find`) instead of being swallowed as an empty result.

Tests mirror Go's `WithCidFromAnotherCollection_ReturnsEmpty`, `WithCidOfBranchableCollectionAndDocID`, and `UnknownCid` (all six cross-runtime variants pass locally), plus a db-level alias-coverage test.

Out of scope (per the parity spec): `_commits(cid:)` — it still returns empty for an unknown CID; follow-up candidate.

**Blocked — do not merge yet:**
1. backbone PR adding `query_expect_error` (`dd26ccb`) must merge — the unknown-CID test asserts through it.
2. #1598's defradb.rs PR must land its backbone pin bump on `main`.

The last commit here duplicates 1598's pin-bump commit (cherry-picked as `de2b35873`) so CI can compile; once both land, this branch rebases onto `main` and drops it.