### PR TITLE
fix(db): match Go wording for create-on-deleted-document error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ dependencies = [
 [[package]]
 name = "acp-light-client"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/backbone.git?rev=f04e9b0716977705494ec40d17fa5f20d29cbfcf#f04e9b0716977705494ec40d17fa5f20d29cbfcf"
+source = "git+https://github.com/sourcenetwork/backbone.git?rev=9526a4ebfaa1cebf07fc3592de6f0a62d77f9e30#9526a4ebfaa1cebf07fc3592de6f0a62d77f9e30"
 dependencies = [
  "alloy-primitives",
  "borsh",
@@ -3512,7 +3512,7 @@ dependencies = [
 [[package]]
 name = "defra-harness"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/backbone.git?rev=f04e9b0716977705494ec40d17fa5f20d29cbfcf#f04e9b0716977705494ec40d17fa5f20d29cbfcf"
+source = "git+https://github.com/sourcenetwork/backbone.git?rev=9526a4ebfaa1cebf07fc3592de6f0a62d77f9e30#9526a4ebfaa1cebf07fc3592de6f0a62d77f9e30"
 dependencies = [
  "eyre",
  "futures",
@@ -5297,7 +5297,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 [[package]]
 name = "hub-harness"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/backbone.git?rev=f04e9b0716977705494ec40d17fa5f20d29cbfcf#f04e9b0716977705494ec40d17fa5f20d29cbfcf"
+source = "git+https://github.com/sourcenetwork/backbone.git?rev=9526a4ebfaa1cebf07fc3592de6f0a62d77f9e30#9526a4ebfaa1cebf07fc3592de6f0a62d77f9e30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11267,7 +11267,7 @@ dependencies = [
 [[package]]
 name = "sourcehub-harness"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/backbone.git?rev=f04e9b0716977705494ec40d17fa5f20d29cbfcf#f04e9b0716977705494ec40d17fa5f20d29cbfcf"
+source = "git+https://github.com/sourcenetwork/backbone.git?rev=9526a4ebfaa1cebf07fc3592de6f0a62d77f9e30#9526a4ebfaa1cebf07fc3592de6f0a62d77f9e30"
 dependencies = [
  "cosmrs",
  "eyre",
@@ -11795,7 +11795,7 @@ dependencies = [
 [[package]]
 name = "test-infra"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/backbone.git?rev=f04e9b0716977705494ec40d17fa5f20d29cbfcf#f04e9b0716977705494ec40d17fa5f20d29cbfcf"
+source = "git+https://github.com/sourcenetwork/backbone.git?rev=9526a4ebfaa1cebf07fc3592de6f0a62d77f9e30#9526a4ebfaa1cebf07fc3592de6f0a62d77f9e30"
 dependencies = [
  "eyre",
  "futures",

--- a/crates/db/src/write/autocommit/helpers.rs
+++ b/crates/db/src/write/autocommit/helpers.rs
@@ -143,8 +143,7 @@ pub(crate) async fn register_created_doc(
             .map_err(|e| query::error::QueryError::execution(e.to_string()))?;
         if is_deleted {
             return Err(query::error::QueryError::execution(format!(
-                "Document with ID {} has been deleted",
-                doc_id_str
+                "a document with the given ID has been deleted. DocID: {doc_id_str}"
             )));
         }
         return Err(query::error::QueryError::execution(format!(

--- a/crates/sourcehub/Cargo.toml
+++ b/crates/sourcehub/Cargo.toml
@@ -68,7 +68,7 @@ alloy-rlp.workspace = true
 bs58.workspace = true
 
 # ACP light client (proof-validated cache)
-acp-light-client = { git = "https://github.com/sourcenetwork/backbone.git", rev = "f04e9b0716977705494ec40d17fa5f20d29cbfcf" }
+acp-light-client = { git = "https://github.com/sourcenetwork/backbone.git", rev = "9526a4ebfaa1cebf07fc3592de6f0a62d77f9e30" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 futures.workspace = true

--- a/proofs/Cargo.toml
+++ b/proofs/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = "1.0"
 anyhow = "1.0"
 
 [dev-dependencies]
-defra-harness = { git = "https://github.com/sourcenetwork/backbone.git", rev = "f04e9b0716977705494ec40d17fa5f20d29cbfcf" }
+defra-harness = { git = "https://github.com/sourcenetwork/backbone.git", rev = "9526a4ebfaa1cebf07fc3592de6f0a62d77f9e30" }
 tokio = { workspace = true, features = ["rt", "macros", "sync", "time"] }
 serial_test = "3"
 

--- a/tools/integration-test/Cargo.toml
+++ b/tools/integration-test/Cargo.toml
@@ -106,8 +106,8 @@ name = "cursor"
 path = "tests/cursor.rs"
 
 [dependencies]
-hub-harness = { git = "https://github.com/sourcenetwork/backbone.git", rev = "f04e9b0716977705494ec40d17fa5f20d29cbfcf" }
-defra-harness = { git = "https://github.com/sourcenetwork/backbone.git", rev = "f04e9b0716977705494ec40d17fa5f20d29cbfcf" }
+hub-harness = { git = "https://github.com/sourcenetwork/backbone.git", rev = "9526a4ebfaa1cebf07fc3592de6f0a62d77f9e30" }
+defra-harness = { git = "https://github.com/sourcenetwork/backbone.git", rev = "9526a4ebfaa1cebf07fc3592de6f0a62d77f9e30" }
 document = { path = "../../crates/document" }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time"] }
 reqwest = { version = "0.12", default-features = false, features = [

--- a/tools/integration-test/tests/basic/document_lifecycle.rs
+++ b/tools/integration-test/tests/basic/document_lifecycle.rs
@@ -1,4 +1,4 @@
-use integration_test::{for_each_runtime, TestCluster};
+use integration_test::{extract_doc_id, for_each_runtime, TestCluster};
 use serde_json::Value;
 
 /// Extract indexes array from index_list output.
@@ -360,4 +360,35 @@ async fn filtered_document_delete_http_contract(cluster: TestCluster) {
 for_each_runtime!(
     filtered_document_delete_http_contract,
     filtered_document_delete_http_contract
+);
+
+async fn create_on_deleted_document_errors(cluster: TestCluster) {
+    let client = cluster.client(0);
+    client
+        .schema_add("type DeletedDocUser { name: String }")
+        .expect("failed to add schema");
+
+    let created = client
+        .query(r#"mutation { add_DeletedDocUser(input: {name: "John"}) { _docID } }"#)
+        .expect("create document");
+    let doc_id = extract_doc_id(&created, "add_DeletedDocUser");
+
+    client
+        .query(&format!(
+            r#"mutation {{ delete_DeletedDocUser(docID: "{doc_id}") {{ _docID }} }}"#
+        ))
+        .expect("delete document");
+
+    let err = client
+        .query_expect_error(r#"mutation { add_DeletedDocUser(input: {name: "John"}) { _docID } }"#)
+        .expect("expected create on deleted doc to fail");
+    assert!(
+        err.contains("a document with the given ID has been deleted"),
+        "expected Go-parity deleted-document error, got: {err}"
+    );
+}
+
+for_each_runtime!(
+    create_on_deleted_document_errors,
+    create_on_deleted_document_errors
 );


### PR DESCRIPTION
Draft: gated on #1566 and sourcenetwork/backbone#29 (harness `query_expect_error`; the
backbone rev pinned here moves to the merge commit once that lands).

## Context

Creating a document whose ID matches a previously deleted one fails correctly but with the wrong wording: Rust said `Document with ID {} has been deleted` where Go renders `a document with the given ID has been deleted. DocID: <id>`. Found via FFI testing (2 failing Go tests in `mutation/add`); it breaks any consumer matching on the message. The Rust message is now byte-identical to Go's, verified against a live Go node at the compat commit.

The test asserts through the new harness `query_expect_error` (sourcenetwork/backbone#29), which normalizes how the two CLIs surface GraphQL errors (Rust: non-zero exit + stderr; Go: exit 0 + `errors` array in the body) — making this the first error-message assertion that runs on both the `rust_` and `go_` arms, with Go as a live oracle.

## Changes

- align the sole emitter in the autocommit create path with Go's exact rendered message, including the `. DocID: <id>` suffix (Go's `NewErrDocumentDeleted` attaches a DocID KV that its error formatter appends)
- add a document-lifecycle integration test asserting the message on the create-after-delete path via `query_expect_error`, cross-runtime
- bump the four backbone pins (defra-harness ×2, hub-harness, acp-light-client) to the commit carrying `query_expect_error`

## Testing

- [x] `rust_create_on_deleted_document_errors` (RED before the fix, GREEN after)
- [x] `go_create_on_deleted_document_errors` against the Go compat binary (13c46ec9)
- [x] `cargo test -p integration-test --test basic` — 46 passed incl. all go_ arms
- [x] `just profile=super-dev test` (~1100 tests, 0 failed)
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo fmt --all`

The sibling `already exists` branch has the same class of divergence (`Document with ID {} already exists` vs Go's `a document with the given ID already exists. DocID: <id>`); left out of scope for a separate issue. Likewise Rust's update-after-delete path likely lacks Go's deleted-document error (unverified hypothesis from review) — same follow-up issue candidate.

Closes #1598
