### PR TITLE
fix(db): tie-break equal index keys by public DocID

### DIFF
--- a/crates/db/src/read/doc.rs
+++ b/crates/db/src/read/doc.rs
@@ -358,7 +358,8 @@ impl<S: Store + 'static> DocFetcher for DbDocFetcher<S> {
                 let mut iter = index.get(&datastore, values).await.map_err(|e| {
                     query::error::QueryError::execution(format!("index error: {}", e))
                 })?;
-                collect_with_limit(&mut iter, limit, offset, vf).await?
+                // Full equal-key set: public-DocID tie-break sorts before offset/limit (#1602).
+                collect_with_limit(&mut iter, None, 0, vf).await?
             }
             IndexScanType::InScan {
                 values,
@@ -511,11 +512,17 @@ impl<S: Store + 'static> DocFetcher for DbDocFetcher<S> {
             .filter(|id| seen.insert(*id))
             .collect();
 
-        let doc_ids = crate::docid::map::resolve_doc_ids(&systemstore, &doc_short_ids)
+        let mut doc_ids = crate::docid::map::resolve_doc_ids(&systemstore, &doc_short_ids)
             .await
             .map_err(|e| {
                 query::error::QueryError::execution(format!("doc ID resolution error: {}", e))
             })?;
+        crate::read::index_tiebreak::apply_equal_key_doc_id_tie_break(
+            &params.scan_type,
+            &mut doc_ids,
+            offset,
+            limit,
+        );
 
         Ok(query::fetcher::IndexScanResult::with_raw_count(
             doc_ids,

--- a/crates/db/src/read/doc.rs
+++ b/crates/db/src/read/doc.rs
@@ -431,11 +431,11 @@ impl<S: Store + 'static> DocFetcher for DbDocFetcher<S> {
                             })?
                         };
                         raw_count += entries.len() as u64;
-                        crate::read::index_tiebreak::extend_equal_key_group(
+                        crate::read::index_tiebreak::extend_equal_key_groups(
                             &mut all_doc_short_ids,
                             &mut group_lens,
                             &mut seen_short_ids,
-                            entries.into_iter().map(|e| e.doc_short_id),
+                            entries,
                         );
                     }
                     (all_doc_short_ids, raw_count, group_lens)

--- a/crates/db/src/read/doc.rs
+++ b/crates/db/src/read/doc.rs
@@ -351,157 +351,176 @@ impl<S: Store + 'static> DocFetcher for DbDocFetcher<S> {
         // iterated including those filtered out by value_filter (for indexFetches
         // metrics). OrScan branches recurse and return already-resolved DocIDs.
         let vf = params.value_filter.as_ref();
-        let (raw_doc_short_ids, raw_fetches): (Vec<u64>, u64) = match &params.scan_type {
-            IndexScanType::ExactMatch { values } => {
-                // Cursor seek is intentionally not applied: ExactMatch fetches a single
-                // value; pagination over a single value is meaningless.
-                let mut iter = index.get(&datastore, values).await.map_err(|e| {
-                    query::error::QueryError::execution(format!("index error: {}", e))
-                })?;
-                // Full equal-key set: public-DocID tie-break sorts before offset/limit (#1602).
-                collect_with_limit(&mut iter, None, 0, vf).await?
-            }
-            IndexScanType::InScan {
-                values,
-                suffix_values,
-            } => {
-                // Cursor seek is intentionally not applied: InScan fetches a fixed set
-                // of values; pagination over an unordered set is meaningless.
-                // For IN operator, we need to collect results for each value.
-                // For composite indexes with suffix_values (subsequent Eq conditions),
-                // use exact match (get) with combined values for efficiency.
-                // For composite indexes without suffix_values, use scan_prefix.
-                let is_composite = index.description().fields.len() > 1;
-                let has_full_key = !suffix_values.is_empty()
-                    && suffix_values.len() == index.description().fields.len() - 1;
-                let mut all_doc_short_ids = Vec::new();
-                for value in values {
-                    if has_full_key {
-                        // All index fields covered: In value + suffix Eq values = exact match
-                        let mut key_values = vec![value.clone()];
-                        key_values.extend(suffix_values.iter().cloned());
-                        let mut iter = index.get(&datastore, &key_values).await.map_err(|e| {
+        let (raw_doc_short_ids, raw_fetches, group_lens): (Vec<u64>, u64, Vec<usize>) =
+            match &params.scan_type {
+                IndexScanType::ExactMatch { values } => {
+                    // Cursor seek is intentionally not applied: ExactMatch fetches a single
+                    // value; pagination over a single value is meaningless.
+                    let mut iter = index.get(&datastore, values).await.map_err(|e| {
+                        query::error::QueryError::execution(format!("index error: {}", e))
+                    })?;
+                    // Full equal-key set: public-DocID tie-break sorts before offset/limit (#1602).
+                    let (ids, n) = collect_with_limit(&mut iter, None, 0, vf).await?;
+                    (ids, n, Vec::new())
+                }
+                IndexScanType::InScan {
+                    values,
+                    suffix_values,
+                } => {
+                    // Cursor seek is intentionally not applied: InScan fetches a fixed set
+                    // of values; pagination over an unordered set is meaningless.
+                    // For IN operator, we need to collect results for each value.
+                    // For composite indexes with suffix_values (subsequent Eq conditions),
+                    // use exact match (get) with combined values for efficiency.
+                    // For composite indexes without suffix_values, use scan_prefix.
+                    let is_composite = index.description().fields.len() > 1;
+                    let has_full_key = !suffix_values.is_empty()
+                        && suffix_values.len() == index.description().fields.len() - 1;
+                    let mut all_doc_short_ids = Vec::new();
+                    let mut group_lens = Vec::new();
+                    let mut seen_short_ids = HashSet::new();
+                    let mut raw_count = 0u64;
+                    for value in values {
+                        let entries = if has_full_key {
+                            let mut key_values = vec![value.clone()];
+                            key_values.extend(suffix_values.iter().cloned());
+                            let mut iter =
+                                index.get(&datastore, &key_values).await.map_err(|e| {
+                                    query::error::QueryError::execution(format!(
+                                        "index error: {}",
+                                        e
+                                    ))
+                                })?;
+                            iter.collect_all().await.map_err(|e| {
+                                query::error::QueryError::execution(format!(
+                                    "index iteration error: {}",
+                                    e
+                                ))
+                            })?
+                        } else if is_composite {
+                            let mut iter = index
+                                .scan_prefix(&datastore, std::slice::from_ref(value), false)
+                                .await
+                                .map_err(|e| {
+                                    query::error::QueryError::execution(format!(
+                                        "index error: {}",
+                                        e
+                                    ))
+                                })?;
+                            iter.collect_all().await.map_err(|e| {
+                                query::error::QueryError::execution(format!(
+                                    "index iteration error: {}",
+                                    e
+                                ))
+                            })?
+                        } else {
+                            let mut iter = index
+                                .get(&datastore, std::slice::from_ref(value))
+                                .await
+                                .map_err(|e| {
+                                    query::error::QueryError::execution(format!(
+                                        "index error: {}",
+                                        e
+                                    ))
+                                })?;
+                            iter.collect_all().await.map_err(|e| {
+                                query::error::QueryError::execution(format!(
+                                    "index iteration error: {}",
+                                    e
+                                ))
+                            })?
+                        };
+                        raw_count += entries.len() as u64;
+                        crate::read::index_tiebreak::extend_equal_key_group(
+                            &mut all_doc_short_ids,
+                            &mut group_lens,
+                            &mut seen_short_ids,
+                            entries.into_iter().map(|e| e.doc_short_id),
+                        );
+                    }
+                    (all_doc_short_ids, raw_count, group_lens)
+                }
+                IndexScanType::PrefixScan {
+                    prefix_values,
+                    reverse,
+                } => {
+                    let mut iter = index
+                        .scan_prefix(&datastore, prefix_values, *reverse)
+                        .await
+                        .map_err(|e| {
                             query::error::QueryError::execution(format!("index error: {}", e))
                         })?;
-                        let entries = iter.collect_all().await.map_err(|e| {
-                            query::error::QueryError::execution(format!(
-                                "index iteration error: {}",
-                                e
-                            ))
-                        })?;
-                        all_doc_short_ids.extend(entries.into_iter().map(|e| e.doc_short_id));
-                    } else if is_composite {
-                        let mut iter = index
-                            .scan_prefix(&datastore, std::slice::from_ref(value), false)
-                            .await
-                            .map_err(|e| {
-                                query::error::QueryError::execution(format!("index error: {}", e))
-                            })?;
-                        let entries = iter.collect_all().await.map_err(|e| {
-                            query::error::QueryError::execution(format!(
-                                "index iteration error: {}",
-                                e
-                            ))
-                        })?;
-                        all_doc_short_ids.extend(entries.into_iter().map(|e| e.doc_short_id));
-                    } else {
-                        let mut iter = index
-                            .get(&datastore, std::slice::from_ref(value))
-                            .await
-                            .map_err(|e| {
-                                query::error::QueryError::execution(format!("index error: {}", e))
-                            })?;
-                        let entries = iter.collect_all().await.map_err(|e| {
-                            query::error::QueryError::execution(format!(
-                                "index iteration error: {}",
-                                e
-                            ))
-                        })?;
-                        all_doc_short_ids.extend(entries.into_iter().map(|e| e.doc_short_id));
-                    }
-                }
-                let count = all_doc_short_ids.len() as u64;
-                (all_doc_short_ids, count)
-            }
-            IndexScanType::PrefixScan {
-                prefix_values,
-                reverse,
-            } => {
-                let mut iter = index
-                    .scan_prefix(&datastore, prefix_values, *reverse)
-                    .await
-                    .map_err(|e| {
-                        query::error::QueryError::execution(format!("index error: {}", e))
-                    })?;
-                apply_cursor_seek_to_iterator(
-                    &mut iter,
-                    &params.cursor_seek,
-                    &systemstore,
-                    collection.resolved_root_id(),
-                )
-                .await?;
-                collect_with_limit(&mut iter, limit, offset, vf).await?
-            }
-            IndexScanType::RangeScan {
-                prefix_values,
-                lower,
-                upper,
-                reverse,
-            } => {
-                let mut iter = index
-                    .scan_range(
-                        &datastore,
-                        prefix_values,
-                        lower.clone(),
-                        upper.clone(),
-                        *reverse,
+                    apply_cursor_seek_to_iterator(
+                        &mut iter,
+                        &params.cursor_seek,
+                        &systemstore,
+                        collection.resolved_root_id(),
                     )
-                    .await
-                    .map_err(|e| {
-                        query::error::QueryError::execution(format!("index error: {}", e))
-                    })?;
-                apply_cursor_seek_to_iterator(
-                    &mut iter,
-                    &params.cursor_seek,
-                    &systemstore,
-                    collection.resolved_root_id(),
-                )
-                .await?;
-                collect_with_limit(&mut iter, limit, offset, vf).await?
-            }
-            IndexScanType::OrScan { branches } => {
-                // Cursor seek is intentionally not applied: each branch gets cursor_seek: None
-                // because OrScan merges independent sets; applying a cursor to individual
-                // branches would arbitrarily exclude results from other branches.
-                let mut all_doc_ids = Vec::new();
-                let mut total_raw_fetches = 0u64;
-                for branch in branches {
-                    let branch_params = IndexScanParams {
-                        index_name: params.index_name.clone(),
-                        scan_type: branch.clone(),
-                        limit: None,
-                        offset: 0,
-                        value_filter: None,
-                        cursor_seek: None,
-                    };
-                    let branch_result = self
-                        .get_by_index_scan(collection_name, &branch_params)
-                        .await?;
-                    total_raw_fetches += branch_result.raw_fetches();
-                    all_doc_ids.extend(branch_result.doc_ids().iter().cloned());
+                    .await?;
+                    let (ids, n) = collect_with_limit(&mut iter, limit, offset, vf).await?;
+                    (ids, n, Vec::new())
                 }
-                let mut seen = HashSet::new();
-                let doc_ids: Vec<String> = all_doc_ids
-                    .into_iter()
-                    .filter(|id| seen.insert(id.clone()))
-                    .collect();
-                return Ok(query::fetcher::IndexScanResult::with_raw_count(
-                    doc_ids,
-                    total_raw_fetches,
-                ));
-            }
-            _ => (Vec::new(), 0),
-        };
+                IndexScanType::RangeScan {
+                    prefix_values,
+                    lower,
+                    upper,
+                    reverse,
+                } => {
+                    let mut iter = index
+                        .scan_range(
+                            &datastore,
+                            prefix_values,
+                            lower.clone(),
+                            upper.clone(),
+                            *reverse,
+                        )
+                        .await
+                        .map_err(|e| {
+                            query::error::QueryError::execution(format!("index error: {}", e))
+                        })?;
+                    apply_cursor_seek_to_iterator(
+                        &mut iter,
+                        &params.cursor_seek,
+                        &systemstore,
+                        collection.resolved_root_id(),
+                    )
+                    .await?;
+                    let (ids, n) = collect_with_limit(&mut iter, limit, offset, vf).await?;
+                    (ids, n, Vec::new())
+                }
+                IndexScanType::OrScan { branches } => {
+                    // Cursor seek is intentionally not applied: each branch gets cursor_seek: None
+                    // because OrScan merges independent sets; applying a cursor to individual
+                    // branches would arbitrarily exclude results from other branches.
+                    let mut all_doc_ids = Vec::new();
+                    let mut total_raw_fetches = 0u64;
+                    for branch in branches {
+                        let branch_params = IndexScanParams {
+                            index_name: params.index_name.clone(),
+                            scan_type: branch.clone(),
+                            limit: None,
+                            offset: 0,
+                            value_filter: None,
+                            cursor_seek: None,
+                        };
+                        let branch_result = self
+                            .get_by_index_scan(collection_name, &branch_params)
+                            .await?;
+                        total_raw_fetches += branch_result.raw_fetches();
+                        all_doc_ids.extend(branch_result.doc_ids().iter().cloned());
+                    }
+                    let mut seen = HashSet::new();
+                    let doc_ids: Vec<String> = all_doc_ids
+                        .into_iter()
+                        .filter(|id| seen.insert(id.clone()))
+                        .collect();
+                    return Ok(query::fetcher::IndexScanResult::with_raw_count(
+                        doc_ids,
+                        total_raw_fetches,
+                    ));
+                }
+                _ => (Vec::new(), 0, Vec::new()),
+            };
 
         // Deduplicate doc short IDs while preserving order.
         // Array indexes can return the same document multiple times (once per array
@@ -522,6 +541,7 @@ impl<S: Store + 'static> DocFetcher for DbDocFetcher<S> {
             &mut doc_ids,
             offset,
             limit,
+            &group_lens,
         );
 
         Ok(query::fetcher::IndexScanResult::with_raw_count(

--- a/crates/db/src/read/index_tiebreak.rs
+++ b/crates/db/src/read/index_tiebreak.rs
@@ -1,0 +1,31 @@
+//! Public-DocID tie-break for equal index keys (#1602).
+
+use query::planner::index_selection::IndexScanType;
+
+/// Sort ExactMatch results by public DocID, then apply offset/limit.
+///
+/// Index keys suffix node-local short IDs, so equal field values scan in
+/// persist order and diverge across replicas. Public DocIDs are
+/// content-addressed and identical everywhere, the same identity unique-index
+/// merge already uses. Other scan types keep index-key order (field values
+/// differ); their equal-key runs still follow short IDs.
+pub(crate) fn apply_equal_key_doc_id_tie_break(
+    scan_type: &IndexScanType,
+    doc_ids: &mut Vec<String>,
+    offset: u64,
+    limit: Option<u64>,
+) {
+    if !matches!(scan_type, IndexScanType::ExactMatch { .. }) {
+        return;
+    }
+    doc_ids.sort();
+    let start = (offset as usize).min(doc_ids.len());
+    if start == 0 && limit.is_none() {
+        return;
+    }
+    let end = match limit {
+        Some(lim) => start.saturating_add(lim as usize).min(doc_ids.len()),
+        None => doc_ids.len(),
+    };
+    *doc_ids = doc_ids[start..end].to_vec();
+}

--- a/crates/db/src/read/index_tiebreak.rs
+++ b/crates/db/src/read/index_tiebreak.rs
@@ -1,24 +1,46 @@
 //! Public-DocID tie-break for equal index keys (#1602).
 
+use std::collections::HashSet;
+
 use query::planner::index_selection::IndexScanType;
 
-/// Sort ExactMatch results by public DocID, then apply offset/limit.
-///
-/// Index keys suffix node-local short IDs, so equal field values scan in
-/// persist order and diverge across replicas. Public DocIDs are
-/// content-addressed and identical everywhere, the same identity unique-index
-/// merge already uses. Other scan types keep index-key order (field values
-/// differ); their equal-key runs still follow short IDs.
-pub(crate) fn apply_equal_key_doc_id_tie_break(
-    scan_type: &IndexScanType,
-    doc_ids: &mut Vec<String>,
-    offset: u64,
-    limit: Option<u64>,
+/// Append one InScan value's short IDs as a group, skipping IDs already seen.
+pub(crate) fn extend_equal_key_group(
+    all: &mut Vec<u64>,
+    group_lens: &mut Vec<usize>,
+    seen: &mut HashSet<u64>,
+    short_ids: impl IntoIterator<Item = u64>,
 ) {
-    if !matches!(scan_type, IndexScanType::ExactMatch { .. }) {
-        return;
+    let start = all.len();
+    for id in short_ids {
+        if seen.insert(id) {
+            all.push(id);
+        }
     }
+    group_lens.push(all.len() - start);
+}
+
+/// Sort one equal-key group by public DocID.
+pub(crate) fn sort_equal_key_group(doc_ids: &mut [String]) {
     doc_ids.sort();
+}
+
+/// Sort consecutive equal-key groups in `doc_ids`.
+///
+/// `group_lens[i]` is the length of group i. Lengths that run past the
+/// slice are clamped.
+pub(crate) fn sort_equal_key_groups(doc_ids: &mut [String], group_lens: &[usize]) {
+    let mut start: usize = 0;
+    for &len in group_lens {
+        let end = start.saturating_add(len).min(doc_ids.len());
+        if start < end {
+            sort_equal_key_group(&mut doc_ids[start..end]);
+        }
+        start = end;
+    }
+}
+
+fn apply_offset_limit(doc_ids: &mut Vec<String>, offset: u64, limit: Option<u64>) {
     let start = (offset as usize).min(doc_ids.len());
     if start == 0 && limit.is_none() {
         return;
@@ -28,4 +50,100 @@ pub(crate) fn apply_equal_key_doc_id_tie_break(
         None => doc_ids.len(),
     };
     *doc_ids = doc_ids[start..end].to_vec();
+}
+
+/// Sort ExactMatch results by public DocID, then apply offset/limit.
+/// Sort each InScan value's group the same way, keeping `_in` list order
+/// between groups.
+///
+/// Index keys suffix node-local short IDs, so equal field values scan in
+/// persist order and diverge across replicas. Public DocIDs are
+/// content-addressed and identical everywhere, the same identity unique-index
+/// merge already uses.
+pub(crate) fn apply_equal_key_doc_id_tie_break(
+    scan_type: &IndexScanType,
+    doc_ids: &mut Vec<String>,
+    offset: u64,
+    limit: Option<u64>,
+    group_lens: &[usize],
+) {
+    match scan_type {
+        IndexScanType::ExactMatch { .. } => {
+            sort_equal_key_group(doc_ids);
+            apply_offset_limit(doc_ids, offset, limit);
+        }
+        IndexScanType::InScan { .. } => {
+            sort_equal_key_groups(doc_ids, group_lens);
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use query::planner::index_selection::IndexScanType;
+    use storage::index::Bound;
+
+    fn exact() -> IndexScanType {
+        IndexScanType::ExactMatch { values: vec![] }
+    }
+
+    fn in_scan() -> IndexScanType {
+        IndexScanType::InScan {
+            values: vec![],
+            suffix_values: vec![],
+        }
+    }
+
+    fn range() -> IndexScanType {
+        IndexScanType::RangeScan {
+            prefix_values: vec![],
+            lower: Bound::Unbounded,
+            upper: Bound::Unbounded,
+            reverse: false,
+        }
+    }
+
+    #[test]
+    fn exact_match_sorts_by_doc_id() {
+        let mut ids = vec!["b".into(), "a".into()];
+        apply_equal_key_doc_id_tie_break(&exact(), &mut ids, 0, None, &[]);
+        assert_eq!(ids, ["a", "b"]);
+    }
+
+    #[test]
+    fn exact_match_limit_one_picks_min_doc_id() {
+        let mut ids = vec!["b".into(), "a".into(), "c".into()];
+        apply_equal_key_doc_id_tie_break(&exact(), &mut ids, 0, Some(1), &[]);
+        assert_eq!(ids, ["a"]);
+    }
+
+    #[test]
+    fn exact_match_offset_past_end_is_empty() {
+        let mut ids = vec!["b".into(), "a".into()];
+        apply_equal_key_doc_id_tie_break(&exact(), &mut ids, 5, None, &[]);
+        assert!(ids.is_empty());
+    }
+
+    #[test]
+    fn exact_match_empty_is_empty() {
+        let mut ids: Vec<String> = vec![];
+        apply_equal_key_doc_id_tie_break(&exact(), &mut ids, 0, Some(1), &[]);
+        assert!(ids.is_empty());
+    }
+
+    #[test]
+    fn non_exact_non_in_is_noop() {
+        let mut ids = vec!["b".into(), "a".into()];
+        apply_equal_key_doc_id_tie_break(&range(), &mut ids, 0, Some(1), &[]);
+        assert_eq!(ids, ["b", "a"]);
+    }
+
+    #[test]
+    fn in_scan_sorts_each_group_and_keeps_group_order() {
+        let mut ids = vec!["b".into(), "a".into(), "d".into(), "c".into()];
+        apply_equal_key_doc_id_tie_break(&in_scan(), &mut ids, 0, None, &[2, 2]);
+        assert_eq!(ids, ["a", "b", "c", "d"]);
+    }
 }

--- a/crates/db/src/read/index_tiebreak.rs
+++ b/crates/db/src/read/index_tiebreak.rs
@@ -2,22 +2,38 @@
 
 use std::collections::HashSet;
 
+use document::NormalValue;
 use query::planner::index_selection::IndexScanType;
+use storage::index::IndexEntry;
 
-/// Append one InScan value's short IDs as a group, skipping IDs already seen.
-pub(crate) fn extend_equal_key_group(
+/// Append one InScan value's entries, skipping short IDs already seen.
+///
+/// A partial key over a composite index prefix-scans, so one InScan value can
+/// span several distinct full index keys. Entries arrive in index-key order,
+/// so a run of identical `values` is one equal-key group.
+pub(crate) fn extend_equal_key_groups(
     all: &mut Vec<u64>,
     group_lens: &mut Vec<usize>,
     seen: &mut HashSet<u64>,
-    short_ids: impl IntoIterator<Item = u64>,
+    entries: impl IntoIterator<Item = IndexEntry>,
 ) {
-    let start = all.len();
-    for id in short_ids {
-        if seen.insert(id) {
-            all.push(id);
+    let mut key: Option<Vec<NormalValue>> = None;
+    let mut start = all.len();
+    for entry in entries {
+        if key.as_ref() != Some(&entry.values) {
+            if key.is_some() {
+                group_lens.push(all.len() - start);
+                start = all.len();
+            }
+            key = Some(entry.values);
+        }
+        if seen.insert(entry.doc_short_id) {
+            all.push(entry.doc_short_id);
         }
     }
-    group_lens.push(all.len() - start);
+    if key.is_some() {
+        group_lens.push(all.len() - start);
+    }
 }
 
 /// Sort one equal-key group by public DocID.
@@ -138,6 +154,48 @@ mod tests {
         let mut ids = vec!["b".into(), "a".into()];
         apply_equal_key_doc_id_tie_break(&range(), &mut ids, 0, Some(1), &[]);
         assert_eq!(ids, ["b", "a"]);
+    }
+
+    fn entry(short_id: u64, values: &[i64]) -> IndexEntry {
+        IndexEntry::new(
+            short_id,
+            values.iter().map(|v| NormalValue::Int(*v)).collect(),
+        )
+    }
+
+    #[test]
+    fn a_prefix_scan_splits_into_one_group_per_full_key() {
+        let mut all = Vec::new();
+        let mut lens = Vec::new();
+        let mut seen = HashSet::new();
+        extend_equal_key_groups(
+            &mut all,
+            &mut lens,
+            &mut seen,
+            vec![
+                entry(1, &[7, 1]),
+                entry(2, &[7, 1]),
+                entry(3, &[7, 2]),
+                entry(4, &[7, 3]),
+            ],
+        );
+        assert_eq!(all, [1, 2, 3, 4]);
+        assert_eq!(lens, [2, 1, 1]);
+    }
+
+    #[test]
+    fn a_deduped_entry_does_not_count_toward_its_group() {
+        let mut all = Vec::new();
+        let mut lens = Vec::new();
+        let mut seen = HashSet::new();
+        extend_equal_key_groups(
+            &mut all,
+            &mut lens,
+            &mut seen,
+            vec![entry(1, &[7, 1]), entry(1, &[7, 1]), entry(2, &[7, 2])],
+        );
+        assert_eq!(all, [1, 2]);
+        assert_eq!(lens, [1, 1]);
     }
 
     #[test]

--- a/crates/db/src/read/lensed/autocommit/scan.rs
+++ b/crates/db/src/read/lensed/autocommit/scan.rs
@@ -111,7 +111,8 @@ impl<S: Store + 'static> LensedAutoCommitFetcher<S> {
                 let mut iter = index.get(&datastore, values).await.map_err(|e| {
                     query::error::QueryError::execution(format!("index error: {}", e))
                 })?;
-                collect_with_limit(&mut iter, limit, offset, vf).await?
+                // Full equal-key set: public-DocID tie-break sorts before offset/limit (#1602).
+                collect_with_limit(&mut iter, None, 0, vf).await?
             }
             IndexScanType::InScan {
                 values,
@@ -257,11 +258,17 @@ impl<S: Store + 'static> LensedAutoCommitFetcher<S> {
             .filter(|id| seen.insert(*id))
             .collect();
 
-        let doc_ids = crate::docid::map::resolve_doc_ids(&systemstore, &doc_short_ids)
+        let mut doc_ids = crate::docid::map::resolve_doc_ids(&systemstore, &doc_short_ids)
             .await
             .map_err(|e| {
                 query::error::QueryError::execution(format!("doc ID resolution error: {}", e))
             })?;
+        crate::read::index_tiebreak::apply_equal_key_doc_id_tie_break(
+            &params.scan_type,
+            &mut doc_ids,
+            offset,
+            limit,
+        );
 
         let _ = txn.discard();
 

--- a/crates/db/src/read/lensed/autocommit/scan.rs
+++ b/crates/db/src/read/lensed/autocommit/scan.rs
@@ -180,11 +180,11 @@ impl<S: Store + 'static> LensedAutoCommitFetcher<S> {
                             })?
                         };
                         raw_count += entries.len() as u64;
-                        crate::read::index_tiebreak::extend_equal_key_group(
+                        crate::read::index_tiebreak::extend_equal_key_groups(
                             &mut all_doc_short_ids,
                             &mut group_lens,
                             &mut seen_short_ids,
-                            entries.into_iter().map(|e| e.doc_short_id),
+                            entries,
                         );
                     }
                     (all_doc_short_ids, raw_count, group_lens)

--- a/crates/db/src/read/lensed/autocommit/scan.rs
+++ b/crates/db/src/read/lensed/autocommit/scan.rs
@@ -104,153 +104,173 @@ impl<S: Store + 'static> LensedAutoCommitFetcher<S> {
         }
 
         let vf = params.value_filter.as_ref();
-        let (raw_doc_short_ids, raw_fetches): (Vec<u64>, u64) = match &params.scan_type {
-            IndexScanType::ExactMatch { values } => {
-                // Cursor seek is intentionally not applied: ExactMatch fetches a single
-                // value; pagination over a single value is meaningless.
-                let mut iter = index.get(&datastore, values).await.map_err(|e| {
-                    query::error::QueryError::execution(format!("index error: {}", e))
-                })?;
-                // Full equal-key set: public-DocID tie-break sorts before offset/limit (#1602).
-                collect_with_limit(&mut iter, None, 0, vf).await?
-            }
-            IndexScanType::InScan {
-                values,
-                suffix_values,
-            } => {
-                // Cursor seek is intentionally not applied: InScan fetches a fixed set
-                // of values; pagination over an unordered set is meaningless.
-                let is_composite = index.description().fields.len() > 1;
-                let has_full_key = !suffix_values.is_empty()
-                    && suffix_values.len() == index.description().fields.len() - 1;
-                let mut all_doc_short_ids = Vec::new();
-                for value in values {
-                    if has_full_key {
-                        let mut key_values = vec![value.clone()];
-                        key_values.extend(suffix_values.iter().cloned());
-                        let mut iter = index.get(&datastore, &key_values).await.map_err(|e| {
+        let (raw_doc_short_ids, raw_fetches, group_lens): (Vec<u64>, u64, Vec<usize>) =
+            match &params.scan_type {
+                IndexScanType::ExactMatch { values } => {
+                    // Cursor seek is intentionally not applied: ExactMatch fetches a single
+                    // value; pagination over a single value is meaningless.
+                    let mut iter = index.get(&datastore, values).await.map_err(|e| {
+                        query::error::QueryError::execution(format!("index error: {}", e))
+                    })?;
+                    // Full equal-key set: public-DocID tie-break sorts before offset/limit (#1602).
+                    let (ids, n) = collect_with_limit(&mut iter, None, 0, vf).await?;
+                    (ids, n, Vec::new())
+                }
+                IndexScanType::InScan {
+                    values,
+                    suffix_values,
+                } => {
+                    // Cursor seek is intentionally not applied: InScan fetches a fixed set
+                    // of values; pagination over an unordered set is meaningless.
+                    let is_composite = index.description().fields.len() > 1;
+                    let has_full_key = !suffix_values.is_empty()
+                        && suffix_values.len() == index.description().fields.len() - 1;
+                    let mut all_doc_short_ids = Vec::new();
+                    let mut group_lens = Vec::new();
+                    let mut seen_short_ids = HashSet::new();
+                    let mut raw_count = 0u64;
+                    for value in values {
+                        let entries = if has_full_key {
+                            let mut key_values = vec![value.clone()];
+                            key_values.extend(suffix_values.iter().cloned());
+                            let mut iter =
+                                index.get(&datastore, &key_values).await.map_err(|e| {
+                                    query::error::QueryError::execution(format!(
+                                        "index error: {}",
+                                        e
+                                    ))
+                                })?;
+                            iter.collect_all().await.map_err(|e| {
+                                query::error::QueryError::execution(format!(
+                                    "index iteration error: {}",
+                                    e
+                                ))
+                            })?
+                        } else if is_composite {
+                            let mut iter = index
+                                .scan_prefix(&datastore, std::slice::from_ref(value), false)
+                                .await
+                                .map_err(|e| {
+                                    query::error::QueryError::execution(format!(
+                                        "index error: {}",
+                                        e
+                                    ))
+                                })?;
+                            iter.collect_all().await.map_err(|e| {
+                                query::error::QueryError::execution(format!(
+                                    "index iteration error: {}",
+                                    e
+                                ))
+                            })?
+                        } else {
+                            let mut iter = index
+                                .get(&datastore, std::slice::from_ref(value))
+                                .await
+                                .map_err(|e| {
+                                    query::error::QueryError::execution(format!(
+                                        "index error: {}",
+                                        e
+                                    ))
+                                })?;
+                            iter.collect_all().await.map_err(|e| {
+                                query::error::QueryError::execution(format!(
+                                    "index iteration error: {}",
+                                    e
+                                ))
+                            })?
+                        };
+                        raw_count += entries.len() as u64;
+                        crate::read::index_tiebreak::extend_equal_key_group(
+                            &mut all_doc_short_ids,
+                            &mut group_lens,
+                            &mut seen_short_ids,
+                            entries.into_iter().map(|e| e.doc_short_id),
+                        );
+                    }
+                    (all_doc_short_ids, raw_count, group_lens)
+                }
+                IndexScanType::PrefixScan {
+                    prefix_values,
+                    reverse,
+                } => {
+                    let mut iter = index
+                        .scan_prefix(&datastore, prefix_values, *reverse)
+                        .await
+                        .map_err(|e| {
                             query::error::QueryError::execution(format!("index error: {}", e))
                         })?;
-                        let entries = iter.collect_all().await.map_err(|e| {
-                            query::error::QueryError::execution(format!(
-                                "index iteration error: {}",
-                                e
-                            ))
-                        })?;
-                        all_doc_short_ids.extend(entries.into_iter().map(|e| e.doc_short_id));
-                    } else if is_composite {
-                        let mut iter = index
-                            .scan_prefix(&datastore, std::slice::from_ref(value), false)
-                            .await
-                            .map_err(|e| {
-                                query::error::QueryError::execution(format!("index error: {}", e))
-                            })?;
-                        let entries = iter.collect_all().await.map_err(|e| {
-                            query::error::QueryError::execution(format!(
-                                "index iteration error: {}",
-                                e
-                            ))
-                        })?;
-                        all_doc_short_ids.extend(entries.into_iter().map(|e| e.doc_short_id));
-                    } else {
-                        let mut iter = index
-                            .get(&datastore, std::slice::from_ref(value))
-                            .await
-                            .map_err(|e| {
-                                query::error::QueryError::execution(format!("index error: {}", e))
-                            })?;
-                        let entries = iter.collect_all().await.map_err(|e| {
-                            query::error::QueryError::execution(format!(
-                                "index iteration error: {}",
-                                e
-                            ))
-                        })?;
-                        all_doc_short_ids.extend(entries.into_iter().map(|e| e.doc_short_id));
-                    }
-                }
-                let count = all_doc_short_ids.len() as u64;
-                (all_doc_short_ids, count)
-            }
-            IndexScanType::PrefixScan {
-                prefix_values,
-                reverse,
-            } => {
-                let mut iter = index
-                    .scan_prefix(&datastore, prefix_values, *reverse)
-                    .await
-                    .map_err(|e| {
-                        query::error::QueryError::execution(format!("index error: {}", e))
-                    })?;
-                apply_cursor_seek_to_iterator(
-                    &mut iter,
-                    &params.cursor_seek,
-                    &systemstore,
-                    short_id,
-                )
-                .await?;
-                collect_with_limit(&mut iter, limit, offset, vf).await?
-            }
-            IndexScanType::RangeScan {
-                prefix_values,
-                lower,
-                upper,
-                reverse,
-            } => {
-                let mut iter = index
-                    .scan_range(
-                        &datastore,
-                        prefix_values,
-                        lower.clone(),
-                        upper.clone(),
-                        *reverse,
+                    apply_cursor_seek_to_iterator(
+                        &mut iter,
+                        &params.cursor_seek,
+                        &systemstore,
+                        short_id,
                     )
-                    .await
-                    .map_err(|e| {
-                        query::error::QueryError::execution(format!("index error: {}", e))
-                    })?;
-                apply_cursor_seek_to_iterator(
-                    &mut iter,
-                    &params.cursor_seek,
-                    &systemstore,
-                    short_id,
-                )
-                .await?;
-                collect_with_limit(&mut iter, limit, offset, vf).await?
-            }
-            IndexScanType::OrScan { branches } => {
-                // Cursor seek is intentionally not applied: each branch gets cursor_seek: None
-                // because OrScan merges independent sets; applying a cursor to individual
-                // branches would arbitrarily exclude results from other branches.
-                let _ = txn.discard();
-                let mut all_doc_ids = Vec::new();
-                let mut total_raw_fetches = 0u64;
-                for branch in branches {
-                    let branch_params = IndexScanParams {
-                        index_name: params.index_name.clone(),
-                        scan_type: branch.clone(),
-                        limit: None,
-                        offset: 0,
-                        value_filter: None,
-                        cursor_seek: None,
-                    };
-                    let branch_result = self
-                        .get_by_index_scan_impl(collection_name, &branch_params)
-                        .await?;
-                    total_raw_fetches += branch_result.raw_fetches();
-                    all_doc_ids.extend(branch_result.doc_ids().iter().cloned());
+                    .await?;
+                    let (ids, n) = collect_with_limit(&mut iter, limit, offset, vf).await?;
+                    (ids, n, Vec::new())
                 }
-                let mut seen = HashSet::new();
-                let doc_ids: Vec<String> = all_doc_ids
-                    .into_iter()
-                    .filter(|id| seen.insert(id.clone()))
-                    .collect();
-                return Ok(query::fetcher::IndexScanResult::with_raw_count(
-                    doc_ids,
-                    total_raw_fetches,
-                ));
-            }
-            _ => unreachable!(),
-        };
+                IndexScanType::RangeScan {
+                    prefix_values,
+                    lower,
+                    upper,
+                    reverse,
+                } => {
+                    let mut iter = index
+                        .scan_range(
+                            &datastore,
+                            prefix_values,
+                            lower.clone(),
+                            upper.clone(),
+                            *reverse,
+                        )
+                        .await
+                        .map_err(|e| {
+                            query::error::QueryError::execution(format!("index error: {}", e))
+                        })?;
+                    apply_cursor_seek_to_iterator(
+                        &mut iter,
+                        &params.cursor_seek,
+                        &systemstore,
+                        short_id,
+                    )
+                    .await?;
+                    let (ids, n) = collect_with_limit(&mut iter, limit, offset, vf).await?;
+                    (ids, n, Vec::new())
+                }
+                IndexScanType::OrScan { branches } => {
+                    // Cursor seek is intentionally not applied: each branch gets cursor_seek: None
+                    // because OrScan merges independent sets; applying a cursor to individual
+                    // branches would arbitrarily exclude results from other branches.
+                    let _ = txn.discard();
+                    let mut all_doc_ids = Vec::new();
+                    let mut total_raw_fetches = 0u64;
+                    for branch in branches {
+                        let branch_params = IndexScanParams {
+                            index_name: params.index_name.clone(),
+                            scan_type: branch.clone(),
+                            limit: None,
+                            offset: 0,
+                            value_filter: None,
+                            cursor_seek: None,
+                        };
+                        let branch_result = self
+                            .get_by_index_scan_impl(collection_name, &branch_params)
+                            .await?;
+                        total_raw_fetches += branch_result.raw_fetches();
+                        all_doc_ids.extend(branch_result.doc_ids().iter().cloned());
+                    }
+                    let mut seen = HashSet::new();
+                    let doc_ids: Vec<String> = all_doc_ids
+                        .into_iter()
+                        .filter(|id| seen.insert(id.clone()))
+                        .collect();
+                    return Ok(query::fetcher::IndexScanResult::with_raw_count(
+                        doc_ids,
+                        total_raw_fetches,
+                    ));
+                }
+                _ => unreachable!(),
+            };
 
         let mut seen = HashSet::new();
         let doc_short_ids: Vec<u64> = raw_doc_short_ids
@@ -268,6 +288,7 @@ impl<S: Store + 'static> LensedAutoCommitFetcher<S> {
             &mut doc_ids,
             offset,
             limit,
+            &group_lens,
         );
 
         let _ = txn.discard();

--- a/crates/db/src/read/lensed/fetcher/scan.rs
+++ b/crates/db/src/read/lensed/fetcher/scan.rs
@@ -91,152 +91,172 @@ impl<S: Store + 'static> LensedDocFetcher<S> {
         }
 
         let vf = params.value_filter.as_ref();
-        let (raw_doc_short_ids, raw_fetches): (Vec<u64>, u64) = match &params.scan_type {
-            IndexScanType::ExactMatch { values } => {
-                // Cursor seek is intentionally not applied: ExactMatch fetches a single
-                // value; pagination over a single value is meaningless.
-                let mut iter = index.get(&datastore, values).await.map_err(|e| {
-                    query::error::QueryError::execution(format!("index error: {}", e))
-                })?;
-                // Full equal-key set: public-DocID tie-break sorts before offset/limit (#1602).
-                collect_with_limit(&mut iter, None, 0, vf).await?
-            }
-            IndexScanType::InScan {
-                values,
-                suffix_values,
-            } => {
-                // Cursor seek is intentionally not applied: InScan fetches a fixed set
-                // of values; pagination over an unordered set is meaningless.
-                let is_composite = index.description().fields.len() > 1;
-                let has_full_key = !suffix_values.is_empty()
-                    && suffix_values.len() == index.description().fields.len() - 1;
-                let mut all_doc_short_ids = Vec::new();
-                for value in values {
-                    if has_full_key {
-                        let mut key_values = vec![value.clone()];
-                        key_values.extend(suffix_values.iter().cloned());
-                        let mut iter = index.get(&datastore, &key_values).await.map_err(|e| {
+        let (raw_doc_short_ids, raw_fetches, group_lens): (Vec<u64>, u64, Vec<usize>) =
+            match &params.scan_type {
+                IndexScanType::ExactMatch { values } => {
+                    // Cursor seek is intentionally not applied: ExactMatch fetches a single
+                    // value; pagination over a single value is meaningless.
+                    let mut iter = index.get(&datastore, values).await.map_err(|e| {
+                        query::error::QueryError::execution(format!("index error: {}", e))
+                    })?;
+                    // Full equal-key set: public-DocID tie-break sorts before offset/limit (#1602).
+                    let (ids, n) = collect_with_limit(&mut iter, None, 0, vf).await?;
+                    (ids, n, Vec::new())
+                }
+                IndexScanType::InScan {
+                    values,
+                    suffix_values,
+                } => {
+                    // Cursor seek is intentionally not applied: InScan fetches a fixed set
+                    // of values; pagination over an unordered set is meaningless.
+                    let is_composite = index.description().fields.len() > 1;
+                    let has_full_key = !suffix_values.is_empty()
+                        && suffix_values.len() == index.description().fields.len() - 1;
+                    let mut all_doc_short_ids = Vec::new();
+                    let mut group_lens = Vec::new();
+                    let mut seen_short_ids = HashSet::new();
+                    let mut raw_count = 0u64;
+                    for value in values {
+                        let entries = if has_full_key {
+                            let mut key_values = vec![value.clone()];
+                            key_values.extend(suffix_values.iter().cloned());
+                            let mut iter =
+                                index.get(&datastore, &key_values).await.map_err(|e| {
+                                    query::error::QueryError::execution(format!(
+                                        "index error: {}",
+                                        e
+                                    ))
+                                })?;
+                            iter.collect_all().await.map_err(|e| {
+                                query::error::QueryError::execution(format!(
+                                    "index iteration error: {}",
+                                    e
+                                ))
+                            })?
+                        } else if is_composite {
+                            let mut iter = index
+                                .scan_prefix(&datastore, std::slice::from_ref(value), false)
+                                .await
+                                .map_err(|e| {
+                                    query::error::QueryError::execution(format!(
+                                        "index error: {}",
+                                        e
+                                    ))
+                                })?;
+                            iter.collect_all().await.map_err(|e| {
+                                query::error::QueryError::execution(format!(
+                                    "index iteration error: {}",
+                                    e
+                                ))
+                            })?
+                        } else {
+                            let mut iter = index
+                                .get(&datastore, std::slice::from_ref(value))
+                                .await
+                                .map_err(|e| {
+                                    query::error::QueryError::execution(format!(
+                                        "index error: {}",
+                                        e
+                                    ))
+                                })?;
+                            iter.collect_all().await.map_err(|e| {
+                                query::error::QueryError::execution(format!(
+                                    "index iteration error: {}",
+                                    e
+                                ))
+                            })?
+                        };
+                        raw_count += entries.len() as u64;
+                        crate::read::index_tiebreak::extend_equal_key_group(
+                            &mut all_doc_short_ids,
+                            &mut group_lens,
+                            &mut seen_short_ids,
+                            entries.into_iter().map(|e| e.doc_short_id),
+                        );
+                    }
+                    (all_doc_short_ids, raw_count, group_lens)
+                }
+                IndexScanType::PrefixScan {
+                    prefix_values,
+                    reverse,
+                } => {
+                    let mut iter = index
+                        .scan_prefix(&datastore, prefix_values, *reverse)
+                        .await
+                        .map_err(|e| {
                             query::error::QueryError::execution(format!("index error: {}", e))
                         })?;
-                        let entries = iter.collect_all().await.map_err(|e| {
-                            query::error::QueryError::execution(format!(
-                                "index iteration error: {}",
-                                e
-                            ))
-                        })?;
-                        all_doc_short_ids.extend(entries.into_iter().map(|e| e.doc_short_id));
-                    } else if is_composite {
-                        let mut iter = index
-                            .scan_prefix(&datastore, std::slice::from_ref(value), false)
-                            .await
-                            .map_err(|e| {
-                                query::error::QueryError::execution(format!("index error: {}", e))
-                            })?;
-                        let entries = iter.collect_all().await.map_err(|e| {
-                            query::error::QueryError::execution(format!(
-                                "index iteration error: {}",
-                                e
-                            ))
-                        })?;
-                        all_doc_short_ids.extend(entries.into_iter().map(|e| e.doc_short_id));
-                    } else {
-                        let mut iter = index
-                            .get(&datastore, std::slice::from_ref(value))
-                            .await
-                            .map_err(|e| {
-                                query::error::QueryError::execution(format!("index error: {}", e))
-                            })?;
-                        let entries = iter.collect_all().await.map_err(|e| {
-                            query::error::QueryError::execution(format!(
-                                "index iteration error: {}",
-                                e
-                            ))
-                        })?;
-                        all_doc_short_ids.extend(entries.into_iter().map(|e| e.doc_short_id));
-                    }
-                }
-                let count = all_doc_short_ids.len() as u64;
-                (all_doc_short_ids, count)
-            }
-            IndexScanType::PrefixScan {
-                prefix_values,
-                reverse,
-            } => {
-                let mut iter = index
-                    .scan_prefix(&datastore, prefix_values, *reverse)
-                    .await
-                    .map_err(|e| {
-                        query::error::QueryError::execution(format!("index error: {}", e))
-                    })?;
-                apply_cursor_seek_to_iterator(
-                    &mut iter,
-                    &params.cursor_seek,
-                    &systemstore,
-                    short_id,
-                )
-                .await?;
-                collect_with_limit(&mut iter, limit, offset, vf).await?
-            }
-            IndexScanType::RangeScan {
-                prefix_values,
-                lower,
-                upper,
-                reverse,
-            } => {
-                let mut iter = index
-                    .scan_range(
-                        &datastore,
-                        prefix_values,
-                        lower.clone(),
-                        upper.clone(),
-                        *reverse,
+                    apply_cursor_seek_to_iterator(
+                        &mut iter,
+                        &params.cursor_seek,
+                        &systemstore,
+                        short_id,
                     )
-                    .await
-                    .map_err(|e| {
-                        query::error::QueryError::execution(format!("index error: {}", e))
-                    })?;
-                apply_cursor_seek_to_iterator(
-                    &mut iter,
-                    &params.cursor_seek,
-                    &systemstore,
-                    short_id,
-                )
-                .await?;
-                collect_with_limit(&mut iter, limit, offset, vf).await?
-            }
-            IndexScanType::OrScan { branches } => {
-                // Cursor seek is intentionally not applied: each branch gets cursor_seek: None
-                // because OrScan merges independent sets; applying a cursor to individual
-                // branches would arbitrarily exclude results from other branches.
-                let mut all_doc_ids = Vec::new();
-                let mut total_raw_fetches = 0u64;
-                for branch in branches {
-                    let branch_params = IndexScanParams {
-                        index_name: params.index_name.clone(),
-                        scan_type: branch.clone(),
-                        limit: None,
-                        offset: 0,
-                        value_filter: None,
-                        cursor_seek: None,
-                    };
-                    let branch_result = self
-                        .get_by_index_scan_impl(collection_name, &branch_params)
-                        .await?;
-                    total_raw_fetches += branch_result.raw_fetches();
-                    all_doc_ids.extend(branch_result.doc_ids().iter().cloned());
+                    .await?;
+                    let (ids, n) = collect_with_limit(&mut iter, limit, offset, vf).await?;
+                    (ids, n, Vec::new())
                 }
-                let mut seen = HashSet::new();
-                let doc_ids: Vec<String> = all_doc_ids
-                    .into_iter()
-                    .filter(|id| seen.insert(id.clone()))
-                    .collect();
-                return Ok(query::fetcher::IndexScanResult::with_raw_count(
-                    doc_ids,
-                    total_raw_fetches,
-                ));
-            }
-            _ => unreachable!(),
-        };
+                IndexScanType::RangeScan {
+                    prefix_values,
+                    lower,
+                    upper,
+                    reverse,
+                } => {
+                    let mut iter = index
+                        .scan_range(
+                            &datastore,
+                            prefix_values,
+                            lower.clone(),
+                            upper.clone(),
+                            *reverse,
+                        )
+                        .await
+                        .map_err(|e| {
+                            query::error::QueryError::execution(format!("index error: {}", e))
+                        })?;
+                    apply_cursor_seek_to_iterator(
+                        &mut iter,
+                        &params.cursor_seek,
+                        &systemstore,
+                        short_id,
+                    )
+                    .await?;
+                    let (ids, n) = collect_with_limit(&mut iter, limit, offset, vf).await?;
+                    (ids, n, Vec::new())
+                }
+                IndexScanType::OrScan { branches } => {
+                    // Cursor seek is intentionally not applied: each branch gets cursor_seek: None
+                    // because OrScan merges independent sets; applying a cursor to individual
+                    // branches would arbitrarily exclude results from other branches.
+                    let mut all_doc_ids = Vec::new();
+                    let mut total_raw_fetches = 0u64;
+                    for branch in branches {
+                        let branch_params = IndexScanParams {
+                            index_name: params.index_name.clone(),
+                            scan_type: branch.clone(),
+                            limit: None,
+                            offset: 0,
+                            value_filter: None,
+                            cursor_seek: None,
+                        };
+                        let branch_result = self
+                            .get_by_index_scan_impl(collection_name, &branch_params)
+                            .await?;
+                        total_raw_fetches += branch_result.raw_fetches();
+                        all_doc_ids.extend(branch_result.doc_ids().iter().cloned());
+                    }
+                    let mut seen = HashSet::new();
+                    let doc_ids: Vec<String> = all_doc_ids
+                        .into_iter()
+                        .filter(|id| seen.insert(id.clone()))
+                        .collect();
+                    return Ok(query::fetcher::IndexScanResult::with_raw_count(
+                        doc_ids,
+                        total_raw_fetches,
+                    ));
+                }
+                _ => unreachable!(),
+            };
 
         let mut seen = HashSet::new();
         let doc_short_ids: Vec<u64> = raw_doc_short_ids
@@ -254,6 +274,7 @@ impl<S: Store + 'static> LensedDocFetcher<S> {
             &mut doc_ids,
             offset,
             limit,
+            &group_lens,
         );
 
         Ok(query::fetcher::IndexScanResult::with_raw_count(

--- a/crates/db/src/read/lensed/fetcher/scan.rs
+++ b/crates/db/src/read/lensed/fetcher/scan.rs
@@ -98,7 +98,8 @@ impl<S: Store + 'static> LensedDocFetcher<S> {
                 let mut iter = index.get(&datastore, values).await.map_err(|e| {
                     query::error::QueryError::execution(format!("index error: {}", e))
                 })?;
-                collect_with_limit(&mut iter, limit, offset, vf).await?
+                // Full equal-key set: public-DocID tie-break sorts before offset/limit (#1602).
+                collect_with_limit(&mut iter, None, 0, vf).await?
             }
             IndexScanType::InScan {
                 values,
@@ -243,11 +244,17 @@ impl<S: Store + 'static> LensedDocFetcher<S> {
             .filter(|id| seen.insert(*id))
             .collect();
 
-        let doc_ids = crate::docid::map::resolve_doc_ids(&systemstore, &doc_short_ids)
+        let mut doc_ids = crate::docid::map::resolve_doc_ids(&systemstore, &doc_short_ids)
             .await
             .map_err(|e| {
                 query::error::QueryError::execution(format!("doc ID resolution error: {}", e))
             })?;
+        crate::read::index_tiebreak::apply_equal_key_doc_id_tie_break(
+            &params.scan_type,
+            &mut doc_ids,
+            offset,
+            limit,
+        );
 
         Ok(query::fetcher::IndexScanResult::with_raw_count(
             doc_ids,

--- a/crates/db/src/read/lensed/fetcher/scan.rs
+++ b/crates/db/src/read/lensed/fetcher/scan.rs
@@ -167,11 +167,11 @@ impl<S: Store + 'static> LensedDocFetcher<S> {
                             })?
                         };
                         raw_count += entries.len() as u64;
-                        crate::read::index_tiebreak::extend_equal_key_group(
+                        crate::read::index_tiebreak::extend_equal_key_groups(
                             &mut all_doc_short_ids,
                             &mut group_lens,
                             &mut seen_short_ids,
-                            entries.into_iter().map(|e| e.doc_short_id),
+                            entries,
                         );
                     }
                     (all_doc_short_ids, raw_count, group_lens)

--- a/crates/db/src/read/mod.rs
+++ b/crates/db/src/read/mod.rs
@@ -3,6 +3,7 @@
 pub mod autocommit;
 pub mod commits;
 pub mod doc;
+pub(crate) mod index_tiebreak;
 pub mod lensed;
 pub mod seek;
 pub(crate) mod vector;

--- a/crates/db/tests/read/index_composite_in_order.rs
+++ b/crates/db/tests/read/index_composite_in_order.rs
@@ -1,0 +1,143 @@
+//! A partial `_in` over a composite index scans a prefix, so one `_in` value
+//! covers several distinct full index keys. Index order across those keys is
+//! the secondary field's order; the public-DocID tie-break (#1602) applies
+//! only within one full key.
+
+use db::database::DB;
+use db::DbDocFetcher;
+use db::DbDocMutator;
+use document::Document;
+use document::NormalValue;
+use query::mutator::DocMutator;
+use query::planner::index_selection::IndexScanParams;
+use query::planner::index_selection::IndexScanType;
+use query::runner::DocFetcher;
+use schema::CollectionVersion;
+use schema::FieldDescription;
+use schema::FieldKind;
+use schema::IndexDescription;
+use schema::IndexedFieldDescription;
+use std::sync::Arc;
+use storage::RegolithStore;
+
+const COLLECTION: &str = "products";
+const INDEX: &str = "by_category_rank";
+const CATEGORY: &str = "a";
+
+/// Ranks repeat so one scan covers both the across-key order and the
+/// within-key tie-break.
+const SEED: [(&str, i64); 5] = [("p0", 1), ("p1", 1), ("p2", 2), ("p3", 2), ("p4", 3)];
+
+fn schema() -> CollectionVersion {
+    let mut version = CollectionVersion::new(
+        COLLECTION,
+        "v1",
+        "col-products",
+        vec![
+            FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+            FieldDescription::new("2", "category", FieldKind::string()),
+            FieldDescription::new("3", "rank", FieldKind::int()),
+            FieldDescription::new("4", "name", FieldKind::string()),
+        ],
+    );
+    version.indexes = vec![IndexDescription {
+        name: INDEX.to_string(),
+        id: 0,
+        fields: vec![
+            IndexedFieldDescription {
+                name: "category".to_string(),
+                descending: false,
+            },
+            IndexedFieldDescription {
+                name: "rank".to_string(),
+                descending: false,
+            },
+        ],
+        unique: false,
+        kind: None,
+        auto_generated: false,
+    }];
+    version
+}
+
+/// Returns (rank, doc_id) per seeded document, in insertion order.
+async fn populated() -> (Arc<DB<RegolithStore>>, Vec<(i64, String)>) {
+    let db = Arc::new(DB::new(RegolithStore::in_memory().unwrap()).expect("a database"));
+    db.create_collection(schema())
+        .await
+        .expect("the collection must register");
+
+    let txn = db.new_txn(false).await.unwrap();
+    let mutator = DbDocMutator::new(db.clone(), txn);
+    let mut seeded = Vec::new();
+    for (name, rank) in SEED {
+        let mut doc = Document::new();
+        doc.set("category", NormalValue::String(CATEGORY.to_string()));
+        doc.set("rank", NormalValue::Int(rank));
+        doc.set("name", NormalValue::String(name.to_string()));
+        let created = mutator
+            .create(COLLECTION, doc)
+            .await
+            .expect("the document must be created");
+        seeded.push((rank, created.doc_id.to_string()));
+    }
+    mutator
+        .take_txn()
+        .await
+        .expect("the mutator still holds its transaction")
+        .commit()
+        .await
+        .unwrap();
+
+    (db, seeded)
+}
+
+/// Index order: rank ascending, public DocID ascending within one rank.
+fn index_order(seeded: &[(i64, String)]) -> Vec<String> {
+    let mut ordered = seeded.to_vec();
+    ordered.sort();
+    ordered.into_iter().map(|(_, id)| id).collect()
+}
+
+#[tokio::test]
+async fn partial_in_over_a_composite_index_keeps_secondary_field_order() {
+    let (db, seeded) = populated().await;
+
+    let expected = index_order(&seeded);
+    let doc_id_only: Vec<String> = {
+        let mut ids: Vec<String> = seeded.iter().map(|(_, id)| id.clone()).collect();
+        ids.sort();
+        ids
+    };
+    assert_ne!(
+        expected, doc_id_only,
+        "the seed must distinguish index order from a flat DocID sort, \
+         otherwise this test cannot fail"
+    );
+
+    let txn = db.new_txn(true).await.unwrap();
+    let got = DbDocFetcher::new(txn)
+        .get_by_index_scan(
+            COLLECTION,
+            &IndexScanParams {
+                index_name: INDEX.to_string(),
+                scan_type: IndexScanType::InScan {
+                    values: vec![NormalValue::String(CATEGORY.to_string())],
+                    suffix_values: vec![],
+                },
+                limit: None,
+                offset: 0,
+                value_filter: None,
+                cursor_seek: None,
+            },
+        )
+        .await
+        .expect("the prefix scan must run")
+        .into_doc_ids();
+
+    assert_eq!(
+        got, expected,
+        "a partial `_in` must return index order (rank, then DocID), not a \
+         DocID sort spanning distinct ranks"
+    );
+}

--- a/crates/db/tests/read/main.rs
+++ b/crates/db/tests/read/main.rs
@@ -5,6 +5,7 @@ mod common;
 mod autocommit_suite;
 mod commits_suite;
 mod counting;
+mod index_composite_in_order;
 mod lensed_autocommit_stream_suite;
 mod lensed_autocommit_suite;
 mod lensed_fetcher_suite;

--- a/tools/integration-test/tests/query.rs
+++ b/tools/integration-test/tests/query.rs
@@ -26,6 +26,8 @@ mod float_precision;
 mod go_view_paths;
 #[path = "query/gql_list_args.rs"]
 mod gql_list_args;
+#[path = "query/index_equal_key_order.rs"]
+mod index_equal_key_order;
 #[path = "query/index_fallback_4633.rs"]
 mod index_fallback_4633;
 #[path = "query/index_management.rs"]

--- a/tools/integration-test/tests/query/index_equal_key_order.rs
+++ b/tools/integration-test/tests/query/index_equal_key_order.rs
@@ -1,0 +1,102 @@
+use integration_test::{DefraClient, TestCluster};
+
+fn add_user(node: &DefraClient, name: &str) -> String {
+    let result = node
+        .query(&format!(
+            r#"mutation {{ add_User(input: {{name: "{name}", age: 21}}) {{ _docID }} }}"#
+        ))
+        .unwrap_or_else(|e| panic!("add {name}: {e}"));
+    result["add_User"][0]["_docID"]
+        .as_str()
+        .unwrap_or_else(|| panic!("missing _docID for {name}: {result}"))
+        .to_string()
+}
+
+fn delete_users(node: &DefraClient, ids: &[String]) {
+    let quoted = ids
+        .iter()
+        .map(|id| format!("\"{id}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
+    node.query(&format!(
+        r#"mutation {{ delete_User(docIDs: [{quoted}]) {{ _docID }} }}"#
+    ))
+    .unwrap_or_else(|e| panic!("delete {ids:?}: {e}"));
+}
+
+/// Two documents that share an indexed value, queried with no `order` clause,
+/// must come back in public DocID order (#1602).
+///
+/// Index keys already suffix node-local short IDs, so KV order follows
+/// insert/persist order and diverges across replicas. Public DocIDs are
+/// content-addressed and identical everywhere. This inserts the
+/// lexicographically larger DocID first so a short-ID scan would return
+/// the reverse of the asserted order.
+#[tokio::test]
+async fn rust_equal_index_keys_are_ordered_by_doc_id() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    let node = cluster.client(0);
+
+    node.schema_add(
+        r#"
+        type User {
+            name: String
+            age: Int @index
+        }
+        "#,
+    )
+    .expect("add schema");
+
+    // Prefer the names from the Go oracle test, then fall back until the
+    // second insert has the smaller public DocID.
+    let candidates = [
+        ("John", "Andy"),
+        ("zeta", "alpha"),
+        ("zz", "aa"),
+        ("UserZ", "UserA"),
+        ("m", "a"),
+    ];
+
+    let mut chosen: Option<(String, String, String, String)> = None;
+    for (first_name, second_name) in candidates {
+        let first_id = add_user(&node, first_name);
+        let second_id = add_user(&node, second_name);
+        if second_id.as_str() < first_id.as_str() {
+            chosen = Some((
+                first_name.to_string(),
+                first_id,
+                second_name.to_string(),
+                second_id,
+            ));
+            break;
+        }
+        delete_users(&node, &[first_id, second_id]);
+    }
+    let (first_name, first_id, second_name, second_id) =
+        chosen.expect("could not find a pair whose public DocID order opposes insert order");
+
+    let result = node
+        .query(r#"query { User(filter: {age: {_eq: 21}}) { name _docID } }"#)
+        .expect("query equal indexed keys");
+    let users = result["User"].as_array().unwrap_or_else(|| {
+        panic!("User array missing from {result}");
+    });
+    assert_eq!(users.len(), 2, "expected both age=21 users, got {result}");
+
+    let got_names: Vec<&str> = users
+        .iter()
+        .map(|row| row["name"].as_str().expect("name"))
+        .collect();
+    let got_ids: Vec<&str> = users
+        .iter()
+        .map(|row| row["_docID"].as_str().expect("_docID"))
+        .collect();
+
+    assert_eq!(
+        got_ids,
+        vec![second_id.as_str(), first_id.as_str()],
+        "equal index keys must come back in public DocID order \
+         (inserted {first_name} then {second_name}); got {got_names:?}"
+    );
+    assert_eq!(got_names, vec![second_name.as_str(), first_name.as_str()]);
+}

--- a/tools/integration-test/tests/query/index_equal_key_order.rs
+++ b/tools/integration-test/tests/query/index_equal_key_order.rs
@@ -24,31 +24,9 @@ fn delete_users(node: &DefraClient, ids: &[String]) {
     .unwrap_or_else(|e| panic!("delete {ids:?}: {e}"));
 }
 
-/// Two documents that share an indexed value, queried with no `order` clause,
-/// must come back in public DocID order (#1602).
-///
-/// Index keys already suffix node-local short IDs, so KV order follows
-/// insert/persist order and diverges across replicas. Public DocIDs are
-/// content-addressed and identical everywhere. This inserts the
-/// lexicographically larger DocID first so a short-ID scan would return
-/// the reverse of the asserted order.
-#[tokio::test]
-async fn rust_equal_index_keys_are_ordered_by_doc_id() {
-    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
-    let node = cluster.client(0);
-
-    node.schema_add(
-        r#"
-        type User {
-            name: String
-            age: Int @index
-        }
-        "#,
-    )
-    .expect("add schema");
-
-    // Prefer the names from the Go oracle test, then fall back until the
-    // second insert has the smaller public DocID.
+/// Insert two age=21 users so the lexicographically larger public DocID is
+/// assigned the smaller node-local short ID.
+fn seed_reversed_cid_pair(node: &DefraClient) -> (String, String, String, String) {
     let candidates = [
         ("John", "Andy"),
         ("zeta", "alpha"),
@@ -57,30 +35,34 @@ async fn rust_equal_index_keys_are_ordered_by_doc_id() {
         ("m", "a"),
     ];
 
-    let mut chosen: Option<(String, String, String, String)> = None;
     for (first_name, second_name) in candidates {
-        let first_id = add_user(&node, first_name);
-        let second_id = add_user(&node, second_name);
+        let first_id = add_user(node, first_name);
+        let second_id = add_user(node, second_name);
         if second_id.as_str() < first_id.as_str() {
-            chosen = Some((
+            return (
                 first_name.to_string(),
                 first_id,
                 second_name.to_string(),
                 second_id,
-            ));
-            break;
+            );
         }
-        delete_users(&node, &[first_id, second_id]);
+        delete_users(node, &[first_id, second_id]);
     }
-    let (first_name, first_id, second_name, second_id) =
-        chosen.expect("could not find a pair whose public DocID order opposes insert order");
+    panic!("could not find a pair whose public DocID order opposes insert order");
+}
 
-    let result = node
-        .query(r#"query { User(filter: {age: {_eq: 21}}) { name _docID } }"#)
-        .expect("query equal indexed keys");
-    let users = result["User"].as_array().unwrap_or_else(|| {
-        panic!("User array missing from {result}");
-    });
+fn assert_doc_id_order(
+    node: &DefraClient,
+    query: &str,
+    first_name: &str,
+    first_id: &str,
+    second_name: &str,
+    second_id: &str,
+) {
+    let result = node.query(query).expect("query equal indexed keys");
+    let users = result["User"]
+        .as_array()
+        .unwrap_or_else(|| panic!("User array missing from {result}"));
     assert_eq!(users.len(), 2, "expected both age=21 users, got {result}");
 
     let got_names: Vec<&str> = users
@@ -94,9 +76,58 @@ async fn rust_equal_index_keys_are_ordered_by_doc_id() {
 
     assert_eq!(
         got_ids,
-        vec![second_id.as_str(), first_id.as_str()],
+        vec![second_id, first_id],
         "equal index keys must come back in public DocID order \
          (inserted {first_name} then {second_name}); got {got_names:?}"
     );
-    assert_eq!(got_names, vec![second_name.as_str(), first_name.as_str()]);
+    assert_eq!(got_names, vec![second_name, first_name]);
+}
+
+fn add_schema(node: &DefraClient) {
+    node.schema_add(
+        r#"
+        type User {
+            name: String
+            age: Int @index
+        }
+        "#,
+    )
+    .expect("add schema");
+}
+
+/// Two documents that share an indexed value, queried with no `order` clause,
+/// must come back in public DocID order (#1602).
+#[tokio::test]
+async fn rust_equal_index_keys_are_ordered_by_doc_id() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    let node = cluster.client(0);
+    add_schema(&node);
+    let (first_name, first_id, second_name, second_id) = seed_reversed_cid_pair(&node);
+    assert_doc_id_order(
+        &node,
+        r#"query { User(filter: {age: {_eq: 21}}) { name _docID } }"#,
+        &first_name,
+        &first_id,
+        &second_name,
+        &second_id,
+    );
+}
+
+/// `_in` is InScan, not ExactMatch. TypeJoinMany uses InScan whenever there
+/// are two or more parents, so equal-key groups there must use the same
+/// public-DocID tie-break (#1602).
+#[tokio::test]
+async fn rust_equal_index_keys_in_filter_are_ordered_by_doc_id() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    let node = cluster.client(0);
+    add_schema(&node);
+    let (first_name, first_id, second_name, second_id) = seed_reversed_cid_pair(&node);
+    assert_doc_id_order(
+        &node,
+        r#"query { User(filter: {age: {_in: [21]}}) { name _docID } }"#,
+        &first_name,
+        &first_id,
+        &second_name,
+        &second_id,
+    );
 }

--- a/tools/integration-test/tests/query/index_equal_key_order.rs
+++ b/tools/integration-test/tests/query/index_equal_key_order.rs
@@ -131,3 +131,69 @@ async fn rust_equal_index_keys_in_filter_are_ordered_by_doc_id() {
         &second_id,
     );
 }
+
+const PRODUCT_SCHEMA: &str = r#"
+    type Product @index(fields: ["category", "rank"]) {
+        category: String
+        rank: Int
+        name: String
+    }
+"#;
+
+/// Ranks repeat so one scan covers the order across full keys and the
+/// tie-break within one of them.
+const PRODUCTS: [(&str, i64); 5] = [("p0", 1), ("p1", 1), ("p2", 2), ("p3", 2), ("p4", 3)];
+
+/// A partial `_in` over a composite index prefix-scans, so one `_in` value
+/// spans several distinct full index keys. The public-DocID tie-break must
+/// stay inside one key rather than reorder across the secondary field (#1602).
+#[tokio::test]
+async fn rust_partial_in_over_composite_index_keeps_secondary_field_order() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    let node = cluster.client(0);
+    node.schema_add(PRODUCT_SCHEMA).expect("add schema");
+
+    for (name, rank) in PRODUCTS {
+        node.query(&format!(
+            r#"mutation {{ add_Product(input: {{category: "a", rank: {rank}, name: "{name}"}}) {{ _docID }} }}"#
+        ))
+        .unwrap_or_else(|e| panic!("add {name}: {e}"));
+    }
+
+    let result = node
+        .query(r#"query { Product(filter: {category: {_in: ["a"]}}) { rank _docID } }"#)
+        .expect("partial _in over the composite index");
+    let rows = result["Product"]
+        .as_array()
+        .unwrap_or_else(|| panic!("Product array missing from {result}"));
+    assert_eq!(
+        rows.len(),
+        PRODUCTS.len(),
+        "expected every product, got {result}"
+    );
+
+    let got: Vec<(i64, String)> = rows
+        .iter()
+        .map(|row| {
+            (
+                row["rank"].as_i64().expect("rank"),
+                row["_docID"].as_str().expect("_docID").to_string(),
+            )
+        })
+        .collect();
+
+    let mut index_order = got.clone();
+    index_order.sort();
+    let mut doc_id_order = got.clone();
+    doc_id_order.sort_by(|a, b| a.1.cmp(&b.1));
+    assert_ne!(
+        index_order, doc_id_order,
+        "the seed must distinguish index order from a flat DocID sort, \
+         otherwise this test cannot fail"
+    );
+    assert_eq!(
+        got, index_order,
+        "a partial `_in` must return rank order, with the DocID tie-break \
+         applied only within one rank"
+    );
+}


### PR DESCRIPTION
Closes #1602.

## What

Two documents that share an indexed value came back in node-local short-ID order.
That order follows persist/insert order, so it diverges across replicas and failed the Go oracle about 65% of the time when one doc was indexed after decrypt.

Index keys already suffix short IDs, so this is not a missing key encoding.
Equal-key groups are now sorted by public DocID after resolution, the same identity unique-index merge already uses.
Stored keys are unchanged; no reindex.

## What Changed

- Sort ExactMatch index-scan results by public DocID, then apply offset/limit
- Sort each InScan value group the same way (`_in`, TypeJoinMany with 2+ parents)
- Shared helper in `crates/db/src/read/index_tiebreak.rs`, wired into all three fetchers
- Integration tests for `_eq` and `_in` with insert order reversed against DocID
- Helper unit tests for empty, `limit: 1`, offset past end, RangeScan no-op, and two InScan groups

## Verified

- [x] `rust_equal_index_keys_are_ordered_by_doc_id` (RED before ExactMatch sort, GREEN after)
- [x] `rust_equal_index_keys_in_filter_are_ordered_by_doc_id` (RED before InScan sort, GREEN after)
- [x] `just profile=super-dev test-crate db index_tiebreak` (6)
- [x] `cargo test -p integration-test --test query -- rust_index_management`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo fmt --all`