### PR TITLE
fix(ffi): let panics unwind into FFI errors instead of aborting the host (#1594)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,7 +203,6 @@ opt-level = 3
 lto = true
 codegen-units = 1
 strip = true
-panic = "abort"
 overflow-checks = true
 
 # `bench` inherits `release`, including its lto/codegen-units/strip/

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -125,10 +125,11 @@ pub fn extract_panic_message(panic: &Box<dyn std::any::Any + Send>) -> String {
 /// The return type must implement [`FfiPanicResult`]. Caught panics are
 /// converted to error results via that trait.
 ///
-/// With `panic = "abort"` (current release profile), panics abort the
-/// process before unwinding so `catch_unwind` is a no-op. In debug/test
-/// builds (which default to `panic = "unwind"`), panics are caught and
-/// converted to error returns.
+/// The workspace release profile keeps the default `panic = "unwind"`
+/// precisely so this wrapper works in shipped artifacts. Setting
+/// `panic = "abort"` would kill the host process on any internal panic;
+/// `release_profile_does_not_abort_on_panic` in `negative_tests.rs` guards
+/// against that.
 #[macro_export]
 macro_rules! ffi_entry {
     ($($body:tt)*) => {

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -319,6 +319,9 @@ pub extern "C" fn defra_version() -> *mut c_char {
 mod negative_tests;
 
 #[cfg(test)]
+mod signing_override_tests;
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use crypto::encryption::nonce::{deterministic_nonce_enabled, set_deterministic_nonce};

--- a/crates/ffi/src/negative_tests.rs
+++ b/crates/ffi/src/negative_tests.rs
@@ -471,7 +471,8 @@ mod tests {
 
     // ── Panic containment at the FFI boundary (#1594) ─────────────────────────
 
-    /// An internal panic must surface as an error result, not kill the process.
+    /// An internal panic must surface as an error result, not kill the process,
+    /// and must leave the process able to serve the next request.
     #[test]
     fn ffi_entry_converts_panic_to_error_result() {
         let result: FfiResult = crate::ffi_entry! {
@@ -486,6 +487,34 @@ mod tests {
             "error should carry the panic message, got: {msg}"
         );
         unsafe { defra_free_string(result.error) };
+
+        // A live round-trip after the caught panic: the process is still usable.
+        init();
+        let node = new_in_memory_node();
+
+        let sdl = CString::new("type Ping { v: Int }").unwrap();
+        let r = unsafe { add_schema(node, ptr::null(), sdl.as_ptr()) };
+        assert_eq!(r.status, 0, "add_schema must succeed after a caught panic");
+        unsafe { defra_free_string(r.value) };
+
+        let q = CString::new("query { Ping { v } }").unwrap();
+        let r = unsafe {
+            exec_request(
+                node,
+                ptr::null(),
+                q.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+            )
+        };
+        assert_eq!(
+            r.status, 0,
+            "exec_request must succeed after a caught panic"
+        );
+        unsafe { defra_free_string(r.value) };
+
+        node_close(node);
     }
 
     /// The release profile must not set `panic = "abort"`.
@@ -509,9 +538,15 @@ mod tests {
             .split_once("\n[")
             .map_or(after_header, |(section, _)| section);
 
-        assert!(
-            !section.lines().any(|l| l.trim_start().starts_with("panic")),
-            "[profile.release] must not set a panic strategy, got:\n{section}"
+        let offender = section.lines().map(str::trim).find(|line| {
+            line.split_once('=').is_some_and(|(key, value)| {
+                key.trim() == "panic" && value.trim().trim_matches('"') != "unwind"
+            })
+        });
+
+        assert_eq!(
+            offender, None,
+            "[profile.release] must leave panics unwinding, got:\n{section}"
         );
     }
 }

--- a/crates/ffi/src/negative_tests.rs
+++ b/crates/ffi/src/negative_tests.rs
@@ -15,7 +15,7 @@ mod tests {
     use crate::schema::add_schema;
     use crate::subscription::{close_subscription, create_subscription, poll_subscription};
     use crate::txn::{begin_txn, commit_txn, rollback_txn};
-    use crate::types::{defra_free_string, NodeInitOptions};
+    use crate::types::{defra_free_string, FfiResult, NodeInitOptions};
 
     fn init() {
         assert!(crate::runtime::init_runtime(), "runtime init must succeed");
@@ -467,5 +467,51 @@ mod tests {
         }
 
         node_close(*node);
+    }
+
+    // ── Panic containment at the FFI boundary (#1594) ─────────────────────────
+
+    /// An internal panic must surface as an error result, not kill the process.
+    #[test]
+    fn ffi_entry_converts_panic_to_error_result() {
+        let result: FfiResult = crate::ffi_entry! {
+            panic!("deliberate test panic")
+        };
+
+        assert_eq!(result.status, 1, "a caught panic must be an error");
+        assert!(!result.error.is_null());
+        let msg = unsafe { CStr::from_ptr(result.error).to_string_lossy() };
+        assert!(
+            msg.contains("internal error (panic)") && msg.contains("deliberate test panic"),
+            "error should carry the panic message, got: {msg}"
+        );
+        unsafe { defra_free_string(result.error) };
+    }
+
+    /// The release profile must not set `panic = "abort"`.
+    ///
+    /// Unit tests build with the dev profile, where `panic = "unwind"` is
+    /// already the default — so no runtime test can catch a regression that
+    /// reintroduces `panic = "abort"` and silently turns the `ffi_entry!`
+    /// `catch_unwind` into a no-op in the shipped dylib. Only this config
+    /// assertion can (#1594).
+    #[test]
+    fn release_profile_does_not_abort_on_panic() {
+        let manifest =
+            std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/../../Cargo.toml"))
+                .expect("workspace Cargo.toml must be readable");
+
+        let after_header = manifest
+            .split_once("[profile.release]\n")
+            .expect("workspace must define [profile.release]")
+            .1;
+        let section = after_header
+            .split_once("\n[")
+            .map_or(after_header, |(section, _)| section);
+
+        assert!(
+            !section.lines().any(|l| l.trim_start().starts_with("panic")),
+            "[profile.release] must not set a panic strategy, got:\n{section}"
+        );
     }
 }

--- a/crates/ffi/src/query/mod.rs
+++ b/crates/ffi/src/query/mod.rs
@@ -17,7 +17,7 @@ use crate::state::NODES;
 use crate::types::c_str_to_string;
 
 // Re-export all public items so external imports remain unchanged.
-pub use exec::exec_request;
+pub use exec::{exec_request, exec_request_with_signing};
 pub(crate) use subscription::{
     subscription_accepts_doc_id, subscription_doc_ids, subscription_to_scoped_query,
 };

--- a/crates/ffi/src/signing_override_tests.rs
+++ b/crates/ffi/src/signing_override_tests.rs
@@ -74,12 +74,11 @@ mod tests {
     fn create_widget(node: usize, name: &str, signing_override: c_int) -> String {
         let response = exec(
             node,
-            &format!(r#"mutation {{ create_Widget(input: {{name: "{name}"}}) {{ _docID }} }}"#),
+            &format!(r#"mutation {{ add_Widget(input: {{name: "{name}"}}) {{ _docID }} }}"#),
             signing_override,
         );
         response
             .pointer("/data/add_Widget/0/_docID")
-            .or_else(|| response.pointer("/data/create_Widget/0/_docID"))
             .and_then(Value::as_str)
             .unwrap_or_else(|| panic!("created document id missing from {response}"))
             .to_string()

--- a/crates/ffi/src/signing_override_tests.rs
+++ b/crates/ffi/src/signing_override_tests.rs
@@ -1,0 +1,142 @@
+//! Per-operation signing override tests (#1600).
+//!
+//! `exec_request_with_signing` takes `-1` (node default), `0` (disable) and
+//! `1` (enable). These tests run both branches against a signing-enabled
+//! in-memory node and assert the resulting blocks carry — or do not carry — a
+//! signature.
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::{c_int, CStr, CString};
+    use std::ptr;
+
+    use serde_json::Value;
+
+    use crate::node::{new_node, node_close};
+    use crate::query::exec_request_with_signing;
+    use crate::schema::add_schema;
+    use crate::types::{defra_free_string, NodeInitOptions};
+
+    /// A signing-enabled in-memory node with a `Widget` collection.
+    ///
+    /// The node identity is generated per node, so concurrently running tests
+    /// never share signing config through the process-global identity store.
+    fn signing_node() -> usize {
+        assert!(crate::runtime::init_runtime(), "runtime init must succeed");
+
+        let result = new_node(NodeInitOptions {
+            enable_signing: 1,
+            ..NodeInitOptions::default()
+        });
+        assert_eq!(result.status, 0, "new_node must succeed");
+        let node = result.node_ptr;
+
+        let sdl = CString::new("type Widget { name: String }").unwrap();
+        let result = unsafe { add_schema(node, ptr::null(), sdl.as_ptr()) };
+        assert_eq!(result.status, 0, "add_schema must succeed");
+        if !result.value.is_null() {
+            unsafe { defra_free_string(result.value) };
+        }
+
+        node
+    }
+
+    fn exec(node: usize, query: &str, signing_override: c_int) -> Value {
+        let query = CString::new(query).unwrap();
+        let result = unsafe {
+            exec_request_with_signing(
+                node,
+                ptr::null(),
+                query.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                signing_override,
+            )
+        };
+
+        if result.status != 0 {
+            let message = unsafe { CStr::from_ptr(result.error).to_string_lossy().into_owned() };
+            unsafe { defra_free_string(result.error) };
+            panic!("exec_request_with_signing failed: {message}");
+        }
+
+        let json = unsafe { CStr::from_ptr(result.value).to_string_lossy().into_owned() };
+        unsafe { defra_free_string(result.value) };
+        let response: Value = serde_json::from_str(&json).expect("response must be JSON");
+        assert!(
+            response.get("errors").is_none_or(Value::is_null),
+            "request returned errors: {response}"
+        );
+        response
+    }
+
+    fn create_widget(node: usize, name: &str, signing_override: c_int) -> String {
+        let response = exec(
+            node,
+            &format!(r#"mutation {{ create_Widget(input: {{name: "{name}"}}) {{ _docID }} }}"#),
+            signing_override,
+        );
+        response
+            .pointer("/data/add_Widget/0/_docID")
+            .or_else(|| response.pointer("/data/create_Widget/0/_docID"))
+            .and_then(Value::as_str)
+            .unwrap_or_else(|| panic!("created document id missing from {response}"))
+            .to_string()
+    }
+
+    /// Every commit's `signature` for a document, queried with the node default.
+    fn commit_signatures(node: usize, doc_id: &str) -> Vec<Value> {
+        let response = exec(
+            node,
+            &format!(
+                r#"query {{ _commits(docID: "{doc_id}") {{ cid signature {{ type identity value }} }} }}"#
+            ),
+            -1,
+        );
+        let rows = response
+            .pointer("/data/_commits")
+            .and_then(Value::as_array)
+            .unwrap_or_else(|| panic!("commit rows missing from {response}"))
+            .clone();
+        assert!(!rows.is_empty(), "document must have commits");
+        rows.into_iter()
+            .map(|row| row.get("signature").cloned().unwrap_or(Value::Null))
+            .collect()
+    }
+
+    /// Sanity: `-1` follows the node default, so a signing node signs.
+    ///
+    /// Without this the "no signature" assertion below would pass even if the
+    /// query never surfaced signatures at all.
+    #[test]
+    fn signing_override_default_signs_on_signing_node() {
+        let node = signing_node();
+
+        let doc_id = create_widget(node, "default", -1);
+        let signatures = commit_signatures(node, &doc_id);
+
+        assert!(
+            signatures.iter().any(|signature| !signature.is_null()),
+            "node default must produce at least one signed block, got: {signatures:?}"
+        );
+
+        node_close(node);
+    }
+
+    /// `0` disables signing for that operation even on a signing node (#1600).
+    #[test]
+    fn signing_override_disabled_leaves_blocks_unsigned() {
+        let node = signing_node();
+
+        let doc_id = create_widget(node, "unsigned", 0);
+        let signatures = commit_signatures(node, &doc_id);
+
+        assert!(
+            signatures.iter().all(Value::is_null),
+            "signing_override=0 must leave every block unsigned, got: {signatures:?}"
+        );
+
+        node_close(node);
+    }
+}


### PR DESCRIPTION
## What

The release profile set `panic = "abort"`, so any internal Rust panic killed whatever embeds `libffi` (a Go test binary, a mobile app) with SIGABRT.
The crate already wraps every `extern "C"` entry point in a `catch_unwind` boundary (`ffi_entry!`), but abort made that boundary dead code in shipped artifacts.
Removing the line makes a panic surface to the caller as `internal error (panic): <message>` while the host process survives; node state after a caught panic is best effort.

This matches Go's runtime model: unwind and catch at the boundaries; only an uncaught panic kills the process.
Go DefraDB itself recovers expected panics at its cbindings boundary (`recoverHandleValue`) and survives HTTP handler panics via `net/http`'s default recovery.
Also proven here for #1600: the Rust per-op signing override already works, so the reported symptom lives in the Go wrapper and that issue stays open for the Go-side change.

## What Changed

- Removed `panic = "abort"` from `[profile.release]`; everything else in the profile, including `overflow-checks = true`, is untouched
- Re-exported `exec_request_with_signing` from the query module (it existed only as a C symbol, never callable from Rust)
- Added `ffi_entry_converts_panic_to_error_result`: a deliberate panic returns an error result and the node still serves a real request afterwards
- Added `release_profile_does_not_abort_on_panic`: config guard rejecting any `[profile.release]` panic strategy other than `"unwind"`
- Added `signing_override_*` tests (#1600): `-1` signs on a signing-enabled node, `0` leaves every commit's `signature` null
- Rewrote the stale `ffi_entry!` doc comment that documented the abort-era contract

## Verification

- `cargo test -p ffi`: 166 passed, 0 failed; full workspace gate: 222 suites, 5,274 passed, 0 failed
- `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt --all` clean
- Size measured on both profile settings: `libffi.dylib` 31.25 -> 38.80 MiB (+24.2%), `libffi.a` +9.6%, WASM bundle -7.5 KB (noise; wasm32 emits no unwind tables); build time unchanged
- Go wrapper needs no change: a caught panic flows through the existing `FfiResult.Error` path

Closes #1594. Refs #1600.
