### PR TITLE
fix(query): preserve child scan order in one-to-many joins

### DIFF
--- a/crates/query/src/plan/type_join/type_join_many/children.rs
+++ b/crates/query/src/plan/type_join/type_join_many/children.rs
@@ -27,8 +27,9 @@ impl TypeJoinMany {
 
         let mut children: Vec<Doc> = docs.iter().map(|d| d.deep_clone()).collect();
 
-        // Apply ordering if specified, otherwise default to _docID order
-        // for deterministic results matching Go DefraDB's storage scan order.
+        // Apply ordering if specified. Without one, the cache order is kept: it is
+        // the child scan order, which follows the doc short ID (insertion order),
+        // matching Go DefraDB.
         if let Some(ref order_by) = self.child_order_by {
             let child_mapping = self.child_plan.document_map();
             children.sort_by(|a, b| {
@@ -65,9 +66,6 @@ impl TypeJoinMany {
                 }
                 Ordering::Equal
             });
-        } else {
-            // Default: sort by _docID (index 0) for deterministic ordering
-            children.sort_by(|a, b| compare_json_values(a.get(0), b.get(0)));
         }
 
         // NOTE: Limit/offset are NOT applied here. They are applied in the runner's

--- a/tools/integration-test/tests/query.rs
+++ b/tools/integration-test/tests/query.rs
@@ -42,6 +42,8 @@ mod limit_pushdown;
 mod limits;
 #[path = "query/multi_cid_vectors.rs"]
 mod multi_cid_vectors;
+#[path = "query/one_to_many_common.rs"]
+mod one_to_many_common;
 #[path = "query/planner_4656.rs"]
 mod planner_4656;
 #[path = "query/planner_4684.rs"]

--- a/tools/integration-test/tests/query.rs
+++ b/tools/integration-test/tests/query.rs
@@ -26,6 +26,8 @@ mod gql_list_args;
 mod index_fallback_4633;
 #[path = "query/index_management.rs"]
 mod index_management;
+#[path = "query/join_order_1596.rs"]
+mod join_order_1596;
 #[path = "query/json_missing_key.rs"]
 mod json_missing_key;
 #[path = "query/lens.rs"]

--- a/tools/integration-test/tests/query/join_order_1596.rs
+++ b/tools/integration-test/tests/query/join_order_1596.rs
@@ -1,69 +1,18 @@
+use crate::one_to_many_common::{add_author, add_book, add_schema};
 use integration_test::{DefraClient, TestCluster};
 
 /// Mirrors the Go one_to_many fixture: authors first, then books in the order
 /// listed by the Go tests, so child scan order == insertion order.
 fn setup(node: &DefraClient) {
-    node.schema_add(
-        r#"
-        type Book {
-            name: String
-            rating: Float
-            author: Author
-        }
+    add_schema(node);
 
-        type Author {
-            name: String
-            age: Int
-            verified: Boolean
-            published: [Book]
-        }
-        "#,
-    )
-    .expect("add schema");
+    let john = add_author(node, "John Grisham", 65, true);
+    let cornelia = add_author(node, "Cornelia Funke", 62, false);
 
-    let john = node
-        .query(
-            r#"mutation { add_Author(input: {name: "John Grisham", age: 65, verified: true}) { _docID } }"#,
-        )
-        .expect("add John");
-    let john_id = john["add_Author"][0]["_docID"]
-        .as_str()
-        .unwrap()
-        .to_string();
-
-    let cornelia = node
-        .query(
-            r#"mutation { add_Author(input: {name: "Cornelia Funke", age: 62, verified: false}) { _docID } }"#,
-        )
-        .expect("add Cornelia");
-    let cornelia_id = cornelia["add_Author"][0]["_docID"]
-        .as_str()
-        .unwrap()
-        .to_string();
-
-    for (name, rating, author) in [
-        ("Painted House", 4.9, &john_id),
-        ("A Time for Mercy", 4.5, &john_id),
-        ("The Associate", 4.2, &john_id),
-        ("Theif Lord", 4.8, &cornelia_id),
-    ] {
-        node.query(&format!(
-            r#"mutation {{ add_Book(input: {{name: "{}", rating: {}, author: "{}"}}) {{ _docID }} }}"#,
-            name, rating, author
-        ))
-        .unwrap_or_else(|e| panic!("add {}: {}", name, e));
-    }
-}
-
-fn sum_for(result: &serde_json::Value, author: &str, key: &str) -> f64 {
-    result["Author"]
-        .as_array()
-        .expect("Author array")
-        .iter()
-        .find(|a| a["name"] == author)
-        .unwrap_or_else(|| panic!("author {} missing", author))[key]
-        .as_f64()
-        .expect("numeric aggregate")
+    add_book(node, "Painted House", 4.9, &john);
+    add_book(node, "A Time for Mercy", 4.5, &john);
+    add_book(node, "The Associate", 4.2, &john);
+    add_book(node, "Theif Lord", 4.8, &cornelia);
 }
 
 async fn sum_with_alias_order_test(cluster: TestCluster) {
@@ -113,8 +62,13 @@ async fn sum_with_limit_test(cluster: TestCluster) {
         )
         .expect("query authors");
 
-    assert_eq!(sum_for(&result, "John Grisham", "SUM"), 9.4);
-    assert_eq!(sum_for(&result, "Cornelia Funke", "SUM"), 4.8);
+    assert_eq!(
+        result["Author"],
+        serde_json::json!([
+            {"name": "John Grisham", "SUM": 9.4},
+            {"name": "Cornelia Funke", "SUM": 4.8},
+        ])
+    );
 }
 
 async fn sum_with_offset_limit_test(cluster: TestCluster) {
@@ -134,8 +88,13 @@ async fn sum_with_offset_limit_test(cluster: TestCluster) {
         )
         .expect("query authors");
 
-    assert_eq!(sum_for(&result, "John Grisham", "SUM"), 8.7);
-    assert_eq!(sum_for(&result, "Cornelia Funke", "SUM"), 0.0);
+    assert_eq!(
+        result["Author"],
+        serde_json::json!([
+            {"name": "John Grisham", "SUM": 8.7},
+            {"name": "Cornelia Funke", "SUM": 0},
+        ])
+    );
 }
 
 async fn relation_render_order_test(cluster: TestCluster) {

--- a/tools/integration-test/tests/query/join_order_1596.rs
+++ b/tools/integration-test/tests/query/join_order_1596.rs
@@ -1,0 +1,190 @@
+use integration_test::{DefraClient, TestCluster};
+
+/// Mirrors the Go one_to_many fixture: authors first, then books in the order
+/// listed by the Go tests, so child scan order == insertion order.
+fn setup(node: &DefraClient) {
+    node.schema_add(
+        r#"
+        type Book {
+            name: String
+            rating: Float
+            author: Author
+        }
+
+        type Author {
+            name: String
+            age: Int
+            verified: Boolean
+            published: [Book]
+        }
+        "#,
+    )
+    .expect("add schema");
+
+    let john = node
+        .query(
+            r#"mutation { add_Author(input: {name: "John Grisham", age: 65, verified: true}) { _docID } }"#,
+        )
+        .expect("add John");
+    let john_id = john["add_Author"][0]["_docID"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let cornelia = node
+        .query(
+            r#"mutation { add_Author(input: {name: "Cornelia Funke", age: 62, verified: false}) { _docID } }"#,
+        )
+        .expect("add Cornelia");
+    let cornelia_id = cornelia["add_Author"][0]["_docID"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    for (name, rating, author) in [
+        ("Painted House", 4.9, &john_id),
+        ("A Time for Mercy", 4.5, &john_id),
+        ("The Associate", 4.2, &john_id),
+        ("Theif Lord", 4.8, &cornelia_id),
+    ] {
+        node.query(&format!(
+            r#"mutation {{ add_Book(input: {{name: "{}", rating: {}, author: "{}"}}) {{ _docID }} }}"#,
+            name, rating, author
+        ))
+        .unwrap_or_else(|e| panic!("add {}: {}", name, e));
+    }
+}
+
+fn sum_for(result: &serde_json::Value, author: &str, key: &str) -> f64 {
+    result["Author"]
+        .as_array()
+        .expect("Author array")
+        .iter()
+        .find(|a| a["name"] == author)
+        .unwrap_or_else(|| panic!("author {} missing", author))[key]
+        .as_f64()
+        .expect("numeric aggregate")
+}
+
+async fn sum_with_alias_order_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    setup(&node);
+
+    let result = node
+        .query(
+            r#"
+            query {
+                Author(order: {_alias: {totalRating: DESC}}) {
+                    name
+                    totalRating: SUM(published: {field: rating})
+                }
+            }
+            "#,
+        )
+        .expect("query authors");
+
+    // Go asserts 13.600000000000001 here (4.9 + 4.5 + 4.2 accumulated in
+    // insertion order). Our response path cannot express that 17th significant
+    // digit, so the order-sensitive assertions live in the limit/offset tests
+    // below, where the difference is visible at 2 significant digits.
+    assert_eq!(
+        result["Author"],
+        serde_json::json!([
+            {"name": "John Grisham", "totalRating": 13.6},
+            {"name": "Cornelia Funke", "totalRating": 4.8},
+        ])
+    );
+}
+
+async fn sum_with_limit_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    setup(&node);
+
+    let result = node
+        .query(
+            r#"
+            query {
+                Author {
+                    name
+                    SUM(published: {field: rating, limit: 2})
+                }
+            }
+            "#,
+        )
+        .expect("query authors");
+
+    assert_eq!(sum_for(&result, "John Grisham", "SUM"), 9.4);
+    assert_eq!(sum_for(&result, "Cornelia Funke", "SUM"), 4.8);
+}
+
+async fn sum_with_offset_limit_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    setup(&node);
+
+    let result = node
+        .query(
+            r#"
+            query {
+                Author {
+                    name
+                    SUM(published: {field: rating, offset: 1, limit: 2})
+                }
+            }
+            "#,
+        )
+        .expect("query authors");
+
+    assert_eq!(sum_for(&result, "John Grisham", "SUM"), 8.7);
+    assert_eq!(sum_for(&result, "Cornelia Funke", "SUM"), 0.0);
+}
+
+async fn relation_render_order_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    setup(&node);
+
+    let result = node
+        .query(
+            r#"
+            query {
+                Author(filter: {name: {_eq: "John Grisham"}}) {
+                    name
+                    published { name }
+                }
+            }
+            "#,
+        )
+        .expect("query authors");
+
+    assert_eq!(
+        result["Author"][0]["published"],
+        serde_json::json!([
+            {"name": "Painted House"},
+            {"name": "A Time for Mercy"},
+            {"name": "The Associate"},
+        ])
+    );
+}
+
+#[tokio::test]
+async fn rust_join_order_1596_sum_with_alias_order() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    sum_with_alias_order_test(cluster).await;
+}
+
+#[tokio::test]
+async fn rust_join_order_1596_sum_with_limit() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    sum_with_limit_test(cluster).await;
+}
+
+#[tokio::test]
+async fn rust_join_order_1596_sum_with_offset_limit() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    sum_with_offset_limit_test(cluster).await;
+}
+
+#[tokio::test]
+async fn rust_join_order_1596_relation_render_order() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    relation_render_order_test(cluster).await;
+}

--- a/tools/integration-test/tests/query/one_to_many_common.rs
+++ b/tools/integration-test/tests/query/one_to_many_common.rs
@@ -1,0 +1,43 @@
+//! Shared Book/Author fixture mirroring the Go `one_to_many` package
+//! (`tests/integration/query/one_to_many/utils.go`).
+
+use integration_test::DefraClient;
+
+pub fn add_schema(node: &DefraClient) {
+    node.schema_add(
+        r#"
+        type Book {
+            name: String
+            rating: Float
+            author: Author
+        }
+
+        type Author {
+            name: String
+            age: Int
+            verified: Boolean
+            published: [Book]
+        }
+        "#,
+    )
+    .expect("add schema");
+}
+
+pub fn add_author(node: &DefraClient, name: &str, age: i64, verified: bool) -> String {
+    let result = node
+        .query(&format!(
+            r#"mutation {{ add_Author(input: {{name: "{name}", age: {age}, verified: {verified}}}) {{ _docID }} }}"#
+        ))
+        .unwrap_or_else(|e| panic!("add author {name}: {e}"));
+    result["add_Author"][0]["_docID"]
+        .as_str()
+        .expect("author _docID")
+        .to_string()
+}
+
+pub fn add_book(node: &DefraClient, name: &str, rating: f64, author: &str) {
+    node.query(&format!(
+        r#"mutation {{ add_Book(input: {{name: "{name}", rating: {rating}, author: "{author}"}}) {{ _docID }} }}"#
+    ))
+    .unwrap_or_else(|e| panic!("add book {name}: {e}"));
+}


### PR DESCRIPTION
Closes #1596. Stack 1/5, base `main`.

## What

One-to-many child lists arrive in reverse order, so `limit`/`offset` windows select different rows than Go and float accumulation diverges (Go: `4.9 + 4.5 + 4.2 = 13.600000000000001`; Rust summed the reverse to `13.6`).

Go scans children by doc short ID (monotonic u64 → insertion order). Rust builds its cache in that same order, then `find_child_docs` re-sorted by the `_docID` content hash under a stale comment claiming that matched Go.

## What changed

- Deleted the default `_docID` sort in `plan/type_join/type_join_many/children.rs`; cache order (scan order = insertion order) is kept on both the full-scan and FK-indexed paths.
- Updated the stale comment; explicit relation `order` is untouched.
- Added `tools/integration-test/tests/query/join_order_1596.rs` (4 tests) mirroring Go's `with_sum_order`/`with_sum_limit`/`with_sum_limit_offset` data exactly.
- Added shared `one_to_many_common.rs` fixture, reused by the later PRs in this stack.

## Verification

- New tests red before the fix with the issue's exact reversal (`limit 2`: 8.7 vs 9.4; `offset 1, limit 2`: 9.4 vs 8.7), green after.
- `cargo test -p query`, clippy `-D warnings`, and the query integration area all pass.
- Note: the alias-order SUM test asserts `13.6` until the float-precision PR at the top of this stack tightens it to Go's exact `13.600000000000001`.
