### PR TITLE
fix(query): plan order-by-relation joins without panicking

### DIFF
--- a/crates/query/src/plan/orphan.rs
+++ b/crates/query/src/plan/orphan.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use document::NormalValue;
 
 use crate::document::DocumentMapping;
-use crate::error::Result;
+use crate::error::{QueryError, Result};
 use crate::fetcher::DocFetcher;
 use crate::planner::{Doc, ExecInfo, PlanNode};
 use crate::planner::{IndexScanParams, IndexScanType};
@@ -155,26 +155,27 @@ impl PlanNode for OrphanNode {
                         continue;
                     }
 
-                    if let Some(fetcher) = fetcher {
-                        let scan_result = fetcher
-                            .get_by_index_scan(
-                                child_collection_name,
-                                &IndexScanParams {
-                                    index_name: child_fk_index_name.clone(),
-                                    scan_type: IndexScanType::ExactMatch {
-                                        values: vec![NormalValue::String(doc_id.to_string())],
-                                    },
-                                    limit: Some(1),
-                                    offset: 0,
-                                    value_filter: None,
-                                    cursor_seek: None,
+                    let fetcher = fetcher.as_ref().ok_or_else(|| {
+                        QueryError::internal("orphan scan: fetcher not initialized")
+                    })?;
+                    let scan_result = fetcher
+                        .get_by_index_scan(
+                            child_collection_name,
+                            &IndexScanParams {
+                                index_name: child_fk_index_name.clone(),
+                                scan_type: IndexScanType::ExactMatch {
+                                    values: vec![NormalValue::String(doc_id.to_string())],
                                 },
-                            )
-                            .await?;
-                        self.exec_info.indexes_fetched += 1;
-                        if !scan_result.doc_ids().is_empty() {
-                            continue;
-                        }
+                                limit: Some(1),
+                                offset: 0,
+                                value_filter: None,
+                                cursor_seek: None,
+                            },
+                        )
+                        .await?;
+                    self.exec_info.indexes_fetched += 1;
+                    if !scan_result.doc_ids().is_empty() {
+                        continue;
                     }
                 }
                 self.current_doc = doc.deep_clone();

--- a/crates/query/src/plan/orphan.rs
+++ b/crates/query/src/plan/orphan.rs
@@ -24,7 +24,7 @@ enum Inner {
     SecondarySide {
         parent_scan: Box<dyn PlanNode>,
         yielded_ids: SharedYieldedIds,
-        fetcher: Arc<dyn DocFetcher>,
+        fetcher: Option<Arc<dyn DocFetcher>>,
         child_collection_name: String,
         child_fk_index_name: String,
     },
@@ -57,7 +57,7 @@ impl OrphanNode {
     pub fn secondary_side(
         parent_scan: Box<dyn PlanNode>,
         yielded_ids: SharedYieldedIds,
-        fetcher: Arc<dyn DocFetcher>,
+        fetcher: Option<Arc<dyn DocFetcher>>,
         child_collection_name: String,
         child_fk_index_name: String,
         document_mapping: DocumentMapping,
@@ -155,24 +155,26 @@ impl PlanNode for OrphanNode {
                         continue;
                     }
 
-                    let scan_result = fetcher
-                        .get_by_index_scan(
-                            child_collection_name,
-                            &IndexScanParams {
-                                index_name: child_fk_index_name.clone(),
-                                scan_type: IndexScanType::ExactMatch {
-                                    values: vec![NormalValue::String(doc_id.to_string())],
+                    if let Some(fetcher) = fetcher {
+                        let scan_result = fetcher
+                            .get_by_index_scan(
+                                child_collection_name,
+                                &IndexScanParams {
+                                    index_name: child_fk_index_name.clone(),
+                                    scan_type: IndexScanType::ExactMatch {
+                                        values: vec![NormalValue::String(doc_id.to_string())],
+                                    },
+                                    limit: Some(1),
+                                    offset: 0,
+                                    value_filter: None,
+                                    cursor_seek: None,
                                 },
-                                limit: Some(1),
-                                offset: 0,
-                                value_filter: None,
-                                cursor_seek: None,
-                            },
-                        )
-                        .await?;
-                    self.exec_info.indexes_fetched += 1;
-                    if !scan_result.doc_ids().is_empty() {
-                        continue;
+                            )
+                            .await?;
+                        self.exec_info.indexes_fetched += 1;
+                        if !scan_result.doc_ids().is_empty() {
+                            continue;
+                        }
                     }
                 }
                 self.current_doc = doc.deep_clone();

--- a/crates/query/src/planner/joins/join_one.rs
+++ b/crates/query/src/planner/joins/join_one.rs
@@ -212,15 +212,17 @@ impl Planner {
                                 child_fk_field_name.trim_start_matches('_')
                             )
                         });
-                    let mut orphan_scan = ScanNode::new(orphan_col, orphan_mapping)
-                        .with_fetcher(orphan_fetcher.unwrap());
+                    let mut orphan_scan = ScanNode::new(orphan_col, orphan_mapping);
+                    if let Some(fetcher) = orphan_fetcher {
+                        orphan_scan = orphan_scan.with_fetcher(fetcher);
+                    }
                     if let Some(filter) = parent_residual_filter.clone() {
                         orphan_scan = orphan_scan.with_filter(filter);
                     }
                     let orphan = OrphanNode::secondary_side(
                         Box::new(orphan_scan),
                         shared_ids.clone(),
-                        self.fetcher.clone().unwrap(),
+                        self.fetcher.clone(),
                         target_collection.name.clone(),
                         child_fk_index_name,
                         mapping.clone(),
@@ -296,9 +298,11 @@ impl Planner {
                         let orphan_filter = parent_residual_filter
                             .clone()
                             .map_or_else(|| null_filter.clone(), |filter| null_filter.and(filter));
-                        let orphan_scan = ScanNode::new(orphan_col, orphan_mapping)
-                            .with_filter(orphan_filter)
-                            .with_fetcher(orphan_fetcher.unwrap());
+                        let mut orphan_scan =
+                            ScanNode::new(orphan_col, orphan_mapping).with_filter(orphan_filter);
+                        if let Some(fetcher) = orphan_fetcher {
+                            orphan_scan = orphan_scan.with_fetcher(fetcher);
+                        }
                         let orphan =
                             OrphanNode::primary_side(Box::new(orphan_scan), mapping.clone());
                         let direction = parent_order_for_child

--- a/tools/integration-test/tests/query.rs
+++ b/tools/integration-test/tests/query.rs
@@ -48,6 +48,8 @@ mod one_to_many_common;
 mod planner_4656;
 #[path = "query/planner_4684.rs"]
 mod planner_4684;
+#[path = "query/relation_order_panic_1594.rs"]
+mod relation_order_panic_1594;
 #[path = "query/sdl_generate.rs"]
 mod sdl_generate;
 #[path = "query/subscription_docid.rs"]

--- a/tools/integration-test/tests/query/relation_order_panic_1594.rs
+++ b/tools/integration-test/tests/query/relation_order_panic_1594.rs
@@ -1,0 +1,218 @@
+use integration_test::{DefraClient, TestCluster};
+use serde_json::Value;
+
+/// Mirrors the Go fixture from TestDebugExplainRequestWithOrderByRelationFieldWithIndex:
+/// `Publisher` is the primary side, so it holds the `_bookID` foreign key, and the
+/// ordering field lives on the child `Book`.
+fn add_schema(node: &DefraClient) {
+    node.schema_add(
+        r#"
+        type Book {
+            title: String
+            rating: Int @index
+            publisher: Publisher
+        }
+
+        type Publisher {
+            name: String
+            book: Book @primary
+        }
+        "#,
+    )
+    .expect("add schema");
+}
+
+/// Names of the children of the `sequenceNode` under the `typeIndexJoin`, in order.
+fn sequence_child_names(explain: &Value) -> Vec<String> {
+    let sequence = explain["explain"]["operationNode"][0]["selectTopNode"]["selectNode"]
+        ["typeIndexJoin"]["sequenceNode"]
+        .as_array()
+        .unwrap_or_else(|| panic!("expected a sequenceNode array, got: {explain}"));
+
+    sequence
+        .iter()
+        .map(|child| {
+            child
+                .as_object()
+                .and_then(|obj| obj.keys().next())
+                .unwrap_or_else(|| panic!("sequenceNode child is not a single-key object: {child}"))
+                .clone()
+        })
+        .collect()
+}
+
+/// Assert the `typeJoinOne` child has Go's shape:
+/// `{root: {scanNode}, subType: {selectTopNode: {selectNode: {scanNode}}}}`.
+fn assert_join_one_shape(explain: &Value) {
+    let sequence = &explain["explain"]["operationNode"][0]["selectTopNode"]["selectNode"]
+        ["typeIndexJoin"]["sequenceNode"];
+    let join = sequence
+        .as_array()
+        .expect("sequenceNode array")
+        .iter()
+        .find_map(|child| child.get("typeJoinOne"))
+        .unwrap_or_else(|| panic!("no typeJoinOne in sequenceNode: {explain}"));
+
+    assert!(
+        join["root"].get("scanNode").is_some(),
+        "typeJoinOne.root should be a scanNode, got: {}",
+        join["root"]
+    );
+    assert!(
+        join["subType"]["selectTopNode"]["selectNode"]
+            .get("scanNode")
+            .is_some(),
+        "typeJoinOne.subType should be selectTopNode > selectNode > scanNode, got: {}",
+        join["subType"]
+    );
+}
+
+async fn debug_explain_asc_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    add_schema(&node);
+
+    let explain = node
+        .query(
+            r#"query @explain(type: debug) @exhaustive {
+                Publisher(order: {book: {rating: ASC}}) {
+                    name
+                }
+            }"#,
+        )
+        .expect("debug explain ASC");
+
+    assert_eq!(
+        sequence_child_names(&explain),
+        vec!["orphanNode", "typeJoinOne"],
+        "ASC orders orphans first: {explain}"
+    );
+    assert_join_one_shape(&explain);
+}
+
+async fn debug_explain_desc_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    add_schema(&node);
+
+    let explain = node
+        .query(
+            r#"query @explain(type: debug) @exhaustive {
+                Publisher(order: {book: {rating: DESC}}) {
+                    name
+                }
+            }"#,
+        )
+        .expect("debug explain DESC");
+
+    assert_eq!(
+        sequence_child_names(&explain),
+        vec!["typeJoinOne", "orphanNode"],
+        "DESC orders orphans last: {explain}"
+    );
+    assert_join_one_shape(&explain);
+}
+
+async fn exhaustive_execution_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    add_schema(&node);
+
+    let add_book = |title: &str, rating: i64| {
+        let result = node
+            .query(&format!(
+                r#"mutation {{ add_Book(input: {{title: "{title}", rating: {rating}}}) {{ _docID }} }}"#
+            ))
+            .expect("add book");
+        result["add_Book"][0]["_docID"]
+            .as_str()
+            .expect("book _docID")
+            .to_string()
+    };
+
+    let high = add_book("HighRated", 2);
+    let low = add_book("LowRated", 1);
+
+    let add_publisher = |name: &str, book: Option<&str>| {
+        let input = match book {
+            Some(book_id) => format!(r#"{{name: "{name}", book: "{book_id}"}}"#),
+            None => format!(r#"{{name: "{name}"}}"#),
+        };
+        node.query(&format!(
+            r#"mutation {{ add_Publisher(input: {input}) {{ _docID }} }}"#
+        ))
+        .expect("add publisher");
+    };
+
+    add_publisher("HighPublisher", Some(&high));
+    add_publisher("LowPublisher", Some(&low));
+    add_publisher("OrphanPublisher", None);
+
+    let plain = node
+        .query(
+            r#"query {
+                Publisher(order: {book: {rating: ASC}}) {
+                    name
+                }
+            }"#,
+        )
+        .expect("query publishers ASC");
+    assert_eq!(
+        plain["Publisher"],
+        serde_json::json!([
+            {"name": "LowPublisher"},
+            {"name": "HighPublisher"}
+        ])
+    );
+
+    let exhaustive_asc = node
+        .query(
+            r#"query @exhaustive {
+                Publisher(order: {book: {rating: ASC}}) {
+                    name
+                }
+            }"#,
+        )
+        .expect("query publishers exhaustive ASC");
+    assert_eq!(
+        exhaustive_asc["Publisher"],
+        serde_json::json!([
+            {"name": "OrphanPublisher"},
+            {"name": "LowPublisher"},
+            {"name": "HighPublisher"}
+        ])
+    );
+
+    let exhaustive_desc = node
+        .query(
+            r#"query @exhaustive {
+                Publisher(order: {book: {rating: DESC}}) {
+                    name
+                }
+            }"#,
+        )
+        .expect("query publishers exhaustive DESC");
+    assert_eq!(
+        exhaustive_desc["Publisher"],
+        serde_json::json!([
+            {"name": "HighPublisher"},
+            {"name": "LowPublisher"},
+            {"name": "OrphanPublisher"}
+        ])
+    );
+}
+
+#[tokio::test]
+async fn rust_relation_order_panic_1594_debug_explain_asc() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    debug_explain_asc_test(cluster).await;
+}
+
+#[tokio::test]
+async fn rust_relation_order_panic_1594_debug_explain_desc() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    debug_explain_desc_test(cluster).await;
+}
+
+#[tokio::test]
+async fn rust_relation_order_panic_1594_exhaustive_execution() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    exhaustive_execution_test(cluster).await;
+}


### PR DESCRIPTION
Refs #1594 — fixes the panic half; the `panic = "abort"` FFI contract is the issue's remaining half. Stack 2/5, base `edjroz/1596-join-order`.

## What

`query @explain(type: debug) @exhaustive { Publisher(order: {book: {rating: ASC}}) { name } }` panics in the planner; through the FFI (release aborts on panic) it kills the whole host process with SIGABRT.

Debug-explain builds its planner without a fetcher (explain never executes), and the exhaustive order-by-relation paths in `joins/join_one.rs` called `.unwrap()` on that `Option` at three sites. Execution paths always set a fetcher, so this was explain-only.

## What changed

- Guarded all three unwrap sites, including the sibling secondary-parent path that panicked identically.
- `OrphanNode::secondary_side` takes an optional fetcher; the orphan `ScanNode` attaches one only when present, so the plan still builds fetcher-less (Go succeeds on this query).
- Fetcherless orphan *filtering* (unreachable today) now returns an internal error instead of silently skipping.
- Added `relation_order_panic_1594.rs`: ASC + DESC debug-explain shapes from Go's patterns, plus an execution test of the same query.

## Verification

- Panic reproduced red-first and captured live: `join_one.rs:301: called Option::unwrap() on a None value`, backtrace ending in the explain runner.
- Explain shapes match Go's `primaryParentASCPattern`/`primaryParentDESCPattern` verbatim; the secondary-parent shape matches `secondaryParentPattern`.
- Execution test's orphan placement (first for ASC, last for DESC) is derived from Go's plan shape — no Go execution test covers this path.
- `cargo test -p query`, clippy, and the query integration area all pass.
