### PR TITLE
fix(query): duplicate relation selections and grouped _docID leak

### DIFF
--- a/crates/query/src/document/mapping.rs
+++ b/crates/query/src/document/mapping.rs
@@ -40,7 +40,7 @@ struct TypeInfo {
 ///
 /// Maps field names to indexes in the document's fields array,
 /// tracks which fields to render, and manages child mappings for nested objects.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct DocumentMapping {
     /// Type information for the object (if provided)
     type_info: Option<TypeInfo>,

--- a/crates/query/src/mapper/cursor.rs
+++ b/crates/query/src/mapper/cursor.rs
@@ -3,7 +3,7 @@
 /// Parsed cursor pagination args from a GraphQL cursor query.
 /// `first`/`after` are mutually exclusive with `last`/`before`
 /// (validated by the parser).
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct CursorParams {
     pub first: Option<u64>,
     pub after: Option<String>, // raw base64 token; decoded in planner
@@ -24,7 +24,7 @@ impl CursorParams {
 /// Which `_pageInfo` fields the client selected, and the output key to emit them under.
 /// `None` means the field was not selected; `Some(key)` means it was selected and should
 /// appear in the response under that key (the alias if provided, else the canonical name).
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct CursorPageInfoFields {
     pub has_next: Option<String>,
     pub has_prev: Option<String>,
@@ -49,7 +49,7 @@ impl CursorPageInfoFields {
 /// The `_pageInfo` block and its subfields are always emitted under their
 /// canonical names (`_pageInfo`, `hasNext`, etc.) regardless of any alias,
 /// mirroring Go's planner.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct CursorAliases {
     /// Alias on `_cursor` (e.g., `{ paged: _cursor { ... } }` => Some("paged")).
     /// None => emit under the literal key `_cursor`.

--- a/crates/query/src/mapper/filter/filter_impl.rs
+++ b/crates/query/src/mapper/filter/filter_impl.rs
@@ -13,7 +13,7 @@ use crate::limits::DEFAULT_MAX_FILTER_DEPTH;
 ///
 /// Conditions map field names to their filter values.
 /// Supports nested conditions for related objects.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Filter {
     /// Parsed filter conditions
     conditions: Map<String, JsonValue>,

--- a/crates/query/src/mapper/types.rs
+++ b/crates/query/src/mapper/types.rs
@@ -23,7 +23,7 @@ impl OrderDirection {
 }
 
 /// A single order condition
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct OrderCondition {
     /// Field path for ordering (may be compound for nested objects)
     pub fields: Vec<String>,
@@ -45,7 +45,7 @@ impl OrderCondition {
 }
 
 /// Order by specification
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct OrderBy {
     pub conditions: Vec<OrderCondition>,
 }
@@ -86,7 +86,7 @@ impl OrderBy {
 }
 
 /// Limit and offset for pagination
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct Limit {
     pub limit: Option<u64>,
     pub offset: u64,
@@ -110,7 +110,7 @@ impl Limit {
 }
 
 /// Group by specification
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct GroupBy {
     pub fields: Vec<String>,
 }
@@ -126,7 +126,7 @@ impl GroupBy {
 }
 
 /// A simple field reference
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Field {
     /// Field name
     pub name: String,
@@ -168,7 +168,7 @@ pub enum SelectionType {
 }
 
 /// A similarity computation (dot product between document vector and query vector)
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Similarity {
     /// The target field containing the document's vector
     pub target_field: String,
@@ -199,7 +199,7 @@ impl Similarity {
 }
 
 /// A full-text search scoring request
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct FullTextSearch {
     /// Fields to search across
     pub target_fields: Vec<String>,
@@ -229,7 +229,7 @@ impl FullTextSearch {
 }
 
 /// Requestable items in a select (field, aggregate, sub-select, similarity, or full-text search)
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Requestable {
     /// Simple field
     Field(Field),
@@ -277,7 +277,7 @@ impl AggregateType {
 }
 
 /// An aggregate operation
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Aggregate {
     /// Type of aggregate
     pub aggregate_type: AggregateType,
@@ -359,7 +359,7 @@ impl Aggregate {
 }
 
 /// Target for an aggregate function
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct AggregateTarget {
     /// Host name (collection or field group)
     pub host_name: String,
@@ -406,7 +406,7 @@ impl AggregateTarget {
 }
 
 /// A complete select operation
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Select {
     /// Collection name
     pub collection_name: String,

--- a/crates/query/src/planner/joins/filter_only.rs
+++ b/crates/query/src/planner/joins/filter_only.rs
@@ -10,7 +10,7 @@ use schema::CollectionVersion;
 
 use crate::document::DocumentMapping;
 use crate::error::Result;
-use crate::mapper::{Requestable, Select};
+use crate::mapper::Select;
 use crate::plan::{IndexScanNode, JoinSide, RelationFilter, ScanNode, TypeJoinMany, TypeJoinOne};
 use crate::planner::PlanNode;
 
@@ -34,14 +34,19 @@ impl Planner {
             None => return Ok(plan),
         };
 
+        // Relations already joined from the selection, including those nested
+        // inside `GROUP`. Joining one of those again would overwrite its child
+        // render mapping with this join's internal one (_docID, FK, filter
+        // fields), leaking those fields into the rendered relation.
+        let selected_relations: std::collections::HashSet<&str> =
+            super::selection::collect_selects_to_process(select, mapping)
+                .into_iter()
+                .map(|(nested, _)| nested.field.name.as_str())
+                .collect();
+
         // Get relations referenced by the filter
         for (relation_name, nested_conditions) in filter.relation_conditions() {
-            // Skip if already joined via selection
-            let already_joined = select
-                .fields
-                .iter()
-                .any(|f| matches!(f, Requestable::Select(s) if s.field.name == relation_name));
-            if already_joined {
+            if selected_relations.contains(relation_name.as_str()) {
                 continue;
             }
 

--- a/crates/query/src/planner/joins/filter_only.rs
+++ b/crates/query/src/planner/joins/filter_only.rs
@@ -10,7 +10,6 @@ use schema::CollectionVersion;
 
 use crate::document::DocumentMapping;
 use crate::error::Result;
-use crate::mapper::Select;
 use crate::plan::{IndexScanNode, JoinSide, RelationFilter, ScanNode, TypeJoinMany, TypeJoinOne};
 use crate::planner::PlanNode;
 
@@ -25,28 +24,22 @@ impl Planner {
         &self,
         mut plan: Box<dyn PlanNode>,
         mapping: &mut DocumentMapping,
-        select: &Select,
         parent_collection: &CollectionVersion,
         parent_filter: Option<&crate::mapper::Filter>,
+        selected_relations: &[&str],
     ) -> Result<Box<dyn PlanNode>> {
         let filter = match parent_filter {
             Some(f) => f,
             None => return Ok(plan),
         };
 
-        // Relations already joined from the selection, including those nested
-        // inside `GROUP`. Joining one of those again would overwrite its child
-        // render mapping with this join's internal one (_docID, FK, filter
-        // fields), leaking those fields into the rendered relation.
-        let selected_relations: std::collections::HashSet<&str> =
-            super::selection::collect_selects_to_process(select, mapping)
-                .into_iter()
-                .map(|(nested, _)| nested.field.name.as_str())
-                .collect();
-
         // Get relations referenced by the filter
         for (relation_name, nested_conditions) in filter.relation_conditions() {
-            if selected_relations.contains(relation_name.as_str()) {
+            // Relations already joined from the selection, including those nested
+            // inside `GROUP`. Joining one of those again would overwrite its child
+            // render mapping with this join's internal one (_docID, FK, filter
+            // fields), leaking those fields into the rendered relation.
+            if selected_relations.contains(&relation_name.as_str()) {
                 continue;
             }
 

--- a/crates/query/src/planner/joins/mod.rs
+++ b/crates/query/src/planner/joins/mod.rs
@@ -72,7 +72,7 @@ impl Planner {
 
         let mut selects_to_process = selection::collect_selects_to_process(select, &mapping);
 
-        let already_selected: std::collections::HashSet<&str> = selects_to_process
+        let already_selected: Vec<&str> = selects_to_process
             .iter()
             .map(|(s, _)| s.field.name.as_str())
             .collect();
@@ -117,9 +117,9 @@ impl Planner {
         plan = self.apply_filter_only_joins(
             plan,
             &mut mapping,
-            select,
             parent_collection,
             parent_filter,
+            &already_selected,
         )?;
         plan = self.apply_secondary_id_joins(plan, &mut mapping, select, parent_collection)?;
         plan = self.apply_aggregate_joins(

--- a/crates/query/src/planner/joins/selection.rs
+++ b/crates/query/src/planner/joins/selection.rs
@@ -1,6 +1,6 @@
 //! Collect nested selects and synthetic ORDER BY joins for planning.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use schema::CollectionVersion;
 
@@ -52,7 +52,7 @@ pub(super) fn collect_selects_to_process<'a>(
 pub(super) fn collect_synthetic_order_selects(
     select: &Select,
     parent_collection: &CollectionVersion,
-    already_selected: &HashSet<&str>,
+    already_selected: &[&str],
 ) -> Vec<Select> {
     // Add synthetic selects for ORDER BY relation fields not already in the selection.
     // Go's resolveOrderDependencies creates joins for relations referenced in ORDER BY
@@ -63,7 +63,7 @@ pub(super) fn collect_synthetic_order_selects(
             // Path like ["device", "model"] — first element is the relation field
             if condition.fields.len() >= 2 {
                 let relation_name = &condition.fields[0];
-                if !already_selected.contains(relation_name.as_str()) {
+                if !already_selected.contains(&relation_name.as_str()) {
                     // Check this is actually a relation field
                     if let Some(field) = parent_collection.field_by_name(relation_name) {
                         if field.kind.is_relation() {

--- a/crates/query/src/query_parse/parser.rs
+++ b/crates/query/src/query_parse/parser.rs
@@ -881,6 +881,49 @@ pub(super) fn parse_field_to_select(
     Ok(select)
 }
 
+/// Record a parsed selection, dropping it if an identical one was already taken.
+///
+/// GraphQL merges selections sharing a response key, so an identical repeat
+/// contributes nothing. Keeping it would give the duplicate its own mapping
+/// index and its own relation join, while the renderer only ever reads one of
+/// the two indexes — the other renders as null. Comparing the parsed form
+/// rather than the source text also catches repeats that arrive through a
+/// fragment or that write their arguments in a different order.
+fn push_unique(
+    fields: &mut Vec<Requestable>,
+    mapping: &mut DocumentMapping,
+    requestable: Requestable,
+) {
+    if fields.contains(&requestable) {
+        return;
+    }
+
+    let index = mapping.next_index();
+    match &requestable {
+        Requestable::Field(f) => {
+            mapping.add(index, &f.name);
+            mapping.add_render_key(index, f.output_name());
+        }
+        Requestable::Aggregate(a) => {
+            mapping.add(index, a.aggregate_type.as_str());
+            mapping.add_render_key(index, a.output_name());
+        }
+        Requestable::Select(s) => {
+            mapping.add(index, &s.field.name);
+            mapping.add_render_key(index, s.field.output_name());
+        }
+        Requestable::Similarity(sim) => {
+            mapping.add(index, "SIMILARITY");
+            mapping.add_render_key(index, sim.output_name());
+        }
+        Requestable::FullTextSearch(fts) => {
+            mapping.add(index, "BM25");
+            mapping.add_render_key(index, fts.output_name());
+        }
+    }
+    fields.push(requestable);
+}
+
 /// Parse a selection set into fields and document mapping.
 pub(super) fn parse_selection_set(
     selection_set: &SelectionSet<'_, String>,
@@ -891,21 +934,10 @@ pub(super) fn parse_selection_set(
 ) -> Result<(Vec<Requestable>, DocumentMapping)> {
     let mut fields = Vec::new();
     let mut mapping = DocumentMapping::new();
-    // Rendered form of each field already taken, to drop identical repeats.
-    // `Field`'s `PartialEq` compares source positions, so it cannot be used here.
-    let mut seen: HashSet<String> = HashSet::new();
 
     for selection in &selection_set.items {
         match selection {
             Selection::Field(field) => {
-                // GraphQL merges selections sharing a response key, so an identical
-                // repeat contributes nothing. Keeping it would give the duplicate its
-                // own mapping index and its own relation join, while the renderer only
-                // ever reads one of the two indexes — the other renders as null.
-                if !seen.insert(field.to_string()) {
-                    continue;
-                }
-
                 let field_name = field.name.clone();
                 let alias = field.alias.clone();
 
@@ -918,11 +950,7 @@ pub(super) fn parse_selection_set(
                         fts
                     };
 
-                    let index = mapping.next_index();
-                    mapping.add(index, "BM25");
-                    mapping.add_render_key(index, fts.output_name());
-
-                    fields.push(Requestable::FullTextSearch(fts));
+                    push_unique(&mut fields, &mut mapping, Requestable::FullTextSearch(fts));
                     continue;
                 }
 
@@ -935,11 +963,7 @@ pub(super) fn parse_selection_set(
                         similarity
                     };
 
-                    let index = mapping.next_index();
-                    mapping.add(index, "SIMILARITY");
-                    mapping.add_render_key(index, sim.output_name());
-
-                    fields.push(Requestable::Similarity(sim));
+                    push_unique(&mut fields, &mut mapping, Requestable::Similarity(sim));
                     continue;
                 }
 
@@ -952,23 +976,16 @@ pub(super) fn parse_selection_set(
                         aggregate = aggregate.with_alias(a.clone());
                     }
 
-                    // Add to document mapping
-                    let index = mapping.next_index();
-                    mapping.add(index, agg_type.as_str());
-                    mapping.add_render_key(index, aggregate.output_name());
-
-                    fields.push(Requestable::Aggregate(aggregate));
+                    push_unique(&mut fields, &mut mapping, Requestable::Aggregate(aggregate));
                 } else if !field.selection_set.items.is_empty() {
                     // This is a nested select (relation)
                     let nested = parse_field_to_select(field, variables, fragments, visiting)?;
 
-                    // Add nested select to document mapping
-                    // Use field name for internal indexing, output_name (alias) for rendering
-                    let index = mapping.next_index();
-                    mapping.add(index, &field_name);
-                    mapping.add_render_key(index, nested.field.output_name());
-
-                    fields.push(Requestable::Select(Box::new(nested)));
+                    push_unique(
+                        &mut fields,
+                        &mut mapping,
+                        Requestable::Select(Box::new(nested)),
+                    );
                 } else {
                     // Simple field
                     let select_field = if let Some(a) = alias {
@@ -977,12 +994,7 @@ pub(super) fn parse_selection_set(
                         SelectField::new(&field_name)
                     };
 
-                    // Add to document mapping
-                    let index = mapping.next_index();
-                    mapping.add(index, &field_name);
-                    mapping.add_render_key(index, select_field.output_name());
-
-                    fields.push(Requestable::Field(select_field));
+                    push_unique(&mut fields, &mut mapping, Requestable::Field(select_field));
                 }
             }
             Selection::FragmentSpread(spread) => {
@@ -1016,31 +1028,7 @@ pub(super) fn parse_selection_set(
 
                 // Merge fragment fields and mapping into our current sets
                 for frag_field in frag_fields {
-                    // Update mapping indices for the merged fields
-                    let index = mapping.next_index();
-                    match &frag_field {
-                        Requestable::Field(f) => {
-                            mapping.add(index, &f.name);
-                            mapping.add_render_key(index, f.output_name());
-                        }
-                        Requestable::Aggregate(a) => {
-                            mapping.add(index, a.aggregate_type.as_str());
-                            mapping.add_render_key(index, a.output_name());
-                        }
-                        Requestable::Select(s) => {
-                            mapping.add(index, &s.field.name);
-                            mapping.add_render_key(index, s.field.output_name());
-                        }
-                        Requestable::Similarity(sim) => {
-                            mapping.add(index, "SIMILARITY");
-                            mapping.add_render_key(index, sim.output_name());
-                        }
-                        Requestable::FullTextSearch(fts) => {
-                            mapping.add(index, "BM25");
-                            mapping.add_render_key(index, fts.output_name());
-                        }
-                    }
-                    fields.push(frag_field);
+                    push_unique(&mut fields, &mut mapping, frag_field);
                 }
             }
             Selection::InlineFragment(inline) => {
@@ -1057,30 +1045,7 @@ pub(super) fn parse_selection_set(
 
                 // Merge inline fragment fields into our current sets
                 for inline_field in inline_fields {
-                    let index = mapping.next_index();
-                    match &inline_field {
-                        Requestable::Field(f) => {
-                            mapping.add(index, &f.name);
-                            mapping.add_render_key(index, f.output_name());
-                        }
-                        Requestable::Aggregate(a) => {
-                            mapping.add(index, a.aggregate_type.as_str());
-                            mapping.add_render_key(index, a.output_name());
-                        }
-                        Requestable::Select(s) => {
-                            mapping.add(index, &s.field.name);
-                            mapping.add_render_key(index, s.field.output_name());
-                        }
-                        Requestable::Similarity(sim) => {
-                            mapping.add(index, "SIMILARITY");
-                            mapping.add_render_key(index, sim.output_name());
-                        }
-                        Requestable::FullTextSearch(fts) => {
-                            mapping.add(index, "BM25");
-                            mapping.add_render_key(index, fts.output_name());
-                        }
-                    }
-                    fields.push(inline_field);
+                    push_unique(&mut fields, &mut mapping, inline_field);
                 }
             }
         }

--- a/crates/query/src/query_parse/parser.rs
+++ b/crates/query/src/query_parse/parser.rs
@@ -891,10 +891,21 @@ pub(super) fn parse_selection_set(
 ) -> Result<(Vec<Requestable>, DocumentMapping)> {
     let mut fields = Vec::new();
     let mut mapping = DocumentMapping::new();
+    // Rendered form of each field already taken, to drop identical repeats.
+    // `Field`'s `PartialEq` compares source positions, so it cannot be used here.
+    let mut seen: HashSet<String> = HashSet::new();
 
     for selection in &selection_set.items {
         match selection {
             Selection::Field(field) => {
+                // GraphQL merges selections sharing a response key, so an identical
+                // repeat contributes nothing. Keeping it would give the duplicate its
+                // own mapping index and its own relation join, while the renderer only
+                // ever reads one of the two indexes — the other renders as null.
+                if !seen.insert(field.to_string()) {
+                    continue;
+                }
+
                 let field_name = field.name.clone();
                 let alias = field.alias.clone();
 

--- a/tools/integration-test/tests/query.rs
+++ b/tools/integration-test/tests/query.rs
@@ -50,6 +50,8 @@ mod planner_4656;
 mod planner_4684;
 #[path = "query/relation_order_panic_1594.rs"]
 mod relation_order_panic_1594;
+#[path = "query/relation_rendering_1597.rs"]
+mod relation_rendering_1597;
 #[path = "query/sdl_generate.rs"]
 mod sdl_generate;
 #[path = "query/subscription_docid.rs"]

--- a/tools/integration-test/tests/query/relation_rendering_1597.rs
+++ b/tools/integration-test/tests/query/relation_rendering_1597.rs
@@ -155,6 +155,65 @@ async fn duplicate_relation_selection_plans_one_join_test(cluster: TestCluster) 
     );
 }
 
+/// Mirrors Go `TestQueryOneToManyWithGroupByAndFilterOnParentRelation`: the `_docID`
+/// the relation filter needs internally must not leak into the rendered GROUP items.
+async fn group_by_with_parent_relation_filter_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    add_schema(&node);
+
+    let john = add_author(&node, "John Grisham", 65, true);
+    let voltaire = add_author(&node, "Voltaire", 327, true);
+
+    add_book(&node, "Painted House", 4.9, &john);
+    add_book(&node, "A Time for Mercy", 4.5, &john);
+    add_book(&node, "Candide", 4.95, &voltaire);
+    add_book(&node, "Zadig", 4.91, &voltaire);
+
+    let result = node
+        .query(
+            r#"query {
+                Book(filter: {author: {name: {_like: "John%"}}}, groupBy: [rating]) {
+                    rating
+                    GROUP {
+                        name
+                        author { name }
+                    }
+                }
+            }"#,
+        )
+        .expect("group by rating with parent relation filter");
+
+    let mut books = result["Book"]
+        .as_array()
+        .unwrap_or_else(|| panic!("expected a Book array, got: {result}"))
+        .clone();
+    books.sort_by(|a, b| {
+        a["rating"]
+            .as_f64()
+            .unwrap()
+            .partial_cmp(&b["rating"].as_f64().unwrap())
+            .unwrap()
+    });
+
+    assert_eq!(
+        serde_json::Value::Array(books),
+        serde_json::json!([
+            {
+                "rating": 4.5,
+                "GROUP": [
+                    {"name": "A Time for Mercy", "author": {"name": "John Grisham"}}
+                ],
+            },
+            {
+                "rating": 4.9,
+                "GROUP": [
+                    {"name": "Painted House", "author": {"name": "John Grisham"}}
+                ],
+            },
+        ])
+    );
+}
+
 #[tokio::test]
 async fn rust_relation_rendering_1597_parent_group_by_relation_with_duplicate_selection() {
     let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
@@ -165,4 +224,10 @@ async fn rust_relation_rendering_1597_parent_group_by_relation_with_duplicate_se
 async fn rust_relation_rendering_1597_duplicate_relation_selection_plans_one_join() {
     let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
     duplicate_relation_selection_plans_one_join_test(cluster).await;
+}
+
+#[tokio::test]
+async fn rust_relation_rendering_1597_group_by_with_parent_relation_filter() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    group_by_with_parent_relation_filter_test(cluster).await;
 }

--- a/tools/integration-test/tests/query/relation_rendering_1597.rs
+++ b/tools/integration-test/tests/query/relation_rendering_1597.rs
@@ -1,45 +1,5 @@
-use integration_test::{DefraClient, TestCluster};
-
-/// Same Book/Author fixture the Go `one_to_many` package shares
-/// (`tests/integration/query/one_to_many/utils.go`).
-fn add_schema(node: &DefraClient) {
-    node.schema_add(
-        r#"
-        type Book {
-            name: String
-            rating: Float
-            author: Author
-        }
-
-        type Author {
-            name: String
-            age: Int
-            verified: Boolean
-            published: [Book]
-        }
-        "#,
-    )
-    .expect("add schema");
-}
-
-fn add_author(node: &DefraClient, name: &str, age: i64, verified: bool) -> String {
-    let result = node
-        .query(&format!(
-            r#"mutation {{ add_Author(input: {{name: "{name}", age: {age}, verified: {verified}}}) {{ _docID }} }}"#
-        ))
-        .unwrap_or_else(|e| panic!("add author {name}: {e}"));
-    result["add_Author"][0]["_docID"]
-        .as_str()
-        .expect("author _docID")
-        .to_string()
-}
-
-fn add_book(node: &DefraClient, name: &str, rating: f64, author: &str) {
-    node.query(&format!(
-        r#"mutation {{ add_Book(input: {{name: "{name}", rating: {rating}, author: "{author}"}}) {{ _docID }} }}"#
-    ))
-    .unwrap_or_else(|e| panic!("add book {name}: {e}"));
-}
+use crate::one_to_many_common::{add_author, add_book, add_schema};
+use integration_test::TestCluster;
 
 /// Mirrors Go `TestQueryOneToManyWithParentGroupByOnRelationAndDuplicateRelationSelection`.
 async fn parent_group_by_relation_with_duplicate_selection_test(cluster: TestCluster) {
@@ -212,6 +172,134 @@ async fn group_by_with_parent_relation_filter_test(cluster: TestCluster) {
             },
         ])
     );
+}
+
+/// The duplicate can arrive through a fragment spread, not just as a literal
+/// repeat, and must dedup the same way.
+async fn duplicate_selection_via_fragment_spread_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    add_schema(&node);
+
+    let john = add_author(&node, "John Grisham", 65, true);
+    add_book(&node, "Painted House", 4.9, &john);
+
+    let expected = serde_json::json!([
+        {
+            "author": {"name": "John Grisham"},
+            "GROUP": [{"name": "Painted House"}],
+        }
+    ]);
+
+    let inline_plus_fragment = node
+        .query(
+            r#"query {
+                Book(groupBy: [author]) {
+                    author { name }
+                    ...AuthorName
+                    GROUP { name }
+                }
+            }
+            fragment AuthorName on Book { author { name } }"#,
+        )
+        .expect("group by relation with fragment duplicate");
+    assert_eq!(inline_plus_fragment["Book"], expected);
+
+    let fragment_twice = node
+        .query(
+            r#"query {
+                Book(groupBy: [author]) {
+                    ...AuthorName
+                    ...AuthorName
+                    GROUP { name }
+                }
+            }
+            fragment AuthorName on Book { author { name } }"#,
+        )
+        .expect("group by relation with repeated fragment spread");
+    assert_eq!(fragment_twice["Book"], expected);
+}
+
+/// Same, through an inline fragment.
+async fn duplicate_selection_via_inline_fragment_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    add_schema(&node);
+
+    let john = add_author(&node, "John Grisham", 65, true);
+    add_book(&node, "Painted House", 4.9, &john);
+
+    let result = node
+        .query(
+            r#"query {
+                Book(groupBy: [author]) {
+                    author { name }
+                    ... on Book { author { name } }
+                    GROUP { name }
+                }
+            }"#,
+        )
+        .expect("group by relation with inline fragment duplicate");
+
+    assert_eq!(
+        result["Book"],
+        serde_json::json!([
+            {
+                "author": {"name": "John Grisham"},
+                "GROUP": [{"name": "Painted House"}],
+            }
+        ])
+    );
+}
+
+/// GraphQL arguments are unordered, so two selections differing only in argument
+/// order are the same selection and must dedup.
+async fn duplicate_selection_with_reordered_arguments_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    add_schema(&node);
+
+    let john = add_author(&node, "John Grisham", 65, true);
+    add_book(&node, "Painted House", 4.9, &john);
+    add_book(&node, "A Time for Mercy", 4.5, &john);
+    add_book(&node, "The Associate", 4.2, &john);
+
+    let result = node
+        .query(
+            r#"query {
+                Author {
+                    name
+                    published(limit: 2, order: {rating: ASC}) { name }
+                    published(order: {rating: ASC}, limit: 2) { name }
+                }
+            }"#,
+        )
+        .expect("relation selection with reordered arguments");
+
+    assert_eq!(
+        result["Author"],
+        serde_json::json!([
+            {
+                "name": "John Grisham",
+                "published": [{"name": "The Associate"}, {"name": "A Time for Mercy"}],
+            }
+        ])
+    );
+}
+
+#[tokio::test]
+async fn rust_relation_rendering_1597_duplicate_selection_via_fragment_spread() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    duplicate_selection_via_fragment_spread_test(cluster).await;
+}
+
+#[tokio::test]
+async fn rust_relation_rendering_1597_duplicate_selection_via_inline_fragment() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    duplicate_selection_via_inline_fragment_test(cluster).await;
+}
+
+#[tokio::test]
+async fn rust_relation_rendering_1597_duplicate_selection_with_reordered_arguments() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    duplicate_selection_with_reordered_arguments_test(cluster).await;
 }
 
 #[tokio::test]

--- a/tools/integration-test/tests/query/relation_rendering_1597.rs
+++ b/tools/integration-test/tests/query/relation_rendering_1597.rs
@@ -1,0 +1,168 @@
+use integration_test::{DefraClient, TestCluster};
+
+/// Same Book/Author fixture the Go `one_to_many` package shares
+/// (`tests/integration/query/one_to_many/utils.go`).
+fn add_schema(node: &DefraClient) {
+    node.schema_add(
+        r#"
+        type Book {
+            name: String
+            rating: Float
+            author: Author
+        }
+
+        type Author {
+            name: String
+            age: Int
+            verified: Boolean
+            published: [Book]
+        }
+        "#,
+    )
+    .expect("add schema");
+}
+
+fn add_author(node: &DefraClient, name: &str, age: i64, verified: bool) -> String {
+    let result = node
+        .query(&format!(
+            r#"mutation {{ add_Author(input: {{name: "{name}", age: {age}, verified: {verified}}}) {{ _docID }} }}"#
+        ))
+        .unwrap_or_else(|e| panic!("add author {name}: {e}"));
+    result["add_Author"][0]["_docID"]
+        .as_str()
+        .expect("author _docID")
+        .to_string()
+}
+
+fn add_book(node: &DefraClient, name: &str, rating: f64, author: &str) {
+    node.query(&format!(
+        r#"mutation {{ add_Book(input: {{name: "{name}", rating: {rating}, author: "{author}"}}) {{ _docID }} }}"#
+    ))
+    .unwrap_or_else(|e| panic!("add book {name}: {e}"));
+}
+
+/// Mirrors Go `TestQueryOneToManyWithParentGroupByOnRelationAndDuplicateRelationSelection`.
+async fn parent_group_by_relation_with_duplicate_selection_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    add_schema(&node);
+
+    let john = add_author(&node, "John Grisham", 65, true);
+    add_book(&node, "Painted House", 4.9, &john);
+
+    let result = node
+        .query(
+            r#"query {
+                Book(groupBy: [author]) {
+                    author {
+                        name
+                    }
+                    author {
+                        name
+                    }
+                    GROUP {
+                        name
+                    }
+                }
+            }"#,
+        )
+        .expect("group by relation with duplicate selection");
+
+    assert_eq!(
+        result["Book"],
+        serde_json::json!([
+            {
+                "author": {"name": "John Grisham"},
+                "GROUP": [{"name": "Painted House"}],
+            }
+        ])
+    );
+}
+
+/// Mirrors Go `TestQueryOneToManyWithDuplicateRelationSelectionEachWithInnerGroupByOnRelation`:
+/// the duplicated relation selection must plan as exactly one `typeIndexJoin`.
+///
+/// Go's `ExpectedFullGraph` also nests `groupNode` and `pipeNode` inside the
+/// `typeJoinMany` subType, which our planner does not emit there. That gap is
+/// independent of the duplication, so this asserts the join topology the
+/// duplication owns: the duplicated request must plan exactly like the
+/// single-selection request, with one join and an unshared `scanNode` root.
+async fn duplicate_relation_selection_plans_one_join_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    add_schema(&node);
+
+    let published_group = r#"published(groupBy: [author]) {
+        author {
+            name
+        }
+        GROUP {
+            name
+        }
+    }"#;
+
+    let explain_for = |selections: String| {
+        node.query(&format!(
+            "query @explain(type: debug) {{ Author {{ {selections} }} }}"
+        ))
+        .expect("debug explain")
+    };
+
+    let duplicated = explain_for(format!("{published_group} {published_group}"));
+
+    assert_eq!(
+        duplicated,
+        serde_json::json!({
+            "explain": {
+                "operationNode": [
+                    {
+                        "selectTopNode": {
+                            "selectNode": {
+                                "typeIndexJoin": {
+                                    "typeJoinMany": {
+                                        "root": {"scanNode": {}},
+                                        "subType": {
+                                            "selectTopNode": {
+                                                "selectNode": {
+                                                    "typeIndexJoin": {
+                                                        "typeJoinOne": {
+                                                            "root": {"scanNode": {}},
+                                                            "subType": {
+                                                                "selectTopNode": {
+                                                                    "selectNode": {
+                                                                        "scanNode": {}
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        }),
+        "duplicate relation selection must dedup into a single join"
+    );
+
+    assert_eq!(
+        duplicated,
+        explain_for(published_group.to_string()),
+        "duplicating a relation selection must not change the plan"
+    );
+}
+
+#[tokio::test]
+async fn rust_relation_rendering_1597_parent_group_by_relation_with_duplicate_selection() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    parent_group_by_relation_with_duplicate_selection_test(cluster).await;
+}
+
+#[tokio::test]
+async fn rust_relation_rendering_1597_duplicate_relation_selection_plans_one_join() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    duplicate_relation_selection_plans_one_join_test(cluster).await;
+}


### PR DESCRIPTION
Closes #1597. Stack 3/5, base `edjroz/1594-relation-order-panic`.

## What

Selecting the same relation twice returns `null` for one occurrence: the parser assigned each duplicate its own mapping index, joins wrote to the first, the renderer read the last. A relation filter also forced `_docID` and filter fields into grouped child output that never requested them.

The leak came from `filter_only.rs` not descending into `GROUP` when checking "already joined?", so a second filter-only join clobbered the real selection join's mapping.

## What changed

- Duplicate selections now merge at parse time on the **parsed structure** (`Requestable` equality) in all three arms — field, fragment spread, inline fragment — matching the layer where Go dedups.
- This closes four routes to the same null: plain duplicates, `...F` spreads, inline fragments, and spec-identical selections with reordered arguments; a skipped duplicate consumes no mapping index.
- Filter-only joins consume the same collected selection set as selection joins (passed in from `apply_joins`), so `GROUP`-nested relations are recognized; the relation filter still applies via `parent_relation_filter_for_child`.
- Added `relation_rendering_1597.rs` (6 tests): the three mirrored Go tests plus the fragment/reordered-args repros.

## Verification

- All repros red-first (`"author": null`, leaked `"_docID"`), green after; the explain test asserts the duplicated request plans byte-identically to the single-selection request.
- Discriminating probe for the clobber: filtering on `age` while selecting `name` rendered `{"_docID": …, "age": 65}` — the filter join's mapping.
- `cargo test -p query`, clippy, query + basic integration areas all pass.
- Out of scope, to be filed separately: Go's `groupNode`/`pipeNode` explain nesting (reproduces with a single selection too) and two remaining leak variants needing a merge-don't-clobber fix in `filter_relation.rs`.
