### PR TITLE
fix(query): honor groupBy on aggregate targets

### DIFF
--- a/crates/query/src/mapper/types.rs
+++ b/crates/query/src/mapper/types.rs
@@ -1,6 +1,9 @@
 //! Core mapper types for query operations
 
+use schema::CollectionVersion;
+
 use crate::document::DocumentMapping;
+use crate::error::{QueryError, Result};
 use crate::mapper::cursor::{CursorAliases, CursorPageInfoFields, CursorParams};
 use crate::mapper::filter::Filter;
 
@@ -122,6 +125,29 @@ impl GroupBy {
 
     pub fn is_empty(&self) -> bool {
         self.fields.is_empty()
+    }
+
+    /// Group fields under the names the planner actually stores them by.
+    ///
+    /// A single relation is stored as its ID field, so grouping by `author`
+    /// keys on `_authorID`; grouping by an array relation is rejected. Mirrors
+    /// Go's `internal/planner/mapper/mapper.go`.
+    pub fn resolved_fields(&self, collection: &CollectionVersion) -> Result<Vec<String>> {
+        self.fields
+            .iter()
+            .map(|name| match collection.field_by_name(name) {
+                Some(field) if field.kind.is_relation() => {
+                    if field.kind.is_array() {
+                        Err(QueryError::parse(format!(
+                            "cannot group by array or object field. Field: {name}"
+                        )))
+                    } else {
+                        Ok(CollectionVersion::relation_id_field_name(name))
+                    }
+                }
+                _ => Ok(name.clone()),
+            })
+            .collect()
     }
 }
 

--- a/crates/query/src/mapper/types.rs
+++ b/crates/query/src/mapper/types.rs
@@ -371,6 +371,9 @@ pub struct AggregateTarget {
     pub limit: Option<Limit>,
     /// Order for the target
     pub order: Option<OrderBy>,
+    /// Grouping for the target: the aggregate is computed over distinct groups
+    /// rather than over individual documents.
+    pub group_by: Option<GroupBy>,
     /// Internal key for looking up relation data when there's a collision
     /// (e.g., when both a relation selection and an aggregate use the same relation)
     pub internal_key: Option<String>,
@@ -384,6 +387,7 @@ impl AggregateTarget {
             filter: None,
             limit: None,
             order: None,
+            group_by: None,
             internal_key: None,
         }
     }
@@ -395,6 +399,7 @@ impl AggregateTarget {
             filter: None,
             limit: None,
             order: None,
+            group_by: None,
             internal_key: None,
         }
     }

--- a/crates/query/src/planner/joins/aggregate_joins.rs
+++ b/crates/query/src/planner/joins/aggregate_joins.rs
@@ -207,6 +207,36 @@ impl Planner {
                                 }
                             }
                         }
+                        // Add groupBy fields from aggregate target to existing child
+                        // mapping, so group keys can be built during post-processing.
+                        if let Some(ref group_by) = target.group_by {
+                            for group_field in &group_by.fields {
+                                if group_field.starts_with('_') {
+                                    continue;
+                                }
+                                if let Some(idx) = target_collection
+                                    .fields
+                                    .iter()
+                                    .position(|f| f.name == *group_field)
+                                {
+                                    if let Some(child_mapping) =
+                                        mapping.child_at_mut(relation_field_index)
+                                    {
+                                        if child_mapping.first_index_of_name(group_field).is_none()
+                                        {
+                                            child_mapping.add(idx, group_field);
+                                        }
+                                        if !child_mapping
+                                            .render_keys
+                                            .iter()
+                                            .any(|rk| rk.key == *group_field)
+                                        {
+                                            child_mapping.add_render_key(idx, group_field);
+                                        }
+                                    }
+                                }
+                            }
+                        }
                         continue;
                     }
 
@@ -269,6 +299,26 @@ impl Planner {
                                         child_mapping.add(idx, order_field);
                                         child_mapping.add_render_key(idx, order_field);
                                     }
+                                }
+                            }
+                        }
+                    }
+
+                    // Add fields referenced by groupBy so they appear in the output
+                    // for post-processing group-key construction
+                    if let Some(ref group_by) = target.group_by {
+                        for group_field in &group_by.fields {
+                            if group_field.starts_with('_') {
+                                continue;
+                            }
+                            if let Some(idx) = target_collection
+                                .fields
+                                .iter()
+                                .position(|f| f.name == *group_field)
+                            {
+                                if child_mapping.first_index_of_name(group_field).is_none() {
+                                    child_mapping.add(idx, group_field);
+                                    child_mapping.add_render_key(idx, group_field);
                                 }
                             }
                         }

--- a/crates/query/src/planner/joins/aggregate_joins.rs
+++ b/crates/query/src/planner/joins/aggregate_joins.rs
@@ -281,22 +281,34 @@ impl Planner {
                     }
 
                     // Add fields referenced by groupBy so they appear in the output
-                    // for post-processing group-key construction
+                    // for post-processing group-key construction. Grouped targets
+                    // render into a private `__agg_` slot, so `_docID` and friends
+                    // are safe to fetch here — they never reach relation output.
                     if let Some(ref group_by) = target.group_by {
-                        for group_field in &group_by.fields {
-                            if group_field.starts_with('_') {
+                        for group_field in group_by.resolved_fields(&target_collection)? {
+                            if child_mapping
+                                .render_keys
+                                .iter()
+                                .any(|rk| rk.key == group_field)
+                            {
                                 continue;
                             }
-                            if let Some(idx) = target_collection
+                            let idx = match target_collection
                                 .fields
                                 .iter()
-                                .position(|f| f.name == *group_field)
+                                .position(|f| f.name == group_field)
                             {
-                                if child_mapping.first_index_of_name(group_field).is_none() {
-                                    child_mapping.add(idx, group_field);
-                                    child_mapping.add_render_key(idx, group_field);
-                                }
+                                Some(idx) => idx,
+                                // `_docID` has no schema slot. Park it past every
+                                // schema index so it cannot share one with a field.
+                                None => child_mapping
+                                    .next_index()
+                                    .max(target_collection.fields.len()),
+                            };
+                            if child_mapping.first_index_of_name(&group_field) != Some(idx) {
+                                child_mapping.add(idx, &group_field);
                             }
+                            child_mapping.add_render_key(idx, &group_field);
                         }
                     }
 

--- a/crates/query/src/planner/joins/aggregate_joins.rs
+++ b/crates/query/src/planner/joins/aggregate_joins.rs
@@ -49,27 +49,33 @@ impl Planner {
                     // limit/offset/order in post-processing.
                     // Go also shares joins between selections and aggregates targeting
                     // the same relation (e.g., books(filter: X) + _count(books: {filter: X})).
-                    let already_joined = aggregate_joined_relations
-                        .contains(relation_field_name.as_str())
-                        || selection_join_info
-                            .get(relation_field_name.as_str())
-                            .is_some_and(|info| {
-                                if info.has_limit {
-                                    return false;
-                                }
-                                // If aggregate has no filter but specifies a field_name, it's a
-                                // field-level operation (e.g. _avg(books: {field: rating})) that
-                                // piggybacks on the selection's join. Share unconditionally.
-                                if target.filter.is_none() {
-                                    return target.field_name.is_some();
-                                }
-                                // If aggregate has a filter, share only if it matches the
-                                // selection's filter exactly.
-                                let agg_filter_json = target.filter.as_ref().map(|f| {
-                                    serde_json::to_string(f.conditions()).unwrap_or_default()
-                                });
-                                info.filter_json == agg_filter_json
-                            });
+                    //
+                    // A grouped target is the exception: it needs its group fields in the
+                    // child scan, and a join captures the mapping by value, so a mapping
+                    // edit made after the join was built would never reach it. Give it its
+                    // own join instead. This diverges from Go, whose Targetable.equal
+                    // ignores groupBy and silently degrades the grouped count.
+                    let already_joined = target.group_by.is_none()
+                        && (aggregate_joined_relations.contains(relation_field_name.as_str())
+                            || selection_join_info
+                                .get(relation_field_name.as_str())
+                                .is_some_and(|info| {
+                                    if info.has_limit {
+                                        return false;
+                                    }
+                                    // If aggregate has no filter but specifies a field_name, it's a
+                                    // field-level operation (e.g. _avg(books: {field: rating})) that
+                                    // piggybacks on the selection's join. Share unconditionally.
+                                    if target.filter.is_none() {
+                                        return target.field_name.is_some();
+                                    }
+                                    // If aggregate has a filter, share only if it matches the
+                                    // selection's filter exactly.
+                                    let agg_filter_json = target.filter.as_ref().map(|f| {
+                                        serde_json::to_string(f.conditions()).unwrap_or_default()
+                                    });
+                                    info.filter_json == agg_filter_json
+                                }));
 
                     // Find the field in the parent collection
                     let relation_field = match parent_collection.field_by_name(relation_field_name)
@@ -207,36 +213,6 @@ impl Planner {
                                 }
                             }
                         }
-                        // Add groupBy fields from aggregate target to existing child
-                        // mapping, so group keys can be built during post-processing.
-                        if let Some(ref group_by) = target.group_by {
-                            for group_field in &group_by.fields {
-                                if group_field.starts_with('_') {
-                                    continue;
-                                }
-                                if let Some(idx) = target_collection
-                                    .fields
-                                    .iter()
-                                    .position(|f| f.name == *group_field)
-                                {
-                                    if let Some(child_mapping) =
-                                        mapping.child_at_mut(relation_field_index)
-                                    {
-                                        if child_mapping.first_index_of_name(group_field).is_none()
-                                        {
-                                            child_mapping.add(idx, group_field);
-                                        }
-                                        if !child_mapping
-                                            .render_keys
-                                            .iter()
-                                            .any(|rk| rk.key == *group_field)
-                                        {
-                                            child_mapping.add_render_key(idx, group_field);
-                                        }
-                                    }
-                                }
-                            }
-                        }
                         continue;
                     }
 
@@ -340,28 +316,31 @@ impl Planner {
                             false
                         }
                     });
-                    let effective_relation_index = if selection_has_relation {
-                        // Selection already uses relation_field_index with its own filter/limit.
-                        // Use a new index and a unique internal key for the aggregate's data
-                        // to avoid collision with the selection's data in rendered JSON.
-                        let idx = mapping.next_index();
-                        let internal_key =
-                            format!("__agg_{}_{}", relation_field_name, agg.output_name());
-                        mapping.add(idx, relation_field_name);
-                        mapping.add_render_key(idx, &internal_key);
-                        // Store the mapping so the runner can look up data using the internal key
-                        aggregate_internal_keys.insert(
-                            agg.output_name().to_string(),
-                            (relation_field_name.clone(), internal_key),
-                        );
-                        idx
-                    } else {
-                        if mapping.first_index_of_name(relation_field_name).is_none() {
-                            mapping.add(relation_field_index, relation_field_name);
-                        }
-                        mapping.add_render_key(relation_field_index, relation_field_name);
-                        relation_field_index
-                    };
+                    // A grouped target also needs a private slot: its child items carry the
+                    // group fields, which must not surface in rendered relation output.
+                    let effective_relation_index =
+                        if selection_has_relation || target.group_by.is_some() {
+                            // Selection already uses relation_field_index with its own filter/limit.
+                            // Use a new index and a unique internal key for the aggregate's data
+                            // to avoid collision with the selection's data in rendered JSON.
+                            let idx = mapping.next_index();
+                            let internal_key =
+                                format!("__agg_{}_{}", relation_field_name, agg.output_name());
+                            mapping.add(idx, relation_field_name);
+                            mapping.add_render_key(idx, &internal_key);
+                            // Store the mapping so the runner can look up data using the internal key
+                            aggregate_internal_keys.insert(
+                                agg.output_name().to_string(),
+                                (relation_field_name.clone(), internal_key),
+                            );
+                            idx
+                        } else {
+                            if mapping.first_index_of_name(relation_field_name).is_none() {
+                                mapping.add(relation_field_index, relation_field_name);
+                            }
+                            mapping.add_render_key(relation_field_index, relation_field_name);
+                            relation_field_index
+                        };
 
                     // Build child plan (simple scan with fetcher)
                     let mut child_scan =
@@ -569,7 +548,9 @@ impl Planner {
                         mapping.clone(),
                     )?);
 
-                    aggregate_joined_relations.insert(relation_field_name.to_string());
+                    if target.group_by.is_none() {
+                        aggregate_joined_relations.insert(relation_field_name.to_string());
+                    }
                 }
             }
         }

--- a/crates/query/src/query_parse/aggregates.rs
+++ b/crates/query/src/query_parse/aggregates.rs
@@ -133,6 +133,9 @@ pub(super) fn parse_aggregate_target_obj(
                 };
                 target.order = Some(order);
             }
+            "groupBy" => {
+                target.group_by = Some(parse_group_by_value(val, variables)?);
+            }
             _ => {}
         }
     }
@@ -176,6 +179,20 @@ pub(super) fn parse_aggregate_target_from_json(
                 }
                 "order" => {
                     target.order = Some(parse_order_from_json(val)?);
+                }
+                "groupBy" => {
+                    let arr = val
+                        .as_array()
+                        .ok_or_else(|| QueryError::parse("groupBy must be a list"))?;
+                    let fields: Result<Vec<String>> = arr
+                        .iter()
+                        .map(|v| {
+                            v.as_str()
+                                .map(|s| s.to_string())
+                                .ok_or_else(|| QueryError::parse("groupBy items must be strings"))
+                        })
+                        .collect();
+                    target.group_by = Some(GroupBy::new(fields?));
                 }
                 _ => {}
             }

--- a/crates/query/src/query_parse/aggregates.rs
+++ b/crates/query/src/query_parse/aggregates.rs
@@ -21,6 +21,19 @@ use super::filters::parse_filter_value;
 use super::ordering::{parse_order_from_json, parse_order_value};
 use super::values::parse_int_value;
 
+/// Parse a JSON array of group field names into GroupBy.
+fn parse_group_by_json_array(arr: &[JsonValue]) -> Result<GroupBy> {
+    let fields: Result<Vec<String>> = arr
+        .iter()
+        .map(|v| {
+            v.as_str()
+                .map(|s| s.to_string())
+                .ok_or_else(|| QueryError::parse("groupBy items must be strings"))
+        })
+        .collect();
+    Ok(GroupBy::new(fields?))
+}
+
 /// Parse groupBy argument into GroupBy.
 pub(super) fn parse_group_by_value(
     value: &Value<'_, String>,
@@ -67,15 +80,7 @@ pub(super) fn parse_group_by_value(
             let arr = json_val.as_array().ok_or_else(|| {
                 QueryError::parse(format!("Variable \"${}\" must be of type [String]", name))
             })?;
-            let fields: Result<Vec<String>> = arr
-                .iter()
-                .map(|v| {
-                    v.as_str()
-                        .map(|s| s.to_string())
-                        .ok_or_else(|| QueryError::parse("groupBy items must be strings"))
-                })
-                .collect();
-            Ok(GroupBy::new(fields?))
+            parse_group_by_json_array(arr)
         }
         _ => Err(QueryError::parse("groupBy must be a list")),
     }
@@ -184,15 +189,7 @@ pub(super) fn parse_aggregate_target_from_json(
                     let arr = val
                         .as_array()
                         .ok_or_else(|| QueryError::parse("groupBy must be a list"))?;
-                    let fields: Result<Vec<String>> = arr
-                        .iter()
-                        .map(|v| {
-                            v.as_str()
-                                .map(|s| s.to_string())
-                                .ok_or_else(|| QueryError::parse("groupBy items must be strings"))
-                        })
-                        .collect();
-                    target.group_by = Some(GroupBy::new(fields?));
+                    target.group_by = Some(parse_group_by_json_array(arr)?);
                 }
                 _ => {}
             }

--- a/crates/query/src/runner/plan.rs
+++ b/crates/query/src/runner/plan.rs
@@ -141,6 +141,17 @@ pub(crate) fn build_mapping(
                         }
                     }
                 }
+                // And the target's groupBy fields, needed to build group keys
+                // for COUNT(Users: {groupBy: [Age]})
+                if let Some(ref group_by) = target.group_by {
+                    for field_name in &group_by.fields {
+                        if mapping.first_index_of_name(field_name).is_none() {
+                            let index = mapping.next_index();
+                            mapping.add(index, field_name);
+                            // Don't add render_key - we don't want to output these fields
+                        }
+                    }
+                }
             }
         }
     }

--- a/crates/query/src/runner/plan.rs
+++ b/crates/query/src/runner/plan.rs
@@ -142,13 +142,16 @@ pub(crate) fn build_mapping(
                     }
                 }
                 // And the target's groupBy fields, needed to build group keys
-                // for COUNT(Users: {groupBy: [Age]})
-                if let Some(ref group_by) = target.group_by {
-                    for field_name in &group_by.fields {
-                        if mapping.first_index_of_name(field_name).is_none() {
-                            let index = mapping.next_index();
-                            mapping.add(index, field_name);
-                            // Don't add render_key - we don't want to output these fields
+                // for COUNT(Users: {groupBy: [Age]}). Relation targets group
+                // against their own collection, resolved in the join builder.
+                if target.host_name.is_empty() || target.host_name == collection.name {
+                    if let Some(ref group_by) = target.group_by {
+                        for field_name in group_by.resolved_fields(collection)? {
+                            if mapping.first_index_of_name(&field_name).is_none() {
+                                let index = mapping.next_index();
+                                mapping.add(index, field_name);
+                                // Don't add render_key - we don't want to output these fields
+                            }
                         }
                     }
                 }

--- a/crates/query/src/runner/query/aggregate.rs
+++ b/crates/query/src/runner/query/aggregate.rs
@@ -7,8 +7,8 @@ use serde_json::Value as JsonValue;
 use std::sync::Arc;
 
 use crate::document::{documents_to_plan_docs, DocumentMapping};
-use crate::error::Result;
-use crate::mapper::{GroupBy, Requestable, Select};
+use crate::error::{QueryError, Result};
+use crate::mapper::{Requestable, Select};
 use crate::planner::{Doc, Planner};
 use crate::txn::TransactionRegistry;
 
@@ -24,19 +24,20 @@ use super::super::{DocFetcher, QueryRunner};
 fn distinct_group_count<'a>(
     docs: impl Iterator<Item = &'a Doc>,
     mapping: &DocumentMapping,
-    group_by: &GroupBy,
+    group_fields: &[String],
 ) -> i64 {
-    let indexes: Vec<Option<usize>> = group_by
-        .fields
+    let indexes: Vec<Option<usize>> = group_fields
         .iter()
         .map(|name| mapping.first_index_of_name(name))
         .collect();
     docs.map(|doc| {
         indexes
             .iter()
-            .map(|index| match index {
-                Some(i) => doc.get(*i).unwrap_or(&JsonValue::Null).to_string(),
-                None => JsonValue::Null.to_string(),
+            .map(|index| {
+                index
+                    .and_then(|i| doc.get(i))
+                    .unwrap_or(&JsonValue::Null)
+                    .to_string()
             })
             .collect::<Vec<_>>()
             .join("\u{1}")
@@ -135,7 +136,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                             Some(group_by) => distinct_group_count(
                                 filtered_docs.iter().copied(),
                                 &mapping,
-                                group_by,
+                                &group_by.resolved_fields(collection)?,
                             ),
                             None => filtered_docs.len() as i64,
                         };
@@ -273,6 +274,17 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         let collection_name = target
             .map(|t| t.host_name.clone())
             .unwrap_or_else(|| select.collection_name.clone());
+
+        let collections_map = self.collections_map().await?;
+        let group_fields = match group_by {
+            Some(gb) => gb.resolved_fields(
+                collections_map
+                    .get(&collection_name)
+                    .ok_or_else(|| QueryError::collection_not_found(&collection_name))?,
+            )?,
+            None => Vec::new(),
+        };
+
         let mut select_fields = if let Some(fname) = field_name {
             // For sum/avg/etc., we need the field value
             vec![Requestable::Field(crate::mapper::Field::new(fname.clone()))]
@@ -283,14 +295,12 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             ))]
         };
         // Grouped targets need the grouped fields available to build group keys.
-        if let Some(gb) = group_by {
-            for name in &gb.fields {
-                let already_selected = select_fields
-                    .iter()
-                    .any(|f| matches!(f, Requestable::Field(existing) if existing.name == *name));
-                if !already_selected {
-                    select_fields.push(Requestable::Field(crate::mapper::Field::new(name.clone())));
-                }
+        for name in &group_fields {
+            let already_selected = select_fields
+                .iter()
+                .any(|f| matches!(f, Requestable::Field(existing) if existing.name == *name));
+            if !already_selected {
+                select_fields.push(Requestable::Field(crate::mapper::Field::new(name.clone())));
             }
         }
 
@@ -318,7 +328,6 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
 
         // Execute with the planner to get filtered documents
         let fetcher_arc = FetcherWrapper::new(fetcher);
-        let collections_map = self.collections_map().await?;
         let collections: Vec<CollectionVersion> =
             collections_map.values().map(|c| (**c).clone()).collect();
 
@@ -352,9 +361,10 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         // Compute the aggregate based on type
         let value = match agg.aggregate_type {
             AggregateType::Count => {
-                let count = match group_by {
-                    Some(gb) => distinct_group_count(docs.iter(), &mapping, gb),
-                    None => docs.len() as i64,
+                let count = if group_by.is_some() {
+                    distinct_group_count(docs.iter(), &mapping, &group_fields)
+                } else {
+                    docs.len() as i64
                 };
                 JsonValue::Number(count.into())
             }

--- a/crates/query/src/runner/query/aggregate.rs
+++ b/crates/query/src/runner/query/aggregate.rs
@@ -6,16 +6,44 @@ use schema::CollectionVersion;
 use serde_json::Value as JsonValue;
 use std::sync::Arc;
 
-use crate::document::documents_to_plan_docs;
+use crate::document::{documents_to_plan_docs, DocumentMapping};
 use crate::error::Result;
-use crate::mapper::{Requestable, Select};
-use crate::planner::Planner;
+use crate::mapper::{GroupBy, Requestable, Select};
+use crate::planner::{Doc, Planner};
 use crate::txn::TransactionRegistry;
 
 use super::super::fetcher::FetcherWrapper;
 use super::super::plan;
 use super::super::plan_drive;
 use super::super::{DocFetcher, QueryRunner};
+
+/// Number of distinct `group_by` keys across `docs`.
+///
+/// A document missing a grouped field is keyed as null, so all such documents
+/// share one group.
+fn distinct_group_count<'a>(
+    docs: impl Iterator<Item = &'a Doc>,
+    mapping: &DocumentMapping,
+    group_by: &GroupBy,
+) -> i64 {
+    let indexes: Vec<Option<usize>> = group_by
+        .fields
+        .iter()
+        .map(|name| mapping.first_index_of_name(name))
+        .collect();
+    docs.map(|doc| {
+        indexes
+            .iter()
+            .map(|index| match index {
+                Some(i) => doc.get(*i).unwrap_or(&JsonValue::Null).to_string(),
+                None => JsonValue::Null.to_string(),
+            })
+            .collect::<Vec<_>>()
+            .join("\u{1}")
+    })
+    .collect::<std::collections::HashSet<_>>()
+    .len() as i64
+}
 
 impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
     /// Top-level aggregates compute a single value over all documents in a collection.
@@ -101,8 +129,16 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                 // Compute the aggregate value
                 let value = match agg.aggregate_type {
                     crate::mapper::AggregateType::Count => {
-                        // Count documents (optionally filtered)
-                        let count = filtered_docs.len() as i64;
+                        // Count documents (optionally filtered), or distinct
+                        // groups when the target is grouped.
+                        let count = match target.and_then(|t| t.group_by.as_ref()) {
+                            Some(group_by) => distinct_group_count(
+                                filtered_docs.iter().copied(),
+                                &mapping,
+                                group_by,
+                            ),
+                            None => filtered_docs.len() as i64,
+                        };
                         JsonValue::Number(count.into())
                     }
                     crate::mapper::AggregateType::Sum => {
@@ -229,6 +265,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         let target = agg.targets.first();
         let target_filter = target.and_then(|t| t.filter.as_ref());
         let field_name = target.and_then(|t| t.field_name.as_ref());
+        let group_by = target.and_then(|t| t.group_by.as_ref());
 
         // Create a modified select that fetches the collection with the filter applied.
         // This select returns documents (not aggregates), so the planner will build
@@ -236,18 +273,31 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         let collection_name = target
             .map(|t| t.host_name.clone())
             .unwrap_or_else(|| select.collection_name.clone());
+        let mut select_fields = if let Some(fname) = field_name {
+            // For sum/avg/etc., we need the field value
+            vec![Requestable::Field(crate::mapper::Field::new(fname.clone()))]
+        } else {
+            // For count, we just need any field to count docs
+            vec![Requestable::Field(crate::mapper::Field::new(
+                "_docID".to_string(),
+            ))]
+        };
+        // Grouped targets need the grouped fields available to build group keys.
+        if let Some(gb) = group_by {
+            for name in &gb.fields {
+                let already_selected = select_fields
+                    .iter()
+                    .any(|f| matches!(f, Requestable::Field(existing) if existing.name == *name));
+                if !already_selected {
+                    select_fields.push(Requestable::Field(crate::mapper::Field::new(name.clone())));
+                }
+            }
+        }
+
         let filter_select = Select {
             collection_name: collection_name.clone(),
             field: crate::mapper::Field::new(collection_name.clone()),
-            fields: if let Some(fname) = field_name {
-                // For sum/avg/etc., we need the field value
-                vec![Requestable::Field(crate::mapper::Field::new(fname.clone()))]
-            } else {
-                // For count, we just need any field to count docs
-                vec![Requestable::Field(crate::mapper::Field::new(
-                    "_docID".to_string(),
-                ))]
-            },
+            fields: select_fields,
             filter: target_filter.cloned(),
             order_by: None,
             limit: None,
@@ -302,7 +352,10 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         // Compute the aggregate based on type
         let value = match agg.aggregate_type {
             AggregateType::Count => {
-                let count = docs.len() as i64;
+                let count = match group_by {
+                    Some(gb) => distinct_group_count(docs.iter(), &mapping, gb),
+                    None => docs.len() as i64,
+                };
                 JsonValue::Number(count.into())
             }
             AggregateType::Sum => {

--- a/crates/query/src/runner/query/relation_aggregate.rs
+++ b/crates/query/src/runner/query/relation_aggregate.rs
@@ -1,5 +1,6 @@
 //! Relation-based aggregate computation.
 
+use schema::CollectionVersion;
 use serde_json::Value as JsonValue;
 
 use crate::error::Result;
@@ -569,7 +570,8 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
 /// Number of distinct `group_by` keys across relation items.
 ///
 /// An item missing a grouped field is keyed as null, so all such items share
-/// one group.
+/// one group. A single relation is fetched under its ID field, so `author`
+/// falls back to `_authorID` (see `GroupBy::resolved_fields`).
 fn distinct_group_count(items: &[&JsonValue], group_by: &crate::mapper::GroupBy) -> i64 {
     items
         .iter()
@@ -579,6 +581,9 @@ fn distinct_group_count(items: &[&JsonValue], group_by: &crate::mapper::GroupBy)
                 .iter()
                 .map(|name| {
                     item.get(name.as_str())
+                        .or_else(|| {
+                            item.get(CollectionVersion::relation_id_field_name(name).as_str())
+                        })
                         .unwrap_or(&JsonValue::Null)
                         .to_string()
                 })

--- a/crates/query/src/runner/query/relation_aggregate.rs
+++ b/crates/query/src/runner/query/relation_aggregate.rs
@@ -269,7 +269,12 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                                 // Step 4: Compute aggregate over final items
                                 match agg_type {
                                     AggregateType::Count => {
-                                        total_count += final_items.len() as i64;
+                                        total_count += match target.group_by {
+                                            Some(ref group_by) => {
+                                                distinct_group_count(&final_items, group_by)
+                                            }
+                                            None => final_items.len() as i64,
+                                        };
                                     }
                                     AggregateType::Sum | AggregateType::Average => {
                                         for item in &final_items {
@@ -559,6 +564,29 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
 
         Ok(results)
     }
+}
+
+/// Number of distinct `group_by` keys across relation items.
+///
+/// An item missing a grouped field is keyed as null, so all such items share
+/// one group.
+fn distinct_group_count(items: &[&JsonValue], group_by: &crate::mapper::GroupBy) -> i64 {
+    items
+        .iter()
+        .map(|item| {
+            group_by
+                .fields
+                .iter()
+                .map(|name| {
+                    item.get(name.as_str())
+                        .unwrap_or(&JsonValue::Null)
+                        .to_string()
+                })
+                .collect::<Vec<_>>()
+                .join("\u{1}")
+        })
+        .collect::<std::collections::HashSet<_>>()
+        .len() as i64
 }
 
 /// Extract a numeric value from a JSON item for aggregate computation.

--- a/tools/integration-test/tests/query.rs
+++ b/tools/integration-test/tests/query.rs
@@ -1,3 +1,5 @@
+#[path = "query/aggregate_groupby_1595.rs"]
+mod aggregate_groupby_1595;
 #[path = "query/commits_aggregate.rs"]
 mod commits_aggregate;
 #[path = "query/commits_collection_id.rs"]

--- a/tools/integration-test/tests/query/aggregate_groupby_1595.rs
+++ b/tools/integration-test/tests/query/aggregate_groupby_1595.rs
@@ -261,6 +261,95 @@ async fn grouped_count_grouped_first_test(cluster: TestCluster) {
     );
 }
 
+/// Go rewrites an object-kind groupBy field to its relation ID field
+/// (`internal/planner/mapper/mapper.go`, `request.ToFieldID`), so grouping by
+/// `author` keys on `_authorID`: two authors -> two groups.
+async fn top_level_group_by_relation_field_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    add_book_author_schema(&node);
+    let john = add_author(&node, "John Grisham", 65, true);
+    let cornelia = add_author(&node, "Cornelia Funke", 62, false);
+    add_book(&node, "Painted House", 4.9, &john);
+    add_book(&node, "A Time for Mercy", 4.5, &john);
+    add_book(&node, "The Associate", 4.2, &john);
+    add_book(&node, "Theif Lord", 4.8, &cornelia);
+
+    let result = node
+        .query(r#"query { COUNT(Book: {groupBy: [author]}) }"#)
+        .expect("count query");
+
+    assert_eq!(result["COUNT"], serde_json::json!(2));
+}
+
+/// Go rejects grouping by an array relation (`NewErrInvalidFieldToGroupBy`).
+async fn top_level_group_by_array_relation_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    add_book_author_schema(&node);
+    add_author(&node, "John Grisham", 65, true);
+
+    let err = node
+        .query(r#"query { COUNT(Author: {groupBy: [published]}) }"#)
+        .expect_err("grouping by an array relation should be rejected");
+    assert!(
+        err.to_string()
+            .contains("cannot group by array or object field"),
+        "unexpected groupBy error: {err}"
+    );
+}
+
+/// `_docID` is distinct per book, so a grouped count over it equals the book
+/// count. The group field has to reach the relation's child scan.
+async fn relation_group_by_doc_id_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    setup_mixed_names(&node).await;
+
+    let result = node
+        .query(
+            r#"
+            query {
+                Author {
+                    name
+                    COUNT(published: {groupBy: [_docID]})
+                }
+            }
+            "#,
+        )
+        .expect("query authors");
+
+    assert_eq!(count_for(&result, "John Grisham"), 4);
+}
+
+/// Fetching a group field must not add it to the rendered relation output
+/// (regression guard for the #1597 `_docID` leak).
+async fn relation_group_by_doc_id_no_leak_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    add_book_author_schema(&node);
+    let john = add_author(&node, "John Grisham", 65, true);
+    add_book(&node, "Painted House", 4.9, &john);
+    add_book(&node, "A Time for Mercy", 4.5, &john);
+
+    let result = node
+        .query(
+            r#"
+            query {
+                Author {
+                    published { name }
+                    COUNT(published: {groupBy: [_docID]})
+                }
+            }
+            "#,
+        )
+        .expect("query authors");
+
+    assert_eq!(
+        result["Author"],
+        serde_json::json!([{
+            "published": [{"name": "Painted House"}, {"name": "A Time for Mercy"}],
+            "COUNT": 2,
+        }])
+    );
+}
+
 #[tokio::test]
 async fn rust_aggregate_groupby_1595_on_single_field() {
     let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
@@ -307,4 +396,28 @@ async fn rust_aggregate_groupby_1595_grouped_count_plain_first() {
 async fn rust_aggregate_groupby_1595_grouped_count_grouped_first() {
     let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
     grouped_count_grouped_first_test(cluster).await;
+}
+
+#[tokio::test]
+async fn rust_aggregate_groupby_1595_top_level_group_by_relation_field() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    top_level_group_by_relation_field_test(cluster).await;
+}
+
+#[tokio::test]
+async fn rust_aggregate_groupby_1595_top_level_group_by_array_relation() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    top_level_group_by_array_relation_test(cluster).await;
+}
+
+#[tokio::test]
+async fn rust_aggregate_groupby_1595_relation_group_by_doc_id() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    relation_group_by_doc_id_test(cluster).await;
+}
+
+#[tokio::test]
+async fn rust_aggregate_groupby_1595_relation_group_by_doc_id_no_leak() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    relation_group_by_doc_id_no_leak_test(cluster).await;
 }

--- a/tools/integration-test/tests/query/aggregate_groupby_1595.rs
+++ b/tools/integration-test/tests/query/aggregate_groupby_1595.rs
@@ -1,3 +1,4 @@
+use crate::one_to_many_common::{add_author, add_book, add_schema};
 use integration_test::{DefraClient, TestCluster};
 
 /// Mirrors the Go `query/simple` fixture
@@ -23,47 +24,6 @@ fn add_user(node: &DefraClient, name: &str, age: i64) {
         r#"mutation {{ add_Users(input: {{Name: "{name}", Age: {age}}}) {{ _docID }} }}"#
     ))
     .unwrap_or_else(|e| panic!("add user {name}: {e}"));
-}
-
-/// Mirrors the Go `query/one_to_many` fixture
-/// (`tests/integration/query/one_to_many/utils.go`).
-fn add_book_author_schema(node: &DefraClient) {
-    node.schema_add(
-        r#"
-        type Book {
-            name: String
-            rating: Float
-            author: Author
-        }
-
-        type Author {
-            name: String
-            age: Int
-            verified: Boolean
-            published: [Book]
-        }
-        "#,
-    )
-    .expect("add schema");
-}
-
-fn add_author(node: &DefraClient, name: &str, age: i64, verified: bool) -> String {
-    let result = node
-        .query(&format!(
-            r#"mutation {{ add_Author(input: {{name: "{name}", age: {age}, verified: {verified}}}) {{ _docID }} }}"#
-        ))
-        .unwrap_or_else(|e| panic!("add author {name}: {e}"));
-    result["add_Author"][0]["_docID"]
-        .as_str()
-        .expect("author _docID")
-        .to_string()
-}
-
-fn add_book(node: &DefraClient, name: &str, rating: f64, author: &str) {
-    node.query(&format!(
-        r#"mutation {{ add_Book(input: {{name: "{name}", rating: {rating}, author: "{author}"}}) {{ _docID }} }}"#
-    ))
-    .unwrap_or_else(|e| panic!("add book {name}: {e}"));
 }
 
 fn count_for(result: &serde_json::Value, author: &str) -> i64 {
@@ -147,7 +107,7 @@ async fn group_by_and_filter_test(cluster: TestCluster) {
 /// Three books sharing one name -> 1 group.
 async fn relation_all_same_name_test(cluster: TestCluster) {
     let node = cluster.client(0);
-    add_book_author_schema(&node);
+    add_schema(&node);
     let john = add_author(&node, "John Grisham", 65, true);
     add_book(&node, "Painted House", 4.9, &john);
     add_book(&node, "Painted House", 4.8, &john);
@@ -173,7 +133,7 @@ async fn relation_all_same_name_test(cluster: TestCluster) {
 /// John has three books under two distinct names, Cornelia has one.
 async fn relation_counting_distinct_names_test(cluster: TestCluster) {
     let node = cluster.client(0);
-    add_book_author_schema(&node);
+    add_schema(&node);
     let john = add_author(&node, "John Grisham", 65, true);
     let cornelia = add_author(&node, "Cornelia Funke", 62, false);
     add_book(&node, "Painted House", 4.9, &john);
@@ -198,11 +158,50 @@ async fn relation_counting_distinct_names_test(cluster: TestCluster) {
     assert_eq!(count_for(&result, "Cornelia Funke"), 1);
 }
 
+/// Go: TestQuerySimple_WithCountWithGroupBy_OnEmptyCollection
+/// No documents -> 0 groups.
+async fn on_empty_collection_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    add_users_schema(&node);
+
+    let result = node
+        .query(r#"query { COUNT(Users: {groupBy: [Age]}) }"#)
+        .expect("count query");
+
+    assert_eq!(result["COUNT"], serde_json::json!(0));
+}
+
+/// Go: TestQueryOneToMany_WithCountWithGroupBy_CountingZero
+/// An author with no books -> 0 groups.
+async fn relation_counting_zero_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    add_schema(&node);
+    add_author(&node, "John Grisham", 65, true);
+
+    let result = node
+        .query(
+            r#"
+            query {
+                Author {
+                    name
+                    COUNT(published: {groupBy: [name]})
+                }
+            }
+            "#,
+        )
+        .expect("query authors");
+
+    assert_eq!(
+        result["Author"],
+        serde_json::json!([{"name": "John Grisham", "COUNT": 0}])
+    );
+}
+
 /// Four books under John, three distinct names (one book has no name at all,
 /// which keys as a single null group). A grouped target must not share the
 /// plain target's join, so both counts must hold whichever is written first.
-async fn setup_mixed_names(node: &DefraClient) {
-    add_book_author_schema(node);
+fn setup_mixed_names(node: &DefraClient) {
+    add_schema(node);
     let john = add_author(node, "John Grisham", 65, true);
     add_book(node, "Painted House", 4.9, &john);
     add_book(node, "Painted House", 4.8, &john);
@@ -215,7 +214,7 @@ async fn setup_mixed_names(node: &DefraClient) {
 
 async fn grouped_count_plain_first_test(cluster: TestCluster) {
     let node = cluster.client(0);
-    setup_mixed_names(&node).await;
+    setup_mixed_names(&node);
 
     let result = node
         .query(
@@ -239,7 +238,7 @@ async fn grouped_count_plain_first_test(cluster: TestCluster) {
 
 async fn grouped_count_grouped_first_test(cluster: TestCluster) {
     let node = cluster.client(0);
-    setup_mixed_names(&node).await;
+    setup_mixed_names(&node);
 
     let result = node
         .query(
@@ -266,7 +265,7 @@ async fn grouped_count_grouped_first_test(cluster: TestCluster) {
 /// `author` keys on `_authorID`: two authors -> two groups.
 async fn top_level_group_by_relation_field_test(cluster: TestCluster) {
     let node = cluster.client(0);
-    add_book_author_schema(&node);
+    add_schema(&node);
     let john = add_author(&node, "John Grisham", 65, true);
     let cornelia = add_author(&node, "Cornelia Funke", 62, false);
     add_book(&node, "Painted House", 4.9, &john);
@@ -284,7 +283,7 @@ async fn top_level_group_by_relation_field_test(cluster: TestCluster) {
 /// Go rejects grouping by an array relation (`NewErrInvalidFieldToGroupBy`).
 async fn top_level_group_by_array_relation_test(cluster: TestCluster) {
     let node = cluster.client(0);
-    add_book_author_schema(&node);
+    add_schema(&node);
     add_author(&node, "John Grisham", 65, true);
 
     let err = node
@@ -301,7 +300,7 @@ async fn top_level_group_by_array_relation_test(cluster: TestCluster) {
 /// count. The group field has to reach the relation's child scan.
 async fn relation_group_by_doc_id_test(cluster: TestCluster) {
     let node = cluster.client(0);
-    setup_mixed_names(&node).await;
+    setup_mixed_names(&node);
 
     let result = node
         .query(
@@ -323,7 +322,7 @@ async fn relation_group_by_doc_id_test(cluster: TestCluster) {
 /// (regression guard for the #1597 `_docID` leak).
 async fn relation_group_by_doc_id_no_leak_test(cluster: TestCluster) {
     let node = cluster.client(0);
-    add_book_author_schema(&node);
+    add_schema(&node);
     let john = add_author(&node, "John Grisham", 65, true);
     add_book(&node, "Painted House", 4.9, &john);
     add_book(&node, "A Time for Mercy", 4.5, &john);
@@ -384,6 +383,18 @@ async fn rust_aggregate_groupby_1595_relation_all_same_name() {
 async fn rust_aggregate_groupby_1595_relation_counting_distinct_names() {
     let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
     relation_counting_distinct_names_test(cluster).await;
+}
+
+#[tokio::test]
+async fn rust_aggregate_groupby_1595_on_empty_collection() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    on_empty_collection_test(cluster).await;
+}
+
+#[tokio::test]
+async fn rust_aggregate_groupby_1595_relation_counting_zero() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    relation_counting_zero_test(cluster).await;
 }
 
 #[tokio::test]

--- a/tools/integration-test/tests/query/aggregate_groupby_1595.rs
+++ b/tools/integration-test/tests/query/aggregate_groupby_1595.rs
@@ -198,6 +198,69 @@ async fn relation_counting_distinct_names_test(cluster: TestCluster) {
     assert_eq!(count_for(&result, "Cornelia Funke"), 1);
 }
 
+/// Four books under John, three distinct names (one book has no name at all,
+/// which keys as a single null group). A grouped target must not share the
+/// plain target's join, so both counts must hold whichever is written first.
+async fn setup_mixed_names(node: &DefraClient) {
+    add_book_author_schema(node);
+    let john = add_author(node, "John Grisham", 65, true);
+    add_book(node, "Painted House", 4.9, &john);
+    add_book(node, "Painted House", 4.8, &john);
+    add_book(node, "A Time for Mercy", 4.5, &john);
+    node.query(&format!(
+        r#"mutation {{ add_Book(input: {{rating: 4.2, author: "{john}"}}) {{ _docID }} }}"#
+    ))
+    .expect("add unnamed book");
+}
+
+async fn grouped_count_plain_first_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    setup_mixed_names(&node).await;
+
+    let result = node
+        .query(
+            r#"
+            query {
+                Author {
+                    name
+                    a: COUNT(published: {})
+                    b: COUNT(published: {groupBy: [name]})
+                }
+            }
+            "#,
+        )
+        .expect("query authors");
+
+    assert_eq!(
+        result["Author"],
+        serde_json::json!([{"name": "John Grisham", "a": 4, "b": 3}])
+    );
+}
+
+async fn grouped_count_grouped_first_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    setup_mixed_names(&node).await;
+
+    let result = node
+        .query(
+            r#"
+            query {
+                Author {
+                    name
+                    b: COUNT(published: {groupBy: [name]})
+                    a: COUNT(published: {})
+                }
+            }
+            "#,
+        )
+        .expect("query authors");
+
+    assert_eq!(
+        result["Author"],
+        serde_json::json!([{"name": "John Grisham", "b": 3, "a": 4}])
+    );
+}
+
 #[tokio::test]
 async fn rust_aggregate_groupby_1595_on_single_field() {
     let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
@@ -232,4 +295,16 @@ async fn rust_aggregate_groupby_1595_relation_all_same_name() {
 async fn rust_aggregate_groupby_1595_relation_counting_distinct_names() {
     let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
     relation_counting_distinct_names_test(cluster).await;
+}
+
+#[tokio::test]
+async fn rust_aggregate_groupby_1595_grouped_count_plain_first() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    grouped_count_plain_first_test(cluster).await;
+}
+
+#[tokio::test]
+async fn rust_aggregate_groupby_1595_grouped_count_grouped_first() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    grouped_count_grouped_first_test(cluster).await;
 }

--- a/tools/integration-test/tests/query/aggregate_groupby_1595.rs
+++ b/tools/integration-test/tests/query/aggregate_groupby_1595.rs
@@ -1,0 +1,235 @@
+use integration_test::{DefraClient, TestCluster};
+
+/// Mirrors the Go `query/simple` fixture
+/// (`tests/integration/query/simple/utils.go`).
+fn add_users_schema(node: &DefraClient) {
+    node.schema_add(
+        r#"
+        type Users {
+            Name: String
+            Email: String
+            Age: Int
+            HeightM: Float
+            Verified: Boolean
+            CreatedAt: DateTime
+        }
+        "#,
+    )
+    .expect("add schema");
+}
+
+fn add_user(node: &DefraClient, name: &str, age: i64) {
+    node.query(&format!(
+        r#"mutation {{ add_Users(input: {{Name: "{name}", Age: {age}}}) {{ _docID }} }}"#
+    ))
+    .unwrap_or_else(|e| panic!("add user {name}: {e}"));
+}
+
+/// Mirrors the Go `query/one_to_many` fixture
+/// (`tests/integration/query/one_to_many/utils.go`).
+fn add_book_author_schema(node: &DefraClient) {
+    node.schema_add(
+        r#"
+        type Book {
+            name: String
+            rating: Float
+            author: Author
+        }
+
+        type Author {
+            name: String
+            age: Int
+            verified: Boolean
+            published: [Book]
+        }
+        "#,
+    )
+    .expect("add schema");
+}
+
+fn add_author(node: &DefraClient, name: &str, age: i64, verified: bool) -> String {
+    let result = node
+        .query(&format!(
+            r#"mutation {{ add_Author(input: {{name: "{name}", age: {age}, verified: {verified}}}) {{ _docID }} }}"#
+        ))
+        .unwrap_or_else(|e| panic!("add author {name}: {e}"));
+    result["add_Author"][0]["_docID"]
+        .as_str()
+        .expect("author _docID")
+        .to_string()
+}
+
+fn add_book(node: &DefraClient, name: &str, rating: f64, author: &str) {
+    node.query(&format!(
+        r#"mutation {{ add_Book(input: {{name: "{name}", rating: {rating}, author: "{author}"}}) {{ _docID }} }}"#
+    ))
+    .unwrap_or_else(|e| panic!("add book {name}: {e}"));
+}
+
+fn count_for(result: &serde_json::Value, author: &str) -> i64 {
+    result["Author"]
+        .as_array()
+        .expect("Author array")
+        .iter()
+        .find(|a| a["name"] == author)
+        .unwrap_or_else(|| panic!("author {author} missing"))["COUNT"]
+        .as_i64()
+        .expect("numeric COUNT")
+}
+
+/// Go: TestQuerySimple_WithCountWithGroupBy_OnSingleField
+/// Three docs, two distinct ages -> 2 groups.
+async fn on_single_field_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    add_users_schema(&node);
+    add_user(&node, "John", 32);
+    add_user(&node, "Bob", 32);
+    add_user(&node, "Alice", 19);
+
+    let result = node
+        .query(r#"query { COUNT(Users: {groupBy: [Age]}) }"#)
+        .expect("count query");
+
+    assert_eq!(result["COUNT"], serde_json::json!(2));
+}
+
+/// Go: TestQuerySimple_WithCountWithGroupBy_OnMultipleFields
+/// Three distinct (Age, Name) pairs -> 3 groups. Guard: also passes when
+/// groupBy is dropped, so it only protects against over-grouping.
+async fn on_multiple_fields_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    add_users_schema(&node);
+    add_user(&node, "John", 32);
+    add_user(&node, "Bob", 32);
+    add_user(&node, "John", 19);
+
+    let result = node
+        .query(r#"query { COUNT(Users: {groupBy: [Age, Name]}) }"#)
+        .expect("count query");
+
+    assert_eq!(result["COUNT"], serde_json::json!(3));
+}
+
+/// Go: TestQuerySimple_WithCountWithGroupBy_AllSameGroupValue
+/// Three docs sharing one age -> 1 group.
+async fn all_same_group_value_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    add_users_schema(&node);
+    add_user(&node, "John", 32);
+    add_user(&node, "Bob", 32);
+    add_user(&node, "Alice", 32);
+
+    let result = node
+        .query(r#"query { COUNT(Users: {groupBy: [Age]}) }"#)
+        .expect("count query");
+
+    assert_eq!(result["COUNT"], serde_json::json!(1));
+}
+
+/// Go: TestQuerySimple_WithCountWithGroupByAndFilter
+/// Filter keeps ages 32, 32, 25 -> 2 groups.
+async fn group_by_and_filter_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    add_users_schema(&node);
+    add_user(&node, "John", 32);
+    add_user(&node, "Bob", 32);
+    add_user(&node, "Alice", 19);
+    add_user(&node, "Chris", 25);
+
+    let result = node
+        .query(r#"query { COUNT(Users: {groupBy: [Age], filter: {Age: {_gt: 20}}}) }"#)
+        .expect("count query");
+
+    assert_eq!(result["COUNT"], serde_json::json!(2));
+}
+
+/// Go: TestQueryOneToMany_WithCountWithGroupBy_AllSameName
+/// Three books sharing one name -> 1 group.
+async fn relation_all_same_name_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    add_book_author_schema(&node);
+    let john = add_author(&node, "John Grisham", 65, true);
+    add_book(&node, "Painted House", 4.9, &john);
+    add_book(&node, "Painted House", 4.8, &john);
+    add_book(&node, "Painted House", 4.7, &john);
+
+    let result = node
+        .query(
+            r#"
+            query {
+                Author {
+                    name
+                    COUNT(published: {groupBy: [name]})
+                }
+            }
+            "#,
+        )
+        .expect("query authors");
+
+    assert_eq!(count_for(&result, "John Grisham"), 1);
+}
+
+/// Go: TestQueryOneToMany_WithCountWithGroupBy_CountingDistinctNames
+/// John has three books under two distinct names, Cornelia has one.
+async fn relation_counting_distinct_names_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    add_book_author_schema(&node);
+    let john = add_author(&node, "John Grisham", 65, true);
+    let cornelia = add_author(&node, "Cornelia Funke", 62, false);
+    add_book(&node, "Painted House", 4.9, &john);
+    add_book(&node, "Painted House", 4.8, &john);
+    add_book(&node, "A Time for Mercy", 4.5, &john);
+    add_book(&node, "Theif Lord", 4.7, &cornelia);
+
+    let result = node
+        .query(
+            r#"
+            query {
+                Author {
+                    name
+                    COUNT(published: {groupBy: [name]})
+                }
+            }
+            "#,
+        )
+        .expect("query authors");
+
+    assert_eq!(count_for(&result, "John Grisham"), 2);
+    assert_eq!(count_for(&result, "Cornelia Funke"), 1);
+}
+
+#[tokio::test]
+async fn rust_aggregate_groupby_1595_on_single_field() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    on_single_field_test(cluster).await;
+}
+
+#[tokio::test]
+async fn rust_aggregate_groupby_1595_on_multiple_fields() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    on_multiple_fields_test(cluster).await;
+}
+
+#[tokio::test]
+async fn rust_aggregate_groupby_1595_all_same_group_value() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    all_same_group_value_test(cluster).await;
+}
+
+#[tokio::test]
+async fn rust_aggregate_groupby_1595_group_by_and_filter() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    group_by_and_filter_test(cluster).await;
+}
+
+#[tokio::test]
+async fn rust_aggregate_groupby_1595_relation_all_same_name() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    relation_all_same_name_test(cluster).await;
+}
+
+#[tokio::test]
+async fn rust_aggregate_groupby_1595_relation_counting_distinct_names() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    relation_counting_distinct_names_test(cluster).await;
+}


### PR DESCRIPTION
Closes #1595. Stack 4/5, base `edjroz/1597-relation-rendering`.

## What

`_count(X: {groupBy: [field]})` counts documents instead of groups — the argument is parsed and silently discarded. `AggregateTarget` had no field to carry it, both target parsers dropped the key, and every runner path counted items; one Go-mirrored test passed only by coincidence.

## What changed

- `AggregateTarget` gains `group_by`; both parsers (GraphQL object and JSON-variable) fill it.
- COUNT counts distinct group keys on the top-level, planner, and relation paths; keys are JSON-typed and control-character-safe (stricter than Go's collidable `%v_` concatenation), and missing fields share one `null` group like Go.
- Grouped fields are injected into document/child mappings so keys are populated, mirroring Go's mapper.
- Relation-kind group fields rewrite to `_<name>ID`; array relations error with Go's message (`cannot group by array or object field. Field: …`).
- A grouped target never shares a join — sharing made the answer depend on selection order. Deliberate divergence: Go's `Targetable.equal` ignores `GroupBy` and silently degrades to the plain count; Rust returns the correct group count in both orders. Upstream issue candidate.
- Underscore group fields (`_docID`, rewritten `_authorID`) are fetched via a private `__agg_` slot stripped before the response — no leak into rendered output.
- Added `aggregate_groupby_1595.rs` (14 tests): the five affected Go tests mirrored exactly, plus order-independence, rewrite/error, `_docID` grouping, leak guard, and Go's zero/empty cases.

## Verification

- Red-first: document counts where group counts were expected (e.g. ages 32/32/19 → 3, expected 2); order-dependence reproduced live (`b` = 1 or 3 by field position).
- Leak guard proves `published { name }` stays `name`-only alongside `COUNT(published: {groupBy: [_docID]})`.
- Full workspace gate at stack head: fmt clean, workspace clippy `-D warnings` exit 0, 5270 unit tests pass, query area 64 rust_* / basic at baseline.
- Known gaps for follow-up issues: grouped-target `limit`/`offset` slices documents not groups; SUM/AVG accept `groupBy` where Go rejects at validation; the relation-path rewrite leg lacks a discriminating fixture.
