### PR TITLE
fix: preserve f64 bits through JSON parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,10 @@ futures = "0.3"
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+# `float_roundtrip`: the default parser is off by up to 1 ULP, which silently
+# rewrites stored f64 bits (and so content-addressed docIDs). Go's
+# encoding/json is correctly rounded; parity requires this.
+serde_json = { version = "1.0", features = ["float_roundtrip"] }
 serde_bytes = "0.11"
 ciborium = "0.2"
 

--- a/tools/integration-test/tests/query.rs
+++ b/tools/integration-test/tests/query.rs
@@ -20,6 +20,8 @@ mod downsample_gc;
 mod exhaustive_orphans_4454;
 #[path = "query/explain_nested.rs"]
 mod explain_nested;
+#[path = "query/float_precision.rs"]
+mod float_precision;
 #[path = "query/go_view_paths.rs"]
 mod go_view_paths;
 #[path = "query/gql_list_args.rs"]

--- a/tools/integration-test/tests/query/float_precision.rs
+++ b/tools/integration-test/tests/query/float_precision.rs
@@ -1,0 +1,80 @@
+//! A stored `Float` must round-trip its exact f64 bits. `13.600000000000001`
+//! is a different double from `13.6`, and Go DefraDB returns it verbatim.
+
+use crate::one_to_many_common::{add_author, add_book, add_schema};
+use integration_test::{DefraClient, TestCluster};
+
+/// `4.9 + 4.5 + 4.2` accumulated in insertion order.
+const PRECISE: f64 = 13.600000000000001;
+
+fn add_rated(node: &DefraClient) {
+    node.schema_add("type Rated { name: String rating: Float }")
+        .expect("add Rated schema");
+    node.collection_create(
+        "Rated",
+        r#"{"name": "precise", "rating": 13.600000000000001}"#,
+    )
+    .expect("create Rated doc");
+}
+
+async fn create_round_trip_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    add_rated(&node);
+
+    let result = node
+        .query("query { Rated { name rating } }")
+        .expect("query Rated");
+
+    assert_eq!(
+        result["Rated"],
+        serde_json::json!([{"name": "precise", "rating": PRECISE}])
+    );
+}
+
+async fn filter_round_trip_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    add_rated(&node);
+
+    let result = node
+        .query("query { Rated(filter: {rating: {_eq: 13.600000000000001}}) { name } }")
+        .expect("query Rated by exact rating");
+
+    assert_eq!(result["Rated"], serde_json::json!([{"name": "precise"}]));
+}
+
+async fn sum_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    add_schema(&node);
+
+    let john = add_author(&node, "John Grisham", 65, true);
+    add_book(&node, "Painted House", 4.9, &john);
+    add_book(&node, "A Time for Mercy", 4.5, &john);
+    add_book(&node, "The Associate", 4.2, &john);
+
+    let result = node
+        .query("query { Author { name totalRating: SUM(published: {field: rating}) } }")
+        .expect("query authors");
+
+    assert_eq!(
+        result["Author"],
+        serde_json::json!([{"name": "John Grisham", "totalRating": PRECISE}])
+    );
+}
+
+#[tokio::test]
+async fn rust_float_precision_create_round_trip() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    create_round_trip_test(cluster).await;
+}
+
+#[tokio::test]
+async fn rust_float_precision_filter_round_trip() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    filter_round_trip_test(cluster).await;
+}
+
+#[tokio::test]
+async fn rust_float_precision_sum() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    sum_test(cluster).await;
+}

--- a/tools/integration-test/tests/query/join_order_1596.rs
+++ b/tools/integration-test/tests/query/join_order_1596.rs
@@ -32,14 +32,10 @@ async fn sum_with_alias_order_test(cluster: TestCluster) {
         )
         .expect("query authors");
 
-    // Go asserts 13.600000000000001 here (4.9 + 4.5 + 4.2 accumulated in
-    // insertion order). Our response path cannot express that 17th significant
-    // digit, so the order-sensitive assertions live in the limit/offset tests
-    // below, where the difference is visible at 2 significant digits.
     assert_eq!(
         result["Author"],
         serde_json::json!([
-            {"name": "John Grisham", "totalRating": 13.6},
+            {"name": "John Grisham", "totalRating": 13.600000000000001},
             {"name": "Cornelia Funke", "totalRating": 4.8},
         ])
     );


### PR DESCRIPTION
Stack 5/5, base `edjroz/1595-aggregate-groupby`. No issue filed — found during #1596's verification.

## What

Any stored f64 needing more than 15 significant digits collapsed to a nearby double: a created `13.600000000000001` stored and returned the bits of `13.6`. Go round-trips exactly (`strconv.ParseFloat`), so JSON-created documents diverged from Go — and from our own GraphQL-inline create path, which parsed correctly.

The cause is serde_json's default number parser, off by up to 1 ULP without the `float_roundtrip` feature. The collapse happened at ingest, **before content addressing**, so affected documents carried docIDs that diverge from Go's.

## What changed

- Enabled `float_roundtrip` on the workspace `serde_json` dependency (one line in `Cargo.toml`); feature unification fixes every entry point — HTTP ingest, document parsing, the CLI's response re-parse — at once.
- Added `tools/integration-test/tests/query/float_precision.rs` (3 tests): exact create round-trip, `_eq` filter match on the precise value, the SUM case.
- Tightened `join_order_1596.rs`'s SUM assertion from `13.6` to Go's exact `13.600000000000001`, dropping the stale ceiling comment.

## Verification

- Discriminating probe: the same string through `str::parse` vs serde_json gives different bits (`…3334` vs `…3333`); equal with the feature enabled.
- Pre-fix probes pinned the loss to ingest, not render: `_eq: 13.6` matched a JSON-created doc while `_gt: 13.6` returned nothing; CBOR storage, index keys, SUM arithmetic, and render are all bit-exact.
- **DocID impact:** identical content gets a different docID before/after (`bae-fa7ac32d-…` → `bae-e48938ce-…`) for >15-digit floats; the new IDs are the Go-parity ones. Pre-1.0, no migration concern. `cargo test -p document` and the basic area pass.
- Full gate: query area 78 passed / 0 rust failures, basic at baseline, workspace tests exit 0, workspace clippy clean.
- Follow-up candidate (not here): `cursor`/`ffi-test`/`integration-test` hardcode `serde_json = "1.0"` — safe today only via feature unification.
