### PR TITLE
feat(db): support filtered collection truncate

### DIFF
--- a/crates/cli/src/collection_mgmt_adapter.rs
+++ b/crates/cli/src/collection_mgmt_adapter.rs
@@ -57,11 +57,27 @@ impl<S: Store + 'static> CollectionManagementOperations for CollectionManagement
             .map_err(|e| format!("{}", e))
     }
 
-    async fn truncate_collection(&self, name: &str) -> Result<(), String> {
-        self.database
-            .truncate_collection(name, None)
-            .await
-            .map_err(|e| format!("{}", e))
+    async fn truncate_collection(
+        &self,
+        name: &str,
+        filter: Option<serde_json::Value>,
+    ) -> Result<(), String> {
+        match filter {
+            Some(serde_json::Value::Object(conditions)) => {
+                self.database
+                    .truncate_collection_with_filter(
+                        name,
+                        query::Filter::from_conditions(conditions),
+                        None,
+                    )
+                    .await
+            }
+            Some(_) => Err(db::Error::Query(query::QueryError::invalid_filter(
+                "filter must be an object",
+            ))),
+            None => self.database.truncate_collection(name, None).await,
+        }
+        .map_err(|error| error.to_string())
     }
 
     async fn purge(&self) -> Result<(), String> {

--- a/crates/cli/src/commands/client/collection/document.rs
+++ b/crates/cli/src/commands/client/collection/document.rs
@@ -49,10 +49,28 @@ impl TruncateArgs {
             .with_auth_token(ctx.auth_token.clone())
             .with_verbose(ctx.verbose);
 
-        client.collection_truncate(collection).await?;
+        let filter = self
+            .filter
+            .as_deref()
+            .map(parse_truncate_filter)
+            .transpose()?;
+
+        client
+            .collection_truncate(collection, filter.as_ref())
+            .await?;
         println!("Truncated collection {}", collection);
         Ok(())
     }
+}
+
+fn parse_truncate_filter(value: &str) -> Result<serde_json::Value> {
+    let filter = serde_json::from_str::<serde_json::Value>(value)?;
+    if !filter.is_object() {
+        return Err(Error::MissingInput(
+            "--filter must be a non-null JSON object".to_string(),
+        ));
+    }
+    Ok(filter)
 }
 
 impl CollectionDeleteArgs {
@@ -86,5 +104,18 @@ impl CollectionDeleteArgs {
             println!("Deleted collections {}", names.join(", "));
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_truncate_filter;
+
+    #[test]
+    fn truncate_filter_requires_a_json_object() {
+        assert!(parse_truncate_filter(r#"{"name":{"_eq":"Alice"}}"#).is_ok());
+        for invalid in ["null", "[]", "not json"] {
+            assert!(parse_truncate_filter(invalid).is_err());
+        }
     }
 }

--- a/crates/cli/src/commands/client/collection/mod.rs
+++ b/crates/cli/src/commands/client/collection/mod.rs
@@ -103,7 +103,11 @@ pub struct SetActiveArgs {
 
 /// Arguments for truncate command
 #[derive(Args, Debug)]
-pub struct TruncateArgs {}
+pub struct TruncateArgs {
+    /// JSON document filter. Without it, every document is removed.
+    #[arg(long)]
+    pub filter: Option<String>,
+}
 
 /// Arguments for delete command (Go #4688 parity).
 #[derive(Args, Debug)]

--- a/crates/cli/src/commands/client/http_client/collection.rs
+++ b/crates/cli/src/commands/client/http_client/collection.rs
@@ -50,13 +50,20 @@ impl HttpClient {
         Ok(())
     }
 
-    pub async fn collection_truncate(&self, name: &str) -> Result<()> {
+    pub async fn collection_truncate(
+        &self,
+        name: &str,
+        filter: Option<&serde_json::Value>,
+    ) -> Result<()> {
         let url = format!(
             "{}/api/v0/collections/{}/truncate",
             self.base_url,
             encode(name)
         );
-        self.request_void("DELETE", &url, None).await
+        let body = filter
+            .map(|filter| serde_json::to_string(&serde_json::json!({ "filter": filter })))
+            .transpose()?;
+        self.request_void("DELETE", &url, body.as_deref()).await
     }
 
     /// Delete one or more collections by name via Go-compatible

--- a/crates/cli/src/commands/start/server_query.rs
+++ b/crates/cli/src/commands/start/server_query.rs
@@ -48,6 +48,7 @@ impl Node {
             registry.clone(),
         )
         .with_mutator(mutator)
+        .with_collection_truncator(db::DbCollectionTruncator::new_arc(database.clone()))
         .with_acp(document_acp)
         .with_node_did(database.node_did())
         .with_lens_store(database.lens_store().clone())

--- a/crates/db/src/block/cleanup.rs
+++ b/crates/db/src/block/cleanup.rs
@@ -127,6 +127,17 @@ pub async fn delete_owned_dag(
     roots: &[Cid],
     doc_id: &str,
 ) -> Result<()> {
+    delete_owned_dag_for_owners(blockstore, systemstore, roots, &[doc_id.to_owned()]).await
+}
+
+/// Remove several aliases' ownership from every block reachable from `roots`.
+/// Shared blocks and everything they still reference remain intact.
+pub async fn delete_owned_dag_for_owners(
+    blockstore: &NamespaceView,
+    systemstore: &NamespaceView,
+    roots: &[Cid],
+    doc_ids: &[String],
+) -> Result<()> {
     let mut stack = roots.to_vec();
     let mut edges: HashMap<Cid, Vec<Cid>> = HashMap::new();
     let mut signatures: HashMap<Cid, Cid> = HashMap::new();
@@ -152,7 +163,11 @@ pub async fn delete_owned_dag(
 
     let mut retained = HashSet::new();
     for cid in &visited {
-        if !remove_owner(systemstore, cid, doc_id).await? {
+        let mut has_owner = true;
+        for doc_id in doc_ids {
+            has_owner = !remove_owner(systemstore, cid, doc_id).await?;
+        }
+        if has_owner {
             retained.insert(*cid);
         }
     }

--- a/crates/db/src/collection/mod.rs
+++ b/crates/db/src/collection/mod.rs
@@ -36,7 +36,10 @@ pub mod retriever;
 pub mod selector;
 pub mod snapshot;
 pub mod stream;
+mod truncator;
 pub mod validation;
+
+pub use truncator::DbCollectionTruncator;
 
 /// Derive the legacy short ID from a collection_id string.
 ///

--- a/crates/db/src/collection/ops/mod.rs
+++ b/crates/db/src/collection/ops/mod.rs
@@ -10,6 +10,7 @@ mod create;
 mod delete;
 mod lookup;
 mod resolve;
+mod truncate_filtered;
 mod version;
 
 use crate::collection::name::CollectionName;

--- a/crates/db/src/collection/ops/truncate_filtered.rs
+++ b/crates/db/src/collection/ops/truncate_filtered.rs
@@ -1,0 +1,259 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use storage::keys::{
+    DataStoreKey, DatastoreSE, HeadstoreDocKey, HeadstorePriorityKey, InstanceType,
+    PrimaryDataStoreKey,
+};
+
+use super::*;
+
+const CHUNK_SIZE: usize = 1000;
+
+impl<S: Store> crate::database::DB<S> {
+    /// Permanently remove documents matching `filter` while preserving the collection.
+    #[instrument(skip(self, filter), fields(collection = %name), name = "db.truncate_collection_filtered")]
+    pub async fn truncate_collection_with_filter(
+        self: &Arc<Self>,
+        name: &str,
+        filter: query::Filter,
+        identity: Option<&identity::Did>,
+    ) -> Result<()>
+    where
+        S: 'static,
+    {
+        self.check_node_access(identity, acp::nac::NodePermission::CollectionTruncate)
+            .await?;
+        filter.validate_depth()?;
+
+        let collection = self
+            .get_collection(name)?
+            .ok_or_else(|| Error::CollectionNotFound(name.to_string()))?;
+        if collection.schema().is_branchable {
+            return Err(Error::FilteredTruncateBranchableCollection);
+        }
+
+        let collection_id = collection.collection_id().to_string();
+        let short_id = collection.resolved_root_id();
+        let _collection_guards = self
+            .collection_write_guards(std::iter::once(collection_id.clone()))
+            .await?;
+        let action_execution = self
+            .register_action(&collection_id, crate::Action::TRUNCATE)
+            .await?;
+
+        let fetcher = crate::LensedAutoCommitFetcher::new_without_write_back(self.clone());
+        let provider = crate::DbCollectionProvider::new_arc(self.clone());
+        let runner = query::QueryRunner::with_provider(fetcher, provider)
+            .with_lens_store(self.lens_store().clone());
+
+        let result: Result<usize> = async {
+            let mut doc_count = 0;
+            loop {
+                let doc_ids = runner
+                    .matching_doc_ids(name, filter.clone(), CHUNK_SIZE, true)
+                    .await?;
+                if doc_ids.is_empty() {
+                    break;
+                }
+                doc_count += self.truncate_filtered_chunk(&collection, &doc_ids).await?;
+            }
+            Ok(doc_count)
+        }
+        .await;
+
+        let doc_count = match result {
+            Ok(doc_count) => doc_count,
+            Err(error) => {
+                if let Err(action_error) =
+                    self.fail_action(action_execution, &error.to_string()).await
+                {
+                    tracing::error!(
+                        error = %action_error,
+                        collection_id = %collection_id,
+                        "Failed to record filtered truncate action error"
+                    );
+                }
+                return Err(error);
+            }
+        };
+
+        self.complete_action(action_execution).await?;
+        tracing::info!(
+            collection_id = %collection_id,
+            short_id,
+            doc_count,
+            "Truncated matching collection documents"
+        );
+        Ok(())
+    }
+
+    async fn truncate_filtered_chunk(
+        &self,
+        collection: &Collection,
+        doc_ids: &[String],
+    ) -> Result<usize> {
+        let txn = self.new_txn(false).await?;
+        let datastore = txn.datastore()?;
+        let headstore = txn.headstore()?;
+        let blockstore = txn.blockstore()?;
+        let systemstore = txn.systemstore()?;
+
+        let result: Result<usize> = async {
+            let index_manager = crate::IndexManager::from_indexes(
+                collection.resolved_root_id(),
+                collection.schema(),
+                collection.write_indexes(),
+            )?;
+            let mut seen = HashSet::new();
+            let mut targets = Vec::with_capacity(doc_ids.len());
+            let mut aliases_to_delete = HashSet::new();
+
+            for doc_id in doc_ids {
+                let parsed = document::DocID::from_string(doc_id)?;
+                let (doc_short_id, canonical_doc_id) = collection
+                    .resolve_doc_identity(&systemstore, &parsed)
+                    .await?
+                    .ok_or_else(|| Error::DocumentNotFound(doc_id.clone()))?;
+                if !seen.insert(doc_short_id) {
+                    continue;
+                }
+
+                let mut aliases =
+                    crate::docid::map::get_doc_id_aliases(&systemstore, doc_short_id).await?;
+                if !aliases
+                    .iter()
+                    .any(|alias| alias == &canonical_doc_id.to_string())
+                {
+                    aliases.push(canonical_doc_id.to_string());
+                }
+                aliases_to_delete.extend(aliases.iter().cloned());
+                targets.push((doc_short_id, canonical_doc_id, aliases));
+            }
+
+            let se_prefix = DatastoreSE::collection_prefix(collection.collection_id());
+            let mut se_iter = datastore
+                .iterator(IterOptions::new().with_prefix(se_prefix))
+                .await
+                .map_err(Error::Storage)?;
+            let mut se_keys = Vec::new();
+            while let Some(pair) = se_iter.next().await.map_err(Error::Storage)? {
+                if extract_last_path_segment_str(&pair.key)
+                    .is_some_and(|doc_id| aliases_to_delete.contains(&doc_id))
+                {
+                    se_keys.push(pair.key.to_vec());
+                }
+            }
+            se_iter.close().await.map_err(Error::Storage)?;
+            for key in se_keys {
+                datastore.delete(&key).await.map_err(Error::Storage)?;
+            }
+
+            for (doc_short_id, canonical_doc_id, aliases) in &targets {
+                if let Some((doc, _)) = collection
+                    .get_with_datastore_include_deleted(
+                        &datastore,
+                        *doc_short_id,
+                        canonical_doc_id,
+                        true,
+                    )
+                    .await?
+                {
+                    index_manager
+                        .on_document_delete(&datastore, &doc, *doc_short_id, collection.schema())
+                        .await?;
+                }
+
+                datastore
+                    .delete(&collection.doc_key(*doc_short_id))
+                    .await
+                    .map_err(Error::Storage)?;
+                datastore
+                    .delete(&collection.deleted_key(*doc_short_id))
+                    .await
+                    .map_err(Error::Storage)?;
+                datastore
+                    .delete(&collection.version_key(*doc_short_id))
+                    .await
+                    .map_err(Error::Storage)?;
+                datastore
+                    .delete(
+                        &PrimaryDataStoreKey::new(collection.resolved_root_id(), *doc_short_id)
+                            .bytes(),
+                    )
+                    .await
+                    .map_err(Error::Storage)?;
+                for instance_type in [
+                    InstanceType::Value,
+                    InstanceType::Priority,
+                    InstanceType::Deleted,
+                ] {
+                    delete_prefix(
+                        &datastore,
+                        DataStoreKey::document_prefix(
+                            collection.resolved_root_id(),
+                            instance_type,
+                            *doc_short_id,
+                        ),
+                    )
+                    .await?;
+                }
+
+                let head_prefix = HeadstoreDocKey::document_prefix(*doc_short_id);
+                let mut block_cids = Vec::new();
+                let mut head_iter = headstore
+                    .iterator(IterOptions::new().with_prefix(head_prefix.clone()))
+                    .await
+                    .map_err(Error::Storage)?;
+                while let Some(pair) = head_iter.next().await.map_err(Error::Storage)? {
+                    if let Some(cid_str) = extract_last_path_segment_str(&pair.key) {
+                        if let Ok(cid) = cid::Cid::try_from(cid_str.as_str()) {
+                            block_cids.push(cid);
+                        }
+                    }
+                }
+                head_iter.close().await.map_err(Error::Storage)?;
+                delete_prefix(&headstore, head_prefix).await?;
+                delete_prefix(
+                    &headstore,
+                    HeadstorePriorityKey::document_prefix(*doc_short_id),
+                )
+                .await?;
+
+                crate::block::cleanup::delete_owned_dag_for_owners(
+                    &blockstore,
+                    &systemstore,
+                    &block_cids,
+                    aliases,
+                )
+                .await?;
+                crate::docid::map::delete_doc_id_mappings(&systemstore, *doc_short_id).await?;
+            }
+
+            Ok(targets.len())
+        }
+        .await;
+
+        drop(datastore);
+        drop(headstore);
+        drop(blockstore);
+        drop(systemstore);
+
+        match result {
+            Ok(count) => {
+                txn.commit().await?;
+                Ok(count)
+            }
+            Err(error) => {
+                if let Err(discard_err) = txn.discard() {
+                    tracing::warn!(
+                        error = %discard_err,
+                        original_error = %error,
+                        "Transaction discard failed during filtered truncate"
+                    );
+                }
+                Err(error)
+            }
+        }
+    }
+}

--- a/crates/db/src/collection/truncator.rs
+++ b/crates/db/src/collection/truncator.rs
@@ -1,0 +1,38 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use storage::corekv::Store;
+
+use crate::DB;
+
+/// Query-layer adapter for collection truncate mutations.
+pub struct DbCollectionTruncator<S: Store> {
+    db: Arc<DB<S>>,
+}
+
+impl<S: Store> DbCollectionTruncator<S> {
+    pub fn new_arc(db: Arc<DB<S>>) -> Arc<Self> {
+        Arc::new(Self { db })
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<S: Store + 'static> query::CollectionTruncator for DbCollectionTruncator<S> {
+    async fn truncate(
+        &self,
+        collection_name: &str,
+        filter: Option<query::Filter>,
+        identity: Option<&identity::Did>,
+    ) -> query::Result<()> {
+        let result = match filter {
+            Some(filter) => {
+                self.db
+                    .truncate_collection_with_filter(collection_name, filter, identity)
+                    .await
+            }
+            None => self.db.truncate_collection(collection_name, identity).await,
+        };
+        result.map_err(|error| query::QueryError::execution(error.to_string()))
+    }
+}

--- a/crates/db/src/docid/map.rs
+++ b/crates/db/src/docid/map.rs
@@ -295,6 +295,34 @@ pub async fn set_doc_id_alias(
         .map_err(Error::Storage)
 }
 
+/// Return every public DocID mapped to a document short ID.
+pub async fn get_doc_id_aliases(
+    systemstore: &NamespaceView,
+    doc_short_id: u64,
+) -> Result<Vec<String>> {
+    use storage::corekv::IterOptions;
+
+    let prefix = DocShortIDToDocIDAliasKey::short_id_prefix(doc_short_id);
+    let prefix_len = prefix.len();
+    let mut iter = systemstore
+        .iterator(IterOptions::new().with_prefix(prefix))
+        .await
+        .map_err(Error::Storage)?;
+
+    let mut aliases = Vec::new();
+    while let Some(kv) = iter.next().await.map_err(Error::Storage)? {
+        if kv.key.len() > prefix_len {
+            aliases.push(
+                String::from_utf8(kv.key[prefix_len..].to_vec()).map_err(|e| {
+                    Error::InvalidDocument(format!("invalid utf-8 in doc-ID alias key: {e}"))
+                })?,
+            );
+        }
+    }
+    iter.close().await.map_err(Error::Storage)?;
+    Ok(aliases)
+}
+
 /// Record that a block belongs to a document.
 ///
 /// Field blocks can be byte-identical across documents, so ownership is a

--- a/crates/db/src/error/mod.rs
+++ b/crates/db/src/error/mod.rs
@@ -46,6 +46,9 @@ pub enum Error {
     #[error("invalid collection name: {0}")]
     InvalidCollectionName(String),
 
+    #[error("filtered truncate is not supported for branchable collections")]
+    FilteredTruncateBranchableCollection,
+
     #[error("database is closed")]
     DatabaseClosed,
 

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -87,7 +87,7 @@ pub use collection::retriever::{resolve_collection_from_doc_id, DocCollectionInf
 pub use collection::selector::CollectionSelector;
 pub use collection::snapshot::CollectionSnapshot;
 #[allow(deprecated)]
-pub use collection::{collection_short_id, Collection};
+pub use collection::{collection_short_id, Collection, DbCollectionTruncator};
 pub use database::{
     DbOptions, EmbeddingClientConfig, DB, DEFAULT_MAX_TXN_RETRIES,
     DEFAULT_MIGRATION_WRITE_BACK_BATCH_SIZE,

--- a/crates/db/tests/block/cleanup.rs
+++ b/crates/db/tests/block/cleanup.rs
@@ -112,6 +112,59 @@ async fn deleting_a_dag_keeps_the_shared_subtree() {
 }
 
 #[tokio::test]
+async fn deleting_all_aliases_removes_the_owned_dag() {
+    let (blockstore, systemstore) = stores().await;
+    let encryption = b"encryption".to_vec();
+    let signature = b"signature".to_vec();
+    let encryption_cid = defra_core::block::generate_cid_from_bytes(&encryption).unwrap();
+    let signature_cid = defra_core::block::generate_cid_from_bytes(&signature).unwrap();
+    let block = Block::new_with_options(
+        CrdtDelta::Lww(LwwDeltaPayload {
+            field_name: "name".to_string(),
+            schema_version_id: "v1".to_string(),
+            priority: 1,
+            data: vec![1],
+        }),
+        vec![],
+        vec![],
+        Some(encryption_cid),
+        Some(signature_cid),
+    );
+    let cid = block.generate_cid().unwrap();
+    for (cid, bytes) in [
+        (cid, block.to_dag_cbor().unwrap()),
+        (encryption_cid, encryption),
+        (signature_cid, signature),
+    ] {
+        blockstore.set(&cid.to_bytes(), &bytes).await.unwrap();
+    }
+    for alias in ["doc-v0", "doc-v1"] {
+        for owned_cid in [cid, encryption_cid] {
+            db::docid::map::set_block_doc_id_mapping(&systemstore, &owned_cid.to_string(), alias)
+                .await
+                .unwrap();
+        }
+    }
+
+    delete_owned_dag_for_owners(
+        &blockstore,
+        &systemstore,
+        &[cid],
+        &["doc-v0".to_string(), "doc-v1".to_string()],
+    )
+    .await
+    .unwrap();
+
+    for deleted_cid in [cid, encryption_cid, signature_cid] {
+        assert!(blockstore
+            .get(&deleted_cid.to_bytes())
+            .await
+            .unwrap()
+            .is_none());
+    }
+}
+
+#[tokio::test]
 async fn deleting_one_commit_owner_clears_child_ownership_but_keeps_shared_bytes() {
     let (blockstore, systemstore) = stores().await;
     let field = Block::new(

--- a/crates/db/tests/collection/main.rs
+++ b/crates/db/tests/collection/main.rs
@@ -10,4 +10,5 @@ mod retriever;
 mod selector;
 mod snapshot;
 mod stream;
+mod truncate;
 mod validation;

--- a/crates/db/tests/collection/truncate.rs
+++ b/crates/db/tests/collection/truncate.rs
@@ -1,0 +1,181 @@
+use std::sync::Arc;
+
+use db::{AutoCommitFetcher, AutoCommitMutator, DB};
+use document::{DocID, Document, NormalValue};
+use query::{DocFetcher, DocMutator, Filter};
+use schema::{CollectionVersion, FieldDescription, FieldKind, IndexDescription};
+use storage::backends::MemoryStore;
+use storage::corekv::Key;
+use storage::keys::DatastoreSE;
+
+fn users_schema() -> CollectionVersion {
+    CollectionVersion::new(
+        "Users",
+        "users-v1",
+        "users-collection",
+        vec![
+            FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+            FieldDescription::new("2", "name", FieldKind::string()),
+            FieldDescription::new("3", "age", FieldKind::int()),
+        ],
+    )
+    .with_index(
+        IndexDescription::new("users_name")
+            .with_field("name", false)
+            .as_unique(),
+    )
+}
+
+fn age_filter(age: i64) -> Filter {
+    let mut conditions = serde_json::Map::new();
+    conditions.insert("age".into(), serde_json::json!({"_eq": age}));
+    Filter::from_conditions(conditions)
+}
+
+async fn create_user(mutator: &AutoCommitMutator<MemoryStore>, name: &str, age: i64) -> DocID {
+    let mut doc = Document::new();
+    doc.set("name", NormalValue::String(name.to_owned()));
+    doc.set("age", NormalValue::Int(age));
+    mutator.create("Users", doc).await.unwrap().doc_id
+}
+
+#[tokio::test]
+async fn filtered_truncate_removes_only_matching_documents_and_indexes() {
+    let db = Arc::new(DB::new(MemoryStore::new()).unwrap());
+    db.create_collection(users_schema()).await.unwrap();
+    let mutator = AutoCommitMutator::new(db.clone());
+    let alice = create_user(&mutator, "Alice", 30).await;
+    create_user(&mutator, "Bob", 40).await;
+
+    db.truncate_collection_with_filter("Users", age_filter(30), None)
+        .await
+        .unwrap();
+
+    let docs = AutoCommitFetcher::new(db.clone())
+        .get_all("Users")
+        .await
+        .unwrap();
+    assert_eq!(docs.len(), 1);
+    assert_eq!(
+        docs[0].get("name"),
+        Some(&NormalValue::String("Bob".into()))
+    );
+
+    let recreated = create_user(&mutator, "Alice", 30).await;
+    assert_eq!(recreated, alice);
+    assert_eq!(
+        AutoCommitFetcher::new(db)
+            .get_all("Users")
+            .await
+            .unwrap()
+            .len(),
+        2
+    );
+}
+
+#[tokio::test]
+async fn filtered_truncate_includes_soft_deleted_documents() {
+    let db = Arc::new(DB::new(MemoryStore::new()).unwrap());
+    db.create_collection(users_schema()).await.unwrap();
+    let mutator = AutoCommitMutator::new(db.clone());
+
+    let mut doc = Document::new();
+    doc.set("name", NormalValue::String("Alice".into()));
+    doc.set("age", NormalValue::Int(30));
+    let created = mutator.create("Users", doc).await.unwrap();
+    mutator.delete("Users", &created.doc_id).await.unwrap();
+
+    db.truncate_collection_with_filter("Users", age_filter(30), None)
+        .await
+        .unwrap();
+    create_user(&mutator, "Alice", 31).await;
+
+    assert_eq!(
+        AutoCommitFetcher::new(db)
+            .get_all("Users")
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn filtered_truncate_rejects_branchable_collections() {
+    let db = Arc::new(DB::new(MemoryStore::new()).unwrap());
+    db.create_collection(users_schema().as_branchable())
+        .await
+        .unwrap();
+
+    let error = db
+        .truncate_collection_with_filter("Users", age_filter(30), None)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        db::Error::FilteredTruncateBranchableCollection
+    ));
+}
+
+#[tokio::test]
+async fn filtered_truncate_removes_only_matching_searchable_encryption_records() {
+    let db = Arc::new(DB::new(MemoryStore::new()).unwrap());
+    db.create_collection(users_schema()).await.unwrap();
+    let mutator = AutoCommitMutator::new(db.clone());
+    let alice = create_user(&mutator, "Alice", 30).await;
+    let bob = create_user(&mutator, "Bob", 40).await;
+    let alice_key =
+        DatastoreSE::new("users-collection", "users-name", vec![1], alice.to_string()).bytes();
+    let bob_key =
+        DatastoreSE::new("users-collection", "users-name", vec![2], bob.to_string()).bytes();
+
+    let txn = db.new_txn(false).await.unwrap();
+    let datastore = txn.datastore().unwrap();
+    datastore.set(&alice_key, b"alice").await.unwrap();
+    datastore.set(&bob_key, b"bob").await.unwrap();
+    drop(datastore);
+    txn.commit().await.unwrap();
+
+    db.truncate_collection_with_filter("Users", age_filter(30), None)
+        .await
+        .unwrap();
+
+    let txn = db.new_txn(true).await.unwrap();
+    let datastore = txn.datastore().unwrap();
+    assert!(datastore.get(&alice_key).await.unwrap().is_none());
+    assert!(datastore.get(&bob_key).await.unwrap().is_some());
+}
+
+#[tokio::test]
+async fn filtered_truncate_processes_more_than_one_chunk() {
+    let db = Arc::new(DB::new(MemoryStore::new()).unwrap());
+    let schema = CollectionVersion::new(
+        "Users",
+        "users-v1",
+        "users-collection",
+        vec![
+            FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+            FieldDescription::new("2", "age", FieldKind::int()),
+            FieldDescription::new("3", "seq", FieldKind::int()),
+        ],
+    );
+    db.create_collection(schema).await.unwrap();
+    let mutator = AutoCommitMutator::new(db.clone());
+    for seq in 0..=1000 {
+        let mut doc = Document::new();
+        doc.set("age", NormalValue::Int(30));
+        doc.set("seq", NormalValue::Int(seq));
+        mutator.create("Users", doc).await.unwrap();
+    }
+
+    db.truncate_collection_with_filter("Users", age_filter(30), None)
+        .await
+        .unwrap();
+
+    assert!(AutoCommitFetcher::new(db)
+        .get_all("Users")
+        .await
+        .unwrap()
+        .is_empty());
+}

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -1500,6 +1500,7 @@ impl NodeBuilder {
         let query_runner =
             query::QueryRunner::with_arc_registry_and_provider(fetcher, provider, registry.clone())
                 .with_mutator(mutator)
+                .with_collection_truncator(db::DbCollectionTruncator::new_arc(database.clone()))
                 .with_acp(document_acp.clone())
                 .with_node_did(database.node_did())
                 .with_lens_store(database.lens_store().clone())

--- a/crates/embedded/src/node.rs
+++ b/crates/embedded/src/node.rs
@@ -695,6 +695,7 @@ where
             .map(|setup| setup.mutator.clone())
             .unwrap_or_else(|| Arc::new(db::AutoCommitMutator::new(database.clone()))),
     )
+    .with_collection_truncator(db::DbCollectionTruncator::new_arc(database.clone()))
     .with_acp(document_acp.clone())
     .with_node_did(database.node_did())
     .with_lens_store(database.lens_store().clone())

--- a/crates/ffi/src/collection/mod.rs
+++ b/crates/ffi/src/collection/mod.rs
@@ -24,4 +24,5 @@ pub use view::{add_view, gc_downsample_histories, refresh_views};
 pub use write::{
     delete_collection, delete_collections, delete_collections_in_txn, patch_collection,
     set_active_collection_version, set_collection_active_in_txn, truncate_collection,
+    truncate_collection_with_filter,
 };

--- a/crates/ffi/src/collection/write.rs
+++ b/crates/ffi/src/collection/write.rs
@@ -295,6 +295,47 @@ pub unsafe extern "C" fn truncate_collection(
     }
 }
 
+/// Truncate documents matching a JSON filter while preserving the collection schema.
+///
+/// # Safety
+///
+/// `name` and `filter_json` must be valid null-terminated UTF-8 strings.
+#[no_mangle]
+pub unsafe extern "C" fn truncate_collection_with_filter(
+    node_ptr: usize,
+    identity_did: *const std::ffi::c_char,
+    name: *const std::ffi::c_char,
+    filter_json: *const std::ffi::c_char,
+) -> crate::types::FfiResult {
+    ffi_node_db_async_body! {
+        node = node_ptr,
+        identity = identity_did,
+        database = database,
+        permission = NodePermission::CollectionTruncate,
+        name => name_str: "name",
+        filter_json => filter_str: "filter_json";
+        {
+        let filter: serde_json::Value = serde_json::from_str(&filter_str)
+            .map_err(|error| format!("invalid filter JSON: {error}"))?;
+        let conditions = filter
+            .as_object()
+            .cloned()
+            .ok_or_else(|| "filter must be a non-null JSON object".to_string())?;
+
+        database
+            .truncate_collection_with_filter(
+                &name_str,
+                query::Filter::from_conditions(conditions),
+                None,
+            )
+            .await
+            .map_err(|e| format!("failed to truncate collection: {}", e))?;
+
+        Ok("{}".to_string())
+    }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -391,6 +432,43 @@ mod tests {
             let value = unsafe { std::ffi::CStr::from_ptr(result.value).to_string_lossy() };
             assert_eq!(value, "false");
             unsafe { crate::types::defra_free_string(result.value) };
+        }
+
+        node_close(node);
+    }
+
+    #[test]
+    fn test_truncate_collection_with_filter_validates_json_object() {
+        assert!(crate::runtime::init_runtime());
+
+        let result = new_node(NodeInitOptions::default());
+        assert_eq!(result.status, 0);
+        let node = result.node_ptr;
+        let sdl = CString::new("type FilteredTruncate { field: String }").unwrap();
+        let result = unsafe { add_schema(node, std::ptr::null(), sdl.as_ptr()) };
+        assert_eq!(result.status, 0);
+        unsafe { crate::types::defra_free_string(result.value) };
+
+        let name = CString::new("FilteredTruncate").unwrap();
+        let filter = CString::new("{}").unwrap();
+        let result = unsafe {
+            truncate_collection_with_filter(node, std::ptr::null(), name.as_ptr(), filter.as_ptr())
+        };
+        assert_eq!(result.status, 0);
+        unsafe { crate::types::defra_free_string(result.value) };
+
+        for invalid in ["null", "[]"] {
+            let filter = CString::new(invalid).unwrap();
+            let result = unsafe {
+                truncate_collection_with_filter(
+                    node,
+                    std::ptr::null(),
+                    name.as_ptr(),
+                    filter.as_ptr(),
+                )
+            };
+            assert_eq!(result.status, 1);
+            unsafe { crate::types::defra_free_string(result.error) };
         }
 
         node_close(node);

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -248,7 +248,7 @@ pub use collection::{
     delete_collections_in_txn, delete_documents, find_collection_by_id, gc_downsample_histories,
     get_collection_by_name, get_collection_by_version_id, has_collection, materialize_collection,
     patch_collection, refresh_views, set_active_collection_version, set_collection_active_in_txn,
-    set_migration, truncate_collection,
+    set_migration, truncate_collection, truncate_collection_with_filter,
 };
 pub use document::{collection_create, is_json_array, parse_duration, parse_string_array};
 pub use encrypted_index::{

--- a/crates/http/src/error.rs
+++ b/crates/http/src/error.rs
@@ -175,6 +175,7 @@ fn classify_backend_message(message: &str) -> Option<ErrorStatus> {
             "invalid collection name",
             "invalid document",
             "invalid entityset",
+            "filtered truncate is not supported",
             "invalid lens configuration",
             "invalid patch",
             "invalid policy",
@@ -235,6 +236,7 @@ fn http_status_from_db_error(err: &DbError) -> HttpError {
         | DbError::InvalidCollectionName(_)
         | DbError::CollectionVersionIDEmpty
         | DbError::ExplicitTxnMustUseForce
+        | DbError::FilteredTruncateBranchableCollection
         | DbError::UnsafePolicyTransition(_)
         | DbError::JsonPatch(_) => HttpError::UnprocessableEntity(message),
         DbError::DatabaseClosed => HttpError::ServiceUnavailable(message),
@@ -356,6 +358,10 @@ mod tests {
             ),
             (
                 DbError::UnsafePolicyTransition("collection policy changed".into()),
+                StatusCode::UNPROCESSABLE_ENTITY,
+            ),
+            (
+                DbError::FilteredTruncateBranchableCollection,
                 StatusCode::UNPROCESSABLE_ENTITY,
             ),
             (DbError::DatabaseClosed, StatusCode::SERVICE_UNAVAILABLE),

--- a/crates/http/src/handlers/collections.rs
+++ b/crates/http/src/handlers/collections.rs
@@ -13,7 +13,7 @@ use axum::{
     Json,
 };
 use query::rest::{CollectionDocIdsPage, CollectionDocIdsPagination};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::error::{http_error_from_backend_message, HttpError};
 use crate::handlers::collection_selector::CollectionSelectorQuery;
@@ -310,25 +310,45 @@ pub async fn set_active(
     Ok(StatusCode::OK)
 }
 
-/// Truncate all documents in a collection.
+#[derive(Deserialize)]
+struct TruncateCollectionRequest {
+    filter: Option<serde_json::Value>,
+}
+
+/// Truncate all or matching documents in a collection.
 ///
 /// DELETE /api/v0/collections/{name}/truncate
 ///
 /// Deletes all documents, heads, blocks, and index entries while
 /// preserving the collection schema.
 ///
-/// Requires `DocumentDelete` permission when NAC is enabled.
+/// Requires `CollectionTruncate` permission when NAC is enabled.
 pub async fn truncate_collection(
     State(state): State<AppState>,
     identity: ExtractIdentity,
     Path(name): Path<String>,
+    body: axum::body::Bytes,
 ) -> Result<Json<()>, HttpError> {
     require_permission(&state, &identity, NodePermission::CollectionTruncate).await?;
 
     let collection_mgmt = state.require_collection_mgmt()?;
 
+    let filter = if body.is_empty() {
+        None
+    } else {
+        let request: TruncateCollectionRequest = serde_json::from_slice(&body)
+            .map_err(|error| HttpError::BadRequest(format!("invalid request body: {error}")))?;
+        match request.filter {
+            Some(serde_json::Value::Object(filter)) => Some(serde_json::Value::Object(filter)),
+            Some(serde_json::Value::Null) | None => {
+                return Err(HttpError::BadRequest("filter is required".into()))
+            }
+            Some(_) => return Err(HttpError::BadRequest("filter must be an object".into())),
+        }
+    };
+
     collection_mgmt
-        .truncate_collection(&name)
+        .truncate_collection(&name, filter)
         .await
         .map_err(http_error_from_backend_message)?;
 

--- a/crates/http/src/handlers/collections_tests.rs
+++ b/crates/http/src/handlers/collections_tests.rs
@@ -97,6 +97,65 @@ fn router_with_rest() -> axum::Router {
 }
 
 #[tokio::test]
+async fn truncate_collection_forwards_optional_filter() {
+    let operations = Arc::new(MockCollectionManagementOperations::new());
+    let router = router_with_collection_mgmt_operations(operations.clone());
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::DELETE)
+                .uri("/api/v0/collections/Users/truncate")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"filter":{"name":{"_eq":"Alice"}}}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method(Method::DELETE)
+                .uri("/api/v0/collections/Users/truncate")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        operations.truncated_collections(),
+        vec![
+            ("Users".to_string(), Some(json!({"name": {"_eq": "Alice"}}))),
+            ("Users".to_string(), None),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn truncate_collection_rejects_missing_or_null_filter_body() {
+    for body in ["{}", r#"{"filter":null}"#, "not json"] {
+        let operations = Arc::new(MockCollectionManagementOperations::new());
+        let response = router_with_collection_mgmt_operations(operations.clone())
+            .oneshot(
+                Request::builder()
+                    .method(Method::DELETE)
+                    .uri("/api/v0/collections/Users/truncate")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert!(operations.truncated_collections().is_empty());
+    }
+}
+
+#[tokio::test]
 async fn collection_doc_ids_returns_paginated_metadata() {
     let router = router_with_rest();
     let response = router

--- a/crates/http/src/mock/collections.rs
+++ b/crates/http/src/mock/collections.rs
@@ -6,6 +6,8 @@ use std::sync::{Arc, Mutex};
 
 use crate::router::{CollectionManagementOperations, CollectionVersionOperations};
 
+type TruncateCall = (String, Option<serde_json::Value>);
+
 fn mock_collection_version(name: &str) -> schema::CollectionVersion {
     serde_json::from_value(json!({
         "Name": name,
@@ -23,6 +25,7 @@ pub struct MockCollectionManagementOperations {
     /// document delete from a collection drop. A no-op mock cannot: it lets a
     /// route wired back to the drop keep every assertion green.
     dropped_collections: Arc<Mutex<Vec<String>>>,
+    truncated_collections: Arc<Mutex<Vec<TruncateCall>>>,
 }
 
 impl MockCollectionManagementOperations {
@@ -37,6 +40,10 @@ impl MockCollectionManagementOperations {
     /// Collections dropped through `delete_collection`.
     pub fn dropped_collections(&self) -> Vec<String> {
         self.dropped_collections.lock().unwrap().clone()
+    }
+
+    pub fn truncated_collections(&self) -> Vec<TruncateCall> {
+        self.truncated_collections.lock().unwrap().clone()
     }
 }
 
@@ -67,7 +74,15 @@ impl CollectionManagementOperations for MockCollectionManagementOperations {
         Ok(())
     }
 
-    async fn truncate_collection(&self, _name: &str) -> Result<(), String> {
+    async fn truncate_collection(
+        &self,
+        name: &str,
+        filter: Option<serde_json::Value>,
+    ) -> Result<(), String> {
+        self.truncated_collections
+            .lock()
+            .unwrap()
+            .push((name.to_string(), filter));
         Ok(())
     }
 

--- a/crates/http/src/router/traits.rs
+++ b/crates/http/src/router/traits.rs
@@ -767,8 +767,12 @@ pub trait CollectionManagementOperations: Send + Sync {
     /// of the same collection.
     async fn set_active_version(&self, version_id: &str) -> Result<(), String>;
 
-    /// Truncate a collection, deleting all documents while preserving the schema.
-    async fn truncate_collection(&self, name: &str) -> Result<(), String>;
+    /// Truncate a collection, optionally limiting removal to matching documents.
+    async fn truncate_collection(
+        &self,
+        name: &str,
+        filter: Option<serde_json::Value>,
+    ) -> Result<(), String>;
 
     /// Purge all data from all collections.
     async fn purge(&self) -> Result<(), String>;

--- a/crates/query/src/lib.rs
+++ b/crates/query/src/lib.rs
@@ -55,7 +55,7 @@ pub use limits::{
 };
 pub use mapper::{Filter, Mutation, MutationType, Select};
 pub use mutator::{
-    BroadcastStatus, CreateResult, DeleteResult, DocMutator, MutationBatch,
+    BroadcastStatus, CollectionTruncator, CreateResult, DeleteResult, DocMutator, MutationBatch,
     MutationBatchController, UpdateResult,
 };
 pub use plan::{

--- a/crates/query/src/mapper/mutation.rs
+++ b/crates/query/src/mapper/mutation.rs
@@ -20,6 +20,8 @@ pub enum MutationType {
     Delete,
     /// Create or update documents (insert if not exists, update if exists)
     Upsert,
+    /// Permanently remove all or matching documents from local storage.
+    Truncate,
 }
 
 impl MutationType {
@@ -38,6 +40,7 @@ impl MutationType {
             "update" => Some(Self::Update),
             "delete" => Some(Self::Delete),
             "upsert" => Some(Self::Upsert),
+            "truncate" => Some(Self::Truncate),
             _ => None,
         }
     }
@@ -49,6 +52,7 @@ impl MutationType {
             Self::Update => "update",
             Self::Delete => "delete",
             Self::Upsert => "upsert",
+            Self::Truncate => "truncate",
         }
     }
 }
@@ -138,6 +142,23 @@ impl Mutation {
     pub fn upsert(collection_name: impl Into<String>) -> Self {
         Self {
             mutation_type: MutationType::Upsert,
+            collection_name: collection_name.into(),
+            alias: None,
+            create_input: Vec::new(),
+            update_input: HashMap::new(),
+            doc_ids: None,
+            filter: None,
+            fields: Vec::new(),
+            document_mapping: DocumentMapping::new(),
+            encrypt_doc: false,
+            encrypt_fields: Vec::new(),
+        }
+    }
+
+    /// Create a new TRUNCATE mutation.
+    pub fn truncate(collection_name: impl Into<String>) -> Self {
+        Self {
+            mutation_type: MutationType::Truncate,
             collection_name: collection_name.into(),
             alias: None,
             create_input: Vec::new(),

--- a/crates/query/src/mutator.rs
+++ b/crates/query/src/mutator.rs
@@ -6,10 +6,24 @@
 use async_trait::async_trait;
 use cid::Cid;
 use document::{DocID, Document};
+use identity::Did;
 use std::sync::Arc;
 use storage::corekv::MaybeSendSync;
 
 use crate::error::Result;
+use crate::Filter;
+
+/// Collection-level truncate operation used by GraphQL mutations.
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+pub trait CollectionTruncator: MaybeSendSync {
+    async fn truncate(
+        &self,
+        collection_name: &str,
+        filter: Option<Filter>,
+        identity: Option<&Did>,
+    ) -> Result<()>;
+}
 
 /// Status of P2P broadcast after a mutation.
 ///

--- a/crates/query/src/query_parse/mutation_tests.rs
+++ b/crates/query/src/query_parse/mutation_tests.rs
@@ -120,6 +120,42 @@ fn test_parse_delete_with_filter() {
 }
 
 #[test]
+fn test_parse_truncate_mutation() {
+    let mutations =
+        parse_mutations(r#"mutation { truncate_Users(filter: {active: {_eq: false}}) }"#).unwrap();
+
+    assert_eq!(mutations.len(), 1);
+    assert_eq!(mutations[0].mutation_type, MutationType::Truncate);
+    assert_eq!(mutations[0].collection_name, "Users");
+    assert!(mutations[0].filter.is_some());
+
+    let unfiltered = parse_mutations(r#"mutation { truncate_Users }"#).unwrap();
+    assert!(unfiltered[0].filter.is_none());
+}
+
+#[test]
+fn test_truncate_rejects_null_filter_and_selection() {
+    for query in [
+        r#"mutation { truncate_Users(filter: null) }"#,
+        r#"mutation { truncate_Users { _docID } }"#,
+    ] {
+        assert!(
+            parse_mutations(query).is_err(),
+            "query should fail: {query}"
+        );
+    }
+
+    let mut variables = HashMap::new();
+    variables.insert("filter".to_string(), JsonValue::Null);
+    let error = parse_mutations_with_variables(
+        r#"mutation ($filter: UsersFilterArg) { truncate_Users(filter: $filter) }"#,
+        Some(&variables),
+    )
+    .unwrap_err();
+    assert!(error.to_string().contains("truncate filter cannot be null"));
+}
+
+#[test]
 fn test_parse_multiple_mutations() {
     let query = r#"
         mutation {

--- a/crates/query/src/query_parse/mutations.rs
+++ b/crates/query/src/query_parse/mutations.rs
@@ -40,6 +40,7 @@ pub(super) fn parse_field_to_mutation(
         MutationType::Update => Mutation::update(&collection_name),
         MutationType::Delete => Mutation::delete(&collection_name),
         MutationType::Upsert => Mutation::upsert(&collection_name),
+        MutationType::Truncate => Mutation::truncate(&collection_name),
     };
 
     // Capture GraphQL alias if present (e.g., "john: update_Users(...)")
@@ -125,6 +126,20 @@ pub(super) fn parse_field_to_mutation(
                 mutation.filter = Some(filter);
             }
 
+            (MutationType::Truncate, "filter") => {
+                let is_null = match arg_value {
+                    Value::Null => true,
+                    Value::Variable(name) => variables
+                        .and_then(|variables| variables.get(name.as_str()))
+                        .is_some_and(JsonValue::is_null),
+                    _ => false,
+                };
+                if is_null {
+                    return Err(QueryError::parse("truncate filter cannot be null"));
+                }
+                mutation.filter = Some(parse_filter_value(arg_value, variables)?);
+            }
+
             // Encryption: encrypt entire document
             (_, "encrypt") => {
                 if let Value::Boolean(b) = arg_value {
@@ -203,6 +218,17 @@ pub(super) fn parse_field_to_mutation(
                 )));
             }
         }
+        MutationType::Truncate => {}
+    }
+
+    if mutation_type == MutationType::Truncate {
+        if !field.selection_set.items.is_empty() {
+            return Err(QueryError::parse(format!(
+                "Field \"{}\" must not have a selection since type \"Boolean!\" has no subfields.",
+                field_name
+            )));
+        }
+        return Ok(mutation);
     }
 
     // Parse selection set (fields to return after mutation)

--- a/crates/query/src/query_parse/validation.rs
+++ b/crates/query/src/query_parse/validation.rs
@@ -78,6 +78,7 @@ async fn validate_mutation_collection(
             crate::mapper::MutationType::Update => format!("update_{}", name),
             crate::mapper::MutationType::Delete => format!("delete_{}", name),
             crate::mapper::MutationType::Upsert => format!("upsert_{}", name),
+            crate::mapper::MutationType::Truncate => format!("truncate_{}", name),
         };
         let mut msg = format!(
             "Cannot query field \"{}\" on type \"Mutation\".",

--- a/crates/query/src/runner/executor.rs
+++ b/crates/query/src/runner/executor.rs
@@ -53,6 +53,11 @@ fn permission_for_operation(parsed: &ParsedOperation) -> NodePermission {
         ParsedOperation::Mutation { mutations, .. } => {
             if mutations
                 .iter()
+                .any(|m| m.mutation_type == crate::mapper::MutationType::Truncate)
+            {
+                NodePermission::CollectionTruncate
+            } else if mutations
+                .iter()
                 .any(|m| m.mutation_type == crate::mapper::MutationType::Delete)
             {
                 NodePermission::DocumentDelete
@@ -553,6 +558,19 @@ mod tests {
     use crate::fetcher::{DocFetcher, FetchByIdsResult};
     use crate::test_utils::{MockFetcher, MockTxnRegistry};
     use crate::txn::{GetTransactionResult, TransactionContext, TransactionRegistry};
+
+    #[test]
+    fn truncate_uses_collection_truncate_permission() {
+        let parsed = ParsedOperation::Mutation {
+            mutations: vec![crate::mapper::Mutation::truncate("Users")],
+            explain: None,
+        };
+
+        assert_eq!(
+            permission_for_operation(&parsed),
+            NodePermission::CollectionTruncate
+        );
+    }
 
     struct ChangingFetcher {
         call_count: std::sync::atomic::AtomicUsize,

--- a/crates/query/src/runner/explain/mutation.rs
+++ b/crates/query/src/runner/explain/mutation.rs
@@ -92,11 +92,18 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
     ) -> Result<(JsonValue, usize, u64)> {
         use crate::mapper::MutationType;
 
+        if mutation.mutation_type == MutationType::Truncate {
+            return Err(QueryError::execution(
+                "truncate mutations cannot be explained",
+            ));
+        }
+
         let node_kind = match mutation.mutation_type {
             MutationType::Create => "addNode",
             MutationType::Update => "updateNode",
             MutationType::Delete => "deleteNode",
             MutationType::Upsert => "upsertNode",
+            MutationType::Truncate => unreachable!(),
         };
 
         // Build a select with the mutation's filter/doc_ids for metric collection.
@@ -222,6 +229,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                     }
                     Box::new(node)
                 }
+                MutationType::Truncate => unreachable!(),
             };
 
             // Execute the mutation plan (ignore results, we just need the side effects)
@@ -310,6 +318,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             MutationType::Upsert => {
                 // Go's upsertNode returns empty map for execute explain (no iterations)
             }
+            MutationType::Truncate => unreachable!(),
         }
 
         mutation_inner.insert("selectTopNode".to_string(), select_node_content);
@@ -403,12 +412,19 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
     ) -> Result<JsonValue> {
         use crate::mapper::MutationType;
 
+        if mutation.mutation_type == MutationType::Truncate {
+            return Err(QueryError::execution(
+                "truncate mutations cannot be explained",
+            ));
+        }
+
         // Get the mutation node kind name
         let node_kind = match mutation.mutation_type {
             MutationType::Create => "addNode",
             MutationType::Update => "updateNode",
             MutationType::Delete => "deleteNode",
             MutationType::Upsert => "upsertNode",
+            MutationType::Truncate => unreachable!(),
         };
 
         // Build the inner select plan explanation
@@ -544,6 +560,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                     mutation_attrs.insert("update".to_string(), JsonValue::Object(update_obj));
                 }
             }
+            MutationType::Truncate => unreachable!(),
         }
 
         // Add selectTopNode containing the inner select explanation

--- a/crates/query/src/runner/introspection/mutations.rs
+++ b/crates/query/src/runner/introspection/mutations.rs
@@ -57,6 +57,20 @@ pub(super) fn build_mutation_type(collections: &[CollectionVersion]) -> Object {
                 TypeRef::named(format!("{}FilterArg", del_coll_name)),
             )),
         );
+
+        // truncate_<Collection>
+        let truncate_coll_name = coll_name.clone();
+        mutation = mutation.field(
+            Field::new(
+                format!("truncate_{}", coll_name),
+                TypeRef::named_nn(TypeRef::BOOLEAN),
+                |_| FieldFuture::new(async { Ok(Some(GqlValue::Null)) }),
+            )
+            .argument(InputValue::new(
+                "filter",
+                TypeRef::named(format!("{}FilterArg", truncate_coll_name)),
+            )),
+        );
     }
 
     mutation

--- a/crates/query/src/runner/mod.rs
+++ b/crates/query/src/runner/mod.rs
@@ -53,6 +53,7 @@ use crate::document::DocumentMapping;
 use crate::error::{QueryError, Result};
 use crate::fetcher::{CollectionProvider, StaticCollectionProvider};
 use crate::limits::QueryLimits;
+use crate::mutator::CollectionTruncator;
 use crate::mutator::DocMutator;
 use crate::planner::Doc;
 use crate::txn::{NoOpTransactionRegistry, TransactionRegistry};
@@ -195,6 +196,8 @@ pub struct QueryRunner<F: DocFetcher, R: TransactionRegistry = NoOpTransactionRe
     pub(crate) registry: Arc<R>,
     /// Document mutator for mutation operations (optional)
     pub(crate) mutator: Option<Arc<dyn DocMutator>>,
+    /// Collection truncator for local hard-delete mutations (optional).
+    pub(crate) collection_truncator: Option<Arc<dyn CollectionTruncator>>,
     /// Document ACP for permission checks.
     ///
     /// Defaults to a no-op ACP implementation that allows access and treats
@@ -236,6 +239,7 @@ impl<F: DocFetcher + 'static> QueryRunner<F, NoOpTransactionRegistry> {
             collection_provider: Arc::new(StaticCollectionProvider::new(collections)),
             registry: Arc::new(NoOpTransactionRegistry),
             mutator: None,
+            collection_truncator: None,
             acp: Arc::new(NoOpDocumentAcp),
             default_identity: None,
             node_did: None,
@@ -257,6 +261,7 @@ impl<F: DocFetcher + 'static> QueryRunner<F, NoOpTransactionRegistry> {
             collection_provider: provider,
             registry: Arc::new(NoOpTransactionRegistry),
             mutator: None,
+            collection_truncator: None,
             acp: Arc::new(NoOpDocumentAcp),
             default_identity: None,
             node_did: None,
@@ -280,6 +285,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             collection_provider: Arc::new(StaticCollectionProvider::new(collections)),
             registry: Arc::new(registry),
             mutator: None,
+            collection_truncator: None,
             acp: Arc::new(NoOpDocumentAcp),
             default_identity: None,
             node_did: None,
@@ -306,6 +312,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             collection_provider: provider,
             registry: Arc::new(registry),
             mutator: None,
+            collection_truncator: None,
             acp: Arc::new(NoOpDocumentAcp),
             default_identity: None,
             node_did: None,
@@ -331,6 +338,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             collection_provider: provider,
             registry,
             mutator: None,
+            collection_truncator: None,
             acp: Arc::new(NoOpDocumentAcp),
             default_identity: None,
             node_did: None,
@@ -347,6 +355,12 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
     /// This enables support for CREATE, UPDATE, and DELETE mutations.
     pub fn with_mutator(mut self, mutator: Arc<dyn DocMutator>) -> Self {
         self.mutator = Some(mutator);
+        self
+    }
+
+    /// Set the collection truncator for `truncate_<Collection>` mutations.
+    pub fn with_collection_truncator(mut self, truncator: Arc<dyn CollectionTruncator>) -> Self {
+        self.collection_truncator = Some(truncator);
         self
     }
 

--- a/crates/query/src/runner/mutation.rs
+++ b/crates/query/src/runner/mutation.rs
@@ -142,6 +142,38 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         caller_identity: Option<Did>,
         fetcher_override: Option<Arc<dyn crate::fetcher::DocFetcher>>,
     ) -> Result<JsonValue> {
+        if mutations
+            .iter()
+            .any(|mutation| mutation.mutation_type == MutationType::Truncate)
+        {
+            if mutations.len() != 1 || mutations[0].mutation_type != MutationType::Truncate {
+                return Err(QueryError::parse(
+                    "truncate mutation must be the only field in an operation",
+                ));
+            }
+            if fetcher_override.is_some() {
+                return Err(QueryError::execution(
+                    "truncate mutation cannot run in a transaction",
+                ));
+            }
+
+            let mutation = &mutations[0];
+            let truncator = self.collection_truncator.as_ref().ok_or_else(|| {
+                QueryError::execution(
+                    "truncate mutations require a collection truncator; call with_collection_truncator() first",
+                )
+            })?;
+            truncator
+                .truncate(
+                    &mutation.collection_name,
+                    mutation.filter.clone(),
+                    caller_identity.as_ref(),
+                )
+                .await?;
+
+            return Ok(serde_json::json!({ mutation.output_name(): true }));
+        }
+
         // Compute request time once for all mutations in this request.
         // This ensures UTC_NOW resolves to the same timestamp across all mutations,
         // matching Go DefraDB's behavior.
@@ -396,6 +428,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                     // CREATE permission is checked implicitly -- anyone can create
                     // but ownership is established via registration after the write.
                 }
+                MutationType::Truncate => unreachable!("truncate bypasses document ACP checks"),
             }
         }
 
@@ -611,6 +644,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
 
                 Box::new(node)
             }
+            MutationType::Truncate => unreachable!("truncate bypasses document mutation plans"),
         };
 
         // Execute the plan.
@@ -960,13 +994,35 @@ mod tests {
     use std::collections::HashSet;
     use std::sync::Mutex;
 
-    use crate::mutator::{CreateResult, DeleteResult, UpdateResult};
+    use crate::mutator::{CollectionTruncator, CreateResult, DeleteResult, UpdateResult};
     use crate::test_utils::MockFetcher;
     use crate::{QueryExecutor, QueryRequest};
 
     struct CapturingMutator {
         created_docs: Mutex<Vec<Document>>,
         broadcast_creators: Mutex<Vec<Option<String>>>,
+    }
+
+    #[derive(Default)]
+    struct CapturingTruncator {
+        calls: Mutex<Vec<(String, bool)>>,
+    }
+
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    impl CollectionTruncator for CapturingTruncator {
+        async fn truncate(
+            &self,
+            collection_name: &str,
+            filter: Option<crate::Filter>,
+            _identity: Option<&Did>,
+        ) -> Result<()> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((collection_name.to_string(), filter.is_some()));
+            Ok(())
+        }
     }
 
     impl CapturingMutator {
@@ -984,6 +1040,65 @@ mod tests {
         fn broadcast_creators(&self) -> Vec<Option<String>> {
             self.broadcast_creators.lock().unwrap().clone()
         }
+    }
+
+    #[tokio::test]
+    async fn truncate_mutation_forwards_filter_and_returns_true() {
+        let collection = CollectionVersion::new(
+            "User",
+            "v1",
+            "coll-user",
+            vec![FieldDescription::new("1", "_docID", FieldKind::doc_id())],
+        );
+        let truncator = Arc::new(CapturingTruncator::default());
+        let runner = QueryRunner::new(MockFetcher::new(), vec![collection])
+            .with_mutator(Arc::new(CapturingMutator::new()))
+            .with_collection_truncator(truncator.clone());
+
+        let result = runner
+            .execute_mutation(r#"mutation { truncate_User(filter: {_docID: {_eq: "bae-1"}}) }"#)
+            .await
+            .unwrap();
+
+        assert_eq!(result, serde_json::json!({"truncate_User": true}));
+        let calls = truncator.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "User");
+        assert!(calls[0].1);
+    }
+
+    #[tokio::test]
+    async fn filtered_truncate_rejects_transactions_and_sibling_mutations() {
+        let collection = CollectionVersion::new(
+            "User",
+            "v1",
+            "coll-user",
+            vec![FieldDescription::new("1", "_docID", FieldKind::doc_id())],
+        );
+        let mutator = Arc::new(CapturingMutator::new());
+        let runner = QueryRunner::new(MockFetcher::new(), vec![collection])
+            .with_mutator(mutator.clone())
+            .with_collection_truncator(Arc::new(CapturingTruncator::default()));
+
+        let mixed = runner
+            .execute_mutation(
+                r#"mutation {
+                    truncate_User
+                    delete_User { _docID }
+                }"#,
+            )
+            .await
+            .unwrap_err();
+        assert!(mixed.to_string().contains("only field in an operation"));
+
+        let mutations = crate::parse_mutations(r#"mutation { truncate_User }"#).unwrap();
+        let transaction = runner
+            .execute_parsed_mutations(mutations, mutator, None, Some(Arc::new(MockFetcher::new())))
+            .await
+            .unwrap_err();
+        assert!(transaction
+            .to_string()
+            .contains("cannot run in a transaction"));
     }
 
     #[cfg_attr(not(target_arch = "wasm32"), async_trait)]

--- a/crates/query/src/runner/mutation_inputs.rs
+++ b/crates/query/src/runner/mutation_inputs.rs
@@ -5,13 +5,54 @@ use std::collections::HashMap;
 
 use crate::document::{document_to_plan_doc, DocumentMapping};
 use crate::error::Result;
-use crate::mapper::{Mutation, Requestable};
+use crate::mapper::{Field, Filter, Mutation, Requestable, Select};
 use crate::plan::{CreateInput, UpdateInput, UpsertInput};
 use crate::txn::TransactionRegistry;
 
 use super::{DocFetcher, QueryRunner};
 
 impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
+    /// Return the document IDs matching a filter, capped to `limit` results.
+    pub async fn matching_doc_ids(
+        &self,
+        collection_name: &str,
+        filter: Filter,
+        limit: usize,
+        show_deleted: bool,
+    ) -> Result<Vec<String>> {
+        let mut mapping = DocumentMapping::new();
+        mapping.add(0, "_docID");
+        mapping.add_render_key(0, "_docID");
+
+        let mut select = Select::new(collection_name)
+            .with_field(Field::new("_docID"))
+            .with_filter(filter)
+            .with_limit(limit as u64);
+        select.document_mapping = mapping;
+        select.show_deleted = show_deleted;
+
+        let result = self
+            .execute_select_internal(&select, self.fetcher.as_ref(), None)
+            .await?;
+        let items = result.as_array().ok_or_else(|| {
+            crate::error::QueryError::internal("filtered document selection returned a non-list")
+        })?;
+
+        items
+            .iter()
+            .map(|item| {
+                item.get("_docID")
+                    .and_then(JsonValue::as_str)
+                    .map(str::to_owned)
+                    .ok_or_else(|| {
+                        crate::error::QueryError::internal(
+                            "filtered document selection returned an invalid document ID",
+                        )
+                    })
+            })
+            .collect()
+    }
+
     fn normalize_mutation_input_fields(
         &self,
         collection: &schema::CollectionVersion,

--- a/crates/query/src/schema_gen/generator.rs
+++ b/crates/query/src/schema_gen/generator.rs
@@ -456,6 +456,17 @@ pub fn generate_mutation_type(collections: &[&CollectionVersion]) -> GqlObjectTy
             format!("upsert_{}", type_name),
             GqlType::list(GqlType::named(type_name)),
         ));
+
+        mutation = mutation.with_field(
+            GqlField::new(
+                format!("truncate_{}", type_name),
+                GqlType::non_null(GqlType::boolean()),
+            )
+            .with_arg(GqlArg::new(
+                "filter",
+                GqlType::named(format!("{}FilterInput", type_name)),
+            )),
+        );
     }
 
     mutation
@@ -730,6 +741,14 @@ mod tests {
 
         let upsert = mutation.fields.iter().find(|f| f.name == "upsert_User");
         assert!(upsert.is_some());
+
+        let truncate = mutation
+            .fields
+            .iter()
+            .find(|f| f.name == "truncate_User")
+            .unwrap();
+        assert_eq!(truncate.field_type.to_sdl(), "Boolean!");
+        assert_eq!(truncate.args[0].to_sdl(), "filter: UserFilterInput");
     }
 
     #[test]

--- a/crates/wasm/src/client.rs
+++ b/crates/wasm/src/client.rs
@@ -212,7 +212,9 @@ impl DefraClient {
         let fetcher = LensedAutoCommitFetcher::new(Arc::clone(&db));
         let provider = DbCollectionProvider::new_arc(Arc::clone(&db));
         let mutator = Arc::new(AutoCommitMutator::new(Arc::clone(&db)));
-        let runner = QueryRunner::with_provider(fetcher, provider).with_mutator(mutator);
+        let runner = QueryRunner::with_provider(fetcher, provider)
+            .with_mutator(mutator)
+            .with_collection_truncator(db::DbCollectionTruncator::new_arc(Arc::clone(&db)));
 
         Ok(Self {
             db: Some(db),

--- a/tools/integration-test/tests/basic/collection_management.rs
+++ b/tools/integration-test/tests/basic/collection_management.rs
@@ -110,4 +110,10 @@ async fn filtered_truncate_test(cluster: TestCluster) {
 
 for_each_runtime!(collection_patch, collection_patch_test);
 for_each_runtime!(collection_versioning, collection_versioning_test);
-for_each_runtime!(filtered_truncate, filtered_truncate_test);
+
+#[tokio::test]
+async fn rust_filtered_truncate() {
+    let _root = integration_test::workspace_root();
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    filtered_truncate_test(cluster).await;
+}

--- a/tools/integration-test/tests/basic/collection_management.rs
+++ b/tools/integration-test/tests/basic/collection_management.rs
@@ -81,5 +81,33 @@ async fn collection_versioning_test(cluster: TestCluster) {
     assert_eq!(items[0]["name"], "widget");
 }
 
+async fn filtered_truncate_test(cluster: TestCluster) {
+    let client = cluster.client(0);
+    client
+        .schema_add("type TruncateUser { name: String age: Int }")
+        .expect("failed to add schema");
+    for (name, age) in [("Alice", 30), ("Bob", 40)] {
+        client
+            .query(&format!(
+                r#"mutation {{ add_TruncateUser(input: {{name: "{name}", age: {age}}}) {{ _docID }} }}"#
+            ))
+            .expect("failed to create document");
+    }
+
+    let result = client
+        .query(r#"mutation { truncate_TruncateUser(filter: {age: {_eq: 30}}) }"#)
+        .expect("filtered truncate failed");
+    assert_eq!(result["truncate_TruncateUser"], true);
+
+    let result = client
+        .query("query { TruncateUser { name age } }")
+        .expect("failed to query survivors");
+    assert_eq!(
+        result["TruncateUser"],
+        serde_json::json!([{"name": "Bob", "age": 40}])
+    );
+}
+
 for_each_runtime!(collection_patch, collection_patch_test);
 for_each_runtime!(collection_versioning, collection_versioning_test);
+for_each_runtime!(filtered_truncate, filtered_truncate_test);


### PR DESCRIPTION
## Context

Rust only supported collection-wide truncate, leaving retention workflows unable to permanently reclaim local storage for selected documents. Go DefraDB added filtered truncate in sourcenetwork/defradb#5097.

## Changes

- accept an optional truncate filter through GraphQL, DB/embedded, HTTP, CLI, FFI, and WASM surfaces
- hard-delete matching documents in bounded chunks while preserving survivors and shared history
- clean document values, indexes, DocID mappings, primary markers, block metadata, signatures, encryption blocks, and searchable-encryption records
- preserve unfiltered truncate behavior and existing collection authorization
- reject filtered truncate for branchable collections, caller-supplied transactions, and multi-field GraphQL mutations
- align filter parsing and validation with Go behavior

## Testing

- [x] strict native Clippy validation with warnings denied
- [x] strict WASM Clippy validation for both supported configurations
- [x] focused query, DB, HTTP, CLI, FFI, block-cleanup, and chunking tests
- [x] C header generation
- [x] live end-to-end filtered truncate: matching document removed and survivor preserved
- [x] `cargo +stable fmt --all -- --check`
- [x] `git diff --check`

Closes #1618