### PR TITLE
feat(p2p): expose authenticated peer identity

### DIFF
--- a/crates/ffi/src/p2p/mod.rs
+++ b/crates/ffi/src/p2p/mod.rs
@@ -35,6 +35,7 @@ pub use version_sync::p2p_sync_collection_versions;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum FfiP2PErrorCode {
     InvalidInput,
+    Unauthorized,
     NotFound,
     Unsupported,
     Transport,
@@ -65,6 +66,13 @@ impl FfiP2PError {
     pub(crate) fn not_found(message: impl Into<String>) -> Self {
         Self {
             code: FfiP2PErrorCode::NotFound,
+            message: message.into(),
+        }
+    }
+
+    pub(crate) fn unauthorized(message: impl Into<String>) -> Self {
+        Self {
+            code: FfiP2PErrorCode::Unauthorized,
             message: message.into(),
         }
     }
@@ -110,6 +118,7 @@ impl From<defra_http::router::P2PError> for FfiP2PError {
         match error {
             defra_http::router::P2PError::InvalidInput(message) => Self::invalid_input(message),
             defra_http::router::P2PError::NotFound(message) => Self::not_found(message),
+            defra_http::router::P2PError::Unauthorized(message) => Self::unauthorized(message),
             defra_http::router::P2PError::Unsupported(message) => Self::unsupported(message),
             defra_http::router::P2PError::Transport(message) => Self::transport(message),
             defra_http::router::P2PError::Internal(message) => Self::internal(message),
@@ -193,6 +202,12 @@ mod tests {
         ));
         assert_eq!(error.code, FfiP2PErrorCode::Transport);
         assert_eq!(error.message, "dial failed");
+
+        let error = FfiP2PError::from(defra_http::router::P2PError::Unauthorized(
+            "permission denied".to_string(),
+        ));
+        assert_eq!(error.code, FfiP2PErrorCode::Unauthorized);
+        assert_eq!(error.message, "permission denied");
     }
 
     #[test]

--- a/crates/http/src/handlers/p2p/mod.rs
+++ b/crates/http/src/handlers/p2p/mod.rs
@@ -22,6 +22,7 @@ fn map_p2p_bad_request(error: P2PError) -> HttpError {
     match error {
         P2PError::InvalidInput(message) => http_error_from_backend_message(message),
         P2PError::NotFound(message) => HttpError::NotFound(message),
+        P2PError::Unauthorized(message) => HttpError::Unauthorized(message),
         P2PError::Unsupported(message) => HttpError::NotImplemented(message),
         P2PError::Transport(message) => http_error_from_backend_message(message),
         P2PError::Internal(message) => HttpError::Internal(message),
@@ -32,6 +33,7 @@ fn map_p2p_internal(error: P2PError) -> HttpError {
     match error {
         P2PError::InvalidInput(message) => HttpError::BadRequest(message),
         P2PError::NotFound(message) => HttpError::NotFound(message),
+        P2PError::Unauthorized(message) => HttpError::Unauthorized(message),
         P2PError::Unsupported(message) => HttpError::NotImplemented(message),
         P2PError::Transport(message) => HttpError::Internal(message),
         P2PError::Internal(message) => HttpError::Internal(message),

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -118,7 +118,7 @@ pub use router::{
     DocumentAcpOperations, IndexFieldInfo, IndexInfo, IndexOperations, ManageRequester, NacStatus,
     NacStatusInfo, NodeAcpOperations, NodePermission, P2PError, P2POperations, P2PResult,
     PolicyInfo, RemoteManageDocRef, RemoteManageOp, RemoteManageQueryOp, RemoteManageQueryResult,
-    ReplicatorInfo, TransactionOperations, ViewOperations, MANAGE_UNAUTHORIZED,
+    ReplicatorInfo, TransactionOperations, TransportPeerId, ViewOperations, MANAGE_UNAUTHORIZED,
 };
 pub use server::{Server, ServerConfig, DEFAULT_MAX_BACKUP_SIZE};
 

--- a/crates/http/src/router/mod.rs
+++ b/crates/http/src/router/mod.rs
@@ -17,5 +17,6 @@ pub use traits::{
     P2PResult, P2pDocumentInfo, P2pDocumentRequest, PolicyInfo, RemoteManageDocRef, RemoteManageOp,
     RemoteManageQueryOp, RemoteManageQueryResult, ReplicationFilter, ReplicationFilters,
     ReplicatorInfo, SchemaOperations, SyncBranchableRequest, SyncDocumentsRequest,
-    SyncVersionsRequest, TransactionOperations, ViewOperations, MANAGE_UNAUTHORIZED,
+    SyncVersionsRequest, TransactionOperations, TransportPeerId, ViewOperations,
+    MANAGE_UNAUTHORIZED,
 };

--- a/crates/http/src/router/traits.rs
+++ b/crates/http/src/router/traits.rs
@@ -98,6 +98,9 @@ pub enum P2PError {
     #[error("not found: {0}")]
     NotFound(String),
 
+    #[error("unauthorized: {0}")]
+    Unauthorized(String),
+
     #[error("unsupported operation: {0}")]
     Unsupported(String),
 
@@ -128,6 +131,53 @@ impl P2PError {
     }
 }
 
+/// Raw transport-specific peer identifier.
+///
+/// This is intentionally distinct from the address strings returned by
+/// [`P2POperations::connected_peers`]. Concrete adapters perform their own
+/// transport-specific parse and canonicalization before issuing a challenge.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize)]
+#[serde(transparent)]
+pub struct TransportPeerId(String);
+
+impl TransportPeerId {
+    /// Constructs a canonical raw transport peer identifier.
+    ///
+    /// Empty values, surrounding whitespace, and address-like values containing
+    /// `/` are rejected as [`P2PError::InvalidInput`]. Concrete transport
+    /// adapters perform their stricter transport-specific parse afterward.
+    pub fn new(value: impl Into<String>) -> P2PResult<Self> {
+        let value = value.into();
+        if value.is_empty() || value.trim() != value || value.contains('/') {
+            return Err(P2PError::InvalidInput(
+                "transport peer ID must be a non-empty canonical raw ID".to_string(),
+            ));
+        }
+        Ok(Self(value))
+    }
+
+    /// Returns the validated raw transport peer identifier.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for TransportPeerId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = <String as serde::Deserialize>::deserialize(deserializer)?;
+        Self::new(value).map_err(serde::de::Error::custom)
+    }
+}
+
+impl std::fmt::Display for TransportPeerId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
 /// Trait for P2P operations that can be accessed via HTTP.
 ///
 /// Abstracts P2P host functionality to decouple HTTP handlers from the
@@ -153,6 +203,26 @@ pub trait P2POperations: Send + Sync {
 
     /// Get connected peers.
     async fn connected_peers(&self) -> P2PResult<Vec<String>>;
+
+    /// Resolve the Defra DID authenticated by a connected transport peer.
+    ///
+    /// Implementations must actively challenge the peer and verify the
+    /// returned identity token against the local transport identity. A cached
+    /// result is acceptable only while its verified token remains fresh and
+    /// the connection remains live. `Ok(None)` means the peer explicitly has
+    /// no configured Defra identity; malformed tokens, wrong audiences,
+    /// protocol failures, and remote internal failures are errors. The input
+    /// is a canonical raw transport peer ID, never an address returned by
+    /// `connected_peers`. Requires `P2pPeerActive`; transports without an
+    /// authenticated identity exchange fail closed.
+    async fn resolve_peer_identity(
+        &self,
+        _peer_id: &TransportPeerId,
+    ) -> P2PResult<Option<identity::Did>> {
+        Err(P2PError::unsupported(
+            "authenticated peer identity resolution is unavailable",
+        ))
+    }
 
     /// Live snapshot of sync resource state (push backlog occupancy,
     /// per-peer backlog, pending DAGs, overload counters) for diagnostics
@@ -1025,4 +1095,34 @@ pub trait ViewOperations: Send + Sync {
 pub trait DumpOperations: Send + Sync {
     /// Dump all database key/value pairs as a list of human-readable strings.
     async fn print_dump(&self) -> Result<Vec<String>, String>;
+}
+
+#[cfg(test)]
+mod transport_peer_id_tests {
+    use super::{P2PError, P2POperations, TransportPeerId};
+
+    #[test]
+    fn transport_peer_id_rejects_addresses_whitespace_and_empty_values() {
+        assert!(TransportPeerId::new("").is_err());
+        assert!(TransportPeerId::new(" peer-id").is_err());
+        assert!(TransportPeerId::new("peer-id ").is_err());
+        assert!(TransportPeerId::new("/ip4/127.0.0.1/p2p/peer-id").is_err());
+        assert_eq!(TransportPeerId::new("peer-id").unwrap().as_str(), "peer-id");
+        assert!(serde_json::from_str::<TransportPeerId>(r#""""#).is_err());
+        assert!(serde_json::from_str::<TransportPeerId>(r#"" peer-id""#).is_err());
+        assert!(
+            serde_json::from_str::<TransportPeerId>(r#""/ip4/127.0.0.1/p2p/peer-id""#).is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn default_identity_resolution_fails_closed() {
+        let peer = TransportPeerId::new("peer-id").unwrap();
+        assert!(matches!(
+            crate::mock::MockP2POperations::new()
+                .resolve_peer_identity(&peer)
+                .await,
+            Err(P2PError::Unsupported(_))
+        ));
+    }
 }

--- a/crates/p2p-adapter/src/iroh.rs
+++ b/crates/p2p-adapter/src/iroh.rs
@@ -9,12 +9,12 @@ use crate::transport_version_syncer::TransportVersionSyncer;
 use crate::{
     ExplicitReplayCapabilityInput, P2PError, P2PErrorExt as _, P2POperations, P2PResult,
     P2pDocumentInfo, P2pDocumentRequest, ReplicationFilters, ReplicatorInfo, ReplicatorPushOptions,
-    ReplicatorPushOptionsState,
+    ReplicatorPushOptionsState, TransportPeerId,
 };
 
 use p2p::iroh::{
     best_shareable_public_addr, canonical_peer_id, format_public_listen_addrs,
-    parse_public_peer_addr, IrohTransport,
+    parse_canonical_peer_id, parse_public_peer_addr, IrohTransport,
 };
 use p2p::sync::IrohSyncCoordinator;
 use p2p::topics::DefraTopic;
@@ -41,7 +41,7 @@ impl<B: Blockstore + 'static> IrohP2PAdapter<B> {
             checker
                 .check_node_access(permission)
                 .await
-                .map_err(|error| P2PError::internal(error.to_string()))?;
+                .map_err(crate::map_nac_error)?;
         }
         Ok(())
     }
@@ -275,6 +275,20 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
             result.push(peer_str);
         }
         Ok(result)
+    }
+
+    async fn resolve_peer_identity(
+        &self,
+        peer_id: &TransportPeerId,
+    ) -> P2PResult<Option<identity::Did>> {
+        self.check_nac(acp::nac::NodePermission::P2pPeerActive)
+            .await?;
+        let peer_id = parse_canonical_peer_id(peer_id.as_str())
+            .map_err(|error| P2PError::invalid_input(error.to_string()))?;
+        self.transport
+            .get_peer_identity(&peer_id)
+            .await
+            .map_err(|error| P2PError::transport(error.to_string()))
     }
 
     async fn connect_peer(&self, addr: &str) -> P2PResult<()> {

--- a/crates/p2p-adapter/src/lib.rs
+++ b/crates/p2p-adapter/src/lib.rs
@@ -39,7 +39,7 @@ pub use version_syncer::DbVersionSyncer;
 
 pub use defra_http::router::{
     ExplicitReplayCapabilityInput, P2PError, P2POperations, P2PResult, P2pDocumentInfo,
-    P2pDocumentRequest, ReplicationFilter, ReplicationFilters, ReplicatorInfo,
+    P2pDocumentRequest, ReplicationFilter, ReplicationFilters, ReplicatorInfo, TransportPeerId,
 };
 
 /// Resolve replicator-delete collection arguments from names to CIDs.
@@ -466,6 +466,7 @@ impl ReplicatorPushOptionsState {
 pub(crate) trait P2PErrorExt {
     fn invalid_input(message: impl Into<String>) -> Self;
     fn not_found(message: impl Into<String>) -> Self;
+    fn unauthorized(message: impl Into<String>) -> Self;
     fn transport(message: impl Into<String>) -> Self;
     fn persistence(message: impl Into<String>) -> Self;
     fn internal(message: impl Into<String>) -> Self;
@@ -478,6 +479,10 @@ impl P2PErrorExt for P2PError {
 
     fn not_found(message: impl Into<String>) -> Self {
         Self::NotFound(message.into())
+    }
+
+    fn unauthorized(message: impl Into<String>) -> Self {
+        Self::Unauthorized(message.into())
     }
 
     fn transport(message: impl Into<String>) -> Self {
@@ -493,9 +498,16 @@ impl P2PErrorExt for P2PError {
     }
 }
 
+fn map_nac_error(error: db::Error) -> P2PError {
+    match error {
+        db::Error::NotAuthorized { .. } => P2PError::unauthorized(error.to_string()),
+        other => P2PError::internal(other.to_string()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{ReplicatorPushOptions, ReplicatorPushOptionsState};
+    use super::{map_nac_error, P2PError, ReplicatorPushOptions, ReplicatorPushOptionsState};
     use zeroize::Zeroizing;
 
     #[test]
@@ -516,5 +528,19 @@ mod tests {
                 se_identity_pubkey: Some(b"did:key:zTest".to_vec()),
             }
         );
+    }
+
+    #[test]
+    fn nac_denial_is_distinct_from_checker_failure() {
+        assert!(matches!(
+            map_nac_error(db::Error::NotAuthorized {
+                permission: "P2pPeerActive".to_string()
+            }),
+            P2PError::Unauthorized(_)
+        ));
+        assert!(matches!(
+            map_nac_error(db::Error::Acp("policy backend unavailable".to_string())),
+            P2PError::Internal(_)
+        ));
     }
 }

--- a/crates/p2p-adapter/src/libp2p.rs
+++ b/crates/p2p-adapter/src/libp2p.rs
@@ -8,7 +8,7 @@ use crate::transport_doc_pusher::TransportDocPusher;
 use crate::{
     ExplicitReplayCapabilityInput, P2PError, P2PErrorExt as _, P2POperations, P2PResult,
     P2pDocumentInfo, P2pDocumentRequest, ReplicationFilters, ReplicatorInfo, ReplicatorPushOptions,
-    ReplicatorPushOptionsState,
+    ReplicatorPushOptionsState, TransportPeerId,
 };
 
 use p2p::sync::Libp2pSyncCoordinator;
@@ -98,7 +98,7 @@ impl<B: Blockstore + 'static> P2PAdapter<B> {
             checker
                 .check_node_access(permission)
                 .await
-                .map_err(|error| P2PError::internal(error.to_string()))?;
+                .map_err(crate::map_nac_error)?;
         }
         Ok(())
     }
@@ -282,6 +282,24 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
             .resolve_peer_addresses(&connected, |peer_id| {
                 self.peer_addresses.read().ok()?.get(peer_id).cloned()
             })
+            .await
+            .map_err(|error| P2PError::transport(error.to_string()))
+    }
+
+    async fn resolve_peer_identity(
+        &self,
+        peer_id: &TransportPeerId,
+    ) -> P2PResult<Option<identity::Did>> {
+        self.check_nac(acp::nac::NodePermission::P2pPeerActive)
+            .await?;
+        let peer_id = peer_id
+            .as_str()
+            .parse::<libp2p::PeerId>()
+            .map_err(|error| {
+                P2PError::invalid_input(format!("invalid peer ID '{peer_id}': {error}"))
+            })?;
+        self.handle
+            .get_peer_identity(peer_id)
             .await
             .map_err(|error| P2PError::transport(error.to_string()))
     }
@@ -1107,6 +1125,25 @@ mod tests {
     use p2p::BitswapStoreAdapter;
     use storage::backends::MemoryStore;
 
+    enum NacOutcome {
+        Denied,
+        Failed,
+    }
+
+    struct FixedNac(NacOutcome);
+
+    #[async_trait]
+    impl db::NodeAccessChecker for FixedNac {
+        async fn check_node_access(&self, permission: acp::nac::NodePermission) -> db::Result<()> {
+            match self.0 {
+                NacOutcome::Denied => Err(db::Error::NotAuthorized {
+                    permission: format!("{permission:?}"),
+                }),
+                NacOutcome::Failed => Err(db::Error::Acp("policy backend unavailable".into())),
+            }
+        }
+    }
+
     #[tokio::test]
     async fn merged_doc_sync_heads_are_not_pending() {
         let blockstore = DefraBlockstore::new(Arc::new(MemoryStore::new()), true);
@@ -1219,6 +1256,25 @@ mod tests {
         }
     }
 
+    async fn wait_until_disconnected(handle: &P2PHostHandle, peer_id: libp2p::PeerId) {
+        let start = std::time::Instant::now();
+        loop {
+            if !handle
+                .connected_peers()
+                .await
+                .unwrap_or_default()
+                .contains(&peer_id)
+            {
+                return;
+            }
+            assert!(
+                start.elapsed() < std::time::Duration::from_secs(5),
+                "timed out waiting for disconnection from {peer_id}"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    }
+
     /// Dials `handle_a` to `handle_b` and waits until each side observes the
     /// other as connected. Mirrors `assert_hosts_connect_over` in
     /// `crates/p2p/tests/host_tests.rs`.
@@ -1234,6 +1290,132 @@ mod tests {
         handle_a.dial(peer_b, vec![addr_b]).await.unwrap();
         wait_until_connected(handle_a, peer_b).await;
         wait_until_connected(handle_b, peer_a).await;
+    }
+
+    fn identity_test_adapter(handle: P2PHostHandle) -> P2PAdapter<NoopBlockstore> {
+        P2PAdapter {
+            handle,
+            sync_coordinator: None,
+            doc_pusher: None,
+            event_bus: None,
+            version_syncer: None,
+            replicator_push_options: ReplicatorPushOptionsState::default(),
+            peer_addresses: Arc::new(std::sync::RwLock::new(HashMap::new())),
+            tracked_documents: Arc::new(std::sync::RwLock::new(HashSet::new())),
+            nac_checker: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn identity_lookup_checks_nac_before_parsing_or_network_io() {
+        let (_host, handle, _events, _replicators) =
+            p2p::host::P2PHost::new(BitswapStoreAdapter::new(Arc::new(NoopBlockstore)))
+                .await
+                .unwrap();
+        let invalid_but_wrapped = TransportPeerId::new("not-a-libp2p-peer-id").unwrap();
+
+        let mut denied = identity_test_adapter(handle.clone());
+        denied.nac_checker = Some(Arc::new(FixedNac(NacOutcome::Denied)));
+        assert!(matches!(
+            denied.resolve_peer_identity(&invalid_but_wrapped).await,
+            Err(P2PError::Unauthorized(_))
+        ));
+
+        let mut failed = identity_test_adapter(handle);
+        failed.nac_checker = Some(Arc::new(FixedNac(NacOutcome::Failed)));
+        assert!(matches!(
+            failed.resolve_peer_identity(&invalid_but_wrapped).await,
+            Err(P2PError::Internal(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn authenticated_identity_lookup_is_fresh_and_unconfigured_is_none() {
+        let first_responder_identity = Arc::new(
+            identity::RawIdentity::from_private_key(crypto::generate_ed25519().unwrap()).unwrap(),
+        );
+        let first_did = identity::Identity::did(first_responder_identity.as_ref()).unwrap();
+        let responder_transport_key = libp2p::identity::Keypair::generate_ed25519();
+        let (host_a, handle_a, _events_a, _replicators_a) =
+            p2p::host::P2PHost::with_keypair_and_config_and_identity(
+                libp2p::identity::Keypair::generate_ed25519(),
+                BitswapStoreAdapter::new(Arc::new(NoopBlockstore)),
+                p2p::host::P2PHostConfig::default(),
+                None,
+            )
+            .await
+            .unwrap();
+        let (host_b, handle_b, _events_b, _replicators_b) =
+            p2p::host::P2PHost::with_keypair_and_config_and_identity(
+                responder_transport_key.clone(),
+                BitswapStoreAdapter::new(Arc::new(NoopBlockstore)),
+                p2p::host::P2PHostConfig::default(),
+                Some(first_responder_identity),
+            )
+            .await
+            .unwrap();
+
+        let task_a = tokio::spawn(host_a.run());
+        let task_b = tokio::spawn(host_b.run());
+        connect_hosts(&handle_a, &handle_b).await;
+
+        let adapter = identity_test_adapter(handle_a.clone());
+        let peer = TransportPeerId::new(handle_b.local_peer_id_cached().to_string()).unwrap();
+        assert_eq!(
+            adapter.resolve_peer_identity(&peer).await.unwrap(),
+            Some(first_did)
+        );
+
+        let responder_peer = handle_b.local_peer_id_cached();
+        handle_b.shutdown().await.unwrap();
+        task_b.await.unwrap();
+        wait_until_disconnected(&handle_a, responder_peer).await;
+
+        let second_responder_identity = Arc::new(
+            identity::RawIdentity::from_private_key(crypto::generate_ed25519().unwrap()).unwrap(),
+        );
+        let second_did = identity::Identity::did(second_responder_identity.as_ref()).unwrap();
+        let (replacement_host, replacement_handle, _events, _replicators) =
+            p2p::host::P2PHost::with_keypair_and_config_and_identity(
+                responder_transport_key,
+                BitswapStoreAdapter::new(Arc::new(NoopBlockstore)),
+                p2p::host::P2PHostConfig::default(),
+                Some(second_responder_identity),
+            )
+            .await
+            .unwrap();
+        let replacement_task = tokio::spawn(replacement_host.run());
+        assert_eq!(replacement_handle.local_peer_id_cached(), responder_peer);
+        connect_hosts(&handle_a, &replacement_handle).await;
+
+        assert_eq!(
+            adapter.resolve_peer_identity(&peer).await.unwrap(),
+            Some(second_did)
+        );
+
+        handle_a.shutdown().await.unwrap();
+        replacement_handle.shutdown().await.unwrap();
+        task_a.await.unwrap();
+        replacement_task.await.unwrap();
+
+        let (host_c, handle_c, _events_c, _replicators_c) =
+            p2p::host::P2PHost::new(BitswapStoreAdapter::new(Arc::new(NoopBlockstore)))
+                .await
+                .unwrap();
+        let (host_d, handle_d, _events_d, _replicators_d) =
+            p2p::host::P2PHost::new(BitswapStoreAdapter::new(Arc::new(NoopBlockstore)))
+                .await
+                .unwrap();
+        let task_c = tokio::spawn(host_c.run());
+        let task_d = tokio::spawn(host_d.run());
+        connect_hosts(&handle_c, &handle_d).await;
+        let adapter = identity_test_adapter(handle_c.clone());
+        let peer = TransportPeerId::new(handle_d.local_peer_id_cached().to_string()).unwrap();
+        assert_eq!(adapter.resolve_peer_identity(&peer).await.unwrap(), None);
+        handle_c.shutdown().await.unwrap();
+        handle_d.shutdown().await.unwrap();
+        task_c.await.unwrap();
+        task_d.await.unwrap();
     }
 
     /// Characterization, libp2p counterpart of the iroh test: a peer that

--- a/crates/p2p/src/host/command_handler/messaging.rs
+++ b/crates/p2p/src/host/command_handler/messaging.rs
@@ -354,11 +354,6 @@ impl<S: Store> P2PHost<S> {
         peer_id: PeerId,
         response: tokio::sync::oneshot::Sender<Result<Option<identity::Did>>>,
     ) {
-        if let Some(identity) = self.peer_identities.get(&peer_id).cloned() {
-            let _ = response.send(Ok(Some(identity)));
-            return;
-        }
-
         let local_peer_id = self.swarm.local_peer_id().to_string();
         let keypair = self.keypair.clone();
         let handler = self.two_stream_handler.clone();
@@ -376,6 +371,9 @@ impl<S: Store> P2PHost<S> {
 
             let result = result.and_then(|reply| {
                 if let Some(error) = reply.err_message.clone() {
+                    if error == crate::message::IDENTITY_UNCONFIGURED_ERROR {
+                        return Ok(None);
+                    }
                     return Err(crate::error::Error::Transport(error));
                 }
                 let token_identity = identity::from_token(&reply.identity_token)

--- a/crates/p2p/src/host/p2p_host/mod.rs
+++ b/crates/p2p/src/host/p2p_host/mod.rs
@@ -263,8 +263,6 @@ pub struct P2PHost<S: Store> {
     pub(super) peer_addrs: HashMap<PeerId, Multiaddr>,
     /// Optional local DEFRA identity used for Go-compatible identity exchange.
     pub(super) node_identity: Option<Arc<identity::RawIdentity>>,
-    /// Verified peer DEFRA DIDs keyed by peer ID.
-    pub(super) peer_identities: HashMap<PeerId, identity::Did>,
     /// Tracks established connections and actively prunes them after the
     /// Go-compatible low/high watermarks are exceeded.
     connection_manager: ActiveConnectionManager,
@@ -594,7 +592,6 @@ impl<S: Store + Clone + Send + Sync + 'static> P2PHost<S> {
             bitswap_queries: HashMap::new(),
             peer_addrs: HashMap::new(),
             node_identity,
-            peer_identities: HashMap::new(),
             connection_manager: ActiveConnectionManager::new(
                 config.connection_manager_low_water,
                 config.connection_manager_high_water,

--- a/crates/p2p/src/host/p2p_host/two_stream.rs
+++ b/crates/p2p/src/host/p2p_host/two_stream.rs
@@ -9,6 +9,43 @@ use crate::two_stream::TwoStreamEvent;
 use super::P2PHost;
 use crate::host::event::HostEvent;
 
+fn identity_request_targets_peer(
+    request: &crate::message::IdentityRequest,
+    authenticated_peer: &libp2p::PeerId,
+) -> bool {
+    request.peer_id == authenticated_peer.to_string()
+}
+
+fn identity_response_for_request(
+    request: &crate::message::IdentityRequest,
+    authenticated_peer: &libp2p::PeerId,
+    node_identity: Option<&identity::RawIdentity>,
+) -> crate::message::IdentityResponse {
+    if !identity_request_targets_peer(request, authenticated_peer) {
+        return crate::message::IdentityResponse::error(
+            &request.message_id,
+            "identity request peer did not match authenticated transport peer",
+        );
+    }
+
+    let Some(node_identity) = node_identity else {
+        return crate::message::IdentityResponse::identity_unconfigured(&request.message_id);
+    };
+
+    match identity::new_token(
+        node_identity,
+        std::time::Duration::from_secs(60 * 60 * 24),
+        Some(authenticated_peer.to_string()),
+        None,
+    ) {
+        Ok(token) => crate::message::IdentityResponse::success(&request.message_id, token),
+        Err(error) => crate::message::IdentityResponse::error(
+            &request.message_id,
+            &format!("failed to generate identity token: {error}"),
+        ),
+    }
+}
+
 impl<S: Store> P2PHost<S> {
     /// Handle two-stream protocol events.
     pub(super) async fn handle_two_stream_event(&mut self, event: TwoStreamEvent) {
@@ -142,26 +179,11 @@ impl<S: Store> P2PHost<S> {
                 }
             }
             TwoStreamEvent::IdentityRequest { peer_id, request } => {
-                let mut reply = match self.node_identity.as_ref() {
-                    Some(node_identity) => match identity::new_token(
-                        node_identity.as_ref(),
-                        std::time::Duration::from_secs(60 * 60 * 24),
-                        Some(request.peer_id.clone()),
-                        None,
-                    ) {
-                        Ok(token) => {
-                            crate::message::IdentityResponse::success(&request.message_id, token)
-                        }
-                        Err(error) => crate::message::IdentityResponse::error(
-                            &request.message_id,
-                            &format!("failed to generate identity token: {error}"),
-                        ),
-                    },
-                    None => crate::message::IdentityResponse::error(
-                        &request.message_id,
-                        "node identity is not configured",
-                    ),
-                };
+                let mut reply = identity_response_for_request(
+                    &request,
+                    &peer_id,
+                    self.node_identity.as_deref(),
+                );
 
                 match crate::signing::sign_message(self.keypair(), &mut reply) {
                     Ok(()) => {
@@ -191,9 +213,7 @@ impl<S: Store> P2PHost<S> {
                     )?;
                     identity::Identity::did(&identity)
                 }) {
-                    Ok(did) => {
-                        self.peer_identities.insert(peer_id, did);
-                    }
+                    Ok(_did) => {}
                     Err(error) => {
                         warn!(peer_id = %peer_id, error = %error, "Failed to verify peer identity token");
                     }
@@ -349,5 +369,49 @@ impl<S: Store> P2PHost<S> {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{identity_request_targets_peer, identity_response_for_request};
+    use identity::Identity as _;
+
+    #[test]
+    fn identity_request_cannot_forward_audience_for_another_transport_peer() {
+        let authenticated = libp2p::PeerId::random();
+        let victim = libp2p::PeerId::random();
+
+        let forwarded = crate::message::IdentityRequest::new(victim.to_string());
+        assert!(!identity_request_targets_peer(&forwarded, &authenticated));
+        let node_identity =
+            identity::RawIdentity::from_private_key(crypto::generate_ed25519().unwrap()).unwrap();
+        let rejected =
+            identity_response_for_request(&forwarded, &authenticated, Some(&node_identity));
+        assert!(rejected.err_message.is_some());
+        assert!(rejected.identity_token.is_empty());
+
+        let bound = crate::message::IdentityRequest::new(authenticated.to_string());
+        assert!(identity_request_targets_peer(&bound, &authenticated));
+        let accepted = identity_response_for_request(&bound, &authenticated, Some(&node_identity));
+        assert!(accepted.err_message.is_none());
+        let token_identity = identity::from_token(&accepted.identity_token).unwrap();
+        identity::verify_auth_token(&token_identity, &authenticated.to_string()).unwrap();
+        assert_eq!(
+            identity::Identity::did(&token_identity).unwrap(),
+            node_identity.did().unwrap()
+        );
+    }
+
+    #[test]
+    fn identity_request_without_node_identity_returns_explicit_none_sentinel() {
+        let authenticated = libp2p::PeerId::random();
+        let request = crate::message::IdentityRequest::new(authenticated.to_string());
+        let response = identity_response_for_request(&request, &authenticated, None);
+        assert_eq!(
+            response.err_message.as_deref(),
+            Some(crate::message::IDENTITY_UNCONFIGURED_ERROR)
+        );
+        assert!(response.identity_token.is_empty());
     }
 }

--- a/crates/p2p/src/iroh/addr.rs
+++ b/crates/p2p/src/iroh/addr.rs
@@ -86,6 +86,14 @@ pub fn canonical_peer_id(peer_id: &PeerId) -> PeerId {
     }
 }
 
+/// Parse one raw iroh endpoint ID and return its canonical spelling.
+/// Address and ticket forms are deliberately rejected at this identity seam.
+pub fn parse_canonical_peer_id(value: &str) -> Result<PeerId> {
+    let id = EndpointId::from_str(value)
+        .map_err(|error| Error::InvalidPeerId(format!("invalid iroh peer ID: {error}")))?;
+    Ok(PeerId::new(id.to_string()))
+}
+
 /// Render raw iroh endpoint listen addresses into stable, connectable public strings.
 ///
 /// The returned list keeps direct addresses first for compatibility with
@@ -373,5 +381,14 @@ mod tests {
         let selected = best_shareable_public_addr(&peer_id, &[PeerAddr::new(addrless_ticket)]);
 
         assert_eq!(selected, None);
+    }
+
+    #[test]
+    fn strict_peer_id_parser_rejects_addresses_and_canonicalizes_ids() {
+        let endpoint = endpoint_id();
+        let parsed = parse_canonical_peer_id(&endpoint.to_string()).unwrap();
+        assert_eq!(parsed.as_str(), endpoint.to_string());
+        assert!(parse_canonical_peer_id("").is_err());
+        assert!(parse_canonical_peer_id(&format!("127.0.0.1:7777/p2p/{endpoint}")).is_err());
     }
 }

--- a/crates/p2p/src/iroh/endpoint_streams.rs
+++ b/crates/p2p/src/iroh/endpoint_streams.rs
@@ -215,10 +215,7 @@ async fn dispatch_stream(
                     ),
                 }
             } else {
-                crate::message::IdentityResponse::error(
-                    &request.message_id,
-                    "node identity is not configured",
-                )
+                crate::message::IdentityResponse::identity_unconfigured(&request.message_id)
             };
             protocols::write_message(&mut send, &response).await?;
             send.finish()

--- a/crates/p2p/src/iroh/mod.rs
+++ b/crates/p2p/src/iroh/mod.rs
@@ -27,7 +27,8 @@ mod two_stream_tests;
 
 pub use addr::{
     best_shareable_public_addr, canonical_peer_id, endpoint_addr_from_parts,
-    endpoint_ticket_string, format_public_listen_addrs, is_ticket_string, parse_public_peer_addr,
+    endpoint_ticket_string, format_public_listen_addrs, is_ticket_string, parse_canonical_peer_id,
+    parse_public_peer_addr,
 };
 pub use config::{IrohDiscoveryConfig, IrohRelayModeConfig};
 pub use endpoint::spawn_endpoint;

--- a/crates/p2p/src/iroh/transport.rs
+++ b/crates/p2p/src/iroh/transport.rs
@@ -118,8 +118,13 @@ impl IrohTransport {
             })
             .await?;
         if let Some(error) = response.err_message.as_deref() {
-            tracing::debug!(peer_id = %peer_id, error, "Iroh peer has no resolvable Defra identity");
-            return Ok(None);
+            if error == crate::message::IDENTITY_UNCONFIGURED_ERROR {
+                tracing::debug!(peer_id = %peer_id, "Iroh peer has no configured Defra identity");
+                return Ok(None);
+            }
+            return Err(Error::Transport(format!(
+                "peer identity challenge failed: {error}"
+            )));
         }
         let token_identity = identity::from_token(&response.identity_token)
             .map_err(|error| Error::Transport(format!("invalid peer identity token: {error}")))?;
@@ -647,6 +652,47 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resolved, Some(expected_did));
+
+        requester.shutdown().await.unwrap();
+        server.shutdown().await.unwrap();
+        requester_task.await.unwrap();
+        server_task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn peer_without_node_identity_is_distinct_from_challenge_failure() {
+        let requester_key = SecretKey::generate();
+        let server_key = SecretKey::generate();
+        let (requester_tx, _requester_events, _requester_replicators, requester_task) =
+            spawn_endpoint(test_config(requester_key.clone()))
+                .await
+                .unwrap();
+        let (server_tx, _server_events, _server_replicators, server_task) =
+            spawn_endpoint(test_config(server_key.clone()))
+                .await
+                .unwrap();
+        let requester = IrohTransport::new(requester_tx, requester_key);
+        let server = IrohTransport::new(server_tx, server_key);
+
+        requester
+            .dial(
+                server.local_peer_id(),
+                server.listen_addresses().await.unwrap(),
+            )
+            .await
+            .unwrap();
+        requester
+            .poll_until_connected(server.local_peer_id(), Duration::from_secs(5))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            requester
+                .get_peer_identity(server.local_peer_id())
+                .await
+                .unwrap(),
+            None
+        );
 
         requester.shutdown().await.unwrap();
         server.shutdown().await.unwrap();

--- a/crates/p2p/src/message/identity.rs
+++ b/crates/p2p/src/message/identity.rs
@@ -3,6 +3,9 @@ use serde::{Deserialize, Serialize};
 use super::cbor::{nullable_bytes, optional_bytes};
 use super::traits::Message;
 
+/// Protocol sentinel indicating that the remote node has no DID identity configured.
+pub const IDENTITY_UNCONFIGURED_ERROR: &str = "node identity is not configured";
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IdentityRequest {
     #[serde(rename = "Version")]
@@ -132,6 +135,14 @@ impl IdentityResponse {
             err_message: None,
             identity_token,
         }
+    }
+
+    /// Returns the protocol sentinel response for a node without a configured DID.
+    ///
+    /// Transport adapters map only this response to `None`; other remote errors
+    /// remain failures.
+    pub fn identity_unconfigured(request_message_id: &str) -> Self {
+        Self::error(request_message_id, IDENTITY_UNCONFIGURED_ERROR)
     }
 
     pub fn error(request_message_id: &str, err: &str) -> Self {

--- a/crates/p2p/src/message/mod.rs
+++ b/crates/p2p/src/message/mod.rs
@@ -42,7 +42,7 @@ mod traits;
 pub use branchable::{BranchableSyncReply, BranchableSyncRequest};
 pub use car::CarFetchRequest;
 pub use docsync::{DocSyncItem, DocSyncReply, DocSyncRequest, MAX_DOC_IDS};
-pub use identity::{IdentityRequest, IdentityResponse};
+pub use identity::{IdentityRequest, IdentityResponse, IDENTITY_UNCONFIGURED_ERROR};
 pub use manage::{
     ManageDocRef, ManageMutateOp, ManageQueryOp, ManageQueryReply, ManageQueryRequest,
     ManageQueryResult, ManageReply, ManageRequest,


### PR DESCRIPTION
## Summary

- add a transport-neutral authenticated peer identity operation to `P2POperations`
- challenge peers on both Iroh and libp2p and return a typed DID
- bind libp2p identity tokens to the authenticated transport peer and remove the stale process-lifetime identity cache
- align strict peer-ID validation, explicit unconfigured identity semantics, NAC error categories, HTTP/FFI surfaces, and tests

## Why

Gents status-first enrollment needs to authenticate the transport peer behind a discovered server address. The operation intentionally accepts a raw transport peer ID rather than the address strings returned by `connected_peers`, requires `P2pPeerActive`, and fails closed on unsupported transports.

## Verification

- `cargo test -p p2p --features "iroh-transport libp2p-transport"` (441 unit tests plus integration/doc tests)
- `cargo test -p defra-p2p-adapter` (56)
- `cargo test -p defra-http --lib` (129)
- `cargo test -p ffi p2p::tests` (7)
- affected all-target checks including `ffi`
- affected Clippy with all targets/features and `-D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Independent exact-head review: clean at `6adef36aafa71156cb2cf3abba2e7dfc3d6d2153`.