### PR TITLE
refactor(db): share auto-commit transaction lifecycle

### DIFF
--- a/crates/db/src/write/autocommit/create.rs
+++ b/crates/db/src/write/autocommit/create.rs
@@ -44,9 +44,7 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
         // No per-doc write guard for creates: the DocID is derived from the
         // genesis block inside the txn, so no identity exists to guard yet.
         // The DocID-mapping duplicate check is the gate.
-        let txn = self.db.new_txn(false).await.map_err(|e| {
-            query::error::QueryError::execution(format!("failed to create txn: {}", e))
-        })?;
+        let txn = self.new_mutation_txn().await?;
 
         // Acquire store views up front (dropped before commit); the mutation
         // itself runs in an async block so errors fall through to the discard.
@@ -166,49 +164,28 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
         drop(blockstore);
         drop(headstore);
 
-        match result {
-            Ok((doc_id, cid, block, col_data)) => {
-                // Commit the transaction (all store references now dropped)
-                if let Err(e) = txn.commit().await {
-                    warn!(
-                        collection = %collection_name,
-                        error = %e,
-                        "Failed to commit transaction after create"
-                    );
-                    return Err(crate::error::commit_query_error(e));
-                }
+        let (doc_id, cid, block, col_data) = self
+            .finish_mutation(txn, result, collection_name, "create")
+            .await?;
 
-                self.register_created_doc_with_acp(&collection, &doc_id.to_string())
-                    .await?;
+        self.register_created_doc_with_acp(&collection, &doc_id.to_string())
+            .await?;
 
-                // Emit update event for subscriptions
-                self.emit_update_events(
-                    &collection,
-                    &doc_id.to_string(),
-                    cid,
-                    block.clone(),
-                    col_data.clone(),
-                );
+        // Emit update event for subscriptions
+        self.emit_update_events(
+            &collection,
+            &doc_id.to_string(),
+            cid,
+            block.clone(),
+            col_data.clone(),
+        );
 
-                let mut result = CreateResult::with_commit(doc_id, doc, cid, block);
-                if let Some((col_cid, col_bytes)) = col_data {
-                    result.broadcast_cid = Some(col_cid);
-                    result.broadcast_block = Some(col_bytes);
-                }
-                Ok(result)
-            }
-            Err(e) => {
-                // Discard the transaction on error
-                if let Err(discard_err) = txn.discard() {
-                    warn!(
-                        collection = %collection_name,
-                        error = %discard_err,
-                        "Failed to discard transaction after create error"
-                    );
-                }
-                Err(e)
-            }
+        let mut result = CreateResult::with_commit(doc_id, doc, cid, block);
+        if let Some((col_cid, col_bytes)) = col_data {
+            result.broadcast_cid = Some(col_cid);
+            result.broadcast_block = Some(col_bytes);
         }
+        Ok(result)
     }
 
     pub(super) async fn create_many_impl(
@@ -278,9 +255,7 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
         // the txn; the DocID-mapping duplicate check is the gate.
 
         // === Phase 2: Transaction — allocate identities, then compute blocks ===
-        let txn = self.db.new_txn(false).await.map_err(|e| {
-            query::error::QueryError::execution(format!("failed to create txn: {}", e))
-        })?;
+        let txn = self.new_mutation_txn().await?;
 
         let mut identities = Vec::with_capacity(prepared_docs.len());
         for _ in &prepared_docs {

--- a/crates/db/src/write/autocommit/delete.rs
+++ b/crates/db/src/write/autocommit/delete.rs
@@ -20,14 +20,10 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
             .map_err(|error| query::error::QueryError::execution(error.to_string()))?;
         ensure_collection_is_active(&self.db, collection_name, &collection)?;
 
-        // Create a write transaction
-        let txn = self.db.new_txn(false).await.map_err(|e| {
-            query::error::QueryError::execution(format!("failed to create txn: {}", e))
-        })?;
+        let txn = self.new_mutation_txn().await?;
 
         // Acquire store views up front (dropped before commit); the mutation
         // itself runs in an async block so errors fall through to the discard.
-        // Some(short_id) means the doc existed and was deleted.
         let datastore = txn.datastore().map_err(|e| {
             query::error::QueryError::execution(format!(
                 "failed to get datastore for collection '{}': {}",
@@ -37,8 +33,14 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
         let systemstore = txn.systemstore().map_err(|e| {
             query::error::QueryError::execution(format!("failed to get systemstore: {}", e))
         })?;
+        let blockstore = txn.blockstore().map_err(|e| {
+            query::error::QueryError::execution(format!("failed to get blockstore: {}", e))
+        })?;
+        let headstore = txn.headstore().map_err(|e| {
+            query::error::QueryError::execution(format!("failed to get headstore: {}", e))
+        })?;
 
-        let result: query::error::Result<Option<(u64, DocID)>> = async {
+        let result: query::error::Result<Option<(DocID, CommitArtifacts)>> = async {
             let Some((doc_short_id, canonical_doc_id)) = collection
                 .resolve_doc_identity(&systemstore, doc_id)
                 .await
@@ -66,136 +68,91 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                 .delete_with_indexes(&datastore, &canonical_doc_id, doc_short_id, &index_manager)
                 .await
                 .map_err(|e| query::error::QueryError::execution(format!("delete error: {}", e)))?;
-            Ok(existed.then_some((doc_short_id, canonical_doc_id)))
+            if !existed {
+                return Ok(None);
+            }
+
+            let schema_version_id = collection.version_id();
+            let doc_id_str = canonical_doc_id.to_string();
+            // Get signing config from thread-local (set by FFI exec_request)
+            let sign_config = get_signing_config();
+
+            let block_result = write_delete_block(
+                &blockstore,
+                &headstore,
+                &doc_id_str,
+                doc_short_id,
+                schema_version_id,
+                sign_config.as_ref(),
+            )
+            .await
+            .map_err(|e| {
+                query::error::QueryError::execution(format!(
+                    "failed to write delete block for collection {}: {}",
+                    collection_name, e
+                ))
+            })?;
+            let composite_cid = block_result.cid;
+
+            crate::docid::map::set_block_doc_id_mapping(
+                &systemstore,
+                &composite_cid.to_string(),
+                &doc_id_str,
+            )
+            .await
+            .map_err(|e| query::error::QueryError::execution(e.to_string()))?;
+
+            let col_block_data = write_branchable_collection_block(
+                &self.db,
+                collection_name,
+                &collection,
+                &blockstore,
+                &headstore,
+                composite_cid,
+                sign_config.as_ref(),
+            )
+            .await?;
+
+            Ok(Some((
+                canonical_doc_id,
+                (composite_cid, block_result.block, col_block_data),
+            )))
         }
         .await;
 
         drop(datastore);
         drop(systemstore);
+        drop(blockstore);
+        drop(headstore);
 
-        match result {
-            Ok(deleted) => {
-                // DeleteNode treats existed==false as a no-op; don't write a
-                // tombstone block or emit an event for a missing doc.
-                // Propagate any commit error so callers see the same failure
-                // surface they get on the normal commit path (Go returns the
-                // commit error on a no-op delete too).
-                let Some((deleted_short_id, canonical_doc_id)) = deleted else {
-                    if let Err(e) = txn.commit().await {
-                        warn!(
-                            collection = %collection_name,
-                            error = %e,
-                            "Failed to commit transaction after no-op delete"
-                        );
-                        return Err(crate::error::commit_query_error(e));
-                    }
-                    return Ok(DeleteResult::new(doc_id.clone(), false));
-                };
-                let existed = true;
+        let operation = if matches!(&result, Ok(None)) {
+            "no-op delete"
+        } else {
+            "delete"
+        };
+        let deleted = self
+            .finish_mutation(txn, result, collection_name, operation)
+            .await?;
 
-                // Build delete block (composite with status=2) in a scoped block
-                let commit_result: CommitArtifacts = {
-                    let blockstore = txn.blockstore().map_err(|e| {
-                        query::error::QueryError::execution(format!(
-                            "failed to get blockstore: {}",
-                            e
-                        ))
-                    })?;
-                    let headstore = txn.headstore().map_err(|e| {
-                        query::error::QueryError::execution(format!(
-                            "failed to get headstore: {}",
-                            e
-                        ))
-                    })?;
+        let Some((canonical_doc_id, commit_result)) = deleted else {
+            return Ok(DeleteResult::new(doc_id.clone(), false));
+        };
 
-                    let schema_version_id = collection.version_id();
-                    let doc_id_str = canonical_doc_id.to_string();
-                    // Get signing config from thread-local (set by FFI exec_request)
-                    let sign_config = get_signing_config();
+        let (cid, block, col_data) = commit_result;
+        self.emit_update_events(
+            &collection,
+            &canonical_doc_id.to_string(),
+            cid,
+            block.clone(),
+            col_data.clone(),
+        );
 
-                    let block_result = write_delete_block(
-                        &blockstore,
-                        &headstore,
-                        &doc_id_str,
-                        deleted_short_id,
-                        schema_version_id,
-                        sign_config.as_ref(),
-                    )
-                    .await
-                    .map_err(|e| {
-                        query::error::QueryError::execution(format!(
-                            "failed to write delete block for collection {}: {}",
-                            collection_name, e
-                        ))
-                    })?;
-                    let composite_cid = block_result.cid;
-
-                    let systemstore = txn.systemstore().map_err(|e| {
-                        query::error::QueryError::execution(format!(
-                            "failed to get systemstore: {}",
-                            e
-                        ))
-                    })?;
-                    crate::docid::map::set_block_doc_id_mapping(
-                        &systemstore,
-                        &composite_cid.to_string(),
-                        &doc_id_str,
-                    )
-                    .await
-                    .map_err(|e| query::error::QueryError::execution(e.to_string()))?;
-
-                    let col_block_data = write_branchable_collection_block(
-                        &self.db,
-                        collection_name,
-                        &collection,
-                        &blockstore,
-                        &headstore,
-                        composite_cid,
-                        sign_config.as_ref(),
-                    )
-                    .await?;
-
-                    (composite_cid, block_result.block, col_block_data)
-                }; // blockstore and headstore dropped here
-
-                // Commit the transaction (datastore reference is now dropped)
-                if let Err(e) = txn.commit().await {
-                    warn!(
-                        collection = %collection_name,
-                        error = %e,
-                        "Failed to commit transaction after delete"
-                    );
-                    return Err(crate::error::commit_query_error(e));
-                }
-
-                let (cid, block, col_data) = commit_result;
-                self.emit_update_events(
-                    &collection,
-                    &canonical_doc_id.to_string(),
-                    cid,
-                    block.clone(),
-                    col_data.clone(),
-                );
-
-                let mut result = DeleteResult::with_commit(canonical_doc_id, existed, cid, block);
-                if let Some((col_cid, col_bytes)) = col_data {
-                    result.broadcast_cid = Some(col_cid);
-                    result.broadcast_block = Some(col_bytes);
-                }
-                Ok(result)
-            }
-            Err(e) => {
-                // Discard the transaction on error
-                if let Err(discard_err) = txn.discard() {
-                    warn!(
-                        collection = %collection_name,
-                        error = %discard_err,
-                        "Failed to discard transaction after delete error"
-                    );
-                }
-                Err(e)
-            }
+        let mut result = DeleteResult::with_commit(canonical_doc_id, true, cid, block);
+        if let Some((col_cid, col_bytes)) = col_data {
+            result.broadcast_cid = Some(col_cid);
+            result.broadcast_block = Some(col_bytes);
         }
+        Ok(result)
     }
 
     /// Delete multiple documents in a single transaction.
@@ -241,9 +198,7 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
             })?;
 
         // Single transaction for all deletes
-        let txn = self.db.new_txn(false).await.map_err(|e| {
-            query::error::QueryError::execution(format!("failed to create txn: {}", e))
-        })?;
+        let txn = self.new_mutation_txn().await?;
 
         let mut results: Vec<(DocID, bool, Option<CommitArtifacts>)> =
             Vec::with_capacity(doc_ids.len());

--- a/crates/db/src/write/autocommit/mod.rs
+++ b/crates/db/src/write/autocommit/mod.rs
@@ -27,6 +27,7 @@ use crate::collection::Collection;
 use crate::database::DB;
 use crate::index::IndexManager;
 use crate::read::lensed::fetcher::LensedDocFetcher;
+use crate::txn::DbTxn;
 
 /// Captured per-mutation commit data: the document block (cid + bytes) plus,
 /// for branchable collections, the collection block (cid + bytes).
@@ -64,6 +65,46 @@ impl<S: Store> AutoCommitMutator<S> {
 
     pub fn set_document_acp(&self, acp: Arc<dyn acp::DocumentACP>) {
         let _ = self.document_acp.set(acp);
+    }
+
+    async fn new_mutation_txn(&self) -> query::error::Result<DbTxn<S>> {
+        self.db.new_txn(false).await.map_err(|error| {
+            query::error::QueryError::execution(format!("failed to create txn: {error}"))
+        })
+    }
+
+    async fn finish_mutation<T>(
+        &self,
+        txn: DbTxn<S>,
+        result: query::error::Result<T>,
+        collection_name: &str,
+        operation: &str,
+    ) -> query::error::Result<T> {
+        match result {
+            Ok(value) => {
+                if let Err(error) = txn.commit().await {
+                    warn!(
+                        collection = %collection_name,
+                        error = %error,
+                        "Failed to commit transaction after {}",
+                        operation
+                    );
+                    return Err(crate::error::commit_query_error(error));
+                }
+                Ok(value)
+            }
+            Err(error) => {
+                if let Err(discard_error) = txn.discard() {
+                    warn!(
+                        collection = %collection_name,
+                        error = %discard_error,
+                        "Failed to discard transaction after {} error",
+                        operation
+                    );
+                }
+                Err(error)
+            }
+        }
     }
 
     async fn register_created_doc_with_acp(
@@ -108,9 +149,7 @@ impl<S: Store> AutoCommitMutator<S> {
     pub async fn new_batch_components(
         &self,
     ) -> query::error::Result<(Arc<BatchMutator<S>>, Arc<LensedDocFetcher<S>>)> {
-        let txn = self.db.new_txn(false).await.map_err(|e| {
-            query::error::QueryError::execution(format!("failed to create txn: {}", e))
-        })?;
+        let txn = self.new_mutation_txn().await?;
         let fetcher = Arc::new(LensedDocFetcher::new(
             self.db.clone(),
             txn,

--- a/crates/db/src/write/autocommit/update.rs
+++ b/crates/db/src/write/autocommit/update.rs
@@ -140,10 +140,7 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
         }
         doc = current_doc;
 
-        // Create a write transaction
-        let txn = self.db.new_txn(false).await.map_err(|e| {
-            query::error::QueryError::execution(format!("failed to create txn: {}", e))
-        })?;
+        let txn = self.new_mutation_txn().await?;
 
         // Acquire store views up front (dropped before commit); the mutation
         // itself runs in an async block so errors fall through to the discard.
@@ -156,8 +153,14 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
         let systemstore = txn.systemstore().map_err(|e| {
             query::error::QueryError::execution(format!("failed to get systemstore: {}", e))
         })?;
+        let blockstore = txn.blockstore().map_err(|e| {
+            query::error::QueryError::execution(format!("failed to get blockstore: {}", e))
+        })?;
+        let headstore = txn.headstore().map_err(|e| {
+            query::error::QueryError::execution(format!("failed to get headstore: {}", e))
+        })?;
 
-        let result: query::error::Result<u64> = async {
+        let result: query::error::Result<CommitArtifacts> = async {
             // Create an IndexManager for index maintenance
             let short_id = collection.resolved_root_id();
             let index_manager = IndexManager::from_indexes(
@@ -205,137 +208,88 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                 &index_manager,
             )
             .await?;
-            Ok(doc_short_id)
+
+            // Use version_id for collectionVersionID (matches Go's VersionID())
+            let schema_version_id = collection.version_id();
+            // Explicit config from the mutation only. A document created
+            // encrypted keeps its encryption because the block writer
+            // inherits it from the previous block, matching Go's
+            // determineBlockEncryption.
+            let enc_config = get_encryption_config();
+            // Get signing config from thread-local (set by FFI exec_request)
+            let sign_config = get_signing_config();
+
+            let identity = DocStorageIdentity::new(collection.resolved_root_id(), doc_short_id);
+
+            // For update operations, pass the modified fields to only create blocks
+            // for the fields that actually changed
+            let block_result = write_document_blocks(
+                &blockstore,
+                &headstore,
+                &doc,
+                schema_version_id,
+                identity,
+                Some(&modified_fields),
+                enc_config.as_ref(),
+                sign_config.as_ref(),
+                None,
+            )
+            .await
+            .map_err(|e| {
+                query::error::QueryError::execution(format!(
+                    "failed to write document blocks for update on collection {}: {}",
+                    collection_name, e
+                ))
+            })?;
+
+            if let Some(doc_id) = doc.id() {
+                register_block_doc_id_mappings(&systemstore, &block_result, &doc_id.to_string())
+                    .await?;
+            }
+
+            let col_block_data = write_branchable_collection_block(
+                &self.db,
+                collection_name,
+                &collection,
+                &blockstore,
+                &headstore,
+                block_result.cid,
+                sign_config.as_ref(),
+            )
+            .await?;
+
+            Ok((block_result.cid, block_result.block, col_block_data))
         }
         .await;
 
         drop(datastore);
         drop(systemstore);
+        drop(blockstore);
+        drop(headstore);
 
-        match result {
-            Ok(doc_short_id) => {
-                // Build blocks and write to blockstore/headstore in a scoped block
-                // This enables _commits queries to find the document's version history
-                // (composite_cid, composite_bytes, optional (collection_cid, collection_bytes))
-                let commit_result: CommitArtifacts = {
-                    let blockstore = txn.blockstore().map_err(|e| {
-                        query::error::QueryError::execution(format!(
-                            "failed to get blockstore: {}",
-                            e
-                        ))
-                    })?;
-                    let headstore = txn.headstore().map_err(|e| {
-                        query::error::QueryError::execution(format!(
-                            "failed to get headstore: {}",
-                            e
-                        ))
-                    })?;
+        let commit_result = self
+            .finish_mutation(txn, result, collection_name, "update")
+            .await?;
 
-                    // Use version_id for collectionVersionID (matches Go's VersionID())
-                    let schema_version_id = collection.version_id();
-                    // Explicit config from the mutation only. A document created
-                    // encrypted keeps its encryption because the block writer
-                    // inherits it from the previous block, matching Go's
-                    // determineBlockEncryption.
-                    let enc_config = get_encryption_config();
-                    // Get signing config from thread-local (set by FFI exec_request)
-                    let sign_config = get_signing_config();
-
-                    let identity =
-                        DocStorageIdentity::new(collection.resolved_root_id(), doc_short_id);
-
-                    // For update operations, pass the modified fields to only create blocks
-                    // for the fields that actually changed
-                    let block_result = write_document_blocks(
-                        &blockstore,
-                        &headstore,
-                        &doc,
-                        schema_version_id,
-                        identity,
-                        Some(&modified_fields),
-                        enc_config.as_ref(),
-                        sign_config.as_ref(),
-                        None,
-                    )
-                    .await
-                    .map_err(|e| {
-                        query::error::QueryError::execution(format!(
-                            "failed to write document blocks for update on collection {}: {}",
-                            collection_name, e
-                        ))
-                    })?;
-
-                    if let Some(doc_id) = doc.id() {
-                        let systemstore = txn.systemstore().map_err(|e| {
-                            query::error::QueryError::execution(format!(
-                                "failed to get systemstore: {}",
-                                e
-                            ))
-                        })?;
-                        register_block_doc_id_mappings(
-                            &systemstore,
-                            &block_result,
-                            &doc_id.to_string(),
-                        )
-                        .await?;
-                    }
-
-                    let col_block_data = write_branchable_collection_block(
-                        &self.db,
-                        collection_name,
-                        &collection,
-                        &blockstore,
-                        &headstore,
-                        block_result.cid,
-                        sign_config.as_ref(),
-                    )
-                    .await?;
-
-                    (block_result.cid, block_result.block, col_block_data)
-                }; // blockstore and headstore dropped here
-
-                // Commit the transaction (all store references now dropped)
-                if let Err(e) = txn.commit().await {
-                    warn!(
-                        collection = %collection_name,
-                        error = %e,
-                        "Failed to commit transaction after update"
-                    );
-                    return Err(crate::error::commit_query_error(e));
-                }
-
-                if let Some(doc_id) = doc.id() {
-                    let (cid, block, col_data) = &commit_result;
-                    self.emit_update_events(
-                        &collection,
-                        &doc_id.to_string(),
-                        *cid,
-                        block.clone(),
-                        col_data.clone(),
-                    );
-                }
-
-                // Count modified fields
-                let fields_modified = doc.values().len();
-                let (cid, block, col_data) = commit_result;
-                let mut result = UpdateResult::with_commit(doc, fields_modified, cid, block);
-                if let Some((col_cid, col_bytes)) = col_data {
-                    result.broadcast_cid = Some(col_cid);
-                    result.broadcast_block = Some(col_bytes);
-                }
-                Ok(result)
-            }
-            Err(e) => {
-                // Discard the transaction on error
-                if let Err(discard_err) = txn.discard() {
-                    warn!(
-                        collection = %collection_name,
-                        error = %discard_err,
-                        "Failed to discard transaction after update error"
-                    );
-                }
-                Err(e)
-            }
+        if let Some(doc_id) = doc.id() {
+            let (cid, block, col_data) = &commit_result;
+            self.emit_update_events(
+                &collection,
+                &doc_id.to_string(),
+                *cid,
+                block.clone(),
+                col_data.clone(),
+            );
         }
+
+        // Count modified fields
+        let fields_modified = doc.values().len();
+        let (cid, block, col_data) = commit_result;
+        let mut result = UpdateResult::with_commit(doc, fields_modified, cid, block);
+        if let Some((col_cid, col_bytes)) = col_data {
+            result.broadcast_cid = Some(col_cid);
+            result.broadcast_block = Some(col_bytes);
+        }
+        Ok(result)
     }
 }


### PR DESCRIPTION
## Context

Single-document create, update, and delete repeated the same auto-commit transaction setup and commit/discard handling. Keeping those paths separate made lifecycle fixes easy to apply inconsistently.

## Changes

- centralize implicit mutation transaction creation and commit/discard finalization
- route create, update, and delete pre-commit failures through the shared lifecycle
- preserve operation-specific errors, no-op delete commits, ACP registration, and post-commit event timing
- reuse the transaction setup helper for existing multi-document entry points without changing their commit models

## Testing

- [x] `cargo test -p db --test write`
- [x] `cargo check -p db --target wasm32-unknown-unknown --no-default-features`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check origin/main...HEAD`

Closes #653
