### PR TITLE
ci: drop iroh from generic FFI artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,19 +161,19 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             platform: linux_amd64
             runner: '["self-hosted", "Linux", "X64"]'
-            features: "--no-default-features --features native,wasmtime-runtime,iroh"
+            features: "--no-default-features --features native,wasmtime-runtime"
           - target: aarch64-unknown-linux-gnu
             platform: linux_arm64
             runner: '["self-hosted", "Linux", "ARM64"]'
-            features: "--no-default-features --features native,wasmtime-runtime,iroh"
+            features: "--no-default-features --features native,wasmtime-runtime"
           - target: x86_64-apple-darwin
             platform: darwin_amd64
             runner: '["self-hosted", "macOS", "ARM64", "studio"]'
-            features: "--no-default-features --features native,wasmtime-runtime,iroh"
+            features: "--no-default-features --features native,wasmtime-runtime"
           - target: aarch64-apple-darwin
             platform: darwin_arm64
             runner: '["self-hosted", "macOS", "ARM64", "studio"]'
-            features: "--no-default-features --features native,wasmtime-runtime,iroh"
+            features: "--no-default-features --features native,wasmtime-runtime"
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Context

The generic Linux and macOS FFI artifacts serve the Go interoperability path, which uses libp2p. Enabling Iroh in those builds adds unused transport code to every artifact.

## Changes

- remove Iroh from the generic Linux and macOS FFI release builds
- keep libp2p enabled for Go interoperability
- leave the Iroh-capable iOS XCFramework unchanged

## Size

| macOS arm64 dylib | Size |
| --- | ---: |
| With Iroh | 32.17 MiB |
| Without Iroh | 25.54 MiB |
| Reduction | 6.62 MiB (20.6%) |

## Testing

- [x] `cargo build --release -p ffi --no-default-features --features native,wasmtime-runtime`
- [x] `cargo tree -p ffi --no-default-features --features native,wasmtime-runtime -i libp2p`
- [x] `ffi-test run node -v --skip-build`
- [x] C header generation
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`

Closes #1341
