### PR TITLE
fix(db): honor Ollama embedding contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3320,6 +3320,7 @@ dependencies = [
  "anyhow",
  "async-lock",
  "async-trait",
+ "axum",
  "base64 0.22.1",
  "blockstore",
  "blst",

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -102,7 +102,8 @@ p2p = { path = "../p2p", default-features = false }
 wasm-bindgen-futures = "0.4"
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "sync", "time"] }
+axum.workspace = true
 proptest.workspace = true
 blst = "0.3"
 getrandom = "0.2"

--- a/crates/db/src/search/embedding.rs
+++ b/crates/db/src/search/embedding.rs
@@ -6,6 +6,9 @@ use std::collections::HashSet;
 use std::sync::OnceLock;
 use tracing::warn;
 
+const DEFAULT_OLLAMA_URL: &str = "http://localhost:11434/api";
+const DEFAULT_OPENAI_URL: &str = "https://api.openai.com/v1";
+
 #[cfg(not(target_arch = "wasm32"))]
 type EmbeddingError = Box<dyn std::error::Error + Send + Sync>;
 #[cfg(target_arch = "wasm32")]
@@ -56,14 +59,6 @@ pub async fn set_embedding(
             }
         }
 
-        if !embedding.provider.is_empty() && embedding.provider != "openai" {
-            warn!(
-                provider = %embedding.provider,
-                field = %embedding.field_name,
-                "embedding provider is not recognized, using OpenAI-compatible API"
-            );
-        }
-
         let resolved_config = match resolve_embedding_config(embedding, embedding_config) {
             Ok(config) => config,
             // Missing runtime config is non-fatal by design: collection schemas may
@@ -95,6 +90,7 @@ pub async fn set_embedding(
         }
 
         let vec = call_embedding(
+            &embedding.provider,
             resolved_config.url,
             resolved_config.model,
             &embedding_config.api_key,
@@ -132,9 +128,15 @@ pub async fn embed_text(
         })
         .ok_or_else(|| anyhow!("embedding model is empty"))?;
 
-    let vector = call_embedding(url, resolved_model, &embedding_config.api_key, text)
-        .await
-        .map_err(|err| anyhow!(err.to_string()))?;
+    let vector = call_embedding(
+        "openai",
+        url,
+        resolved_model,
+        &embedding_config.api_key,
+        text,
+    )
+    .await
+    .map_err(|err| anyhow!(err.to_string()))?;
     Ok(vector)
 }
 
@@ -165,14 +167,17 @@ pub fn resolve_embedding_config<'a>(
     embedding: &'a VectorEmbeddingDescription,
     embedding_config: &'a EmbeddingClientConfig,
 ) -> Result<ResolvedEmbeddingConfig<'a>, MissingEmbeddingConfig> {
-    let url = if embedding.url.is_empty() {
+    let url = if !embedding.url.is_empty() {
+        embedding.url.as_str()
+    } else if !embedding_config.url.is_empty() {
         embedding_config.url.as_str()
     } else {
-        embedding.url.as_str()
+        match embedding.provider.as_str() {
+            "ollama" => DEFAULT_OLLAMA_URL,
+            "openai" => DEFAULT_OPENAI_URL,
+            _ => return Err(MissingEmbeddingConfig::Url),
+        }
     };
-    if url.is_empty() {
-        return Err(MissingEmbeddingConfig::Url);
-    }
 
     let model = if embedding.model.is_empty() {
         embedding_config.model.as_str()
@@ -187,19 +192,27 @@ pub fn resolve_embedding_config<'a>(
 }
 
 async fn call_embedding(
+    provider: &str,
     url: &str,
     model: &str,
     api_key: &str,
     text: &str,
 ) -> Result<Vec<f64>, EmbeddingError> {
     let endpoint = format!("{}/embeddings", url.trim_end_matches('/'));
-    let body = serde_json::json!({
-        "model": model,
-        "input": text,
-    });
+    let (body, response_pointer) = match provider {
+        "ollama" => (
+            serde_json::json!({ "model": model, "prompt": text }),
+            "/embedding",
+        ),
+        "openai" => (
+            serde_json::json!({ "model": model, "input": text }),
+            "/data/0/embedding",
+        ),
+        _ => return Err(format!("unsupported embedding provider: {provider}").into()),
+    };
 
     let mut request = embedding_client().post(&endpoint);
-    if !api_key.is_empty() {
+    if provider == "openai" && !api_key.is_empty() {
         request = request.bearer_auth(api_key);
     }
 
@@ -213,13 +226,34 @@ async fn call_embedding(
 
     let result: serde_json::Value = resp.json().await?;
     let embedding = result
-        .pointer("/data/0/embedding")
+        .pointer(response_pointer)
         .and_then(|v| v.as_array())
-        .ok_or("embedding response missing data[0].embedding")?;
+        .ok_or_else(|| format!("embedding response missing {response_pointer}"))?;
 
-    let vec = parse_embedding_vector(embedding).map_err(|err| -> EmbeddingError { err.into() })?;
+    let mut vec =
+        parse_embedding_vector(embedding).map_err(|err| -> EmbeddingError { err.into() })?;
+    if provider == "ollama" {
+        normalize_embedding(&mut vec)?;
+    }
 
     Ok(vec)
+}
+
+fn normalize_embedding(embedding: &mut [f64]) -> Result<(), EmbeddingError> {
+    let magnitude = embedding
+        .iter()
+        .map(|value| value * value)
+        .sum::<f64>()
+        .sqrt();
+    if magnitude == 0.0 {
+        return Err("embedding response contains a zero vector".into());
+    }
+    if (magnitude - 1.0).abs() >= 1e-6 {
+        for value in embedding {
+            *value /= magnitude;
+        }
+    }
+    Ok(())
 }
 
 fn embedding_client() -> &'static reqwest::Client {

--- a/crates/db/tests/search/embedding.rs
+++ b/crates/db/tests/search/embedding.rs
@@ -5,11 +5,15 @@ use document::Document;
 use schema::VectorEmbeddingDescription;
 
 fn embedding_with(url: &str, model: &str) -> VectorEmbeddingDescription {
+    embedding_with_provider("openai", url, model)
+}
+
+fn embedding_with_provider(provider: &str, url: &str, model: &str) -> VectorEmbeddingDescription {
     VectorEmbeddingDescription {
         field_name: "content_v".to_string(),
         fields: vec!["content".to_string()],
         model: model.to_string(),
-        provider: "openai".to_string(),
+        provider: provider.to_string(),
         template: String::new(),
         url: url.to_string(),
     }
@@ -53,13 +57,30 @@ fn resolve_embedding_config_falls_back_to_node_values() {
 }
 
 #[test]
-fn resolve_embedding_config_requires_url() {
+fn resolve_embedding_config_uses_openai_default_url() {
     let embedding = embedding_with("", "schema-model");
     let config = EmbeddingClientConfig::new();
 
     assert_eq!(
-        resolve_embedding_config(&embedding, &config),
-        Err(MissingEmbeddingConfig::Url)
+        resolve_embedding_config(&embedding, &config).unwrap(),
+        ResolvedEmbeddingConfig {
+            url: "https://api.openai.com/v1",
+            model: "schema-model",
+        }
+    );
+}
+
+#[test]
+fn resolve_embedding_config_uses_ollama_default_url() {
+    let embedding = embedding_with_provider("ollama", "", "schema-model");
+    let config = EmbeddingClientConfig::new();
+
+    assert_eq!(
+        resolve_embedding_config(&embedding, &config).unwrap(),
+        ResolvedEmbeddingConfig {
+            url: "http://localhost:11434/api",
+            model: "schema-model",
+        }
     );
 }
 
@@ -85,7 +106,7 @@ fn parse_embedding_vector_errors_on_non_numeric_value() {
 
 #[tokio::test]
 async fn set_embedding_skips_when_effective_config_is_missing() {
-    let embeddings = vec![embedding_with("", "")];
+    let embeddings = vec![embedding_with_provider("unknown", "", "")];
     let mut doc = Document::new();
     doc.set("content", "hello");
 
@@ -101,4 +122,55 @@ async fn set_embedding_skips_when_effective_config_is_missing() {
 
     assert!(generated.is_empty());
     assert!(doc.get("content_v").is_none());
+}
+
+#[tokio::test]
+async fn set_embedding_uses_ollama_contract() {
+    use axum::{routing::post, Json, Router};
+    use serde_json::{json, Value};
+    use tokio::net::TcpListener;
+
+    async fn embed(Json(request): Json<Value>) -> Json<Value> {
+        assert_eq!(
+            request,
+            json!({"model": "nomic-embed-text", "prompt": "hello\n"})
+        );
+        Json(json!({"embedding": [3.0, 4.0]}))
+    }
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        axum::serve(
+            listener,
+            Router::new().route("/api/embeddings", post(embed)),
+        )
+        .await
+        .unwrap();
+    });
+
+    let embeddings = vec![embedding_with_provider(
+        "ollama",
+        &format!("http://{address}/api"),
+        "nomic-embed-text",
+    )];
+    let mut doc = Document::new();
+    doc.set("content", "hello");
+
+    let generated = set_embedding(
+        &embeddings,
+        &mut doc,
+        true,
+        None,
+        &EmbeddingClientConfig::new(),
+    )
+    .await
+    .unwrap();
+    server.abort();
+
+    assert_eq!(generated, vec!["content_v"]);
+    assert_eq!(
+        doc.get("content_v"),
+        Some(&document::NormalValue::Float64Array(vec![0.6, 0.8]))
+    );
 }

--- a/tools/ffi-test/src/embedding_fixture.rs
+++ b/tools/ffi-test/src/embedding_fixture.rs
@@ -87,11 +87,9 @@ impl Drop for EmbeddingFixture {
 }
 
 async fn embeddings(Json(_request): Json<Value>) -> Json<Value> {
-    Json(json!({
-        "data": [{
-            "embedding": vec![0.0; EMBEDDING_DIMENSIONS],
-        }],
-    }))
+    let mut embedding = vec![0.0; EMBEDDING_DIMENSIONS];
+    embedding[0] = 1.0;
+    Json(json!({ "embedding": embedding }))
 }
 
 #[cfg(test)]
@@ -102,9 +100,9 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn serves_openai_compatible_embedding() {
+    async fn serves_ollama_embedding() {
         let (_fixture, address) = EmbeddingFixture::start_on("127.0.0.1:0").await.unwrap();
-        let body = r#"{"model":"nomic-embed-text","input":"hello"}"#;
+        let body = r#"{"model":"nomic-embed-text","prompt":"hello"}"#;
         let request = format!(
             "POST /api/embeddings HTTP/1.1\r\nHost: {address}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
             body.len()
@@ -119,7 +117,7 @@ mod tests {
         let (_, body) = response.split_once("\r\n\r\n").unwrap();
         let json: Value = serde_json::from_str(body).unwrap();
         assert_eq!(
-            json.pointer("/data/0/embedding")
+            json.pointer("/embedding")
                 .and_then(Value::as_array)
                 .map(Vec::len),
             Some(EMBEDDING_DIMENSIONS)


### PR DESCRIPTION
## Context

Embedding generation currently applies the OpenAI request and response contract to every provider. Ollama uses a different endpoint, payload, response shape, and authentication model, so configured Ollama embeddings cannot be generated correctly.

This depends on #1630, which carries the shared clippy cleanup.

## Changes

- add provider-specific OpenAI and Ollama embedding requests
- use provider-appropriate default endpoints and authentication
- honor schema URL overrides before falling back to node configuration
- normalize returned vectors and update the FFI embedding fixture

## Testing

- [x] `cargo clippy --profile super-dev -p db -p ffi-test --all-targets -- -D warnings`
- [x] `cargo test --profile super-dev -p db --test search embedding -- --nocapture`
- [x] `cargo test --profile super-dev -p ffi-test embedding_fixture -- --nocapture`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check origin/main...HEAD`

Refs #634