### PR TITLE
fix(query): encode commit signatures as base64

### DIFF
--- a/crates/db/src/read/commits/conversion.rs
+++ b/crates/db/src/read/commits/conversion.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 
+use base64::Engine;
 use cid::Cid;
 use defra_core::block::{Block, Signature};
 use document::Document;
@@ -92,7 +93,6 @@ impl<S: Store> CommitsFetcher<S> {
 
         let delta_data = self.get_delta_data(&block.delta);
         if let Some(data) = delta_data {
-            use base64::Engine;
             map.insert(
                 "delta".to_string(),
                 json!(base64::engine::general_purpose::STANDARD.encode(&data)),
@@ -191,7 +191,7 @@ impl<S: Store> CommitsFetcher<S> {
                     let sig_json = json!({
                         "type": sig_type,
                         "identity": String::from_utf8_lossy(&sig.header.identity).to_string(),
-                        "value": hex::encode(&sig.value),
+                        "value": base64::engine::general_purpose::STANDARD.encode(&sig.value),
                     });
                     tracing::debug!(sig_type, "Signature loaded successfully");
                     sig_json

--- a/crates/db/tests/read/commits_suite.rs
+++ b/crates/db/tests/read/commits_suite.rs
@@ -87,7 +87,9 @@ mod shared_owner_tests {
     use storage::RegolithStore;
 
     use async_lock::Mutex;
-    use defra_core::{Block, CrdtDelta, LwwDeltaPayload};
+    use defra_core::{
+        Block, CrdtDelta, LwwDeltaPayload, Signature, SignatureHeader, SignatureType,
+    };
     use document::{DocID, NormalValue};
 
     use db::read::commits::{CommitsFetcher, CommitsQueryOptions};
@@ -156,5 +158,65 @@ mod shared_owner_tests {
             .filter_map(|document| document.id().map(ToString::to_string))
             .collect();
         assert_eq!(document_owners, owners.into_iter().collect());
+    }
+
+    #[tokio::test]
+    async fn signature_value_uses_graphql_base64_encoding() {
+        let db = Arc::new(DB::new(RegolithStore::in_memory().unwrap()).unwrap());
+        let signature = Signature::new(
+            SignatureHeader::new(SignatureType::ES256K, b"identity".to_vec()),
+            vec![1, 2, 3, 4],
+        );
+        let signature_cid = signature.generate_cid().unwrap();
+        let mut data = Vec::new();
+        ciborium::into_writer(&NormalValue::String("value".to_string()), &mut data).unwrap();
+        let block = Block::new_with_options(
+            CrdtDelta::Lww(LwwDeltaPayload {
+                field_name: "name".to_string(),
+                schema_version_id: "v1".to_string(),
+                priority: 1,
+                data,
+            }),
+            vec![],
+            vec![],
+            None,
+            Some(signature_cid),
+        );
+        let cid = block.generate_cid().unwrap();
+        let doc_id = DocID::new_v0(defra_core::block::generate_cid_from_bytes(b"owner").unwrap())
+            .to_string();
+
+        let txn = db.new_txn(false).await.unwrap();
+        {
+            let blockstore = txn.blockstore().unwrap();
+            let systemstore = txn.systemstore().unwrap();
+            blockstore
+                .set(&signature_cid.to_bytes(), &signature.to_dag_cbor().unwrap())
+                .await
+                .unwrap();
+            blockstore
+                .set(&cid.to_bytes(), &block.to_dag_cbor().unwrap())
+                .await
+                .unwrap();
+            db::docid::map::set_block_doc_id_mapping(&systemstore, &cid.to_string(), &doc_id)
+                .await
+                .unwrap();
+        }
+        txn.commit().await.unwrap();
+
+        let commits_txn = db.new_txn(true).await.unwrap();
+        let commits = CommitsFetcher::new(Arc::new(Mutex::new(Some(commits_txn))))
+            .fetch_commits(&CommitsQueryOptions {
+                cid: Some(cid.to_string()),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        let signature = commits[0]
+            .get("signature")
+            .and_then(NormalValue::as_json)
+            .unwrap();
+
+        assert_eq!(signature["value"], "AQIDBA==");
     }
 }

--- a/crates/defra-version/src/lib.rs
+++ b/crates/defra-version/src/lib.rs
@@ -12,10 +12,10 @@ pub const GO_COMPAT_TAG: &str = "";
 /// Deliberately independent of `GO_COMPAT_COMMIT`: that pin selects the Go
 /// binary the parity job measures against and tracks upstream drift, while this
 /// one fixes the Go *test corpus* the FFI oracle runs, so its pass rate stays
-/// comparable across baseline bumps. It lives on `jack/ffi-rust-compat`, a
-/// maintained chore branch upstream does not merge, and moves only when we
-/// retarget the parity claim or fix the client.
-pub const GO_FFI_CLIENT_COMMIT: &str = "f2f532b2";
+/// comparable across baseline bumps. It lives on a dedicated compatibility
+/// branch upstream does not merge, and moves only when we retarget the parity
+/// claim or fix the client.
+pub const GO_FFI_CLIENT_COMMIT: &str = "e7cd3a8de";
 
 /// Go compatibility metadata.
 #[derive(Debug, Clone, Serialize)]

--- a/tools/ffi-test/src/error.rs
+++ b/tools/ffi-test/src/error.rs
@@ -8,8 +8,7 @@ pub enum FfiTestError {
 
     #[error(
         "Go checkout not found at {path}. It must be a checkout of \
-         sourcenetwork/defradb carrying the rustffi client: the \
-         `edjroz/ffi-rust-compat` branch, or one based on it"
+         sourcenetwork/defradb carrying the rustffi client"
     )]
     GoWorktreeNotFound { path: String },
 

--- a/tools/ffi-test/src/worktree.rs
+++ b/tools/ffi-test/src/worktree.rs
@@ -467,16 +467,13 @@ mod tests {
     }
 
     #[test]
-    fn the_missing_go_worktree_hint_names_the_client_branch() {
+    fn the_missing_go_worktree_hint_names_the_required_client() {
         let hint = FfiTestError::GoWorktreeNotFound {
             path: "/r/defradb-ffi-port".to_string(),
         }
         .to_string();
 
-        assert!(
-            hint.contains("edjroz/ffi-rust-compat"),
-            "names the branch carrying the client: {hint}"
-        );
+        assert!(hint.contains("rustffi client"), "names the client: {hint}");
         // the path may have come from --go-path or DEFRADB_GO_REPO, where
         // `git worktree add` is the wrong mechanism entirely
         assert!(


### PR DESCRIPTION
## Context

Commit signatures are byte values on the wire, but the Rust GraphQL response encodes them as hexadecimal text while Go clients expect standard base64. The FFI compatibility revision also predates the corresponding Go client support.

This depends on #1630, which carries the shared clippy cleanup.

## Changes

- encode commit signature values as standard base64
- update the GraphQL signature regression expectation
- pin the Go FFI client to the audited compatibility revision
- make the missing-client error independent of a development branch name

## Testing

- [x] `cargo clippy --profile super-dev -p db -p ffi-test -p defra-version --all-targets -- -D warnings`
- [x] `cargo test --profile super-dev -p db --test query signature -- --nocapture`
- [x] `cargo test --profile super-dev -p ffi-test`
- [x] `cargo test --profile super-dev -p defra-version`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check origin/main...HEAD`

Refs #1510