### PR TITLE
ci: run encryption and SourceHub Go compatibility tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -471,6 +471,7 @@ jobs:
         run: >-
           cargo test --profile super-dev -p integration-test
           --test basic --test query --test acp --test nac --test backup --test p2p --test identity
+          --test encryption --test sourcehub
           -- --test-threads=1 go_
           --skip go_acp_link_collection_nonexistent_policy_reject
           --skip go_acp_link_collection_nonexistent_resource_reject

--- a/tools/integration-test/tests/encryption/cross_runtime_p2p.rs
+++ b/tools/integration-test/tests/encryption/cross_runtime_p2p.rs
@@ -12,17 +12,13 @@
 //! exercise Go↔Rust KMS wire-compat over libp2p: the reader must fetch the DEK
 //! from the writer's KMS over the `encryption` gossip topic (bare CBOR
 //! `FetchEncryptionKeyRequest`/`Reply`, ECIES-wrapped key blocks) and decrypt.
-//! These require the Go KMS binary at `GO_KMS_BINARY`.
+//! These require the Go `defradb` binary on `PATH`.
 
 use std::path::Path;
 use std::time::{Duration, Instant};
 
 use integration_test::identity::generate_identity;
-use integration_test::{BinarySource, TestCluster};
-
-/// Path to the Go `defradb` binary built with KMS + the #4778 fix.
-const GO_KMS_BINARY: &str =
-    "/Users/johnzampolin/go/src/github.com/sourcenetwork/defradb/build/defradb";
+use integration_test::TestCluster;
 
 #[tokio::test]
 async fn rust_rust_encrypted_p2p_replication() {
@@ -128,7 +124,7 @@ async fn go_rust_kms_interop(writer_idx: usize, reader_idx: usize) {
     // `encryption`, and the Rust requester's publish has zero targets. Dev
     // mode gives both nodes a node identity. We also mint explicit request
     // identities so the fetch carries a real DID. Node index 0 = Rust, 1 = Go.
-    let go_binary = Path::new(GO_KMS_BINARY);
+    let go_binary = Path::new("defradb");
     let rust_identity =
         generate_identity(go_binary).expect("generate request identity for rust node");
     let go_identity = generate_identity(go_binary).expect("generate request identity for go node");
@@ -141,7 +137,6 @@ async fn go_rust_kms_interop(writer_idx: usize, reader_idx: usize) {
         .with_development()
         .with_node_identity(0, rust_identity.private_key_hex)
         .with_node_identity(1, go_identity.private_key_hex)
-        .with_go_binary(BinarySource::Path(GO_KMS_BINARY.into()))
         .build()
         .await
         .expect("build mixed go/rust cluster with p2p + encryption");

--- a/tools/integration-test/tests/encryption/se_cross_runtime.rs
+++ b/tools/integration-test/tests/encryption/se_cross_runtime.rs
@@ -33,11 +33,7 @@
 
 use std::time::{Duration, Instant};
 
-use integration_test::{BinarySource, TestCluster};
-
-/// Path to the Go `defradb` binary built with KMS + searchable encryption.
-const GO_KMS_BINARY: &str =
-    "/Users/johnzampolin/go/src/github.com/sourcenetwork/defradb/build/defradb";
+use integration_test::TestCluster;
 
 /// A fixed 32-byte AES-256 searchable-encryption key shared across nodes.
 /// Distinct value per byte so a wrong key (e.g. a freshly generated one)
@@ -187,7 +183,6 @@ async fn go_rust_se_cross_node_rust_owner() {
         .with_p2p()
         .with_encryption()
         .with_shared_searchable_encryption_key(SHARED_SE_KEY)
-        .with_go_binary(BinarySource::Path(GO_KMS_BINARY.into()))
         .build()
         .await
         .expect("build mixed go/rust cluster with shared SE key");
@@ -230,7 +225,6 @@ async fn go_to_rust_se_cross_node() {
         .with_p2p()
         .with_encryption()
         .with_shared_searchable_encryption_key(SHARED_SE_KEY)
-        .with_go_binary(BinarySource::Path(GO_KMS_BINARY.into()))
         .build()
         .await
         .expect("build mixed go/rust cluster with shared SE key");


### PR DESCRIPTION
## Context

The Go compatibility job does not run the encryption or SourceHub integration suites, leaving those cross-runtime paths outside the merge gate. The tests also contain a developer-specific Go binary path instead of using the binary prepared by CI.

This depends on #1630, which carries the shared clippy cleanup.

## Changes

- add the encryption and SourceHub suites to the Go compatibility job
- resolve the Go `defradb` binary from `PATH`
- keep local runs configurable through the existing harness environment

## Testing

- [x] `cargo clippy --profile super-dev -p integration-test --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check origin/main...HEAD`

Closes #1402