### PR TITLE
fix(p2p): cancel pending sync work during shutdown

### DIFF
--- a/crates/embedded/src/node.rs
+++ b/crates/embedded/src/node.rs
@@ -508,30 +508,38 @@ where
         ..Default::default()
     };
 
-    let mut p2p_setup = match &config.transport {
-        TransportConfig::None => None,
-        TransportConfig::Libp2p(libp2p) => Some(
-            crate::node_p2p::setup_libp2p(
-                store.clone(),
-                database.clone(),
-                event_bus.clone(),
-                libp2p,
-                sync_config.clone(),
-            )
-            .await?,
-        ),
+    let p2p_setup = match &config.transport {
+        TransportConfig::None => Ok(None),
+        TransportConfig::Libp2p(libp2p) => crate::node_p2p::setup_libp2p(
+            store.clone(),
+            database.clone(),
+            event_bus.clone(),
+            libp2p,
+            sync_config.clone(),
+        )
+        .await
+        .map(Some),
         #[cfg(feature = "iroh")]
-        TransportConfig::Iroh(iroh) => Some(
-            crate::node_p2p::setup_iroh(
-                store.clone(),
-                database.clone(),
-                event_bus.clone(),
-                iroh,
-                sync_config.clone(),
-                raw_identity.clone(),
-            )
-            .await?,
-        ),
+        TransportConfig::Iroh(iroh) => crate::node_p2p::setup_iroh(
+            store.clone(),
+            database.clone(),
+            event_bus.clone(),
+            iroh,
+            sync_config.clone(),
+            raw_identity.clone(),
+        )
+        .await
+        .map(Some),
+    };
+    let mut p2p_setup = match p2p_setup {
+        Ok(setup) => setup,
+        Err(error) => {
+            background_tasks.shutdown().await;
+            if let Err(close_error) = database.close().await {
+                tracing::warn!(%close_error, "failed to close database after P2P setup error");
+            }
+            return Err(error);
+        }
     };
 
     let acp_setup =

--- a/crates/embedded/src/node_p2p.rs
+++ b/crates/embedded/src/node_p2p.rs
@@ -63,6 +63,21 @@ async fn shutdown_libp2p_host(handle: &p2p::P2PHostHandle, host_task: tokio::tas
     }
 }
 
+#[cfg(feature = "iroh")]
+async fn shutdown_iroh_endpoint(
+    transport: &p2p::iroh::IrohTransport,
+    endpoint_task: tokio::task::JoinHandle<()>,
+) {
+    use p2p::transport::P2PTransport;
+
+    if let Err(error) = transport.shutdown().await {
+        tracing::debug!(%error, "failed to signal Iroh endpoint during setup rollback");
+    }
+    if let Err(error) = endpoint_task.await {
+        tracing::debug!(%error, "Iroh endpoint task failed during setup rollback");
+    }
+}
+
 pub(crate) async fn setup_libp2p<S>(
     store: Arc<S>,
     database: Arc<db::DB<S>>,
@@ -466,7 +481,7 @@ where
     let head_provider: Arc<dyn p2p::sync::DocumentHeadProvider> =
         Arc::new(db::merge::create_head_provider(database.clone()));
     let (mut coordinator, sync_events_rx) =
-        p2p::sync::SyncCoordinator::with_head_provider_and_serve_gate(
+        match p2p::sync::SyncCoordinator::with_head_provider_and_serve_gate(
             transport.clone(),
             blockstore.clone(),
             sync_config,
@@ -479,13 +494,44 @@ where
             serve_acp.clone(),
         )
         .await
-        .map_err(|error| anyhow!("failed to create iroh sync coordinator: {error}"))?;
+        {
+            Ok(coordinator) => coordinator,
+            Err(error) => {
+                shutdown_iroh_endpoint(&transport, endpoint_task).await;
+                return Err(anyhow!("failed to create iroh sync coordinator: {error}"));
+            }
+        };
 
     let failure_rx = db::merge::attach_failure_channel(&mut coordinator, 1024);
     let coordinator = Arc::new(coordinator);
     coordinator
         .install_pending_dag_store(Arc::new(p2p::sync::PendingDagStore::new(store.clone())))
         .await;
+    let local_peer_id = {
+        use p2p::transport::P2PTransport;
+        transport.local_peer_id().to_string()
+    };
+    let kms_transport = match p2p::kms::PubsubKeyTransport::new(
+        transport.clone(),
+        Arc::new(p2p::AnonymousResolver),
+    )
+    .await
+    {
+        Ok(transport) => transport,
+        Err(error) => {
+            coordinator.shutdown().await;
+            shutdown_iroh_endpoint(&transport, endpoint_task).await;
+            return Err(anyhow!("failed to create KMS transport: {error}"));
+        }
+    };
+    coordinator.install_kms_transport(kms_transport.clone());
+    let replication = db::merge::create_replication_stack(
+        database.clone(),
+        blockstore.clone(),
+        coordinator.clone(),
+    );
+    let merge_handler_inner_for_kms = replication.merge_handler_inner.clone();
+
     let coordinator_for_restore = coordinator.clone();
     let pending_dag_resync_task = tokio::spawn(async move {
         coordinator_for_restore
@@ -501,22 +547,6 @@ where
             .run_pending_dag_retry_clock(std::time::Duration::from_secs(2))
             .await;
     });
-    let replication = db::merge::create_replication_stack(
-        database.clone(),
-        blockstore.clone(),
-        coordinator.clone(),
-    );
-
-    let local_peer_id = {
-        use p2p::transport::P2PTransport;
-        transport.local_peer_id().to_string()
-    };
-    let kms_transport =
-        p2p::kms::PubsubKeyTransport::new(transport.clone(), Arc::new(p2p::AnonymousResolver))
-            .await
-            .map_err(|e| anyhow!("failed to create KMS transport: {e}"))?;
-    coordinator.install_kms_transport(kms_transport.clone());
-    let merge_handler_inner_for_kms = replication.merge_handler_inner.clone();
 
     match db::merge::load_persisted_collections(&coordinator).await {
         Ok(count) if count > 0 => tracing::debug!(count, "loaded persisted P2P collections"),

--- a/crates/embedded/src/node_p2p.rs
+++ b/crates/embedded/src/node_p2p.rs
@@ -54,6 +54,15 @@ pub(crate) struct P2PSetup<S: storage::corekv::Store + 'static> {
     pub manage_query_correlator: p2p::ManageQueryCorrelator,
 }
 
+async fn shutdown_libp2p_host(handle: &p2p::P2PHostHandle, host_task: tokio::task::JoinHandle<()>) {
+    if let Err(error) = handle.shutdown().await {
+        tracing::debug!(%error, "failed to signal P2P host during setup rollback");
+    }
+    if let Err(error) = host_task.await {
+        tracing::debug!(%error, "P2P host task failed during setup rollback");
+    }
+}
+
 pub(crate) async fn setup_libp2p<S>(
     store: Arc<S>,
     database: Arc<db::DB<S>>,
@@ -68,6 +77,10 @@ where
     use p2p::sync::DocumentHeadProvider;
     use storage::stores::Peerstore;
 
+    let listen_addr = config
+        .listen_addr
+        .parse()
+        .map_err(|error| anyhow!("invalid multiaddr '{}': {error}", config.listen_addr))?;
     let blockstore = Arc::new(EmbeddedBlockstore::new(store.clone(), true));
     let bitswap_store = BitswapStoreAdapter::new(blockstore.clone());
 
@@ -112,14 +125,10 @@ where
         host.run().await;
     });
 
-    let listen_addr = config
-        .listen_addr
-        .parse()
-        .map_err(|error| anyhow!("invalid multiaddr '{}': {error}", config.listen_addr))?;
-    handle
-        .listen(listen_addr)
-        .await
-        .map_err(|error| anyhow!("failed to start listening: {error}"))?;
+    if let Err(error) = handle.listen(listen_addr).await {
+        shutdown_libp2p_host(&handle, host_task).await;
+        return Err(anyhow!("failed to start listening: {error}"));
+    }
 
     for topic in [
         DefraTopic::DocSync,
@@ -136,7 +145,7 @@ where
     let head_provider: Arc<dyn DocumentHeadProvider> =
         Arc::new(db::merge::create_head_provider(database.clone()));
     let (mut coordinator, sync_events_rx) =
-        p2p::sync::SyncCoordinator::with_head_provider_and_serve_gate(
+        match p2p::sync::SyncCoordinator::with_head_provider_and_serve_gate(
             p2p::Libp2pTransport::new(handle.clone()),
             blockstore.clone(),
             sync_config,
@@ -149,13 +158,46 @@ where
             serve_acp.clone(),
         )
         .await
-        .map_err(|error| anyhow!("failed to create sync coordinator: {error}"))?;
+        {
+            Ok(coordinator) => coordinator,
+            Err(error) => {
+                shutdown_libp2p_host(&handle, host_task).await;
+                return Err(anyhow!("failed to create sync coordinator: {error}"));
+            }
+        };
 
     let failure_rx = db::merge::attach_failure_channel(&mut coordinator, 1024);
     let coordinator = Arc::new(coordinator);
     coordinator
         .install_pending_dag_store(Arc::new(p2p::sync::PendingDagStore::new(store.clone())))
         .await;
+    let replication = db::merge::create_replication_stack(
+        database.clone(),
+        blockstore.clone(),
+        coordinator.clone(),
+    );
+
+    let kms_libp2p_transport = p2p::Libp2pTransport::new(handle.clone());
+    let local_peer_id = {
+        use p2p::transport::P2PTransport;
+        kms_libp2p_transport.local_peer_id().to_string()
+    };
+    let kms_transport = match p2p::kms::PubsubKeyTransport::new(
+        kms_libp2p_transport,
+        Arc::new(p2p::HandlePeerIdentityResolver::new(handle.clone())),
+    )
+    .await
+    {
+        Ok(transport) => transport,
+        Err(error) => {
+            coordinator.shutdown().await;
+            shutdown_libp2p_host(&handle, host_task).await;
+            return Err(anyhow!("failed to create KMS transport: {error}"));
+        }
+    };
+    coordinator.install_kms_transport(kms_transport.clone());
+    let merge_handler_inner_for_kms = replication.merge_handler_inner.clone();
+
     let coordinator_for_restore = coordinator.clone();
     let pending_dag_resync_task = tokio::spawn(async move {
         coordinator_for_restore
@@ -171,25 +213,6 @@ where
             .run_pending_dag_retry_clock(std::time::Duration::from_secs(2))
             .await;
     });
-    let replication = db::merge::create_replication_stack(
-        database.clone(),
-        blockstore.clone(),
-        coordinator.clone(),
-    );
-
-    let kms_libp2p_transport = p2p::Libp2pTransport::new(handle.clone());
-    let local_peer_id = {
-        use p2p::transport::P2PTransport;
-        kms_libp2p_transport.local_peer_id().to_string()
-    };
-    let kms_transport = p2p::kms::PubsubKeyTransport::new(
-        kms_libp2p_transport,
-        Arc::new(p2p::HandlePeerIdentityResolver::new(handle.clone())),
-    )
-    .await
-    .map_err(|e| anyhow!("failed to create KMS transport: {e}"))?;
-    coordinator.install_kms_transport(kms_transport.clone());
-    let merge_handler_inner_for_kms = replication.merge_handler_inner.clone();
 
     match db::merge::load_persisted_collections(&coordinator).await {
         Ok(count) if count > 0 => tracing::debug!(count, "loaded persisted P2P collections"),

--- a/crates/embedded/tests/shutdown.rs
+++ b/crates/embedded/tests/shutdown.rs
@@ -101,6 +101,33 @@ async fn p2p_shutdown_releases_persistent_store() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn failed_p2p_setup_releases_persistent_store() -> Result<()> {
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("data.regolith");
+    let listener = std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))?;
+    let port = listener.local_addr()?.port();
+    let config = EmbeddedNodeConfig {
+        persistence: Persistence::Persistent,
+        transport: TransportConfig::Libp2p(Libp2pConfig {
+            listen_addr: format!("/ip4/127.0.0.1/tcp/{port}"),
+        }),
+        ..Default::default()
+    };
+
+    let result =
+        embedded::build_with_store(Arc::new(storage::RegolithStore::open(&path)?), config).await;
+    assert!(
+        result.is_err(),
+        "P2P setup should fail when the port is busy"
+    );
+
+    let reopened = storage::RegolithStore::open(&path)?;
+    storage::Store::close(&reopened).await?;
+
+    Ok(())
+}
+
 #[derive(Clone)]
 struct SlowCloseStore {
     inner: storage::RegolithStore,

--- a/crates/p2p/src/sync/coordinator/mod.rs
+++ b/crates/p2p/src/sync/coordinator/mod.rs
@@ -515,7 +515,14 @@ impl SyncShutdownHandle {
             None => return false,
         }
 
-        tasks.insert(root_cid, PendingDagFetchTask::Running(tokio::spawn(future)));
+        let shutdown = self.clone();
+        let task = tokio::spawn(async move {
+            tokio::select! {
+                _ = shutdown.cancelled() => {}
+                _ = future => {}
+            }
+        });
+        tasks.insert(root_cid, PendingDagFetchTask::Running(task));
         true
     }
 
@@ -1090,7 +1097,10 @@ mod dag_fetch_limiter_tests {
 #[cfg(test)]
 mod shutdown_tests {
     use super::broadcast::tests::TestTransport;
-    use super::{SyncCoordinator, SyncShutdownHandle, NON_AUTHORITATIVE_BROADCAST_TASK_LIMIT};
+    use super::{
+        SyncCoordinator, SyncShutdownHandle, BACKGROUND_TASK_SHUTDOWN_TIMEOUT,
+        NON_AUTHORITATIVE_BROADCAST_TASK_LIMIT,
+    };
     use cid::Cid;
     use multihash_codetable::{Code, MultihashDigest};
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -1302,6 +1312,22 @@ mod shutdown_tests {
         assert!(shutdown.reserve_pending_dag_fetch(third));
         release.notify_one();
         shutdown.shutdown().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn shutdown_signals_pending_fetches_before_the_drain_timeout() {
+        let shutdown = SyncShutdownHandle::new(1);
+        let root = Cid::new_v1(0x55, Code::Sha2_256.digest(b"pending-root"));
+        assert!(shutdown.spawn_pending_dag_fetch(root, std::future::pending()));
+        tokio::task::yield_now().await;
+
+        let started = tokio::time::Instant::now();
+        shutdown.shutdown().await;
+
+        assert!(
+            started.elapsed() < BACKGROUND_TASK_SHUTDOWN_TIMEOUT,
+            "pending fetch waited for the abort deadline instead of the shutdown signal"
+        );
     }
 
     #[tokio::test]

--- a/crates/p2p/src/sync/coordinator/mod.rs
+++ b/crates/p2p/src/sync/coordinator/mod.rs
@@ -804,7 +804,10 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             if self.runtime.shutdown.is_shutting_down() {
                 return;
             }
-            self.manager.resync_persisted_pending_dags().await;
+            tokio::select! {
+                _ = self.runtime.shutdown.cancelled() => return,
+                _ = self.manager.resync_persisted_pending_dags() => {}
+            }
             tokio::select! {
                 _ = tokio::time::sleep(interval) => {}
                 _ = self.runtime.shutdown.cancelled() => return,
@@ -1086,12 +1089,84 @@ mod dag_fetch_limiter_tests {
 
 #[cfg(test)]
 mod shutdown_tests {
-    use super::{SyncShutdownHandle, NON_AUTHORITATIVE_BROADCAST_TASK_LIMIT};
+    use super::broadcast::tests::TestTransport;
+    use super::{SyncCoordinator, SyncShutdownHandle, NON_AUTHORITATIVE_BROADCAST_TASK_LIMIT};
     use cid::Cid;
     use multihash_codetable::{Code, MultihashDigest};
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
     use std::time::Duration;
+
+    struct BlockingResyncStore {
+        load_calls: std::sync::atomic::AtomicUsize,
+        resync_entered: tokio::sync::Notify,
+    }
+
+    impl BlockingResyncStore {
+        fn new() -> Self {
+            Self {
+                load_calls: std::sync::atomic::AtomicUsize::new(0),
+                resync_entered: tokio::sync::Notify::new(),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl crate::sync::pending_store::PendingDagStorage for BlockingResyncStore {
+        async fn put(
+            &self,
+            _root_cid: &Cid,
+            _record: &crate::sync::pending_store::PersistedPendingDag,
+        ) -> crate::Result<()> {
+            unreachable!()
+        }
+
+        async fn replace_scope_head(
+            &self,
+            _superseded_root: Option<&Cid>,
+            _root_cid: &Cid,
+            _record: &crate::sync::pending_store::PersistedPendingDag,
+        ) -> crate::Result<()> {
+            unreachable!()
+        }
+
+        async fn remove(&self, _root_cid: &Cid) -> crate::Result<()> {
+            unreachable!()
+        }
+
+        async fn load_all(
+            &self,
+        ) -> crate::Result<Vec<(Cid, crate::sync::pending_store::PersistedPendingDag)>> {
+            if self.load_calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                return Ok(Vec::new());
+            }
+            self.resync_entered.notify_one();
+            std::future::pending().await
+        }
+
+        async fn quarantine(
+            &self,
+            _root_cid: &Cid,
+            _entry: &crate::sync::pending_store::PersistedQuarantinedDag,
+        ) -> crate::Result<()> {
+            unreachable!()
+        }
+
+        async fn is_quarantined(&self, _root_cid: &Cid) -> crate::Result<bool> {
+            unreachable!()
+        }
+
+        async fn load_quarantined(
+            &self,
+        ) -> crate::Result<Vec<(Cid, crate::sync::pending_store::PersistedQuarantinedDag)>>
+        {
+            Ok(Vec::new())
+        }
+
+        async fn remove_quarantined(&self, _root_cid: &Cid) -> crate::Result<()> {
+            unreachable!()
+        }
+    }
 
     #[tokio::test]
     async fn shutdown_waits_for_in_flight_background_task_completion() {
@@ -1292,6 +1367,49 @@ mod shutdown_tests {
             .expect("loop must wake on the signal, not wait out its interval")
             .expect("loop task should not panic");
         assert!(exited.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn shutdown_cancels_an_in_flight_pending_resync() {
+        let blockstore = Arc::new(blockstore::DefraBlockstore::new(
+            Arc::new(storage::RegolithStore::in_memory().expect("in-memory store")),
+            true,
+        ));
+        let (coordinator, _events) = SyncCoordinator::new(
+            TestTransport::new(Vec::new()),
+            blockstore,
+            crate::sync::SyncConfig::default(),
+        )
+        .await
+        .expect("coordinator");
+        let pending_store = Arc::new(BlockingResyncStore::new());
+        coordinator
+            .install_pending_dag_store(pending_store.clone())
+            .await;
+        let coordinator = Arc::new(coordinator);
+
+        let resync_task = tokio::spawn({
+            let coordinator = Arc::clone(&coordinator);
+            async move {
+                coordinator
+                    .run_pending_dag_resync(Duration::from_secs(3600))
+                    .await;
+            }
+        });
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            pending_store.resync_entered.notified(),
+        )
+        .await
+        .expect("resync did not enter durable storage");
+        assert!(coordinator.manager().pending_resync_in_flight());
+
+        coordinator.shutdown().await;
+        tokio::time::timeout(Duration::from_secs(5), resync_task)
+            .await
+            .expect("resync did not stop on shutdown")
+            .expect("resync task should not panic");
+        assert!(!coordinator.manager().pending_resync_in_flight());
     }
 
     #[tokio::test]

--- a/crates/p2p/src/sync/manager/process/pending_dag.rs
+++ b/crates/p2p/src/sync/manager/process/pending_dag.rs
@@ -16,6 +16,14 @@ use crate::sync::pending_store::{PersistedPendingDag, PersistedQuarantinedDag};
 
 use super::SyncManager;
 
+struct PendingResyncInFlight<'a>(&'a std::sync::atomic::AtomicBool);
+
+impl Drop for PendingResyncInFlight<'_> {
+    fn drop(&mut self) {
+        self.0.store(false, std::sync::atomic::Ordering::Release);
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct PendingDagLease {
     root_cid: Cid,
@@ -628,10 +636,8 @@ impl<B: Blockstore + 'static> SyncManager<B> {
         {
             return 0;
         }
-        let resynced = self.resync_persisted_pending_dags_inner(store).await;
-        self.pending_resync_in_flight
-            .store(false, std::sync::atomic::Ordering::Release);
-        resynced
+        let _in_flight = PendingResyncInFlight(&self.pending_resync_in_flight);
+        self.resync_persisted_pending_dags_inner(store).await
     }
 
     async fn resync_persisted_pending_dags_inner(


### PR DESCRIPTION
## Context

Several P2P background tasks can outlive their owning operation. Partial setup failures can leave a swarm running, while pending resync and block-fetch tasks can continue after shutdown begins.

This is 1/2 in the P2P reliability stack and depends on #1630.

## Changes

- roll back partially initialized P2P resources when setup fails
- retain and cancel pending resync task handles
- cancel pending block fetches during shutdown
- add focused cleanup and cancellation coverage

## Testing

- [x] `cargo clippy --profile super-dev -p defra-core -p db -p embedded -p p2p --all-targets -- -D warnings`
- [x] `cargo test --profile super-dev -p p2p --lib`
- [x] `cargo test --profile super-dev -p embedded failed_p2p_setup_rolls_back -- --nocapture`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check origin/main...HEAD`

Refs #1356