### PR TITLE
fix(acp): scope node identity bypass to collection operations

### DIFF
--- a/crates/acp/src/read_access.rs
+++ b/crates/acp/src/read_access.rs
@@ -1,7 +1,6 @@
 //! Shared document/collection read-access rule.
 
 use async_trait::async_trait;
-use identity::Did;
 use storage::corekv::MaybeSendSync;
 
 use crate::{DocumentACP, DocumentPermission, Identity, Result};
@@ -26,7 +25,6 @@ pub trait ObjectAccessChecker: MaybeSendSync {
 pub struct DirectChecker<'a> {
     pub acp: &'a dyn DocumentACP,
     pub identity: &'a Identity,
-    pub node_did: Option<&'a Did>,
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
@@ -43,15 +41,6 @@ impl ObjectAccessChecker for DirectChecker<'_> {
                 has_access: true,
                 explicit: true,
             });
-        }
-
-        if let (Some(node), Identity::Authenticated(requester)) = (self.node_did, self.identity) {
-            if node == requester {
-                return Ok(DocAccess {
-                    has_access: true,
-                    explicit: true,
-                });
-            }
         }
 
         if !self

--- a/crates/cli/src/commands/start/server_p2p/iroh.rs
+++ b/crates/cli/src/commands/start/server_p2p/iroh.rs
@@ -85,7 +85,6 @@ impl Node {
             .await;
         let coordinator_for_acp = coordinator.clone();
         let serve_acp_for_acp = serve_acp.clone();
-        let database_for_acp = database.clone();
 
         // Build the KMS pubsub transport and install it on the coordinator so
         // raw gossip on the encryption topic is routed to it (mirrors
@@ -443,10 +442,7 @@ impl Node {
             wire_merge_acp: Some(Box::new(move |acp| {
                 serve_acp_for_acp.set(p2p::bitswap::ServeAcp {
                     resolver: Arc::new(p2p::IrohPeerIdentityResolver::new(transport.clone())),
-                    gate: defra_p2p_adapter::DbBlockReadGate::new_arc(
-                        acp.clone(),
-                        database_for_acp.node_did(),
-                    ),
+                    gate: defra_p2p_adapter::DbBlockReadGate::new_arc(acp.clone()),
                 });
                 coordinator_for_acp.set_document_acp(acp.clone());
                 // Wire the document ACP into the broadcast mutator so newly

--- a/crates/cli/src/commands/start/server_p2p/libp2p.rs
+++ b/crates/cli/src/commands/start/server_p2p/libp2p.rs
@@ -79,7 +79,6 @@ impl Node {
         let coordinator_for_acp = coordinator.clone();
         let serve_acp_for_acp = serve_acp.clone();
         let handle_for_acp = handle.clone();
-        let database_for_acp = database.clone();
 
         // Build the KMS pubsub transport and install it on the coordinator so
         // raw gossip on the encryption topic is routed to it (mirrors
@@ -456,10 +455,7 @@ impl Node {
             wire_merge_acp: Some(Box::new(move |acp| {
                 serve_acp_for_acp.set(p2p::bitswap::ServeAcp {
                     resolver: Arc::new(p2p::HandlePeerIdentityResolver::new(handle_for_acp)),
-                    gate: defra_p2p_adapter::DbBlockReadGate::new_arc(
-                        acp.clone(),
-                        database_for_acp.node_did(),
-                    ),
+                    gate: defra_p2p_adapter::DbBlockReadGate::new_arc(acp.clone()),
                 });
                 coordinator_for_acp.set_document_acp(acp.clone());
                 // Wire the document ACP into the broadcast mutator so newly

--- a/crates/cli/src/commands/start/server_query.rs
+++ b/crates/cli/src/commands/start/server_query.rs
@@ -50,7 +50,6 @@ impl Node {
         .with_mutator(mutator)
         .with_collection_truncator(db::DbCollectionTruncator::new_arc(database.clone()))
         .with_acp(document_acp)
-        .with_node_did(database.node_did())
         .with_lens_store(database.lens_store().clone())
         .with_query_timeout(config.api.query_timeout)
         .with_query_limits(query::QueryLimits {

--- a/crates/db/src/block/heads.rs
+++ b/crates/db/src/block/heads.rs
@@ -208,9 +208,9 @@ pub async fn prune_superseded_heads(
         {
             marker = next_marker(marker_iter.as_mut(), marker_prefix_len).await?;
         }
-        if !marker
+        if marker
             .as_ref()
-            .is_some_and(|(parent, _)| parent.as_slice() == cid_text)
+            .is_none_or(|(parent, _)| parent.as_slice() != cid_text)
         {
             continue;
         }

--- a/crates/db/src/block/verify.rs
+++ b/crates/db/src/block/verify.rs
@@ -298,11 +298,9 @@ async fn load_authorized_block_signature<S: Store>(
                         .map_err(|e| format!("failed to resolve block owners: {}", e))?
                         .ok_or_else(|| "missing permission".to_string())?;
 
-                let node_did = database.node_did();
                 let checker = acp::read_access::DirectChecker {
                     acp: document_acp,
                     identity: caller_identity,
-                    node_did: node_did.as_ref(),
                 };
 
                 let candidates = if owning_doc_ids.is_empty() {

--- a/crates/defra-node/src/dac_api_tests.rs
+++ b/crates/defra-node/src/dac_api_tests.rs
@@ -291,6 +291,80 @@ async fn document_acp_handle_registers_and_checks_a_document() {
 }
 
 #[tokio::test]
+async fn node_identity_does_not_bypass_protected_history_reads() {
+    let _serial = SIGNING_STORE_GUARD.lock().await;
+    defra_core::signing::clear_identity_store();
+    let node_did = register_local_node_identity();
+    let node_identity = identity::Did::new(&node_did).unwrap();
+    let owner = identity::Did::new(DID_A).unwrap();
+
+    let node = EmbeddedNode::builder()
+        .with_node_identity_did(&node_did)
+        .build()
+        .await
+        .unwrap();
+    let policy_id = node.add_dac_policy(DID_A, POLICY_YAML).await.unwrap();
+    node.add_schema(&format!(
+        "type Users @policy(id: \"{policy_id}\", resource: \"users\") {{ name: String }}"
+    ))
+    .await
+    .unwrap();
+
+    let create = node
+        .execute_request_with_retry(
+            query::QueryRequest::new(
+                "mutation { add_Users(input: {name: \"secret\"}) { _docID } }",
+            )
+            .with_identity(Some(owner.clone())),
+            Default::default(),
+        )
+        .await;
+    assert!(!create.has_errors(), "{:?}", create.errors);
+    let doc_id = create.data.as_ref().unwrap()["add_Users"][0]["_docID"]
+        .as_str()
+        .unwrap();
+
+    assert_eq!(visible_users(&node, Some(node_identity.clone())).await, 0);
+
+    let commits_query = format!(
+        r#"query {{ _commits(docID: "{doc_id}", filter: {{fieldName: {{_eq: "_C"}}}}) {{ cid }} }}"#
+    );
+    let node_commits = node
+        .execute_request_with_retry(
+            query::QueryRequest::new(&commits_query).with_identity(Some(node_identity.clone())),
+            Default::default(),
+        )
+        .await;
+    assert!(!node_commits.has_errors(), "{:?}", node_commits.errors);
+    assert!(node_commits.data.unwrap()["_commits"]
+        .as_array()
+        .unwrap()
+        .is_empty());
+
+    let owner_commits = node
+        .execute_request_with_retry(
+            query::QueryRequest::new(&commits_query).with_identity(Some(owner)),
+            Default::default(),
+        )
+        .await;
+    assert!(!owner_commits.has_errors(), "{:?}", owner_commits.errors);
+    let cid = owner_commits.data.unwrap()["_commits"][0]["cid"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    node.authorized_signed_block_bytes(&cid, Some(&node_did))
+        .await
+        .expect_err("the process owner must satisfy document ACP when reading signed blocks");
+    node.authorized_signed_block_bytes(&cid, Some(DID_A))
+        .await
+        .expect("the document owner may read signed block material");
+
+    node.shutdown().await;
+    defra_core::signing::clear_identity_store();
+}
+
+#[tokio::test]
 async fn add_dac_policy_is_gated_by_node_access_control() {
     let _serial = SIGNING_STORE_GUARD.lock().await;
     defra_core::signing::clear_identity_store();

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -1512,7 +1512,6 @@ impl NodeBuilder {
                 .with_mutator(mutator)
                 .with_collection_truncator(db::DbCollectionTruncator::new_arc(database.clone()))
                 .with_acp(document_acp.clone())
-                .with_node_did(database.node_did())
                 .with_lens_store(database.lens_store().clone())
                 .with_query_limits(query_limits);
         let query_runner = if let Some(timeout) = query_timeout {

--- a/crates/defra-node/src/p2p_runtime.rs
+++ b/crates/defra-node/src/p2p_runtime.rs
@@ -284,7 +284,6 @@ pub(super) async fn setup_p2p<S: storage::corekv::Store + 'static>(
     let broadcast_mutator = replication.broadcast_mutator.clone();
     let merge_handler_for_acp = replication.merge_handler.clone();
     let serve_acp_for_acp = serve_acp.clone();
-    let database_for_acp = database.clone();
 
     // 9. Replication loop (transport-generic)
     let coord_for_repl = coordinator.clone();
@@ -385,10 +384,7 @@ pub(super) async fn setup_p2p<S: storage::corekv::Store + 'static>(
         wire_document_acp: Some(Box::new(move |acp, strict| {
             serve_acp_for_acp.set(p2p::bitswap::ServeAcp {
                 resolver: Arc::new(peer_identity_resolver),
-                gate: defra_p2p_adapter::DbBlockReadGate::new_arc(
-                    acp.clone(),
-                    database_for_acp.node_did(),
-                ),
+                gate: defra_p2p_adapter::DbBlockReadGate::new_arc(acp.clone()),
             });
             merge_handler_for_acp.set_document_acp(acp.clone());
             merge_handler_for_acp.set_strict_replicated_doc_access(strict);

--- a/crates/embedded/src/node.rs
+++ b/crates/embedded/src/node.rs
@@ -677,7 +677,6 @@ where
     )
     .with_collection_truncator(db::DbCollectionTruncator::new_arc(database.clone()))
     .with_acp(document_acp.clone())
-    .with_node_did(database.node_did())
     .with_lens_store(database.lens_store().clone())
     .with_query_limits(config.query_limits);
 

--- a/crates/embedded/src/node_p2p.rs
+++ b/crates/embedded/src/node_p2p.rs
@@ -275,7 +275,6 @@ where
     let coordinator_for_acp = coordinator.clone();
     let serve_acp_for_acp = serve_acp.clone();
     let handle_for_acp = handle.clone();
-    let database_for_acp = database.clone();
     let broadcast_mutator_for_acp = replication.broadcast_mutator.clone();
     let broadcast_mutator_for_se = replication.broadcast_mutator.clone();
     // Lazy SE-key handle: teed by the callback below (runtime provisioning),
@@ -357,10 +356,7 @@ where
         wire_document_acp: Some(Box::new(move |acp| {
             serve_acp_for_acp.set(p2p::bitswap::ServeAcp {
                 resolver: Arc::new(p2p::HandlePeerIdentityResolver::new(handle_for_acp)),
-                gate: defra_p2p_adapter::DbBlockReadGate::new_arc(
-                    acp.clone(),
-                    database_for_acp.node_did(),
-                ),
+                gate: defra_p2p_adapter::DbBlockReadGate::new_arc(acp.clone()),
             });
             coordinator_for_acp.set_document_acp(acp.clone());
             doc_pusher_for_acp.set_document_acp(acp.clone());
@@ -568,7 +564,6 @@ where
     adapter.set_initial_tracked_documents(restored_doc_ids);
     let coordinator_for_acp = coordinator.clone();
     let serve_acp_for_acp = serve_acp.clone();
-    let database_for_acp = database.clone();
     let broadcast_mutator_for_acp = replication.broadcast_mutator.clone();
     let broadcast_mutator_for_se = replication.broadcast_mutator.clone();
     let se_key_handle = db::merge::empty_se_key_handle();
@@ -648,10 +643,7 @@ where
         wire_document_acp: Some(Box::new(move |acp| {
             serve_acp_for_acp.set(p2p::bitswap::ServeAcp {
                 resolver: Arc::new(p2p::IrohPeerIdentityResolver::new(transport.clone())),
-                gate: defra_p2p_adapter::DbBlockReadGate::new_arc(
-                    acp.clone(),
-                    database_for_acp.node_did(),
-                ),
+                gate: defra_p2p_adapter::DbBlockReadGate::new_arc(acp.clone()),
             });
             coordinator_for_acp.set_document_acp(acp.clone());
             doc_pusher_for_acp.set_document_acp(acp.clone());

--- a/crates/ffi/src/query/mod.rs
+++ b/crates/ffi/src/query/mod.rs
@@ -40,14 +40,10 @@ pub(crate) fn nac_permission_for_query(query_str: &str) -> NodePermission {
     }
 }
 
-/// Check if the identity has DAC bypass permission (NAC admin/owner) or
-/// is the node identity itself.
+/// Check if the identity has DAC bypass permission (NAC admin/owner).
 ///
-/// Sets the thread-local `dac_bypass` flag to `true` if either:
-///
-/// - The request identity equals the configured node identity (matches Go's
-///   `internal/db/collection_acp.go:60-62` — process owner gets full access).
-/// - The identity has the `DacBypass` NAC permission.
+/// Sets the thread-local `dac_bypass` flag when the identity has the
+/// `DacBypass` NAC permission.
 pub(crate) fn check_and_set_dac_bypass(
     rt: &tokio::runtime::Runtime,
     node_ptr: usize,
@@ -64,17 +60,6 @@ pub(crate) fn check_and_set_dac_bypass(
         },
         _ => None,
     };
-
-    // Node-identity full-access shortcut.
-    let node_did = NODES
-        .get(node_ptr, |state| state.node_identity_did.clone())
-        .flatten();
-    if let (Some(node), Some(req)) = (&node_did, &did) {
-        if node.as_str() == req.as_str() {
-            defra_core::dac_bypass::set_dac_bypass(true);
-            return;
-        }
-    }
 
     let nac_manager = match NODES.get(node_ptr, |state| state.nac_manager.clone()) {
         Some(m) => m,

--- a/crates/ffi/src/query/tests.rs
+++ b/crates/ffi/src/query/tests.rs
@@ -3,9 +3,37 @@ use std::ptr;
 
 use crate::node::{new_node, node_close};
 use crate::schema::add_schema;
+use crate::state::NODES;
 use crate::types::NodeInitOptions;
 
-use super::exec_request;
+use super::{check_and_set_dac_bypass, exec_request};
+
+#[test]
+fn node_identity_is_not_promoted_to_nac_dac_bypass() {
+    assert!(crate::runtime::init_runtime());
+
+    let options = NodeInitOptions {
+        enable_signing: 1,
+        ..Default::default()
+    };
+    let result = new_node(options);
+    assert_eq!(result.status, 0);
+    let node = result.node_ptr;
+    let node_did = NODES
+        .get(node, |state| state.node_identity_did.clone())
+        .flatten()
+        .unwrap();
+    let node_did = CString::new(node_did).unwrap();
+
+    check_and_set_dac_bypass(
+        crate::runtime::runtime_handle().unwrap(),
+        node,
+        node_did.as_ptr(),
+    );
+
+    assert!(!defra_core::dac_bypass::get_dac_bypass());
+    node_close(node);
+}
 
 #[test]
 fn test_exec_request() {

--- a/crates/http/src/query_context.rs
+++ b/crates/http/src/query_context.rs
@@ -46,10 +46,7 @@ async fn execute_once_with_context(
     let dac_bypass = resolve_dac_bypass(state, identity).await;
 
     // Fast path: when there is nothing to put on the thread-locals, skip
-    // spawn_blocking entirely. `dac_bypass` must be part of the condition --
-    // the node-owner shortcut is keyed on identity alone, independent of
-    // signing (Go: `internal/db/collection_acp.go:86`), so a node started with
-    // --no-signing would otherwise silently lose full DAC access.
+    // spawn_blocking entirely.
     if signing_config.is_none() && state.nac.is_none() && !dac_bypass {
         return state.executor.execute(request).await;
     }
@@ -138,8 +135,7 @@ pub async fn execute_in_txn_with_context(
 
     let dac_bypass = resolve_dac_bypass(state, identity).await;
 
-    // Fast path: see the note in `execute_once_with_context`. `dac_bypass`
-    // belongs in the condition for the same reason.
+    // Fast path: see the note in `execute_once_with_context`.
     if signing_config.is_none() && state.nac.is_none() && !dac_bypass {
         return state.executor.execute_in_txn(request, &txn_handle).await;
     }
@@ -210,19 +206,9 @@ pub(crate) fn resolve_signing_config(
 
 /// Resolve whether DAC bypass should be enabled for this request.
 ///
-/// - If the request identity equals the configured node identity, bypass.
-///   (Matches Go's `internal/db/collection_acp.go:60-62` — the process owner
-///   gets full access to all documents regardless of DAC.)
 /// - If NAC is configured and the identity has `DacBypass` permission, bypass.
 /// - Otherwise, no bypass.
 pub(crate) async fn resolve_dac_bypass(state: &AppState, identity: &ExtractIdentity) -> bool {
-    // Node-identity full-access shortcut.
-    if let (Some(node_did), Some(req_did)) = (&state.node_identity_did, identity.did()) {
-        if node_did.as_str() == req_did.as_str() {
-            return true;
-        }
-    }
-
     let Some(nac) = &state.nac else {
         return false;
     };
@@ -393,11 +379,8 @@ mod tests {
         ExtractIdentity::from_did(Some(identity::Did::new_unchecked(OWNER_DID.to_string())))
     }
 
-    /// Go gates the node-owner full-access shortcut on identity alone
-    /// (`internal/db/collection_acp.go:86`), with no reference to signing
-    /// anywhere in that file. Disabling signing must not take DAC access with it.
     #[tokio::test]
-    async fn node_owner_keeps_dac_bypass_when_signing_is_disabled() {
+    async fn node_owner_is_not_promoted_to_nac_dac_bypass() {
         let executor = Arc::new(DacBypassRecorder::default());
         let state = AppStateBuilder::new(executor.clone())
             .with_node_identity_did(OWNER_DID.to_string())
@@ -411,10 +394,7 @@ mod tests {
         )
         .await;
 
-        assert!(
-            executor.observed.load(Ordering::SeqCst),
-            "the node owner lost DAC bypass because --no-signing sent the request down the fast path"
-        );
+        assert!(!executor.observed.load(Ordering::SeqCst));
     }
 
     #[tokio::test]

--- a/crates/kms/src/nac_dac_policy.rs
+++ b/crates/kms/src/nac_dac_policy.rs
@@ -74,7 +74,6 @@ impl NacDacPolicy {
         let checker = acp::read_access::DirectChecker {
             acp: self.doc_acp.as_ref(),
             identity: &actor_id,
-            node_did: None,
         };
         let allowed = acp::read_access::check_doc_read_access(
             &checker,

--- a/crates/p2p-adapter/src/read_gate.rs
+++ b/crates/p2p-adapter/src/read_gate.rs
@@ -92,19 +92,15 @@ impl<S: Store + 'static> BlockClassifier for DbBlockClassifier<S> {
 
 pub struct DbBlockReadGate {
     acp: Arc<dyn acp::DocumentACP>,
-    node_did: Option<identity::Did>,
 }
 
 impl DbBlockReadGate {
-    pub fn new(acp: Arc<dyn acp::DocumentACP>, node_did: Option<identity::Did>) -> Self {
-        Self { acp, node_did }
+    pub fn new(acp: Arc<dyn acp::DocumentACP>) -> Self {
+        Self { acp }
     }
 
-    pub fn new_arc(
-        acp: Arc<dyn acp::DocumentACP>,
-        node_did: Option<identity::Did>,
-    ) -> Arc<dyn BlockReadGate> {
-        Arc::new(Self::new(acp, node_did))
+    pub fn new_arc(acp: Arc<dyn acp::DocumentACP>) -> Arc<dyn BlockReadGate> {
+        Arc::new(Self::new(acp))
     }
 }
 
@@ -118,7 +114,6 @@ impl BlockReadGate for DbBlockReadGate {
         let checker = acp::read_access::DirectChecker {
             acp: self.acp.as_ref(),
             identity,
-            node_did: self.node_did.as_ref(),
         };
 
         if meta.doc_ids.is_empty() {
@@ -158,10 +153,12 @@ impl BlockReadGate for DbBlockReadGate {
 mod tests {
     use std::sync::Arc;
 
-    use super::DbBlockClassifier;
-    use p2p::bitswap::{BlockClass, BlockClassifier};
+    use acp::{DocumentACP, Identity, LocalDocumentACP, MemoryAcpStore};
+    use p2p::bitswap::{BlockAcpMeta, BlockClass, BlockClassifier, BlockReadGate};
     use schema::{CollectionVersion, FieldDescription, FieldKind, PolicyDescription};
     use storage::RegolithStore;
+
+    use super::{DbBlockClassifier, DbBlockReadGate};
 
     fn test_collection() -> CollectionVersion {
         CollectionVersion::new(
@@ -238,5 +235,29 @@ mod tests {
         let classifier = DbBlockClassifier::new(db);
 
         assert_eq!(classifier.classify(&cid, &bytes).await, BlockClass::Deny);
+    }
+
+    #[tokio::test]
+    async fn node_identity_without_a_grant_cannot_read_a_protected_block() {
+        let owner =
+            identity::Did::new("did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK").unwrap();
+        let node =
+            identity::Did::new("did:key:z6MkfXG2FkNy3u7Eg3jm8e2YQpGz7Z1JqWgHDAP1hLk9r2bR").unwrap();
+        let acp = Arc::new(LocalDocumentACP::new(Arc::new(MemoryAcpStore::new())));
+        acp.register_doc_object(&owner, "policy1", "users", "doc1")
+            .await
+            .unwrap();
+        let gate = DbBlockReadGate::new(acp);
+        let meta = BlockAcpMeta {
+            collection_id: "collection1".to_string(),
+            is_branchable: false,
+            policy: Some(("policy1".to_string(), "users".to_string())),
+            doc_ids: vec!["doc1".to_string()],
+        };
+
+        assert!(
+            !gate.may_read(&Identity::Authenticated(node), &meta).await,
+            "the process owner must satisfy document ACP when serving blocks"
+        );
     }
 }

--- a/crates/query/src/plan/permission_filter.rs
+++ b/crates/query/src/plan/permission_filter.rs
@@ -118,7 +118,6 @@ impl PermissionFilterNode {
                     policy_id.as_ref(),
                     resource_name.as_ref(),
                     &doc_id,
-                    None,
                 )
                 .await
                 .unwrap_or_else(|error| {

--- a/crates/query/src/runner/commits.rs
+++ b/crates/query/src/runner/commits.rs
@@ -131,7 +131,6 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             use acp::Identity;
 
             let identity = Identity::from(caller_identity.clone());
-            let node_did = self.node_did().cloned();
 
             // Active-version fast path. Historical commits authored under a
             // now-inactive version (after a schema migration) are NOT in this
@@ -186,7 +185,6 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                             let checker = crate::txn::OverlayChecker {
                                 acp: self.acp.as_ref(),
                                 identity: &identity,
-                                node_did: node_did.as_ref(),
                             };
                             acp::read_access::check_doc_read_access(
                                 &checker,

--- a/crates/query/src/runner/mod.rs
+++ b/crates/query/src/runner/mod.rs
@@ -208,8 +208,6 @@ pub struct QueryRunner<F: DocFetcher, R: TransactionRegistry = NoOpTransactionRe
     /// Used when a request doesn't include an explicit identity (e.g., no bearer token).
     /// Typically set from the `--identity` CLI flag.
     pub(crate) default_identity: Option<Did>,
-    /// Local node DID for Go-parity ACP node-identity shortcuts.
-    pub(crate) node_did: Option<Did>,
     /// Optional lens transform store for view queries with transforms
     pub(crate) lens_store: Option<Arc<dyn lens::TransformStore>>,
     /// NAC checker for query-level enforcement.
@@ -242,7 +240,6 @@ impl<F: DocFetcher + 'static> QueryRunner<F, NoOpTransactionRegistry> {
             collection_truncator: None,
             acp: Arc::new(NoOpDocumentAcp),
             default_identity: None,
-            node_did: None,
             lens_store: None,
             nac: Arc::new(NoOpNacChecker),
             query_timeout: 30,
@@ -264,7 +261,6 @@ impl<F: DocFetcher + 'static> QueryRunner<F, NoOpTransactionRegistry> {
             collection_truncator: None,
             acp: Arc::new(NoOpDocumentAcp),
             default_identity: None,
-            node_did: None,
             lens_store: None,
             nac: Arc::new(NoOpNacChecker),
             query_timeout: 30,
@@ -288,7 +284,6 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             collection_truncator: None,
             acp: Arc::new(NoOpDocumentAcp),
             default_identity: None,
-            node_did: None,
             lens_store: None,
             nac: Arc::new(NoOpNacChecker),
             query_timeout: 30,
@@ -315,7 +310,6 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             collection_truncator: None,
             acp: Arc::new(NoOpDocumentAcp),
             default_identity: None,
-            node_did: None,
             lens_store: None,
             nac: Arc::new(NoOpNacChecker),
             query_timeout: 30,
@@ -341,7 +335,6 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             collection_truncator: None,
             acp: Arc::new(NoOpDocumentAcp),
             default_identity: None,
-            node_did: None,
             lens_store: None,
             nac: Arc::new(NoOpNacChecker),
             query_timeout: 30,
@@ -412,16 +405,6 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
     pub fn with_default_identity(mut self, identity: Did) -> Self {
         self.default_identity = Some(identity);
         self
-    }
-
-    /// Set the local node DID for ACP node-identity shortcuts.
-    pub fn with_node_did(mut self, node_did: Option<Did>) -> Self {
-        self.node_did = node_did;
-        self
-    }
-
-    pub(crate) fn node_did(&self) -> Option<&Did> {
-        self.node_did.as_ref()
     }
 
     /// Set query execution timeout in seconds (0 = no timeout).

--- a/crates/query/src/runner/mutation.rs
+++ b/crates/query/src/runner/mutation.rs
@@ -345,7 +345,6 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                                 &policy.id,
                                 &policy.resource_name,
                                 doc_id,
-                                None,
                             )
                             .await
                             .unwrap_or(false);
@@ -363,7 +362,6 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                                 &policy.id,
                                 &policy.resource_name,
                                 doc_id,
-                                None,
                             )
                             .await
                             .map_err(|e| QueryError::acp_check_failed("update", doc_id, e))?;
@@ -391,7 +389,6 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                                 &policy.id,
                                 &policy.resource_name,
                                 doc_id,
-                                None,
                             )
                             .await
                             .unwrap_or(false);
@@ -409,7 +406,6 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                                 &policy.id,
                                 &policy.resource_name,
                                 doc_id,
-                                None,
                             )
                             .await
                             .map_err(|e| QueryError::acp_check_failed("delete", doc_id, e))?;

--- a/crates/query/src/runner/query/aggregate.rs
+++ b/crates/query/src/runner/query/aggregate.rs
@@ -82,7 +82,6 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                             &policy.id,
                             &policy.resource_name,
                             doc_id,
-                            None,
                         )
                         .await
                         .unwrap_or(false);

--- a/crates/query/src/runner/query/select.rs
+++ b/crates/query/src/runner/query/select.rs
@@ -448,7 +448,6 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                 &policy.id,
                 &policy.resource_name,
                 doc_id,
-                None,
             )
             .await
             .unwrap_or_else(|e| {

--- a/crates/query/src/runner/version.rs
+++ b/crates/query/src/runner/version.rs
@@ -102,7 +102,6 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                     &policy.id,
                     &policy.resource_name,
                     &doc_id,
-                    None,
                 )
                 .await
                 {

--- a/crates/query/src/txn/context.rs
+++ b/crates/query/src/txn/context.rs
@@ -323,14 +323,7 @@ pub async fn check_doc_access_with_overlay(
     policy_id: &str,
     resource_name: &str,
     doc_id: &str,
-    node_did: Option<&Did>,
 ) -> AcpResult<bool> {
-    if let (Some(node), Identity::Authenticated(requester)) = (node_did, identity) {
-        if node == requester {
-            return Ok(true);
-        }
-    }
-
     if let Some(mutations) = current_deferred_acp_mutations() {
         if let Some(projected) =
             mutations.projected_registration(policy_id, resource_name, doc_id)?
@@ -450,7 +443,6 @@ mod tests {
                 "policy",
                 "User",
                 "doc-1",
-                None,
             ),
         )
         .await
@@ -466,7 +458,6 @@ mod tests {
                 "policy",
                 "User",
                 "doc-1",
-                None,
             ),
         )
         .await
@@ -495,7 +486,6 @@ mod tests {
                 "policy",
                 "User",
                 "doc-1",
-                None,
             ),
         )
         .await

--- a/crates/query/src/txn/read_access.rs
+++ b/crates/query/src/txn/read_access.rs
@@ -3,14 +3,12 @@
 use acp::read_access::{DocAccess, ObjectAccessChecker};
 use acp::{DocumentACP, DocumentPermission, Identity};
 use async_trait::async_trait;
-use identity::Did;
 
 use super::context::{check_doc_access_with_overlay, is_doc_registered_with_overlay};
 
 pub struct OverlayChecker<'a> {
     pub acp: &'a dyn DocumentACP,
     pub identity: &'a Identity,
-    pub node_did: Option<&'a Did>,
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
@@ -31,15 +29,6 @@ impl ObjectAccessChecker for OverlayChecker<'_> {
             });
         }
 
-        if let (Some(node), Identity::Authenticated(requester)) = (self.node_did, self.identity) {
-            if node == requester {
-                return Ok(DocAccess {
-                    has_access: true,
-                    explicit: true,
-                });
-            }
-        }
-
         if !is_doc_registered_with_overlay(self.acp, policy_id, resource_name, object_id).await? {
             return Ok(DocAccess {
                 has_access: true,
@@ -54,7 +43,6 @@ impl ObjectAccessChecker for OverlayChecker<'_> {
             policy_id,
             resource_name,
             object_id,
-            self.node_did,
         )
         .await?;
 

--- a/crates/query/tests/cross_object_read_path.rs
+++ b/crates/query/tests/cross_object_read_path.rs
@@ -68,7 +68,6 @@ async fn gate_allows(
         policy_id,
         resource,
         doc,
-        None,
     )
     .await
     .unwrap()
@@ -147,7 +146,6 @@ async fn overlay_checker_applies_branchable_collection_fallback() {
     let checker = OverlayChecker {
         acp: &acp,
         identity: &identity,
-        node_did: None,
     };
 
     let public_doc_allowed =


### PR DESCRIPTION
## Context

The node identity ACP bypass is intended for direct collection operations. Propagating it into commit access, signature verification, and P2P block serving grants broader authority than the configured relationship permits.

This depends on #1630, which carries the shared clippy cleanup.

## Changes

- make the node identity bypass explicit at collection-access boundaries
- prevent the bypass from reaching commit, signature, and block-serving checks
- thread the narrower authorization context through DB, HTTP, FFI, and P2P adapters
- add regression coverage for allowed and denied paths

## Testing

- [x] `cargo clippy --profile super-dev -p acp -p cli -p db -p defra-node -p embedded -p ffi -p defra-http -p kms -p defra-p2p-adapter -p query --all-targets -- -D warnings`
- [x] focused node API, FFI, HTTP, P2P adapter, and cross-object authorization tests
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check origin/main...HEAD`

Closes #1412