### PR TITLE
fix(http): match permissions to axum route templates

### DIFF
--- a/crates/http/src/route_permissions.rs
+++ b/crates/http/src/route_permissions.rs
@@ -27,7 +27,8 @@ pub enum RoutePermission {
 /// Look up the permission requirement for a route.
 ///
 /// The `path` parameter is the Axum `MatchedPath` template string
-/// (e.g., `/api/v0/collections/:name/:docID`). The `method` is the HTTP method.
+/// (e.g., `/api/v0/collections/{name}/document/{docID}`). The `method` is the
+/// HTTP method.
 ///
 /// Unknown routes return `Required(DocumentRead)` as a safe default:
 /// when NAC is enabled, this blocks unauthenticated access.
@@ -66,10 +67,10 @@ pub fn route_permission(path: &str, method: &Method) -> RoutePermission {
         // Transactions (permissions enforced per-operation within tx)
         // =====================================================================
         "/api/v0/tx" => RoutePermission::IdentityOnly,
-        "/api/v0/tx/:id" => RoutePermission::IdentityOnly,
-        "/api/v0/tx/:id/lens" => RoutePermission::Required(NodePermission::CollectionPatch),
-        "/api/v0/tx/:id/collections" => RoutePermission::Required(NodePermission::CollectionGet),
-        "/api/v0/tx/:id/schema" => RoutePermission::Required(NodePermission::CollectionPatch),
+        "/api/v0/tx/{id}" => RoutePermission::IdentityOnly,
+        "/api/v0/tx/{id}/lens" => RoutePermission::Required(NodePermission::CollectionPatch),
+        "/api/v0/tx/{id}/collections" => RoutePermission::Required(NodePermission::CollectionGet),
+        "/api/v0/tx/{id}/schema" => RoutePermission::Required(NodePermission::CollectionPatch),
 
         // =====================================================================
         // Collections
@@ -91,8 +92,10 @@ pub fn route_permission(path: &str, method: &Method) -> RoutePermission {
             _ => RoutePermission::Required(NodePermission::CollectionGet),
         },
         "/api/v0/collections/migrations" => RoutePermission::Required(NodePermission::MigrationSet),
-        "/api/v0/collections/by-id/:id" => RoutePermission::Required(NodePermission::CollectionGet),
-        "/api/v0/collections/by-version/:id" => {
+        "/api/v0/collections/by-id/{id}" => {
+            RoutePermission::Required(NodePermission::CollectionGet)
+        }
+        "/api/v0/collections/by-version/{id}" => {
             RoutePermission::Required(NodePermission::CollectionGet)
         }
         "/api/v0/collections/indexes" => RoutePermission::Required(NodePermission::IndexList),
@@ -100,42 +103,42 @@ pub fn route_permission(path: &str, method: &Method) -> RoutePermission {
         // collection ones, so they are document permissions. Dropping a
         // collection is `DELETE /collections?name=...`, which keeps
         // `CollectionPatch`.
-        "/api/v0/collections/:name" => match *method {
+        "/api/v0/collections/{name}" => match *method {
             Method::GET => RoutePermission::Required(NodePermission::CollectionGet),
             Method::POST => RoutePermission::Required(NodePermission::DocumentUpdate),
             Method::PATCH => RoutePermission::Required(NodePermission::DocumentUpdate),
             Method::DELETE => RoutePermission::Required(NodePermission::DocumentDelete),
             _ => RoutePermission::Required(NodePermission::CollectionGet),
         },
-        "/api/v0/collections/:name/describe" => {
+        "/api/v0/collections/{name}/describe" => {
             RoutePermission::Required(NodePermission::CollectionGet)
         }
-        "/api/v0/collections/:name/exists" => {
+        "/api/v0/collections/{name}/exists" => {
             RoutePermission::Required(NodePermission::CollectionGet)
         }
-        "/api/v0/collections/:name/truncate" => {
+        "/api/v0/collections/{name}/truncate" => {
             RoutePermission::Required(NodePermission::CollectionTruncate)
         }
-        "/api/v0/collections/:name/document/:docID" => match *method {
+        "/api/v0/collections/{name}/document/{docID}" => match *method {
             Method::GET => RoutePermission::Required(NodePermission::DocumentRead),
             Method::PATCH => RoutePermission::Required(NodePermission::DocumentUpdate),
             Method::DELETE => RoutePermission::Required(NodePermission::DocumentDelete),
             _ => RoutePermission::Required(NodePermission::DocumentRead),
         },
-        "/api/v0/collections/:name/indexes" => match *method {
+        "/api/v0/collections/{name}/indexes" => match *method {
             Method::GET => RoutePermission::Required(NodePermission::IndexList),
             Method::POST => RoutePermission::Required(NodePermission::IndexCreate),
             _ => RoutePermission::Required(NodePermission::IndexList),
         },
-        "/api/v0/collections/:name/indexes/:index" => {
+        "/api/v0/collections/{name}/indexes/{index}" => {
             RoutePermission::Required(NodePermission::IndexDelete)
         }
-        "/api/v0/collections/:name/encrypted-indexes" => match *method {
+        "/api/v0/collections/{name}/encrypted-indexes" => match *method {
             Method::GET => RoutePermission::Required(NodePermission::EncryptedIndexList),
             Method::POST => RoutePermission::Required(NodePermission::EncryptedIndexAdd),
             _ => RoutePermission::Required(NodePermission::EncryptedIndexList),
         },
-        "/api/v0/collections/:name/encrypted-indexes/:field" => {
+        "/api/v0/collections/{name}/encrypted-indexes/{field}" => {
             RoutePermission::Required(NodePermission::EncryptedIndexDelete)
         }
 
@@ -200,7 +203,7 @@ pub fn route_permission(path: &str, method: &Method) -> RoutePermission {
             Method::GET => RoutePermission::Required(NodePermission::DacStatus),
             _ => RoutePermission::Required(NodePermission::DacStatus),
         },
-        "/api/v0/acp/policy/:id" => RoutePermission::Required(NodePermission::DacStatus),
+        "/api/v0/acp/policy/{id}" => RoutePermission::Required(NodePermission::DacStatus),
         "/api/v0/acp/document/decide" => RoutePermission::Required(NodePermission::DacStatus),
         "/api/v0/acp/document/relationship" => match *method {
             Method::POST => RoutePermission::Required(NodePermission::DacRelationAdd),

--- a/crates/http/src/router/routes.rs
+++ b/crates/http/src/router/routes.rs
@@ -97,7 +97,7 @@ pub(crate) fn create_router_with_state_and_body_limits(
         );
 
     // Collection routes (REST API)
-    // Static routes must come before parametric `:name` routes
+    // Static routes must come before parametric `{name}` routes.
     let collection_routes = Router::new()
         .route(
             "/",

--- a/crates/http/tests/filtered_document_delete.rs
+++ b/crates/http/tests/filtered_document_delete.rs
@@ -183,7 +183,7 @@ async fn dropping_a_collection_still_has_its_own_route() {
 #[tokio::test]
 async fn the_route_is_gated_as_a_document_delete() {
     assert_eq!(
-        route_permission("/api/v0/collections/:name", &Method::DELETE),
+        route_permission("/api/v0/collections/{name}", &Method::DELETE),
         RoutePermission::Required(NodePermission::DocumentDelete)
     );
     assert_eq!(

--- a/crates/http/tests/filtered_document_update.rs
+++ b/crates/http/tests/filtered_document_update.rs
@@ -189,7 +189,7 @@ async fn an_unknown_collection_is_not_a_success() {
 #[tokio::test]
 async fn the_route_is_gated_as_a_document_update() {
     assert_eq!(
-        route_permission("/api/v0/collections/:name", &Method::PATCH),
+        route_permission("/api/v0/collections/{name}", &Method::PATCH),
         RoutePermission::Required(NodePermission::DocumentUpdate)
     );
 }

--- a/crates/http/tests/route_permission_matching.rs
+++ b/crates/http/tests/route_permission_matching.rs
@@ -1,0 +1,201 @@
+//! Parameterized permission keys must match the templates Axum puts in `MatchedPath`.
+
+mod common;
+
+use axum::body::{to_bytes, Body};
+use axum::extract::{MatchedPath, Request};
+use axum::http::Method;
+use axum::middleware::{self, Next};
+use axum::response::{IntoResponse, Response};
+use defra_http::route_permissions::{route_permission, RoutePermission};
+use defra_http::router::NodePermission;
+use tower::ServiceExt;
+
+async fn echo_matched_path(request: Request, _next: Next) -> Response {
+    request
+        .extensions()
+        .get::<MatchedPath>()
+        .expect("matched route should expose its template")
+        .as_str()
+        .to_owned()
+        .into_response()
+}
+
+#[tokio::test]
+async fn parameterized_routes_use_their_registered_permissions() {
+    let router = common::router().route_layer(middleware::from_fn(echo_matched_path));
+    let cases = [
+        (
+            "/api/v0/tx/7",
+            Method::POST,
+            "/api/v0/tx/{id}",
+            RoutePermission::IdentityOnly,
+        ),
+        (
+            "/api/v0/tx/7",
+            Method::DELETE,
+            "/api/v0/tx/{id}",
+            RoutePermission::IdentityOnly,
+        ),
+        (
+            "/api/v0/tx/7/lens",
+            Method::POST,
+            "/api/v0/tx/{id}/lens",
+            RoutePermission::Required(NodePermission::CollectionPatch),
+        ),
+        (
+            "/api/v0/tx/7/collections",
+            Method::GET,
+            "/api/v0/tx/{id}/collections",
+            RoutePermission::Required(NodePermission::CollectionGet),
+        ),
+        (
+            "/api/v0/tx/7/schema",
+            Method::POST,
+            "/api/v0/tx/{id}/schema",
+            RoutePermission::Required(NodePermission::CollectionPatch),
+        ),
+        (
+            "/api/v0/collections/by-id/abc",
+            Method::GET,
+            "/api/v0/collections/by-id/{id}",
+            RoutePermission::Required(NodePermission::CollectionGet),
+        ),
+        (
+            "/api/v0/collections/by-version/v1",
+            Method::GET,
+            "/api/v0/collections/by-version/{id}",
+            RoutePermission::Required(NodePermission::CollectionGet),
+        ),
+        (
+            "/api/v0/collections/Users",
+            Method::GET,
+            "/api/v0/collections/{name}",
+            RoutePermission::Required(NodePermission::CollectionGet),
+        ),
+        (
+            "/api/v0/collections/Users",
+            Method::POST,
+            "/api/v0/collections/{name}",
+            RoutePermission::Required(NodePermission::DocumentUpdate),
+        ),
+        (
+            "/api/v0/collections/Users",
+            Method::PATCH,
+            "/api/v0/collections/{name}",
+            RoutePermission::Required(NodePermission::DocumentUpdate),
+        ),
+        (
+            "/api/v0/collections/Users",
+            Method::DELETE,
+            "/api/v0/collections/{name}",
+            RoutePermission::Required(NodePermission::DocumentDelete),
+        ),
+        (
+            "/api/v0/collections/Users/describe",
+            Method::GET,
+            "/api/v0/collections/{name}/describe",
+            RoutePermission::Required(NodePermission::CollectionGet),
+        ),
+        (
+            "/api/v0/collections/Users/exists",
+            Method::GET,
+            "/api/v0/collections/{name}/exists",
+            RoutePermission::Required(NodePermission::CollectionGet),
+        ),
+        (
+            "/api/v0/collections/Users/truncate",
+            Method::DELETE,
+            "/api/v0/collections/{name}/truncate",
+            RoutePermission::Required(NodePermission::CollectionTruncate),
+        ),
+        (
+            "/api/v0/collections/Users/document/doc",
+            Method::GET,
+            "/api/v0/collections/{name}/document/{docID}",
+            RoutePermission::Required(NodePermission::DocumentRead),
+        ),
+        (
+            "/api/v0/collections/Users/document/doc",
+            Method::PATCH,
+            "/api/v0/collections/{name}/document/{docID}",
+            RoutePermission::Required(NodePermission::DocumentUpdate),
+        ),
+        (
+            "/api/v0/collections/Users/document/doc",
+            Method::DELETE,
+            "/api/v0/collections/{name}/document/{docID}",
+            RoutePermission::Required(NodePermission::DocumentDelete),
+        ),
+        (
+            "/api/v0/collections/Users/indexes",
+            Method::GET,
+            "/api/v0/collections/{name}/indexes",
+            RoutePermission::Required(NodePermission::IndexList),
+        ),
+        (
+            "/api/v0/collections/Users/indexes",
+            Method::POST,
+            "/api/v0/collections/{name}/indexes",
+            RoutePermission::Required(NodePermission::IndexCreate),
+        ),
+        (
+            "/api/v0/collections/Users/indexes/by_name",
+            Method::DELETE,
+            "/api/v0/collections/{name}/indexes/{index}",
+            RoutePermission::Required(NodePermission::IndexDelete),
+        ),
+        (
+            "/api/v0/collections/Users/encrypted-indexes",
+            Method::GET,
+            "/api/v0/collections/{name}/encrypted-indexes",
+            RoutePermission::Required(NodePermission::EncryptedIndexList),
+        ),
+        (
+            "/api/v0/collections/Users/encrypted-indexes",
+            Method::POST,
+            "/api/v0/collections/{name}/encrypted-indexes",
+            RoutePermission::Required(NodePermission::EncryptedIndexAdd),
+        ),
+        (
+            "/api/v0/collections/Users/encrypted-indexes/email",
+            Method::DELETE,
+            "/api/v0/collections/{name}/encrypted-indexes/{field}",
+            RoutePermission::Required(NodePermission::EncryptedIndexDelete),
+        ),
+        (
+            "/api/v0/acp/policy/test",
+            Method::GET,
+            "/api/v0/acp/policy/{id}",
+            RoutePermission::Required(NodePermission::DacStatus),
+        ),
+    ];
+
+    for (path, method, expected_path, expected_permission) in cases {
+        let response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(method.clone())
+                    .uri(path)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("router should respond");
+        let matched_path = String::from_utf8(
+            to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap()
+                .to_vec(),
+        )
+        .unwrap();
+
+        assert_eq!(matched_path, expected_path, "{method} {path}");
+        assert_eq!(
+            route_permission(&matched_path, &method),
+            expected_permission,
+            "{method} {path}"
+        );
+    }
+}

--- a/crates/http/tests/route_permissions.rs
+++ b/crates/http/tests/route_permissions.rs
@@ -9,12 +9,6 @@
 //! that catches that, and it is deliberately the only one, so the two copies
 //! cannot drift apart.
 //!
-//! Note the parameterized entries here use colon syntax (`:name`). axum 0.8's
-//! `MatchedPath` yields brace syntax (`{name}`), so those entries never fire in
-//! production and these assertions do not speak for them. That is #1497, not
-//! something this file can fix by itself: the table's keys have to change with
-//! it.
-
 use axum::http::Method;
 
 use defra_http::route_permissions::{route_permission, RoutePermission};
@@ -47,11 +41,11 @@ fn identity_only_routes() {
         RoutePermission::IdentityOnly
     );
     assert_eq!(
-        route_permission("/api/v0/tx/:id", &Method::POST),
+        route_permission("/api/v0/tx/{id}", &Method::POST),
         RoutePermission::IdentityOnly
     );
     assert_eq!(
-        route_permission("/api/v0/tx/:id", &Method::DELETE),
+        route_permission("/api/v0/tx/{id}", &Method::DELETE),
         RoutePermission::IdentityOnly
     );
 }
@@ -99,11 +93,11 @@ fn collection_routes() {
         RoutePermission::Required(NodePermission::CollectionPatch)
     );
     assert_eq!(
-        route_permission("/api/v0/collections/:name", &Method::POST),
+        route_permission("/api/v0/collections/{name}", &Method::POST),
         RoutePermission::Required(NodePermission::DocumentUpdate)
     );
     assert_eq!(
-        route_permission("/api/v0/collections/:name", &Method::DELETE),
+        route_permission("/api/v0/collections/{name}", &Method::DELETE),
         RoutePermission::Required(NodePermission::DocumentDelete)
     );
 }
@@ -111,15 +105,21 @@ fn collection_routes() {
 #[test]
 fn document_routes() {
     assert_eq!(
-        route_permission("/api/v0/collections/:name/document/:docID", &Method::GET),
+        route_permission("/api/v0/collections/{name}/document/{docID}", &Method::GET),
         RoutePermission::Required(NodePermission::DocumentRead)
     );
     assert_eq!(
-        route_permission("/api/v0/collections/:name/document/:docID", &Method::PATCH),
+        route_permission(
+            "/api/v0/collections/{name}/document/{docID}",
+            &Method::PATCH,
+        ),
         RoutePermission::Required(NodePermission::DocumentUpdate)
     );
     assert_eq!(
-        route_permission("/api/v0/collections/:name/document/:docID", &Method::DELETE),
+        route_permission(
+            "/api/v0/collections/{name}/document/{docID}",
+            &Method::DELETE,
+        ),
         RoutePermission::Required(NodePermission::DocumentDelete)
     );
 }
@@ -249,27 +249,27 @@ fn all_registered_routes_return_expected_permission() {
         // Transactions
         ("/api/v0/tx", Method::POST, RoutePermission::IdentityOnly),
         (
-            "/api/v0/tx/:id",
+            "/api/v0/tx/{id}",
             Method::POST,
             RoutePermission::IdentityOnly,
         ),
         (
-            "/api/v0/tx/:id",
+            "/api/v0/tx/{id}",
             Method::DELETE,
             RoutePermission::IdentityOnly,
         ),
         (
-            "/api/v0/tx/:id/lens",
+            "/api/v0/tx/{id}/lens",
             Method::POST,
             RoutePermission::Required(NodePermission::CollectionPatch),
         ),
         (
-            "/api/v0/tx/:id/collections",
+            "/api/v0/tx/{id}/collections",
             Method::GET,
             RoutePermission::Required(NodePermission::CollectionGet),
         ),
         (
-            "/api/v0/tx/:id/schema",
+            "/api/v0/tx/{id}/schema",
             Method::POST,
             RoutePermission::Required(NodePermission::CollectionPatch),
         ),
@@ -310,38 +310,38 @@ fn all_registered_routes_return_expected_permission() {
             RoutePermission::Required(NodePermission::MigrationSet),
         ),
         (
-            "/api/v0/collections/:name",
+            "/api/v0/collections/{name}",
             Method::POST,
             RoutePermission::Required(NodePermission::DocumentUpdate),
         ),
         // Go's filtered document operations, not collection ones.
         (
-            "/api/v0/collections/:name",
+            "/api/v0/collections/{name}",
             Method::PATCH,
             RoutePermission::Required(NodePermission::DocumentUpdate),
         ),
         (
-            "/api/v0/collections/:name",
+            "/api/v0/collections/{name}",
             Method::DELETE,
             RoutePermission::Required(NodePermission::DocumentDelete),
         ),
         (
-            "/api/v0/collections/:name/truncate",
+            "/api/v0/collections/{name}/truncate",
             Method::DELETE,
             RoutePermission::Required(NodePermission::CollectionTruncate),
         ),
         (
-            "/api/v0/collections/:name/document/:docID",
+            "/api/v0/collections/{name}/document/{docID}",
             Method::GET,
             RoutePermission::Required(NodePermission::DocumentRead),
         ),
         (
-            "/api/v0/collections/:name/document/:docID",
+            "/api/v0/collections/{name}/document/{docID}",
             Method::PATCH,
             RoutePermission::Required(NodePermission::DocumentUpdate),
         ),
         (
-            "/api/v0/collections/:name/document/:docID",
+            "/api/v0/collections/{name}/document/{docID}",
             Method::DELETE,
             RoutePermission::Required(NodePermission::DocumentDelete),
         ),
@@ -592,7 +592,7 @@ fn every_mount_form_uses_the_same_permission_as_v0() {
     for (v0_path, method) in [
         ("/api/v0/version", Method::GET),
         ("/api/v0/graphql", Method::POST),
-        ("/api/v0/collections/:name", Method::POST),
+        ("/api/v0/collections/{name}", Method::POST),
         ("/api/v0/p2p/replicators", Method::DELETE),
         ("/api/v0/acp/node/disable", Method::POST),
         ("/api/v0/backup/export", Method::POST),

--- a/crates/http/tests/unversioned_api_mount.rs
+++ b/crates/http/tests/unversioned_api_mount.rs
@@ -7,11 +7,8 @@
 //! but does not fold is enforced as `DocumentRead`, a privilege downgrade
 //! rather than a 404.
 //!
-//! Parameterized routes are deliberately not asserted here. axum 0.8 yields a
-//! brace `MatchedPath` (`/api/collections/{name}`) while the table is keyed
-//! with colons, so those entries never match on any mount, versioned or not.
-//! That defect is #1497 and is not what this change is about; asserting it
-//! here would only certify the `_` arm.
+//! Parameterized templates are exercised through the real router in
+//! `route_permission_matching.rs`; this file focuses on mount equivalence.
 
 mod common;
 use common::*;


### PR DESCRIPTION
## Context

Permission rules use colon-prefixed path parameters while axum reports matched paths with brace-prefixed parameters. Requests to parameterized routes therefore miss their configured permission entry.

This is 1/2 in the HTTP routing stack and depends on #1630.

## Changes

- express permission paths using axum's matched-route syntax
- cover authorization lookup for parameterized collection and document routes
- update the route coverage expectation to include the corrected permission paths

## Testing

- [x] `cargo clippy --profile super-dev -p defra-http --all-targets -- -D warnings`
- [x] `cargo test --profile super-dev -p defra-http`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check origin/main...HEAD`

Closes #1497