### PR TITLE
test(schema): enforce validation parity with Go

### DIFF
--- a/crates/schema/src/collection.rs
+++ b/crates/schema/src/collection.rs
@@ -216,7 +216,7 @@ impl CollectionVersion {
             fulltext_indexes: Vec::new(),
             policy: None,
             is_active: true,
-            is_materialized: false,
+            is_materialized: true,
             downsample_interval: None,
             downsample_time_field: None,
             downsample_retention: None,
@@ -326,6 +326,7 @@ impl CollectionVersion {
 
     /// Validate the collection schema
     pub fn validate(&self) -> Result<()> {
+        self.validate_materialization()?;
         self.validate_no_duplicate_names()?;
         self.validate_no_duplicate_index_names()?;
         self.validate_encrypted_indexes()?;
@@ -333,6 +334,13 @@ impl CollectionVersion {
         self.validate_relation_id_field_kinds()?;
         self.validate_policy()?;
         self.validate_downsample()?;
+        Ok(())
+    }
+
+    fn validate_materialization(&self) -> Result<()> {
+        if self.query.is_none() && !self.is_materialized {
+            return Err(SchemaError::NonMaterializedCollection(self.name.clone()));
+        }
         Ok(())
     }
 

--- a/crates/schema/src/definition_validation/global_validators.rs
+++ b/crates/schema/src/definition_validation/global_validators.rs
@@ -323,7 +323,7 @@ pub(super) fn validate_materialized_has_no_policy(
 ) -> Vec<String> {
     let mut errs = Vec::new();
     for col in &new_state.collections {
-        if col.is_materialized && col.policy.is_some() {
+        if col.is_materialized && col.query.is_some() && col.policy.is_some() {
             errs.push(format!(
                 "materialized views do not support ACP. Collection: {}",
                 col.name

--- a/crates/schema/src/error.rs
+++ b/crates/schema/src/error.rs
@@ -74,6 +74,9 @@ pub enum SchemaError {
     #[error("invalid downsample configuration: {0}")]
     InvalidDownsample(String),
 
+    #[error("non-materialized collections are not supported. Collection: {0}")]
+    NonMaterializedCollection(String),
+
     #[error("invalid immutable field {field_name}: {reason}")]
     InvalidImmutableField { field_name: String, reason: String },
 }

--- a/crates/schema/tests/collection_tests.rs
+++ b/crates/schema/tests/collection_tests.rs
@@ -35,6 +35,7 @@ fn test_new_collection() {
     assert_eq!(coll.name, "users");
     assert_eq!(coll.version_id, "v1");
     assert!(coll.is_active);
+    assert!(coll.is_materialized);
     assert_eq!(coll.fields.len(), 3);
 }
 
@@ -143,6 +144,17 @@ fn test_validate_invalid_crdt_fails() {
 fn test_validate_valid_collection() {
     let coll = CollectionVersion::new("users", "v1", "coll-1", sample_fields());
     assert!(coll.validate().is_ok());
+}
+
+#[test]
+fn test_validate_non_view_collection_is_materialized() {
+    let mut coll = CollectionVersion::new("users", "v1", "coll-1", sample_fields());
+    coll.is_materialized = false;
+
+    assert!(matches!(
+        coll.validate().unwrap_err(),
+        SchemaError::NonMaterializedCollection(name) if name == "users"
+    ));
 }
 
 #[test]

--- a/crates/schema/tests/validation_tests.rs
+++ b/crates/schema/tests/validation_tests.rs
@@ -5,7 +5,10 @@
 //! - Duplicate collection name detection
 //! - Relation primary side validation
 
-use schema::{validate_schema, CollectionVersion, FieldDescription, FieldKind, SchemaError};
+use schema::{
+    validate_schema, CollectionVersion, FieldDescription, FieldKind, PolicyDescription,
+    QuerySource, SchemaError,
+};
 use std::collections::HashMap;
 
 // ============================================================================
@@ -257,4 +260,29 @@ fn self_relation_must_use_self_kind() {
     assert!(
         error.contains("must specify 'Self' kind for self referencing relations. Field: manager")
     );
+}
+
+#[test]
+fn materialized_collection_can_have_policy() {
+    let collection = user_collection().with_policy(PolicyDescription::new("policy", "users"));
+
+    schema::definition_validation::validate_collection_changes(
+        std::slice::from_ref(&collection),
+        std::slice::from_ref(&collection),
+    )
+    .unwrap();
+}
+
+#[test]
+fn materialized_view_cannot_have_policy() {
+    let mut collection = user_collection().with_policy(PolicyDescription::new("policy", "users"));
+    collection.query = Some(QuerySource::new(serde_json::json!({})));
+
+    let error = schema::definition_validation::validate_collection_changes(
+        std::slice::from_ref(&collection),
+        std::slice::from_ref(&collection),
+    )
+    .unwrap_err();
+
+    assert!(error.contains("materialized views do not support ACP"));
 }

--- a/tools/integration-test/tests/basic.rs
+++ b/tools/integration-test/tests/basic.rs
@@ -8,6 +8,8 @@ mod collection_management;
 mod cross_runtime_cids;
 #[path = "basic/cross_runtime_queries.rs"]
 mod cross_runtime_queries;
+#[path = "basic/cross_runtime_schema_validation.rs"]
+mod cross_runtime_schema_validation;
 #[path = "basic/document_lifecycle.rs"]
 mod document_lifecycle;
 #[path = "basic/multi_collection.rs"]

--- a/tools/integration-test/tests/basic/cross_runtime_schema_validation.rs
+++ b/tools/integration-test/tests/basic/cross_runtime_schema_validation.rs
@@ -1,0 +1,381 @@
+use std::fmt::Display;
+
+use integration_test::{DefraClient, TestCluster};
+
+#[path = "cross_runtime_schema_validation/stateful.rs"]
+mod stateful;
+
+struct AddCase {
+    validator: &'static str,
+    sdl: &'static str,
+    accepted: bool,
+}
+
+struct PatchCase {
+    validator: &'static str,
+    sdl: &'static str,
+    patch: &'static str,
+    accepted: bool,
+}
+
+fn assert_outcome<RT, RE, GT, GE>(
+    case: &str,
+    expected: bool,
+    rust: &Result<RT, RE>,
+    go: &Result<GT, GE>,
+) where
+    RE: Display,
+    GE: Display,
+{
+    let rust_accepted = rust.is_ok();
+    let go_accepted = go.is_ok();
+    assert_eq!(
+        rust_accepted,
+        go_accepted,
+        "{case}: Rust and Go outcomes differ; Rust={:?}, Go={:?}",
+        rust.as_ref().err().map(ToString::to_string),
+        go.as_ref().err().map(ToString::to_string),
+    );
+    assert_eq!(
+        rust_accepted,
+        expected,
+        "{case}: unexpected shared outcome; Rust={:?}, Go={:?}",
+        rust.as_ref().err().map(ToString::to_string),
+        go.as_ref().err().map(ToString::to_string),
+    );
+}
+
+fn purge_both(rust: &DefraClient, go: &DefraClient) {
+    rust.purge().expect("purge Rust node");
+    go.purge().expect("purge Go node");
+}
+
+#[tokio::test]
+async fn go_schema_creation_validation_parity() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(1)
+        .go_nodes(1)
+        .with_development()
+        .with_acp_local()
+        .build()
+        .await
+        .unwrap();
+    let rust = cluster.client(0);
+    let go = cluster.client(1);
+
+    let cases = [
+        AddCase {
+            validator: "valid schema",
+            sdl: "type ValidSchema { name: String score: Int @default(value: 1) }",
+            accepted: true,
+        },
+        AddCase {
+            validator: "valid relation",
+            sdl: r#"
+                type ValidAuthor {
+                    books: [ValidBook] @relation(name: "valid_author_books")
+                }
+                type ValidBook {
+                    author: ValidAuthor @primary @relation(name: "valid_author_books")
+                }
+            "#,
+            accepted: true,
+        },
+        AddCase {
+            validator: "validateRelationPointsToValidKind",
+            sdl: "type InvalidRelationTarget { missing: MissingType @primary }",
+            accepted: false,
+        },
+        AddCase {
+            validator: "validateSecondaryFieldsPairUp",
+            sdl: r#"
+                type MissingPrimary {
+                    boss: MissingPrimary @relation(name: "missing_primary")
+                    report: MissingPrimary @relation(name: "missing_primary")
+                }
+            "#,
+            accepted: false,
+        },
+        AddCase {
+            validator: "validateSingleSidePrimary",
+            sdl: r#"
+                type MultiplePrimaries {
+                    boss: MultiplePrimaries @primary @relation(name: "multiple_primaries")
+                    report: MultiplePrimaries @primary @relation(name: "multiple_primaries")
+                }
+            "#,
+            accepted: false,
+        },
+        AddCase {
+            validator: "validateCollectionDefinitionPolicyDesc",
+            sdl: r#"type PolicyWithoutACP @policy(id: "missing", resource: "records") { name: String }"#,
+            accepted: false,
+        },
+        AddCase {
+            validator: "validateTypeAndKindCompatible",
+            sdl: r#"type IncompatibleCRDT { enabled: Boolean @crdt(type: "pncounter") }"#,
+            accepted: false,
+        },
+        AddCase {
+            validator: "validateFieldNotDuplicated",
+            sdl: "type DuplicateField { name: String name: Int }",
+            accepted: false,
+        },
+        AddCase {
+            validator: "validateCollectionNameUnique",
+            sdl: "type DuplicateCollection { first: String } type DuplicateCollection { second: Int }",
+            accepted: false,
+        },
+        AddCase {
+            validator: "validateRelationNameUnique",
+            sdl: r#"
+                type DuplicateRelationName {
+                    boss: Self @primary @relation(name: "duplicate_relation")
+                    report: Self @relation(name: "duplicate_relation")
+                    mentor: Self @primary @relation(name: "duplicate_relation")
+                    student: Self @relation(name: "duplicate_relation")
+                }
+            "#,
+            accepted: false,
+        },
+        AddCase {
+            validator: "valid self-reference normalization",
+            sdl: "type InvalidSelfReference { parent: InvalidSelfReference @primary }",
+            accepted: true,
+        },
+        AddCase {
+            validator: "validateCollectionMaterialized",
+            sdl: "type DematerializedCollection @materialized(if: false) { name: String }",
+            accepted: false,
+        },
+        AddCase {
+            validator: "validateCollectionFieldDefaultValue",
+            sdl: r#"type InvalidDefault { score: Int @default(value: "bad") }"#,
+            accepted: false,
+        },
+        AddCase {
+            validator: "validateEmbeddingAndKindCompatible",
+            sdl: r#"
+                type InvalidEmbeddingKind {
+                    source: String
+                    vector: String @embedding(provider: "openai", model: "ada", fields: ["source"])
+                }
+            "#,
+            accepted: false,
+        },
+        AddCase {
+            validator: "validateEmbeddingFieldsForGeneration",
+            sdl: r#"
+                type InvalidEmbeddingField {
+                    vector: [Float32!] @embedding(provider: "openai", model: "ada", fields: ["missing"])
+                }
+            "#,
+            accepted: false,
+        },
+        AddCase {
+            validator: "validateEmbeddingProviderAndModel",
+            sdl: r#"
+                type InvalidEmbeddingProvider {
+                    source: String
+                    vector: [Float32!] @embedding(provider: "unknown", model: "ada", fields: ["source"])
+                }
+            "#,
+            accepted: false,
+        },
+    ];
+
+    for case in cases {
+        let rust_result = rust.schema_add(case.sdl);
+        let go_result = go.schema_add(case.sdl);
+        assert_outcome(case.validator, case.accepted, &rust_result, &go_result);
+        purge_both(&rust, &go);
+    }
+}
+
+#[tokio::test]
+async fn go_schema_patch_validation_parity() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(1)
+        .go_nodes(1)
+        .with_development()
+        .build()
+        .await
+        .unwrap();
+    let rust = cluster.client(0);
+    let go = cluster.client(1);
+
+    let cases = [
+        PatchCase {
+            validator: "valid nullable field addition",
+            sdl: "type PatchValid { name: String }",
+            patch: r#"[{"op":"add","path":"/PatchValid/Fields/-","value":{"Name":"extra","Kind":"String"}}]"#,
+            accepted: true,
+        },
+        PatchCase {
+            validator: "validateSourcesNotRedefined",
+            sdl: "type PatchSources { name: String }",
+            patch: r#"[{"op":"replace","path":"/PatchSources/PreviousVersion","value":{"SourceCollectionID":"bafkreibifvyfr6qvb6wx4v4cogvcdksb3v7vniaon7hdzzqb62cotpmlc4"}}]"#,
+            accepted: false,
+        },
+        PatchCase {
+            validator: "validateIndexesNotModified",
+            sdl: "type PatchIndexes { name: String @index }",
+            patch: r#"[{"op":"replace","path":"/PatchIndexes/Indexes","value":[]}]"#,
+            accepted: false,
+        },
+        PatchCase {
+            validator: "validateEncryptedIndexesNotModified",
+            sdl: "type PatchEncryptedIndexes { secret: String @encryptedIndex }",
+            patch: r#"[{"op":"replace","path":"/PatchEncryptedIndexes/EncryptedIndexes","value":[]}]"#,
+            accepted: false,
+        },
+        PatchCase {
+            validator: "validatePolicyNotModified",
+            sdl: "type PatchPolicy { name: String }",
+            patch: r#"[{"op":"replace","path":"/PatchPolicy/Policy","value":{}}]"#,
+            accepted: false,
+        },
+        PatchCase {
+            validator: "validateIDNotEmpty",
+            sdl: "type PatchEmptyID { name: String }",
+            patch: r#"[{"op":"replace","path":"/PatchEmptyID/CollectionID","value":""}]"#,
+            accepted: false,
+        },
+        PatchCase {
+            validator: "validateCollectionIDNotMutated",
+            sdl: "type PatchCollectionID { name: String }",
+            patch: r#"[{"op":"replace","path":"/PatchCollectionID/CollectionID","value":"bafkreibifvyfr6qvb6wx4v4cogvcdksb3v7vniaon7hdzzqb62cotpmlc4"}]"#,
+            accepted: false,
+        },
+        PatchCase {
+            validator: "validateFieldNotMutated",
+            sdl: "type PatchFieldMutation { name: String }",
+            patch: r#"[{"op":"replace","path":"/PatchFieldMutation/Fields/1/Kind","value":"Int"}]"#,
+            accepted: false,
+        },
+        PatchCase {
+            validator: "validateFieldNotMoved",
+            sdl: "type PatchFieldMove { first: String second: Int }",
+            patch: r#"[{"op":"move","from":"/PatchFieldMove/Fields/1","path":"/PatchFieldMove/Fields/2"}]"#,
+            accepted: false,
+        },
+        PatchCase {
+            validator: "validateCollectionNameNotMutated",
+            sdl: "type PatchName { name: String }",
+            patch: r#"[{"op":"replace","path":"/PatchName/Name","value":"Renamed"}]"#,
+            accepted: false,
+        },
+        PatchCase {
+            validator: "validateCollectionNameNotEmpty",
+            sdl: "type PatchEmptyName { name: String }",
+            patch: r#"[{"op":"replace","path":"/PatchEmptyName/Name","value":""}]"#,
+            accepted: false,
+        },
+        PatchCase {
+            validator: "validateNonNillableFieldNotAdded",
+            sdl: "type PatchRequired { name: String }",
+            patch: r#"[{"op":"add","path":"/PatchRequired/Fields/-","value":{"Name":"required","Kind":23}}]"#,
+            accepted: false,
+        },
+        PatchCase {
+            validator: "validateCollectionNotAdded",
+            sdl: "type PatchCollectionAdd { name: String }",
+            patch: r#"[{"op":"add","path":"/-","value":{"Name":"Added"}}]"#,
+            accepted: false,
+        },
+        PatchCase {
+            validator: "validateCollectionVersionIDNotMutated",
+            sdl: "type PatchVersionID { name: String }",
+            patch: r#"[{"op":"replace","path":"/PatchVersionID/VersionID","value":"bafkreibifvyfr6qvb6wx4v4cogvcdksb3v7vniaon7hdzzqb62cotpmlc4"}]"#,
+            accepted: false,
+        },
+        PatchCase {
+            validator: "validateCollectionIsBranchableNotMutated",
+            sdl: "type PatchBranchable { name: String }",
+            patch: r#"[{"op":"replace","path":"/PatchBranchable/IsBranchable","value":true}]"#,
+            accepted: false,
+        },
+        PatchCase {
+            validator: "validateRelationNameSet",
+            sdl: "type PatchRelationName { name: String }",
+            patch: r#"[{"op":"add","path":"/PatchRelationName/Fields/-","value":{"Name":"children","Kind":"[PatchRelationName]"}}]"#,
+            accepted: false,
+        },
+        PatchCase {
+            validator: "validateRelationalFieldIDType",
+            sdl:
+                "type PatchRelationTarget { name: String } type PatchRelationHost { name: String }",
+            patch: r#"[
+                {"op":"add","path":"/PatchRelationHost/Fields/-","value":{"Name":"target","Kind":"PatchRelationTarget","RelationName":"patch_relation","IsPrimary":true}},
+                {"op":"add","path":"/PatchRelationHost/Fields/-","value":{"Name":"_targetID","Kind":2}}
+            ]"#,
+            accepted: false,
+        },
+        PatchCase {
+            validator: "validateTypeSupported",
+            sdl: "type PatchUnsupportedType { name: String }",
+            patch: r#"[{"op":"add","path":"/PatchUnsupportedType/Fields/-","value":{"Name":"invalid","Kind":111}}]"#,
+            accepted: false,
+        },
+        PatchCase {
+            validator: "validateTypeAndKindCompatible",
+            sdl: "type PatchIncompatibleType { name: String }",
+            patch: r#"[{"op":"add","path":"/PatchIncompatibleType/Fields/-","value":{"Name":"invalid","Kind":"Boolean","Typ":4}}]"#,
+            accepted: false,
+        },
+        PatchCase {
+            validator: "validateFieldNotDuplicated",
+            sdl: "type PatchDuplicateField { name: String }",
+            patch: r#"[{"op":"add","path":"/PatchDuplicateField/Fields/-","value":{"Name":"name","Kind":"String"}}]"#,
+            accepted: false,
+        },
+        PatchCase {
+            validator: "validateCollectionMaterialized",
+            sdl: "type PatchMaterialized { name: String }",
+            patch: r#"[{"op":"replace","path":"/PatchMaterialized/IsMaterialized","value":false}]"#,
+            accepted: false,
+        },
+        PatchCase {
+            validator: "validateCollectionFieldDefaultValue",
+            sdl: "type PatchDefault { name: String }",
+            patch: r#"[{"op":"add","path":"/PatchDefault/Fields/-","value":{"Name":"score","Kind":"Int","DefaultValue":"bad"}}]"#,
+            accepted: false,
+        },
+        PatchCase {
+            validator: "validateEncryptedIndexes",
+            sdl: "type PatchInvalidEncryptedIndex { name: String }",
+            patch: r#"[{"op":"replace","path":"/PatchInvalidEncryptedIndex/EncryptedIndexes","value":[{"FieldName":"missing"}]}]"#,
+            accepted: false,
+        },
+        PatchCase {
+            validator: "validateVersionID",
+            sdl: "type PatchInvalidVersionCID { name: String }",
+            patch: r#"[{"op":"replace","path":"/PatchInvalidVersionCID/VersionID","value":"invalid"}]"#,
+            accepted: false,
+        },
+        PatchCase {
+            validator: "validateCollectionID",
+            sdl: "type PatchInvalidCollectionCID { name: String }",
+            patch: r#"[{"op":"replace","path":"/PatchInvalidCollectionCID/CollectionID","value":"invalid"}]"#,
+            accepted: false,
+        },
+        PatchCase {
+            validator: "validateCollectionSourceFromSameCollection",
+            sdl: "type PatchInvalidSource { name: String }",
+            patch: r#"[{"op":"replace","path":"/PatchInvalidSource/PreviousVersion","value":{"SourceCollectionID":"bafkreibifvyfr6qvb6wx4v4cogvcdksb3v7vniaon7hdzzqb62cotpmlc4"}}]"#,
+            accepted: false,
+        },
+    ];
+
+    for case in cases {
+        rust.schema_add(case.sdl)
+            .unwrap_or_else(|error| panic!("{} Rust setup failed: {error}", case.validator));
+        go.schema_add(case.sdl)
+            .unwrap_or_else(|error| panic!("{} Go setup failed: {error}", case.validator));
+
+        let rust_result = rust.collection_patch(case.patch);
+        let go_result = go.collection_patch(case.patch);
+        assert_outcome(case.validator, case.accepted, &rust_result, &go_result);
+        purge_both(&rust, &go);
+    }
+}

--- a/tools/integration-test/tests/basic/cross_runtime_schema_validation/stateful.rs
+++ b/tools/integration-test/tests/basic/cross_runtime_schema_validation/stateful.rs
@@ -1,0 +1,234 @@
+use integration_test::{generate_identity, TestCluster};
+use serde_json::Value;
+
+use super::{assert_outcome, purge_both};
+
+const VIEW_POLICY: &str = r#"name: view-policy
+description: Policy used by schema validation parity tests
+resources:
+  - name: records
+    permissions:
+      - name: read
+        expr: reader
+      - name: update
+      - name: delete
+    relations:
+      - name: reader
+        types:
+          - actor"#;
+
+fn active_description(description: &Value) -> &Value {
+    description
+        .as_array()
+        .and_then(|versions| {
+            versions.iter().find(|version| {
+                version
+                    .get("IsActive")
+                    .or_else(|| version.get("is_active"))
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false)
+            })
+        })
+        .unwrap_or(description)
+}
+
+fn active_version_id(description: &Value) -> &str {
+    let version = active_description(description);
+    version
+        .get("VersionID")
+        .or_else(|| version.get("version_id"))
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("active VersionID missing from {description}"))
+}
+
+fn active_collection_id(description: &Value) -> &str {
+    let version = active_description(description);
+    version
+        .get("CollectionID")
+        .or_else(|| version.get("collection_id"))
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("active CollectionID missing from {description}"))
+}
+
+fn policy_id(policy: &Value) -> &str {
+    policy
+        .get("PolicyID")
+        .or_else(|| policy.get("policyID"))
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("PolicyID missing from {policy}"))
+}
+
+#[tokio::test]
+async fn go_schema_stateful_validation_parity() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(1)
+        .go_nodes(1)
+        .with_development()
+        .with_acp_local()
+        .build()
+        .await
+        .unwrap();
+    let rust = cluster.client(0);
+    let go = cluster.client(1);
+
+    let sdl = "type FirstVersion { name: String } type SecondVersion { name: String }";
+    rust.schema_add(sdl).expect("add Rust ID schema");
+    go.schema_add(sdl).expect("add Go ID schema");
+    let rust_second = rust
+        .collection_describe_version("SecondVersion")
+        .expect("describe Rust SecondVersion");
+    let go_second = go
+        .collection_describe_version("SecondVersion")
+        .expect("describe Go SecondVersion");
+    let rust_second_id = active_version_id(&rust_second);
+    let go_second_id = active_version_id(&go_second);
+    assert_eq!(rust_second_id, go_second_id);
+    let duplicate_id_patch = format!(
+        r#"[{{"op":"replace","path":"/FirstVersion/VersionID","value":"{rust_second_id}"}}]"#
+    );
+    let rust_result = rust.collection_patch(&duplicate_id_patch);
+    let go_result = go.collection_patch(&duplicate_id_patch);
+    assert_outcome("validateIDUnique", false, &rust_result, &go_result);
+    purge_both(&rust, &go);
+
+    let sdl = "type VersionedCollection { name: String }";
+    rust.schema_add(sdl).expect("add Rust versioned schema");
+    go.schema_add(sdl).expect("add Go versioned schema");
+    let rust_original = rust
+        .collection_describe_version("VersionedCollection")
+        .expect("describe Rust original version");
+    let go_original = go
+        .collection_describe_version("VersionedCollection")
+        .expect("describe Go original version");
+    let rust_original_id = active_version_id(&rust_original);
+    let go_original_id = active_version_id(&go_original);
+    assert_eq!(rust_original_id, go_original_id);
+    let add_field = r#"[{"op":"add","path":"/VersionedCollection/Fields/-","value":{"Name":"extra","Kind":"String"}}]"#;
+    let rust_result = rust.collection_patch(add_field);
+    let go_result = go.collection_patch(add_field);
+    assert_outcome("valid version creation", true, &rust_result, &go_result);
+    let activate_original =
+        format!(r#"[{{"op":"replace","path":"/{rust_original_id}/IsActive","value":true}}]"#);
+    let rust_result = rust.collection_patch(&activate_original);
+    let go_result = go.collection_patch(&activate_original);
+    assert_outcome(
+        "validateSingleVersionActive",
+        false,
+        &rust_result,
+        &go_result,
+    );
+    purge_both(&rust, &go);
+
+    let sdl = "type SelfReference { name: String }";
+    rust.schema_add(sdl).expect("add Rust self schema");
+    go.schema_add(sdl).expect("add Go self schema");
+    let rust_description = rust
+        .collection_describe_version("SelfReference")
+        .expect("describe Rust self collection");
+    let go_description = go
+        .collection_describe_version("SelfReference")
+        .expect("describe Go self collection");
+    let rust_collection_id = active_collection_id(&rust_description);
+    let go_collection_id = active_collection_id(&go_description);
+    assert_eq!(rust_collection_id, go_collection_id);
+    let self_reference = format!(
+        r#"[{{"op":"add","path":"/SelfReference/Fields/-","value":{{"Name":"parent","Kind":{{"CollectionID":"{rust_collection_id}","Array":false}},"RelationName":"self_reference","IsPrimary":true}}}}]"#
+    );
+    let rust_result = rust.collection_patch(&self_reference);
+    let go_result = go.collection_patch(&self_reference);
+    assert_outcome("validateSelfReferences", false, &rust_result, &go_result);
+    purge_both(&rust, &go);
+
+    rust.schema_add("type ViewSource { name: String }")
+        .expect("add Rust view source");
+    go.schema_add("type ViewSource { name: String }")
+        .expect("add Go view source");
+    let add_source = r#"mutation { add_ViewSource(input: {name: "value"}) { _docID } }"#;
+    rust.query(add_source).expect("add Rust source document");
+    go.query(add_source).expect("add Go source document");
+    rust.view_add(
+        "ViewSource { name }",
+        "type MaterializedView { name: String }",
+    )
+    .expect("add Rust materialized view");
+    go.view_add(
+        "ViewSource { name }",
+        "type MaterializedView { name: String }",
+    )
+    .expect("add Go materialized view");
+    let _ = rust.view_refresh(Some("MaterializedView"));
+    let _ = go.view_refresh(Some("MaterializedView"));
+    let rust_view = rust
+        .query("query { MaterializedView { name } }")
+        .expect("query Rust materialized view");
+    let go_view = go
+        .query("query { MaterializedView { name } }")
+        .expect("query Go materialized view");
+    assert_eq!(rust_view, go_view);
+    assert_eq!(
+        rust_view
+            .pointer("/MaterializedView/0/name")
+            .and_then(Value::as_str),
+        Some("value")
+    );
+    let dematerialize =
+        r#"[{"op":"replace","path":"/MaterializedView/IsMaterialized","value":false}]"#;
+    let rust_result = rust.collection_patch(dematerialize);
+    let go_result = go.collection_patch(dematerialize);
+    assert_outcome(
+        "validateDematerializedViewHasNoData",
+        false,
+        &rust_result,
+        &go_result,
+    );
+    purge_both(&rust, &go);
+
+    let owner = generate_identity(rust.binary_path()).expect("generate policy owner");
+    let rust_policy = rust
+        .acp_policy_add(VIEW_POLICY, &owner.private_key_hex)
+        .expect("add Rust policy");
+    let go_policy = go
+        .acp_policy_add(VIEW_POLICY, &owner.private_key_hex)
+        .expect("add Go policy");
+    let rust_policy_id = policy_id(&rust_policy);
+    let go_policy_id = policy_id(&go_policy);
+    assert_eq!(rust_policy_id, go_policy_id);
+
+    let protected_collection = format!(
+        r#"type ProtectedCollection @policy(id: "{rust_policy_id}", resource: "records") {{ name: String }}"#
+    );
+    let rust_result = rust.schema_add_with_identity(&protected_collection, &owner.private_key_hex);
+    let go_result = go.schema_add_with_identity(&protected_collection, &owner.private_key_hex);
+    assert_outcome(
+        "valid materialized collection with policy",
+        true,
+        &rust_result,
+        &go_result,
+    );
+
+    let source_sdl = "type PolicyViewSource { name: String }";
+    rust.schema_add(source_sdl)
+        .expect("add Rust policy view source");
+    go.schema_add(source_sdl)
+        .expect("add Go policy view source");
+    let protected_view = format!(
+        r#"type ProtectedView @policy(id: "{rust_policy_id}", resource: "records") @materialized(if: false) {{ name: String }}"#
+    );
+    let rust_result = rust.view_add("PolicyViewSource { name }", &protected_view);
+    let go_result = go.view_add("PolicyViewSource { name }", &protected_view);
+    assert_outcome(
+        "valid non-materialized view with policy",
+        true,
+        &rust_result,
+        &go_result,
+    );
+    let materialize = r#"[{"op":"replace","path":"/ProtectedView/IsMaterialized","value":true}]"#;
+    let rust_result = rust.collection_patch(materialize);
+    let go_result = go.collection_patch(materialize);
+    assert_outcome(
+        "validateMaterializedHasNoPolicy",
+        false,
+        &rust_result,
+        &go_result,
+    );
+}


### PR DESCRIPTION
## Context

Schema validation is implemented independently in Rust and Go, but the shared integration suite does not compare their accepted and rejected schema states. Small validator differences can therefore ship without a parity signal.

This is 1/2 in the schema parity stack and depends on #1630.

## Changes

- add stateful cross-runtime schema validation cases
- compare table-driven valid and invalid schema inputs
- align validator behavior exposed by the new parity cases

## Testing

- [x] `cargo clippy --profile super-dev -p schema -p integration-test --all-targets -- -D warnings`
- [x] `cargo test --profile super-dev -p schema`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check origin/main...HEAD`

Closes #1420