### PR TITLE
fix(p2p): quarantine deterministic merge errors

### DIFF
--- a/crates/db/src/merge/merge_handler/authorization.rs
+++ b/crates/db/src/merge/merge_handler/authorization.rs
@@ -15,7 +15,7 @@ impl<S: Store, B: blockstore::Blockstore> DbMergeHandler<S, B> {
         };
 
         if authorization.collection_id != block.collection_id {
-            return Err(MergeError::MergeFailed(format!(
+            return Err(MergeError::InvalidReplayAuthorization(format!(
                 "explicit replay authorization collection '{}' does not match block collection '{}'",
                 authorization.collection_id, block.collection_id
             )));
@@ -31,7 +31,7 @@ impl<S: Store, B: blockstore::Blockstore> DbMergeHandler<S, B> {
             .unwrap_or(block.creator.as_str());
 
         if effective_creator != authorization.authorizer_did {
-            return Err(MergeError::MergeFailed(format!(
+            return Err(MergeError::InvalidReplayAuthorization(format!(
                 "explicit replay authorization authorizer '{}' does not match block creator '{}'",
                 authorization.authorizer_did, effective_creator
             )));

--- a/crates/db/src/merge/merge_handler/dispatch.rs
+++ b/crates/db/src/merge/merge_handler/dispatch.rs
@@ -2,8 +2,8 @@ use async_trait::async_trait;
 use cid::Cid;
 use defra_core::block::{Block, CrdtDelta};
 use defra_core::merge::{
-    BlockMetadata, ExplicitReplayAuthorization, MergeBlock, MergeHandler, MergeOutcome,
-    RecoveredBlockMetadata,
+    BlockMetadata, ExplicitReplayAuthorization, MergeBlock, MergeErrorDisposition, MergeHandler,
+    MergeOutcome, RecoveredBlockMetadata,
 };
 use storage::corekv::Store;
 
@@ -15,6 +15,10 @@ impl<S: Store + 'static, B: blockstore::Blockstore + 'static> MergeHandler
     for DbMergeHandler<S, B>
 {
     type Error = MergeError;
+
+    fn error_disposition(&self, error: &Self::Error) -> MergeErrorDisposition {
+        error.disposition()
+    }
 
     async fn validate_authorization(
         &self,
@@ -80,14 +84,8 @@ impl<S: Store + 'static, B: blockstore::Blockstore + 'static> MergeHandler
             }
         }
         match result {
-            // Signature verification is a property of the block bytes. It
-            // cannot become valid on a later retry, so route it through the
-            // existing terminal-rejection outcome and pending-DAG quarantine
-            // instead of returning `Err` to the receiver retry clock (#1159).
-            Err(error @ MergeError::SignatureVerificationFailed { .. }) => {
-                Ok(MergeOutcome::Rejected {
-                    reason: error.to_string(),
-                })
+            Err(error) if error.disposition() == MergeErrorDisposition::Terminal => {
+                Ok(MergeOutcome::rejected(error.to_string()))
             }
             other => other,
         }

--- a/crates/db/src/merge/merge_handler/error.rs
+++ b/crates/db/src/merge/merge_handler/error.rs
@@ -1,6 +1,7 @@
 //! Error types for database merge operations.
 
 use cid::Cid;
+use defra_core::merge::MergeErrorDisposition;
 use document::NormalValue;
 
 /// Error type for database merge operations.
@@ -17,6 +18,10 @@ pub enum MergeError {
     /// Missing metadata during non-recovery operation.
     #[error("missing metadata: {0}")]
     MissingMetadata(String),
+
+    /// Explicit replay authorization does not apply to the supplied block.
+    #[error("invalid explicit replay authorization: {0}")]
+    InvalidReplayAuthorization(String),
 
     /// CRDT merge failed.
     #[error("merge failed: {0}")]
@@ -87,6 +92,25 @@ impl MergeError {
                 _ => false,
             },
             _ => false,
+        }
+    }
+
+    /// Classify failures that cannot change while replaying the same block.
+    pub(crate) fn disposition(&self) -> MergeErrorDisposition {
+        match self {
+            Self::BlockDecode(_)
+            | Self::UnsupportedDelta(_)
+            | Self::InvalidReplayAuthorization(_)
+            | Self::ImmutableFieldChanged(_)
+            | Self::UniqueConstraintViolation(_)
+            | Self::SignatureVerificationFailed { .. }
+            | Self::DepthExceeded { .. } => MergeErrorDisposition::Terminal,
+            Self::MissingMetadata(_)
+            | Self::MergeFailed(_)
+            | Self::Database(_)
+            | Self::Storage(_)
+            | Self::Kms(_)
+            | Self::GateContended => MergeErrorDisposition::Retryable,
         }
     }
 }

--- a/crates/db/tests/merge/merge_handler_tests.rs
+++ b/crates/db/tests/merge/merge_handler_tests.rs
@@ -30,6 +30,7 @@ use defra_core::block::SignatureHeader;
 use defra_core::block::SignatureType;
 use defra_core::merge::BlockMetadata;
 use defra_core::merge::MergeBlock;
+use defra_core::merge::MergeErrorDisposition;
 use defra_core::merge::MergeHandler;
 use defra_core::merge::MergeOutcome;
 use defra_core::types::DocId;
@@ -542,6 +543,10 @@ async fn validate_explicit_replay_authorization_checks_collection_and_creator() 
         .await
         .unwrap_err();
     assert!(error.to_string().contains("does not match block creator"));
+    assert_eq!(
+        handler.error_disposition(&error),
+        MergeErrorDisposition::Terminal
+    );
 
     merge_block.collection_id = "other-collection".to_string();
     let error = handler
@@ -551,6 +556,27 @@ async fn validate_explicit_replay_authorization_checks_collection_and_creator() 
     assert!(error
         .to_string()
         .contains("does not match block collection"));
+    assert_eq!(
+        handler.error_disposition(&error),
+        MergeErrorDisposition::Terminal
+    );
+}
+
+#[tokio::test]
+async fn malformed_block_is_a_terminal_merge_rejection() {
+    let (handler, _blockstore) = make_handler();
+    let cid = make_lww_block(None).generate_cid().unwrap();
+
+    let outcome = handler
+        .handle_block(
+            &cid,
+            b"not dag-cbor",
+            BlockMetadata::normal("doc1", "v1", "creator", Some("peer1"), true),
+        )
+        .await
+        .expect("malformed content should be classified, not retried");
+
+    assert!(matches!(outcome, MergeOutcome::Rejected { .. }));
 }
 
 #[tokio::test]

--- a/crates/defra-core/src/merge.rs
+++ b/crates/defra-core/src/merge.rs
@@ -111,6 +111,18 @@ pub enum MergeOutcome {
     },
 }
 
+/// Durable disposition for an error returned by a merge handler.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MergeErrorDisposition {
+    /// The failure may succeed after local state or an external dependency changes.
+    Retryable,
+    /// Replaying the same block cannot succeed without changing its content.
+    ///
+    /// Replication quarantines terminal failures before releasing their live
+    /// pending-DAG slot.
+    Terminal,
+}
+
 impl MergeOutcome {
     /// Create a terminal skipped outcome with the given reason.
     pub fn terminal_skip(reason: impl Into<String>) -> Self {
@@ -336,6 +348,14 @@ impl<'a> BlockMetadata<'a> {
 pub trait MergeHandler: MaybeSendSync {
     /// Error type for merge operations
     type Error: std::error::Error + MaybeSendSync + 'static;
+
+    /// Classify a merge error for durable replication retry handling.
+    ///
+    /// Implementations must opt deterministic content failures into terminal
+    /// handling. Unknown errors remain retryable by default.
+    fn error_disposition(&self, _error: &Self::Error) -> MergeErrorDisposition {
+        MergeErrorDisposition::Retryable
+    }
 
     /// Handle an incoming block.
     ///

--- a/crates/p2p/src/sync/mod.rs
+++ b/crates/p2p/src/sync/mod.rs
@@ -53,7 +53,10 @@ pub use manager::{
     DEFAULT_PUSH_SEND_TIMEOUT, DEFAULT_RATE_LIMIT_BACKOFF_SECS, DEFAULT_RATE_LIMIT_BURST,
     DEFAULT_RATE_LIMIT_RATE,
 };
-pub use merge::{BlockMetadata, MergeBlock, MergeHandler, MergeOutcome, RecoveredBlockMetadata};
+pub use merge::{
+    BlockMetadata, MergeBlock, MergeErrorDisposition, MergeHandler, MergeOutcome,
+    RecoveredBlockMetadata,
+};
 pub use peer_state::{PeerStateTracker, PeerStats};
 pub use pending_store::{
     PendingDagStorage, PendingDagStore, PersistedPendingDag, PersistedQuarantinedDag,

--- a/crates/p2p/src/sync/replication/handlers.rs
+++ b/crates/p2p/src/sync/replication/handlers.rs
@@ -9,7 +9,8 @@ use crate::sync::coordinator::dag_context::DagFetchContext;
 use crate::sync::coordinator::SyncCoordinator;
 use crate::sync::manager::SyncEvent;
 use crate::sync::merge::{
-    BlockMetadata, MergeBlock, MergeHandler, MergeOutcome, RecoveredBlockMetadata,
+    BlockMetadata, MergeBlock, MergeErrorDisposition, MergeHandler, MergeOutcome,
+    RecoveredBlockMetadata,
 };
 use crate::transport::P2PTransport;
 
@@ -53,36 +54,37 @@ fn merge_block_from_metadata(
     })
 }
 
+async fn merge_error_result<B, T, H>(
+    coordinator: &SyncCoordinator<B, T>,
+    handler: &H,
+    cid: Cid,
+    doc_id: &str,
+    collection_id: &str,
+    error: H::Error,
+) -> ReplicationResult
+where
+    B: Blockstore + 'static,
+    T: P2PTransport,
+    H: MergeHandler + ?Sized + 'static,
+{
+    let reason = error.to_string();
+    if handler.error_disposition(&error) == MergeErrorDisposition::Terminal {
+        coordinator.quarantine_pending_dag(&cid, &reason).await;
+        ReplicationResult::Quarantined {
+            cid,
+            doc_id: doc_id.to_string(),
+            collection_id: collection_id.to_string(),
+            reason,
+        }
+    } else {
+        ReplicationResult::Failed { cid, error: reason }
+    }
+}
+
 fn recovered_metadata_error(cid: Cid, details: impl Into<String>) -> ReplicationResult {
     ReplicationResult::Failed {
         cid,
         error: format!("Recovery metadata incomplete: {}", details.into()),
-    }
-}
-
-#[allow(clippy::result_large_err)]
-async fn recover_metadata_for_block<H>(
-    handler: &H,
-    cid: Cid,
-    block_data: &[u8],
-) -> Result<RecoveredBlockMetadata, ReplicationResult>
-where
-    H: MergeHandler + ?Sized + 'static,
-{
-    match handler.recover_block_metadata(&cid, block_data).await {
-        Ok(Some(metadata)) if metadata.is_complete() => Ok(metadata),
-        Ok(Some(metadata)) => Err(recovered_metadata_error(
-            cid,
-            format!(
-                "handler returned doc_id='{}', collection_id='{}', creator='{}'",
-                metadata.doc_id, metadata.collection_id, metadata.creator
-            ),
-        )),
-        Ok(None) => Err(recovered_metadata_error(
-            cid,
-            "handler did not return recovered metadata",
-        )),
-        Err(error) => Err(recovered_metadata_error(cid, error.to_string())),
     }
 }
 
@@ -264,9 +266,23 @@ where
 
     let recovered_metadata: Option<RecoveredBlockMetadata>;
     let metadata = if metadata.is_recovery && metadata.is_incomplete() {
-        let recovered = match recover_metadata_for_block(handler, cid, &block_data).await {
-            Ok(recovered) => recovered,
-            Err(result) => return result,
+        let recovered = match handler.recover_block_metadata(&cid, &block_data).await {
+            Ok(Some(recovered)) if recovered.is_complete() => recovered,
+            Ok(Some(recovered)) => {
+                return recovered_metadata_error(
+                    cid,
+                    format!(
+                        "handler returned doc_id='{}', collection_id='{}', creator='{}'",
+                        recovered.doc_id, recovered.collection_id, recovered.creator
+                    ),
+                )
+            }
+            Ok(None) => {
+                return recovered_metadata_error(cid, "handler did not return recovered metadata")
+            }
+            Err(error) => {
+                return merge_error_result(coordinator, handler, cid, "", "", error).await
+            }
         };
         recovered_metadata = Some(recovered);
         let recovered = recovered_metadata
@@ -282,6 +298,13 @@ where
         metadata
     };
 
+    // Extract identifiers before validation so terminal authorization errors
+    // can use the same durable quarantine path as merge errors.
+    let doc_id_for_result = metadata.doc_id.unwrap_or("").to_string();
+    let collection_id_for_result = metadata.collection_id.unwrap_or("").to_string();
+    let collection_id_for_broadcast = metadata.collection_id.unwrap_or("");
+    let creator_for_forward = metadata.creator.unwrap_or("").to_string();
+
     if metadata.explicit_replay_authorization.is_some() {
         let Some(block) = merge_block_from_metadata(cid, block_data.clone(), &metadata) else {
             return ReplicationResult::Failed {
@@ -293,18 +316,17 @@ where
             .validate_authorization(block.explicit_replay_authorization.as_ref(), &block)
             .await
         {
-            return ReplicationResult::Failed {
+            return merge_error_result(
+                coordinator,
+                handler,
                 cid,
-                error: error.to_string(),
-            };
+                &doc_id_for_result,
+                &collection_id_for_result,
+                error,
+            )
+            .await;
         }
     }
-
-    // Extract doc_id and collection_id for use in result.
-    let doc_id_for_result = metadata.doc_id.unwrap_or("").to_string();
-    let collection_id_for_result = metadata.collection_id.unwrap_or("").to_string();
-    let collection_id_for_broadcast = metadata.collection_id.unwrap_or("");
-    let creator_for_forward = metadata.creator.unwrap_or("").to_string();
 
     // Delegate merge to handler
     match handler.handle_block(&cid, &block_data, metadata).await {
@@ -432,10 +454,17 @@ where
             cid,
             error: "unsupported merge outcome".to_string(),
         },
-        Err(e) => ReplicationResult::Failed {
-            cid,
-            error: e.to_string(),
-        },
+        Err(error) => {
+            merge_error_result(
+                coordinator,
+                handler,
+                cid,
+                &doc_id_for_result,
+                &collection_id_for_result,
+                error,
+            )
+            .await
+        }
     }
 }
 
@@ -588,10 +617,17 @@ where
                     .validate_authorization(block.explicit_replay_authorization.as_ref(), &block)
                     .await
                 {
-                    results.push(ReplicationResult::Failed {
-                        cid,
-                        error: error.to_string(),
-                    });
+                    results.push(
+                        merge_error_result(
+                            coordinator,
+                            handler,
+                            cid,
+                            &block.doc_id,
+                            &block.collection_id,
+                            error,
+                        )
+                        .await,
+                    );
                     continue;
                 }
 
@@ -664,11 +700,18 @@ where
                     error: "unsupported merge outcome".to_string(),
                 });
             }
-            Err(e) => {
-                results.push(ReplicationResult::Failed {
-                    cid: block.cid,
-                    error: e.to_string(),
-                });
+            Err(error) => {
+                results.push(
+                    merge_error_result(
+                        coordinator,
+                        handler,
+                        block.cid,
+                        &block.doc_id,
+                        &block.collection_id,
+                        error,
+                    )
+                    .await,
+                );
             }
         }
     }

--- a/crates/p2p/src/sync/replication/tests.rs
+++ b/crates/p2p/src/sync/replication/tests.rs
@@ -9,7 +9,8 @@ use crate::message::{
 use crate::replicator::EqOnlyFilterMatcher;
 use crate::sync::manager::SyncEvent;
 use crate::sync::merge::{
-    BlockMetadata, MergeBlock, MergeHandler, MergeOutcome, RecoveredBlockMetadata,
+    BlockMetadata, MergeBlock, MergeErrorDisposition, MergeHandler, MergeOutcome,
+    RecoveredBlockMetadata,
 };
 use crate::topics::DefraTopic;
 use crate::transport::{MessageId, P2PTransport, PeerAddr, PeerId, TransportEvent};
@@ -782,6 +783,20 @@ struct RetryThenMergeHandler {
     call_count: AtomicUsize,
 }
 
+struct ErrorThenMergeHandler {
+    call_count: AtomicUsize,
+    disposition: MergeErrorDisposition,
+}
+
+impl ErrorThenMergeHandler {
+    fn new(disposition: MergeErrorDisposition) -> Self {
+        Self {
+            call_count: AtomicUsize::new(0),
+            disposition,
+        }
+    }
+}
+
 impl RetryThenMergeHandler {
     fn new() -> Self {
         Self {
@@ -830,6 +845,28 @@ impl MergeHandler for RetryThenMergeHandler {
         let attempt = self.call_count.fetch_add(1, Ordering::SeqCst);
         if attempt == 0 {
             Ok(MergeOutcome::retryable_skip("pending ACP"))
+        } else {
+            Ok(MergeOutcome::Merged)
+        }
+    }
+}
+
+#[async_trait]
+impl MergeHandler for ErrorThenMergeHandler {
+    type Error = TestError;
+
+    fn error_disposition(&self, _error: &Self::Error) -> MergeErrorDisposition {
+        self.disposition
+    }
+
+    async fn handle_block(
+        &self,
+        _cid: &Cid,
+        _block_data: &[u8],
+        _metadata: BlockMetadata<'_>,
+    ) -> Result<MergeOutcome, Self::Error> {
+        if self.call_count.fetch_add(1, Ordering::SeqCst) == 0 {
+            Err(TestError("classified merge failure".to_string()))
         } else {
             Ok(MergeOutcome::Merged)
         }
@@ -1323,6 +1360,11 @@ async fn test_rejected_merge_quarantines_and_leaves_block_unmerged() {
 
     let (coordinator, pending_store) =
         coordinator_with_live_pending_dag(blockstore.clone(), cid).await;
+    assert_eq!(
+        coordinator.manager().resync_persisted_pending_dags().await,
+        1
+    );
+    assert_eq!(coordinator.pending_dag_count(), 1);
 
     let handler = RejectingMergeHandler::new("unique constraint violation");
     let result = handle_block_received(
@@ -1358,6 +1400,116 @@ async fn test_rejected_merge_quarantines_and_leaves_block_unmerged() {
         pending_store.load_all().await.unwrap().is_empty(),
         "live durable record must be removed after quarantine"
     );
+}
+
+#[tokio::test]
+async fn terminal_merge_error_quarantines_and_releases_pending_slot() {
+    use crate::sync::pending_store::PendingDagStorage;
+
+    let store = Arc::new(RegolithStore::in_memory().unwrap());
+    let blockstore = Arc::new(DefraBlockstore::new(store, true));
+    let cid = test_cid();
+    blockstore.put(&cid, b"test data").await.unwrap();
+    let (coordinator, pending_store) =
+        coordinator_with_live_pending_dag(blockstore.clone(), cid).await;
+    assert_eq!(
+        coordinator.manager().resync_persisted_pending_dags().await,
+        1
+    );
+    assert_eq!(coordinator.pending_dag_count(), 1);
+
+    let result = handle_block_received(
+        &coordinator,
+        &ErrorThenMergeHandler::new(MergeErrorDisposition::Terminal),
+        &ReplicationConfig::default(),
+        cid,
+        BlockMetadata::normal("doc1", "col1", "peer1", Some("sender1"), true),
+    )
+    .await;
+
+    assert!(
+        matches!(result, ReplicationResult::Quarantined { cid: result_cid, .. } if result_cid == cid)
+    );
+    assert!(pending_store.load_all().await.unwrap().is_empty());
+    assert!(pending_store.is_quarantined(&cid).await.unwrap());
+    let status = coordinator.sync_status();
+    assert_eq!(status.pending_dags, 0);
+    assert_eq!(status.persisted_pending_dags, 0);
+    assert_eq!(status.pending_dag_terminal_quarantined, 1);
+    assert_eq!(status.quarantined_pending_dags, 1);
+}
+
+#[tokio::test]
+async fn batched_terminal_merge_error_quarantines_and_releases_pending_slot() {
+    use crate::sync::pending_store::PendingDagStorage;
+
+    let store = Arc::new(RegolithStore::in_memory().unwrap());
+    let blockstore = Arc::new(DefraBlockstore::new(store, true));
+    let cid = test_cid();
+    blockstore.put(&cid, b"test data").await.unwrap();
+    let (coordinator, pending_store) =
+        coordinator_with_live_pending_dag(blockstore.clone(), cid).await;
+    assert_eq!(
+        coordinator.manager().resync_persisted_pending_dags().await,
+        1
+    );
+
+    let results = process_merge_batch(
+        &coordinator,
+        vec![dag_ready_event(cid)],
+        &ErrorThenMergeHandler::new(MergeErrorDisposition::Terminal),
+        &ReplicationConfig::default(),
+    )
+    .await;
+
+    assert!(matches!(
+        results.as_slice(),
+        [ReplicationResult::Quarantined { cid: result_cid, .. }] if *result_cid == cid
+    ));
+    assert_eq!(coordinator.pending_dag_count(), 0);
+    assert!(pending_store.load_all().await.unwrap().is_empty());
+    assert!(pending_store.is_quarantined(&cid).await.unwrap());
+}
+
+#[tokio::test]
+async fn retryable_merge_error_retains_pending_slot_and_can_converge() {
+    use crate::sync::pending_store::PendingDagStorage;
+
+    let store = Arc::new(RegolithStore::in_memory().unwrap());
+    let blockstore = Arc::new(DefraBlockstore::new(store, true));
+    let cid = test_cid();
+    blockstore.put(&cid, b"test data").await.unwrap();
+    let (coordinator, pending_store) =
+        coordinator_with_live_pending_dag(blockstore.clone(), cid).await;
+    assert_eq!(
+        coordinator.manager().resync_persisted_pending_dags().await,
+        1
+    );
+    let handler = ErrorThenMergeHandler::new(MergeErrorDisposition::Retryable);
+    let metadata = || BlockMetadata::normal("doc1", "col1", "peer1", Some("sender1"), true);
+
+    let first = handle_block_received(
+        &coordinator,
+        &handler,
+        &ReplicationConfig::default(),
+        cid,
+        metadata(),
+    )
+    .await;
+    assert!(matches!(first, ReplicationResult::Failed { .. }));
+    assert_eq!(pending_store.load_all().await.unwrap().len(), 1);
+    assert!(!pending_store.is_quarantined(&cid).await.unwrap());
+
+    let second = handle_block_received(
+        &coordinator,
+        &handler,
+        &ReplicationConfig::default(),
+        cid,
+        metadata(),
+    )
+    .await;
+    assert!(matches!(second, ReplicationResult::Merged { .. }));
+    assert!(pending_store.load_all().await.unwrap().is_empty());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Context

Pending DAG blocks are retried after every merge failure. Deterministically malformed blocks can therefore occupy pending slots indefinitely and repeatedly block descendants that cannot converge.

This is 2/2 in the P2P reliability stack and depends on #1634.

## Changes

- classify merge failures as retryable or terminal
- quarantine terminal blocks before releasing their pending slots
- retain retryable blocks so missing dependencies can still converge
- cover single, batched, terminal, and retryable merge outcomes

## Testing

- [x] `cargo clippy --profile super-dev -p defra-core -p db -p embedded -p p2p --all-targets -- -D warnings`
- [x] `cargo test --profile super-dev -p p2p --lib`
- [x] `cargo test --profile super-dev -p db malformed_block_is_a_terminal_merge_rejection -- --nocapture`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check origin/main...HEAD`

Closes #1537