### PR TITLE
test(query): compare CRUD results with Go

### DIFF
--- a/crates/query/src/json_convert.rs
+++ b/crates/query/src/json_convert.rs
@@ -169,7 +169,11 @@ fn float64_to_json(f: f64) -> Result<JsonValue> {
     }
     // Match Go's json.Marshal behavior: whole-number floats serialize
     // without a decimal point (e.g., float64(21.0) → "21").
-    if f.fract() == 0.0 && f >= i64::MIN as f64 && f <= i64::MAX as f64 {
+    if f.fract() == 0.0
+        && !(f == 0.0 && f.is_sign_negative())
+        && f >= i64::MIN as f64
+        && f <= i64::MAX as f64
+    {
         return Ok(JsonValue::Number(serde_json::Number::from(f as i64)));
     }
     serde_json::Number::from_f64(f)
@@ -191,7 +195,11 @@ fn float32_to_json(f: f32) -> Result<JsonValue> {
         )));
     }
     // Match Go's json.Marshal behavior for whole-number floats
-    if f64_val.fract() == 0.0 && f64_val >= i64::MIN as f64 && f64_val <= i64::MAX as f64 {
+    if f64_val.fract() == 0.0
+        && !(f64_val == 0.0 && f64_val.is_sign_negative())
+        && f64_val >= i64::MIN as f64
+        && f64_val <= i64::MAX as f64
+    {
         return Ok(JsonValue::Number(serde_json::Number::from(f64_val as i64)));
     }
     serde_json::Number::from_f64(f64_val)
@@ -307,9 +315,15 @@ mod tests {
         assert_eq!(float64_to_json(3.15).unwrap(), serde_json::json!(3.15));
         // Whole-number floats are serialized as integers to match Go's json.Marshal
         assert_eq!(float64_to_json(0.0).unwrap(), serde_json::json!(0));
+        assert_eq!(float64_to_json(-0.0).unwrap().to_string(), "-0.0");
         assert_eq!(float64_to_json(-42.5).unwrap(), serde_json::json!(-42.5));
         assert_eq!(float64_to_json(21.0).unwrap(), serde_json::json!(21));
         assert_eq!(float64_to_json(21.5).unwrap(), serde_json::json!(21.5));
+    }
+
+    #[test]
+    fn test_float32_to_json_preserves_negative_zero() {
+        assert_eq!(float32_to_json(-0.0).unwrap().to_string(), "-0.0");
     }
 
     #[test]

--- a/tools/integration-test/src/cross_runtime.rs
+++ b/tools/integration-test/src/cross_runtime.rs
@@ -1,0 +1,20 @@
+use defra_harness::DefraClient;
+use serde_json::Value;
+
+pub fn query_both(rust: &DefraClient, go: &DefraClient, query: &str) -> (Value, Value) {
+    (
+        rust.query(query)
+            .unwrap_or_else(|error| panic!("Rust query failed: {error}\n{query}")),
+        go.query(query)
+            .unwrap_or_else(|error| panic!("Go query failed: {error}\n{query}")),
+    )
+}
+
+pub fn assert_query_equivalent(rust: &DefraClient, go: &DefraClient, query: &str) -> Value {
+    let (rust_response, go_response) = query_both(rust, go, query);
+    assert_eq!(
+        rust_response, go_response,
+        "query responses diverged: {query}"
+    );
+    rust_response
+}

--- a/tools/integration-test/src/lib.rs
+++ b/tools/integration-test/src/lib.rs
@@ -1,7 +1,9 @@
 use std::path::PathBuf;
 
+mod cross_runtime;
 mod feature_binaries;
 
+pub use cross_runtime::{assert_query_equivalent, query_both};
 pub use feature_binaries::build_cli_variant;
 
 // Re-export modules from defra-harness

--- a/tools/integration-test/tests/basic.rs
+++ b/tools/integration-test/tests/basic.rs
@@ -6,6 +6,8 @@ mod collection_delete_4657;
 mod collection_management;
 #[path = "basic/cross_runtime_cids.rs"]
 mod cross_runtime_cids;
+#[path = "basic/cross_runtime_queries.rs"]
+mod cross_runtime_queries;
 #[path = "basic/document_lifecycle.rs"]
 mod document_lifecycle;
 #[path = "basic/multi_collection.rs"]

--- a/tools/integration-test/tests/basic/cross_runtime_cids.rs
+++ b/tools/integration-test/tests/basic/cross_runtime_cids.rs
@@ -1,4 +1,4 @@
-use integration_test::{DefraClient, TestCluster};
+use integration_test::{query_both, DefraClient, TestCluster};
 use serde_json::Value;
 
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -99,13 +99,6 @@ fn assert_counter_history_matches(
         deterministic(&go_commits),
         "{stage}: LWW field CIDs diverged"
     );
-}
-
-fn query_both(rust: &DefraClient, go: &DefraClient, query: &str) -> (Value, Value) {
-    (
-        rust.query(query).expect("Rust query"),
-        go.query(query).expect("Go query"),
-    )
 }
 
 #[tokio::test]

--- a/tools/integration-test/tests/basic/cross_runtime_queries.rs
+++ b/tools/integration-test/tests/basic/cross_runtime_queries.rs
@@ -1,0 +1,203 @@
+use integration_test::{assert_query_equivalent, TestCluster};
+
+const SCHEMA: &str = r#"
+    type ScalarCase {
+        tag: String!
+        text: String!
+        optionalText: String
+        integer: Int!
+        optionalInteger: Int
+        ratio: Float64!
+        optionalRatio: Float64
+        enabled: Boolean!
+        optionalEnabled: Boolean
+        observed: DateTime!
+        optionalObserved: DateTime
+        payload: Blob!
+        optionalPayload: Blob
+        metadata: JSON!
+        optionalMetadata: JSON
+    }
+
+    type QueryCase {
+        name: String
+        category: String
+        rank: Int
+        score: Float
+        optionalRank: Int
+    }
+
+    type Book {
+        name: String
+        rating: Float
+        author: Author
+    }
+
+    type Author {
+        name: String
+        published: [Book]
+    }
+"#;
+
+#[tokio::test]
+async fn go_cross_runtime_crud_and_query_equivalence() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(1)
+        .go_nodes(1)
+        .build()
+        .await
+        .unwrap();
+    let rust = cluster.client(0);
+    let go = cluster.client(1);
+    rust.schema_add(SCHEMA).expect("add Rust schema");
+    go.schema_add(SCHEMA).expect("add Go schema");
+
+    for document in [
+        r#"{
+            "tag": "boundaries",
+            "text": "Grusse 東京",
+            "optionalText": "",
+            "integer": 9223372036854775807,
+            "optionalInteger": -9223372036854775808,
+            "ratio": 1.23456789012345,
+            "optionalRatio": -0.0,
+            "enabled": true,
+            "optionalEnabled": false,
+            "observed": "2400-01-01T00:00:00Z",
+            "optionalObserved": "1600-01-01T00:00:00Z",
+            "payload": "00FF",
+            "optionalPayload": "00",
+            "metadata": {"nested": {"value": 1}, "list": [true, null, "x"]},
+            "optionalMetadata": {}
+        }"#,
+        r#"{
+            "tag": "nulls",
+            "text": "",
+            "integer": -9223372036854775808,
+            "ratio": 0.0,
+            "enabled": false,
+            "observed": "2000-01-01T00:00:00Z",
+            "payload": "00",
+            "metadata": {}
+        }"#,
+    ] {
+        rust.collection_create("ScalarCase", document)
+            .expect("create Rust scalar fixture");
+        go.collection_create("ScalarCase", document)
+            .expect("create Go scalar fixture");
+    }
+    assert_query_equivalent(
+        &rust,
+        &go,
+        r#"query {
+            ScalarCase(order: {tag: ASC}) {
+                tag text optionalText integer optionalInteger ratio optionalRatio
+                enabled optionalEnabled observed optionalObserved payload optionalPayload
+                metadata optionalMetadata
+            }
+        }"#,
+    );
+
+    for input in [
+        r#"{name: "alpha", category: "a", rank: 1, score: 10.5}"#,
+        r#"{name: "beta", category: "a", rank: 2, score: 20, optionalRank: 2}"#,
+        r#"{name: "gamma", category: "b", rank: 2, score: 30.25}"#,
+        r#"{name: "alphabet", category: "b", rank: 3, score: 40, optionalRank: 3}"#,
+        r#"{name: "omega", category: "a", rank: 4, score: 50.25, optionalRank: 4}"#,
+    ] {
+        assert_query_equivalent(
+            &rust,
+            &go,
+            &format!(r#"mutation {{ add_QueryCase(input: {input}) {{ _docID }} }}"#),
+        );
+    }
+
+    for query in [
+        "query { QueryCase { name rank } }",
+        "query { QueryCase(order: [{rank: ASC}, {name: DESC}]) { name rank } }",
+        "query { QueryCase(order: {optionalRank: ASC}) { name optionalRank } }",
+        r#"query { QueryCase(filter: {name: {_eq: "alpha"}}) { name } }"#,
+        r#"query { QueryCase(filter: {name: {_neq: "alpha"}}, order: {name: ASC}) { name } }"#,
+        "query { QueryCase(filter: {_and: [{rank: {_gt: 1, _geq: 2}}, {rank: {_lt: 4, _leq: 3}}]}, order: {name: ASC}) { name rank } }",
+        "query { QueryCase(filter: {rank: {_in: [1, 3], _nin: [2]}}, order: {rank: ASC}) { name rank } }",
+        r#"query { QueryCase(filter: {name: {_like: "alpha%"}}, order: {name: ASC}) { name } }"#,
+        r#"query { QueryCase(filter: {name: {_nlike: "%ha%"}}, order: {name: ASC}) { name } }"#,
+        "query { QueryCase(filter: {optionalRank: {_eq: null}}, order: {name: ASC}) { name optionalRank } }",
+        "query { QueryCase(filter: {optionalRank: {_in: [null, 3]}}, order: {name: ASC}) { name optionalRank } }",
+        "query { QueryCase(order: {rank: ASC}, limit: 2, offset: 1) { name rank } }",
+        "query { count: COUNT(QueryCase: {}) sum: SUM(QueryCase: {field: score}) avg: AVG(QueryCase: {field: score}) }",
+        "query { count: COUNT(QueryCase: {filter: {rank: {_gt: 100}}}) sum: SUM(QueryCase: {field: score, filter: {rank: {_gt: 100}}}) avg: AVG(QueryCase: {field: score, filter: {rank: {_gt: 100}}}) }",
+    ] {
+        assert_query_equivalent(&rust, &go, query);
+    }
+
+    assert_query_equivalent(
+        &rust,
+        &go,
+        r#"mutation {
+            update_QueryCase(filter: {name: {_eq: "beta"}}, input: {score: 21.5}) {
+                name score
+            }
+        }"#,
+    );
+    assert_query_equivalent(
+        &rust,
+        &go,
+        r#"mutation {
+            delete_QueryCase(filter: {name: {_eq: "omega"}}) {
+                name rank
+            }
+        }"#,
+    );
+    assert_query_equivalent(
+        &rust,
+        &go,
+        "query { QueryCase(order: {name: ASC}) { name rank score } }",
+    );
+
+    let ada = assert_query_equivalent(
+        &rust,
+        &go,
+        r#"mutation { add_Author(input: {name: "Ada"}) { _docID } }"#,
+    )["add_Author"][0]["_docID"]
+        .as_str()
+        .expect("Ada document ID")
+        .to_string();
+    let grace = assert_query_equivalent(
+        &rust,
+        &go,
+        r#"mutation { add_Author(input: {name: "Grace"}) { _docID } }"#,
+    )["add_Author"][0]["_docID"]
+        .as_str()
+        .expect("Grace document ID")
+        .to_string();
+
+    for (name, rating, author) in [
+        ("Compiler", 4.9, ada.as_str()),
+        ("Notes", 4.2, ada.as_str()),
+        ("Systems", 4.8, grace.as_str()),
+        ("COBOL", 4.0, grace.as_str()),
+    ] {
+        assert_query_equivalent(
+            &rust,
+            &go,
+            &format!(
+                r#"mutation {{ add_Book(input: {{name: "{name}", rating: {rating}, author: "{author}"}}) {{ _docID }} }}"#
+            ),
+        );
+    }
+
+    for query in [
+        r#"query {
+            Author(filter: {name: {_like: "A%"}}) {
+                name
+                published(filter: {rating: {_gt: 4}}, order: {rating: DESC}, limit: 1) {
+                    name rating author { name }
+                }
+            }
+        }"#,
+        "query { Book(order: {rating: ASC}, limit: 2, offset: 1) { name rating author { name } } }",
+    ] {
+        assert_query_equivalent(&rust, &go, query);
+    }
+}


### PR DESCRIPTION
## Context

Matching block CIDs establish storage parity, but they do not verify that Rust and Go expose the same document values through CRUD and GraphQL query paths.

This is 2/3 in the data parity stack and depends on #1636.

## Changes

- add shared helpers for equivalent Rust and Go queries
- compare create, update, delete, filtering, ordering, and aggregate results
- normalize JSON conversion so cross-runtime values retain the same shape

## Testing

- [x] `cargo clippy --profile super-dev -p query -p integration-test --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check origin/main...HEAD`

Closes #1417