### PR TITLE
fix(http): normalize trailing slashes before routing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,7 +145,7 @@ graphql-parser = "0.4"
 # HTTP
 axum = { version = "0.8.9", features = ["ws"] }
 tower = { version = "0.5", features = ["timeout", "limit"] }
-tower-http = { version = "0.6", features = ["cors", "trace"] }
+tower-http = { version = "0.6", features = ["cors", "normalize-path", "trace"] }
 hyper = "1.9.0"
 
 # Error handling

--- a/crates/http/src/server.rs
+++ b/crates/http/src/server.rs
@@ -11,8 +11,9 @@ use axum::Router;
 use tokio::net::TcpListener;
 use tower::limit::ConcurrencyLimitLayer;
 use tower::timeout::TimeoutLayer;
-use tower::ServiceBuilder;
+use tower::{Layer, ServiceBuilder};
 use tower_http::cors::CorsLayer;
+use tower_http::normalize_path::NormalizePathLayer;
 use tower_http::trace::TraceLayer;
 
 use query::executor::QueryExecutor;
@@ -567,7 +568,10 @@ impl Server {
 
         router = router.layer(TraceLayer::new_for_http()).layer(cors);
 
-        Ok(router)
+        // Router layers run after route matching, so normalize misses through a
+        // clone that already carries the complete auth and request middleware.
+        let normalized = NormalizePathLayer::trim_trailing_slash().layer(router.clone());
+        Ok(router.fallback_service(normalized))
     }
 
     /// Build CORS layer matching Go DefraDB behavior.

--- a/crates/http/src/server_tests.rs
+++ b/crates/http/src/server_tests.rs
@@ -1,8 +1,13 @@
 use axum::body::Body;
+use axum::http::header::{AUTHORIZATION, HOST};
 use axum::http::{Method, Request, StatusCode};
+use identity::{new_token, Identity, RawIdentity};
+use std::sync::Arc;
+use std::time::Duration;
 use tower::ServiceExt;
 
-use crate::mock::{MockBackupOperations, MockQueryExecutor};
+use crate::mock::{MockBackupOperations, MockNodeAcpOperations, MockQueryExecutor};
+use crate::router::{NodeAcpOperations, NodePermission};
 use crate::server::{Server, ServerConfig};
 
 const OVERSIZED: usize = 64;
@@ -11,6 +16,22 @@ const LIMIT: u64 = 8;
 fn server(config: ServerConfig) -> Server {
     Server::with_config(MockQueryExecutor::new(), config)
         .with_backup_arc(std::sync::Arc::new(MockBackupOperations::default()))
+}
+
+async fn get(config: ServerConfig, uri: &str) -> StatusCode {
+    server(config)
+        .router()
+        .expect("router builds")
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri(uri)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+        .status()
 }
 
 async fn post(config: ServerConfig, uri: &str, body_len: usize) -> StatusCode {
@@ -27,6 +48,82 @@ async fn post(config: ServerConfig, uri: &str, body_len: usize) -> StatusCode {
         .await
         .unwrap()
         .status()
+}
+
+#[tokio::test]
+async fn trailing_slashes_are_normalized_at_every_mount() {
+    for path in [
+        "/health-check",
+        "/api/version",
+        "/api/v0/version",
+        "/api/v1/version",
+    ] {
+        let canonical = get(ServerConfig::default(), path).await;
+        let trailing = get(ServerConfig::default(), &format!("{path}/")).await;
+        assert_ne!(canonical, StatusCode::NOT_FOUND, "{path}");
+        assert_eq!(trailing, canonical, "{path}/");
+    }
+}
+
+#[tokio::test]
+async fn trailing_slash_normalization_preserves_the_method() {
+    let canonical = get(ServerConfig::default(), "/api/v0/schema").await;
+    let trailing = get(ServerConfig::default(), "/api/v0/schema/").await;
+    assert_eq!(trailing, canonical);
+
+    let canonical = post(ServerConfig::default(), "/api/v0/schema", 0).await;
+    let trailing = post(ServerConfig::default(), "/api/v0/schema/", 0).await;
+    assert_eq!(trailing, canonical);
+}
+
+fn bearer_identity() -> (identity::Did, String) {
+    let identity = RawIdentity::from_private_key(crypto::generate_ed25519().unwrap()).unwrap();
+    let did = identity.did().unwrap();
+    let token = new_token(
+        &identity,
+        Duration::from_secs(60),
+        Some("localhost:9181".to_string()),
+        None,
+    )
+    .unwrap();
+    (did, format!("Bearer {}", String::from_utf8(token).unwrap()))
+}
+
+async fn trailing_collection_status(granted: NodePermission) -> StatusCode {
+    let (owner, _) = bearer_identity();
+    let (caller, token) = bearer_identity();
+    let nac =
+        Arc::new(MockNodeAcpOperations::enabled_with_owner(owner).with_grant(caller, granted));
+    let router = server(ServerConfig::default())
+        .with_nac_arc(nac as Arc<dyn NodeAcpOperations>)
+        .router()
+        .unwrap();
+
+    router
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/api/v0/collections/Users/")
+                .header(HOST, "localhost:9181")
+                .header(AUTHORIZATION, token)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+        .status()
+}
+
+#[tokio::test]
+async fn normalized_parameterized_routes_keep_their_matched_permission() {
+    assert_ne!(
+        trailing_collection_status(NodePermission::CollectionGet).await,
+        StatusCode::UNAUTHORIZED
+    );
+    assert_eq!(
+        trailing_collection_status(NodePermission::DocumentRead).await,
+        StatusCode::UNAUTHORIZED
+    );
 }
 
 fn schema_limited() -> ServerConfig {

--- a/crates/http/tests/go_route_paths.rs
+++ b/crates/http/tests/go_route_paths.rs
@@ -116,16 +116,6 @@ async fn a_method_mismatch_answers_the_same_on_both_paths() {
     }
 }
 
-/// Rust does not normalize trailing slashes where Go does. That divergence is
-/// out of scope, but the alias must not be inconsistent with the path it
-/// mirrors, which is what this pins.
-#[tokio::test]
-async fn a_trailing_slash_behaves_the_same_on_both_paths() {
-    let (go_status, _) = Call::post("/api/v0/view/").json("{}").send().await;
-    let (rust_status, _) = Call::post("/api/v0/views/").json("{}").send().await;
-    assert_eq!(go_status, rust_status);
-}
-
 // ---------------------------------------------------------------------------
 // Permissions
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Context

Equivalent HTTP paths with a trailing slash currently bypass normal route matching. Normalization must happen before routing so method handling, request bodies, and matched-path permissions retain their existing semantics.

This is 2/2 in the HTTP routing stack and depends on #1638.

## Changes

- normalize non-root trailing slashes before axum route matching
- preserve request methods and bodies through normalization
- keep normalized parameterized routes connected to their permission entries
- cover root, API, collection, and method-sensitive paths

## Testing

- [x] `cargo clippy --profile super-dev -p defra-http --all-targets -- -D warnings`
- [x] `cargo test --profile super-dev -p defra-http`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check origin/main...HEAD`

Closes #1496