### PR TITLE
feat(schema): add the EUCLIDEAN distance metric

### DIFF
--- a/crates/db/src/index/vector/core/metric.rs
+++ b/crates/db/src/index/vector/core/metric.rs
@@ -22,9 +22,9 @@ use super::kernel::{self, Element};
 
 /// How two vectors are compared.
 ///
-/// `Cosine` is the only metric the query surface exposes today, matching Go's
-/// `DistanceMetricCosine`. The others exist because the index substrate is
-/// meant to carry future index kinds.
+/// One per [`schema::DistanceMetric`], which is Go's set: `Cosine`,
+/// `Euclidean`, and `NegativeDot` for Go's `DOT`. The negation is ours; a dot
+/// product is a similarity, and everything here is a distance.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
 pub enum Metric {
     /// `1 - cos(a, b)`, in `[0, 2]`.
@@ -88,11 +88,36 @@ impl Metric {
 
     /// Distance between two vectors already in the form the index stored them.
     pub fn distance_stored<T: Element>(self, a: &[T], b: &[T]) -> f64 {
-        if self == Metric::Cosine {
+        if self.requires_normalized() {
             self.distance_normalized(a, b)
         } else {
             self.distance(a, b)
         }
+    }
+
+    /// Whether the metric reads direction alone, so vectors must be scaled to
+    /// unit length before it compares them.
+    ///
+    /// Only cosine does. The other two read magnitude, so scaling would change
+    /// the answer rather than merely the values.
+    pub fn requires_normalized(self) -> bool {
+        match self {
+            Metric::Cosine => true,
+            Metric::Euclidean | Metric::NegativeDot => false,
+        }
+    }
+
+    /// A vector in the form this metric compares: narrowed to the width the
+    /// engines store, and scaled to unit length when the metric needs it.
+    ///
+    /// Every engine converts through here, so an engine cannot disagree with
+    /// another about whether its metric normalizes.
+    pub fn prepare<T: Element>(self, vector: &[T]) -> Vec<f32> {
+        let mut out: Vec<f32> = vector.iter().map(|x| f32::narrow(x.widen())).collect();
+        if self.requires_normalized() {
+            normalize(&mut out);
+        }
+        out
     }
 }
 

--- a/crates/db/src/index/vector/engine/flat.rs
+++ b/crates/db/src/index/vector/engine/flat.rs
@@ -44,10 +44,7 @@ impl<S: VectorNodeStore> VectorIndexEngine for Flat<S> {
 
     /// No graph to maintain, so a node is stored with no layers at all.
     async fn insert<E: Element>(&mut self, id: NodeId, vector: &[E]) -> Result<()> {
-        let mut vector: Vec<f32> = vector.iter().map(|x| f32::narrow(x.widen())).collect();
-        if self.metric == Metric::Cosine {
-            crate::index::vector::core::normalize(&mut vector);
-        }
+        let vector = self.metric.prepare(vector);
         self.store
             .put_node(Node {
                 id,
@@ -82,10 +79,7 @@ impl<S: VectorNodeStore> VectorIndexEngine for Flat<S> {
         if k == 0 {
             return Ok(Vec::new());
         }
-        let mut query: Vec<f32> = query.iter().map(|x| f32::narrow(x.widen())).collect();
-        if self.metric == Metric::Cosine {
-            crate::index::vector::core::normalize(&mut query);
-        }
+        let query = self.metric.prepare(query);
 
         // A max-heap of size k: the worst of the current best is on top, so a
         // new candidate is one comparison and at most one pop.
@@ -97,11 +91,7 @@ impl<S: VectorNodeStore> VectorIndexEngine for Flat<S> {
                 if !admit.admits(node.id) {
                     return Ok(());
                 }
-                let distance = if metric == Metric::Cosine {
-                    metric.distance_normalized(&query, &node.vector)
-                } else {
-                    metric.distance(&query, &node.vector)
-                };
+                let distance = metric.distance_stored(&query, &node.vector);
                 best.push(Ranked {
                     id: node.id,
                     distance,

--- a/crates/db/src/index/vector/engine/hnsw/mod.rs
+++ b/crates/db/src/index/vector/engine/hnsw/mod.rs
@@ -34,7 +34,7 @@ pub use level::LevelSampler;
 use super::ann::{Admit, Candidate, EdgeSelector, EngineKind, Neighbor, VectorIndexEngine};
 use super::select::Heuristic;
 use crate::index::error::Result;
-use crate::index::vector::core::{metric::normalize, Element, Metric};
+use crate::index::vector::core::{Element, Metric};
 use crate::index::vector::params::Params;
 use crate::index::vector::store::{Node, NodeId, VectorNodeStore};
 
@@ -89,20 +89,12 @@ impl<S> Hnsw<S> {
     /// the reference; rejecting it belongs at the index boundary, where there
     /// is a document to name.
     fn prepared<E: Element>(&self, vector: &[E]) -> Vec<f32> {
-        let mut out: Vec<f32> = vector.iter().map(|x| f32::narrow(x.widen())).collect();
-        if self.metric == Metric::Cosine {
-            normalize(&mut out);
-        }
-        out
+        self.metric.prepare(vector)
     }
 
     /// Distance between two vectors already in stored form.
     fn distance(&self, a: &[f32], b: &[f32]) -> f64 {
-        if self.metric == Metric::Cosine {
-            self.metric.distance_normalized(a, b)
-        } else {
-            self.metric.distance(a, b)
-        }
+        self.metric.distance_stored(a, b)
     }
 }
 

--- a/crates/db/src/index/vector/engine/ivfpq/search.rs
+++ b/crates/db/src/index/vector/engine/ivfpq/search.rs
@@ -5,7 +5,7 @@ use std::collections::BinaryHeap;
 use super::codec::{self, TrainedState};
 use super::IvfPq;
 use crate::index::error::Result;
-use crate::index::vector::core::{normalize, Element, Metric};
+use crate::index::vector::core::{Element, Metric};
 use crate::index::vector::engine::ann::{Admit, Neighbor, Quantizer};
 use crate::index::vector::store::{NodeId, VectorNodeStore};
 
@@ -22,10 +22,7 @@ impl<S: VectorNodeStore> IvfPq<S> {
             return Ok(Vec::new());
         }
 
-        let mut query: Vec<f32> = query.iter().map(|x| f32::narrow(x.widen())).collect();
-        if self.metric() == Metric::Cosine {
-            normalize(&mut query);
-        }
+        let query = self.metric().prepare(query);
 
         let (coarse, quantizer) = self.trained_parts(state).await?;
 

--- a/crates/db/src/index/vector/engine/ssg/search.rs
+++ b/crates/db/src/index/vector/engine/ssg/search.rs
@@ -5,7 +5,7 @@ use std::collections::{BinaryHeap, HashSet};
 use super::codec::BuiltState;
 use super::Ssg;
 use crate::index::error::Result;
-use crate::index::vector::core::{normalize, Element, Metric};
+use crate::index::vector::core::Element;
 use crate::index::vector::engine::ann::{Admit, Candidate, Neighbor};
 use crate::index::vector::store::{NodeId, VectorNodeStore};
 
@@ -23,10 +23,7 @@ impl<S: VectorNodeStore> Ssg<S> {
         }
 
         let metric = self.metric();
-        let mut query: Vec<f32> = query.iter().map(|x| f32::narrow(x.widen())).collect();
-        if metric == Metric::Cosine {
-            normalize(&mut query);
-        }
+        let query = metric.prepare(query);
 
         let pool = effort
             .map(|e| e.max(1))

--- a/crates/db/src/index/vector/index.rs
+++ b/crates/db/src/index/vector/index.rs
@@ -78,6 +78,7 @@ impl VectorIndex {
 
         let metric = match vector.metric {
             DistanceMetric::Cosine => Metric::Cosine,
+            DistanceMetric::Euclidean => Metric::Euclidean,
             DistanceMetric::Dot => Metric::NegativeDot,
         };
 

--- a/crates/db/tests/vector/main.rs
+++ b/crates/db/tests/vector/main.rs
@@ -13,7 +13,7 @@ mod support;
 mod vector_aux_store;
 mod vector_collection_index;
 mod vector_dimensions;
-mod vector_dot_metric;
+mod vector_distance_metrics;
 mod vector_engine;
 mod vector_filtered_search;
 mod vector_flat_algorithm;

--- a/crates/db/tests/vector/vector_distance_metrics.rs
+++ b/crates/db/tests/vector/vector_distance_metrics.rs
@@ -1,5 +1,12 @@
-//! The `DOT` metric. A wire divergence from Go, so it has to earn that by
-//! being magnitude-sensitive rather than an alias for cosine.
+//! The three distance metrics, which are Go's set as of
+//! sourcenetwork/defradb#5169.
+//!
+//! Each has to earn its place by ordering a corpus differently from the other
+//! two, so the shared fixture is built to separate them: documents 1 and 2 are
+//! collinear with 2 four times longer, and 3 points elsewhere. Against the
+//! query `[1, 0]` cosine cannot tell 1 from 2, dot puts 2 first, and euclidean
+//! puts 1 first and 2 last. A metric that quietly aliased another would fail
+//! here rather than on a corpus where the difference does not show.
 
 use db::index::vector::index::VectorIndex;
 use db::index::vector::kv_store::KvNodeStore;
@@ -111,21 +118,61 @@ async fn dot_prefers_the_longer_vector() {
     assert_eq!(hits[1], 1, "then the shorter one: {hits:?}");
 }
 
+/// `[1, 0]` is nearest 1 exactly, `sqrt(2)` from 3, and 3 from 2, so the
+/// magnitude that dot rewards is the one euclidean penalises. The two
+/// magnitude-sensitive metrics therefore produce opposite orders, which is the
+/// only way to show neither is an alias for the other.
 #[tokio::test]
-async fn dot_stores_vectors_unnormalized() {
-    let dot = stored(DistanceMetric::Dot, vec![3.0, 4.0]).await.unwrap();
-    assert!((dot[0] - 3.0).abs() < 1e-6, "dot stored {dot:?}");
+async fn euclidean_ranks_by_straight_line_distance() {
+    let hits = ranked(DistanceMetric::Euclidean, &[1.0, 0.0]).await;
+    assert_eq!(
+        hits,
+        vec![1, 3, 2],
+        "nearest, then the orthogonal unit vector, then the distant collinear one: {hits:?}"
+    );
+}
 
+/// Normalizing is cosine's alone: it is what makes magnitude unreadable, so a
+/// metric that reads magnitude must not have it applied. Storing `[3, 4]` shows
+/// it directly, since cosine scales it to `[0.6, 0.8]`.
+#[tokio::test]
+async fn only_cosine_normalizes_what_it_stores() {
     let cosine = stored(DistanceMetric::Cosine, vec![3.0, 4.0])
         .await
         .unwrap();
     assert!((cosine[0] - 0.6).abs() < 1e-6, "cosine stored {cosine:?}");
+
+    for metric in [DistanceMetric::Euclidean, DistanceMetric::Dot] {
+        let kept = stored(metric, vec![3.0, 4.0]).await.unwrap();
+        assert!(
+            (kept[0] - 3.0).abs() < 1e-6,
+            "{metric:?} stored {kept:?}, which is normalized"
+        );
+    }
 }
 
+/// A zero vector has no direction, so cosine cannot rank it and the index
+/// refuses to store one. The other two rank it fine, so they must.
 #[tokio::test]
-async fn dot_indexes_a_zero_vector_and_cosine_does_not() {
-    assert!(stored(DistanceMetric::Dot, vec![0.0, 0.0]).await.is_some());
+async fn a_zero_vector_is_indexed_by_every_metric_but_cosine() {
     assert!(stored(DistanceMetric::Cosine, vec![0.0, 0.0])
         .await
         .is_none());
+
+    for metric in [DistanceMetric::Euclidean, DistanceMetric::Dot] {
+        assert!(
+            stored(metric, vec![0.0, 0.0]).await.is_some(),
+            "{metric:?} must index a zero vector"
+        );
+    }
+}
+
+/// Every metric in the enum has to be constructible as an index, or an
+/// algorithm that claims to support it would still fail at description time.
+#[tokio::test]
+async fn every_metric_builds_a_searchable_index() {
+    for metric in DistanceMetric::ALL {
+        let hits = ranked(*metric, &[1.0, 0.0]).await;
+        assert_eq!(hits.len(), 3, "{metric:?} returned {hits:?}");
+    }
 }

--- a/crates/query/tests/vector_index_sdl.rs
+++ b/crates/query/tests/vector_index_sdl.rs
@@ -113,10 +113,24 @@ fn unknown_or_mistyped_arguments_are_refused() {
         r#"type Doc { e: [Float!] @vectorIndex(dimensions: 4, HNSW: { efSarch: 10 }) }"#,
         r#"type Doc { e: [Float!] @vectorIndex(dimensions: 4, HNSW: { M: "big" }) }"#,
         r#"type Doc { e: [Float!] @vectorIndex(dimensions: "many") }"#,
-        r#"type Doc { e: [Float!] @vectorIndex(dimensions: 4, HNSW: { metric: "EUCLIDEAN" }) }"#,
+        r#"type Doc { e: [Float!] @vectorIndex(dimensions: 4, HNSW: { metric: "MANHATTAN" }) }"#,
         r#"type Doc { e: [Float!] @vectorIndex(dimensions: 4, HNSW: 5) }"#,
     ] {
         assert!(parse_sdl(sdl).is_err(), "should have been refused: {sdl}");
+    }
+}
+
+/// Every metric the enum carries is spellable in SDL. `EUCLIDEAN` in
+/// particular used to be refused, back when the metric set was smaller than
+/// Go's.
+#[test]
+fn every_metric_is_spellable() {
+    for metric in DistanceMetric::ALL {
+        let sdl = format!(
+            r#"type Doc {{ e: [Float!] @vectorIndex(dimensions: 4, HNSW: {{ metric: "{}" }}) }}"#,
+            metric.as_str()
+        );
+        assert_eq!(only_vector(&sdl).metric, *metric, "{sdl}");
     }
 }
 

--- a/crates/schema/src/index.rs
+++ b/crates/schema/src/index.rs
@@ -404,9 +404,15 @@ impl VectorAlgorithm {
 
     /// Whether this algorithm can rank by `metric`.
     ///
-    /// IVF-PQ scores through its codebooks by squared distance, which does not
-    /// order a dot product, so the pair is refused when the definition is
-    /// written rather than when the first document is indexed.
+    /// IVF-PQ scores through its codebooks by squared distance. Under cosine
+    /// the vectors are unit length, so that squared distance orders them the
+    /// way the cosine does; a dot product it cannot order at all. `EUCLIDEAN`
+    /// is the metric that squared distance *is*, so the restriction is not
+    /// inherent there, but the quantized path has no measured recall for it, so
+    /// it stays refused rather than shipped unmeasured.
+    ///
+    /// Refused when the definition is written rather than when the first
+    /// document is indexed.
     pub fn supports_metric(self, metric: DistanceMetric) -> bool {
         match self {
             Self::IvfPq => metric == DistanceMetric::Cosine,
@@ -417,23 +423,31 @@ impl VectorAlgorithm {
 
 /// How a vector index compares two vectors.
 ///
-/// Go defines only `COSINE`. `DOT` is a deliberate wire divergence: a
-/// definition carrying it is not parseable by a Go node.
+/// The three Go defines, spelled its way, so a description carrying any of them
+/// crosses runtimes unchanged.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum DistanceMetric {
+    /// Direction only: magnitude is normalized away before anything is
+    /// compared.
     #[default]
     #[serde(rename = "COSINE")]
     Cosine,
+    /// Straight-line (L2) distance. Compares direction and magnitude.
+    #[serde(rename = "EUCLIDEAN")]
+    Euclidean,
+    /// Dot product, which grows with magnitude, so a longer vector pointing the
+    /// same way is nearer.
     #[serde(rename = "DOT")]
     Dot,
 }
 
 impl DistanceMetric {
-    pub const ALL: &'static [Self] = &[Self::Cosine, Self::Dot];
+    pub const ALL: &'static [Self] = &[Self::Cosine, Self::Euclidean, Self::Dot];
 
     pub fn as_str(self) -> &'static str {
         match self {
             Self::Cosine => "COSINE",
+            Self::Euclidean => "EUCLIDEAN",
             Self::Dot => "DOT",
         }
     }
@@ -445,8 +459,13 @@ impl DistanceMetric {
             .find(|metric| metric.as_str() == name)
     }
 
+    /// Every metric here is one Go defines, so a description carrying any of
+    /// them parses on either runtime. Exhaustive rather than `true` so a
+    /// Rust-only metric cannot be added without answering the question.
     pub fn is_go_compatible(self) -> bool {
-        matches!(self, Self::Cosine)
+        match self {
+            Self::Cosine | Self::Euclidean | Self::Dot => true,
+        }
     }
 }
 

--- a/crates/schema/tests/index_wire_shape.rs
+++ b/crates/schema/tests/index_wire_shape.rs
@@ -206,21 +206,22 @@ fn an_absent_hnsw_block_is_omitted_and_parses_back() {
     assert_eq!(from_go.vector().map(|v| v.hnsw), Some(None));
 }
 
-/// `DOT` is ours alone: Go's `DistanceMetric` defines only `COSINE`, so a
-/// definition carrying it is not parseable by a Go node. The divergence has to
-/// be visible to anything deciding whether a definition can leave this node.
+/// Every metric is Go's, spelled Go's way, so the metric axis carries no
+/// divergence at all: `EUCLIDEAN` and `DOT` are both `client.DistanceMetric`
+/// values as of sourcenetwork/defradb#5169. Anything deciding whether a
+/// definition can leave this node reads that off `is_go_compatible`.
 #[test]
-fn dot_is_the_one_metric_go_cannot_parse() {
-    assert!(DistanceMetric::Cosine.is_go_compatible());
-    assert!(!DistanceMetric::Dot.is_go_compatible());
+fn every_metric_is_one_go_parses() {
+    for metric in DistanceMetric::ALL {
+        assert!(metric.is_go_compatible(), "{metric:?} must be exchangeable");
+    }
 
     assert_eq!(
-        serde_json::to_value(DistanceMetric::Cosine).unwrap(),
-        json!("COSINE")
-    );
-    assert_eq!(
-        serde_json::to_value(DistanceMetric::Dot).unwrap(),
-        json!("DOT")
+        DistanceMetric::ALL
+            .iter()
+            .map(|metric| serde_json::to_value(metric).unwrap())
+            .collect::<Vec<_>>(),
+        vec![json!("COSINE"), json!("EUCLIDEAN"), json!("DOT")]
     );
 
     let desc = IndexDescription::new("i")
@@ -283,11 +284,24 @@ fn flat_is_an_algorithm_go_cannot_parse() {
     );
 }
 
-/// A definition is exchangeable only when every divergent value is absent.
+/// A definition is exchangeable only when every divergent value is absent. The
+/// algorithm is the only axis that still carries one; the check reads both so
+/// that a Rust-only metric added later is caught here rather than on the wire.
 #[test]
 fn go_compatibility_is_checkable_across_both_axes() {
     let ok = vector();
     assert!(ok.algorithm.is_go_compatible() && ok.metric.is_go_compatible());
+
+    for metric in DistanceMetric::ALL {
+        let exchangeable = VectorIndexDescription {
+            metric: *metric,
+            ..vector()
+        };
+        assert!(
+            exchangeable.algorithm.is_go_compatible() && exchangeable.metric.is_go_compatible(),
+            "{exchangeable:?} must be exchangeable"
+        );
+    }
 
     for diverged in [
         VectorIndexDescription {
@@ -296,7 +310,8 @@ fn go_compatibility_is_checkable_across_both_axes() {
             ..vector()
         },
         VectorIndexDescription {
-            metric: DistanceMetric::Dot,
+            algorithm: VectorAlgorithm::Ssg,
+            hnsw: None,
             ..vector()
         },
     ] {


### PR DESCRIPTION
> **Stacked PR, part of the #1517 vector-index alignment.**
> Review and merge bottom-up. Each PR is based on the one above it, so each shows only its own commit.
>
> | | PR | based on |
> |---|---|---|
> | **this** | **#1656** feat(schema): add the EUCLIDEAN distance metric | main |
> |  | #1657 fix(query): score SIMILARITY by the target index's metric | #1656 |
> |  | #1658 feat(query): fold @vectorIndex into @index(vector: ...) | #1657 |
> |  | #1659 feat(cli): index create takes Go's --vector JSON flag | #1658 |
>
> Still to come on top of this stack: the rescoped sourcenetwork/defradb#5072 metric argument on `SIMILARITY`, the Go compat baseline bump (#1519), the IVF correctness fixes (#1465, #1462, #1463) and the IVF_FLAT engine (#1516).

Part of #1517.

Go added `EUCLIDEAN` and `DOT` to `client.DistanceMetric` in sourcenetwork/defradb#5169 (merged 2026-08-20). We had `COSINE` and `DOT`, and still documented `DOT` as a wire divergence Go could not parse. Both statements are now wrong: `EUCLIDEAN` is missing, and `DOT` crosses runtimes fine.

## What changed

`schema::DistanceMetric` gains `Euclidean`, spelled `EUCLIDEAN` on the wire and in SDL, and `is_go_compatible` becomes true for every metric. It is written as an exhaustive `match` rather than `true` so a Rust-only metric cannot be added later without someone answering the question.

The engine already had all three metrics: `defra_core::vector::Metric` has carried `Cosine`, `Euclidean` and `NegativeDot` from the start, and every engine already normalized only under cosine. So the gap was purely the described set, not the computed one. The mapping arm and the SDL/CLI name tables pick the new variant up from `DistanceMetric::ALL` with no further edits.

While there: the `if metric == Metric::Cosine { normalize(...) }` guard was copy-pasted across five call sites (`flat` insert, `flat` search, `hnsw::prepared`, `ivfpq` search, `ssg` search), and two more sites duplicated the matching distance branch. Normalization is a property of the metric, so `Metric` now owns it as `requires_normalized()` and `prepare()`, and the two distance sites call the existing `distance_stored()`. Five engines can no longer disagree about whether their metric normalizes.

## Not in scope

`VectorAlgorithm::supports_metric` still refuses `EUCLIDEAN` for IVF-PQ. That restriction is not inherent: IVF-PQ ranks through its codebooks by squared distance, which is exactly what Euclidean is, so it should work. But the quantized path has no measured recall for it, and shipping an unmeasured claim is worse than refusing. The doc comment now says this rather than implying the refusal is a mathematical necessity. Worth its own issue.

## Verification

```
cargo test -p schema -p db -p query -p cli    40 test binaries, all pass
cargo test -p defra-node --test vector_index_query_path    12 pass
cargo clippy --all --all-targets -- -D warnings    clean
RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p schema -p db    clean
cargo fmt --all --check    clean
```

`crates/db/tests/vector/vector_dot_metric.rs` becomes `vector_distance_metrics.rs`, since the concept is now the metric set rather than one metric. The shared fixture separates all three: against the query `[1, 0]` over documents `[1,0]`, `[4,0]`, `[0,1]`, cosine cannot tell the first two apart, dot puts `[4,0]` first, and euclidean puts `[1,0]` first and `[4,0]` last. A metric that quietly aliased another fails there.

`every_combination_agrees_with_an_exhaustive_scan` in `defra-node` picks up `EUCLIDEAN` from `DistanceMetric::ALL`, so the algorithm x metric x filter x fetcher matrix covers it with no edit.
