### PR TITLE
feat(query): fold @vectorIndex into @index(vector: ...)

### DIFF
--- a/crates/defra-node/src/benchmark_support.rs
+++ b/crates/defra-node/src/benchmark_support.rs
@@ -152,7 +152,7 @@ type CodingMessage {
     files_referenced: [String]
     input_tokens: Int
     output_tokens: Int
-    content_v: [Float32!] @vectorIndex(dimensions: 14, metric: "DOT") @embedding(provider: "openai", model: "coding-message-model", fields: ["content"])
+    content_v: [Float32!] @index(vector: {dimensions: 14, hnsw: {metric: DOT}}) @embedding(provider: "openai", model: "coding-message-model", fields: ["content"])
     search_chunks: [CodingSearchChunk]
 }
 
@@ -164,7 +164,7 @@ type CodingAction {
     tags: [String]
     created_at: DateTime @index(direction: DESC)
     command: String @fulltext
-    command_v: [Float32!] @vectorIndex(dimensions: 14, metric: "DOT") @embedding(provider: "openai", model: "coding-action-model", fields: ["command"])
+    command_v: [Float32!] @index(vector: {dimensions: 14, hnsw: {metric: DOT}}) @embedding(provider: "openai", model: "coding-action-model", fields: ["command"])
     search_chunks: [CodingSearchChunk]
 }
 
@@ -186,7 +186,7 @@ type CodingSearchChunk {
     chunk_count: Int
     created_at: DateTime @index(direction: DESC)
     content: String @fulltext
-    content_v: [Float32!] @vectorIndex(dimensions: 14, metric: "DOT") @embedding(provider: "openai", model: "coding-search-chunk-model", fields: ["content"])
+    content_v: [Float32!] @index(vector: {dimensions: 14, hnsw: {metric: DOT}}) @embedding(provider: "openai", model: "coding-search-chunk-model", fields: ["content"])
 }
 "#;
 

--- a/crates/defra-node/tests/vector_index_query_path.rs
+++ b/crates/defra-node/tests/vector_index_query_path.rs
@@ -20,10 +20,20 @@ fn schema(algorithm: &str) -> String {
     let args = if algorithm.is_empty() {
         format!("dimensions: {DIMENSIONS}")
     } else {
-        format!("dimensions: {DIMENSIONS}, algorithm: \"{algorithm}\"")
+        format!("dimensions: {DIMENSIONS}, alg: {algorithm}")
     };
     format!(
-        "type Note {{ title: String  tag: String  embedding: [Float32!] @vectorIndex({args}) }}"
+        "type Note {{ title: String  tag: String  embedding: [Float32!] @index(vector: {{{args}}}) }}"
+    )
+}
+
+/// `@index(vector: {...})` for one algorithm and metric. The metric lives in
+/// the algorithm's own block, so the block name has to come from the algorithm.
+fn vector_index_sdl(algorithm: schema::VectorAlgorithm, metric: schema::DistanceMetric) -> String {
+    format!(
+        "@index(vector: {{dimensions: {DIMENSIONS}, {}: {{metric: {}}}}})",
+        algorithm.sdl_block(),
+        metric.as_str()
     )
 }
 
@@ -228,7 +238,7 @@ async fn a_filtered_similarity_query_returns_a_full_page() {
 async fn a_cosine_index_routes_and_agrees_with_the_exhaustive_scan() {
     let node = EmbeddedNode::builder().build().await.unwrap();
     node.add_schema(&format!(
-        "type Note {{ title: String  tag: String  embedding: [Float32!] @vectorIndex(dimensions: {DIMENSIONS}, metric: \"COSINE\") }}"
+        "type Note {{ title: String  tag: String  embedding: [Float32!] @index(vector: {{dimensions: {DIMENSIONS}, hnsw: {{metric: COSINE}}}}) }}"
     ))
     .await
     .expect("add cosine schema");
@@ -301,7 +311,7 @@ async fn a_cosine_index_routes_and_agrees_with_the_exhaustive_scan() {
 async fn a_scalar_index_on_the_filter_does_not_displace_the_vector_index() {
     let node = EmbeddedNode::builder().build().await.unwrap();
     node.add_schema(&format!(
-        "type Note {{ title: String  tag: String @index  embedding: [Float32!] @vectorIndex(dimensions: {DIMENSIONS}, metric: \"DOT\") }}"
+        "type Note {{ title: String  tag: String @index  embedding: [Float32!] @index(vector: {{dimensions: {DIMENSIONS}, hnsw: {{metric: DOT}}}}) }}"
     ))
     .await
     .expect("add schema with an indexed tag");
@@ -370,9 +380,8 @@ async fn every_combination_agrees_with_an_exhaustive_scan() {
                     };
                     let node = EmbeddedNode::builder().build().await.unwrap();
                     node.add_schema(&format!(
-                        "type Note {{ title: String  {tag_field}  embedding: [Float32!] @vectorIndex(dimensions: {DIMENSIONS}, algorithm: \"{}\", metric: \"{}\") }}",
-                        algorithm.as_str(),
-                        metric.as_str()
+                        "type Note {{ title: String  {tag_field}  embedding: [Float32!] {} }}",
+                        vector_index_sdl(*algorithm, *metric)
                     ))
                     .await
                     .unwrap_or_else(|e| panic!("{case}: add schema: {e}"));
@@ -457,6 +466,34 @@ async fn every_combination_agrees_with_an_exhaustive_scan() {
     }
 }
 
+/// Dimensions are required and must be greater than zero, which Go made
+/// unconditional in sourcenetwork/defradb#5188 by dropping the inference from an
+/// `@embedding` on the same field. A zero-dimension index cannot check a query
+/// vector's length, so a wrong-length query would be scored on its shared
+/// leading elements alone: silently wrong rather than merely approximate.
+#[tokio::test]
+async fn dimensions_are_required_when_the_schema_is_written() {
+    for sdl in [
+        "type Note { embedding: [Float32!] @index(vector: {}) }".to_string(),
+        "type Note { embedding: [Float32!] @index(vector: {dimensions: 0}) }".to_string(),
+        // An @embedding fixes the length, and used to supply it. It no longer does.
+        "type Note { title: String  embedding: [Float32!] @index(vector: {}) \
+             @embedding(provider: \"openai\", model: \"m\", fields: [\"title\"]) }"
+            .to_string(),
+    ] {
+        let node = EmbeddedNode::builder().build().await.unwrap();
+        let error = node
+            .add_schema(&sdl)
+            .await
+            .expect_err(&format!("must be refused: {sdl}"))
+            .to_string();
+        assert!(
+            error.contains("dimensions"),
+            "the error must name dimensions, got: {error}"
+        );
+    }
+}
+
 /// An algorithm that cannot rank by a metric must be refused when the schema is
 /// written, not when the first document is indexed.
 #[tokio::test]
@@ -469,9 +506,8 @@ async fn an_unsupported_metric_is_refused_when_the_schema_is_written() {
             let node = EmbeddedNode::builder().build().await.unwrap();
             let result = node
                 .add_schema(&format!(
-                    "type Note {{ embedding: [Float32!] @vectorIndex(dimensions: {DIMENSIONS}, algorithm: \"{}\", metric: \"{}\") }}",
-                    algorithm.as_str(),
-                    metric.as_str()
+                    "type Note {{ embedding: [Float32!] {} }}",
+                    vector_index_sdl(*algorithm, *metric)
                 ))
                 .await;
             let error = result.expect_err(&format!(
@@ -498,7 +534,7 @@ async fn a_relation_filter_above_the_scan_still_fills_the_page() {
     let node = EmbeddedNode::builder().build().await.unwrap();
     node.add_schema(
         "type Owner { name: String  notes: [Note] }
-         type Note { title: String  owner: Owner  embedding: [Float32!] @vectorIndex(dimensions: 4, metric: \"DOT\") }",
+         type Note { title: String  owner: Owner  embedding: [Float32!] @index(vector: {dimensions: 4, hnsw: {metric: DOT}}) }",
     )
     .await
     .expect("add schema");

--- a/crates/query/src/sdl_parse/builder.rs
+++ b/crates/query/src/sdl_parse/builder.rs
@@ -760,7 +760,7 @@ impl<'a> SdlParser<'a> {
             .map(|f| schema::EncryptedIndexDescription::new(&f.name))
             .collect();
 
-        // Build vector indexes from @vectorIndex directives.
+        // Build vector indexes from `@index(vector: {...})` directives.
         //
         // These join `indexes` as a kind rather than becoming a parallel list
         // the way full-text did. That is what #1326 asks for, and it is what
@@ -771,26 +771,70 @@ impl<'a> SdlParser<'a> {
             let Some(config) = field.directives.vector_index.as_ref() else {
                 continue;
             };
-            let name = generate_index_name(&type_def.name, &field.name, &existing_index_names);
+            let name = config.name.clone().unwrap_or_else(|| {
+                generate_index_name(&type_def.name, &field.name, &existing_index_names)
+            });
             existing_index_names.push(name.clone());
             index_id_counter += 1;
 
-            let algorithm = match config.algorithm.as_deref() {
-                None => schema::VectorAlgorithm::default(),
-                Some(name) => schema::VectorAlgorithm::from_sdl_name(name).ok_or_else(|| {
-                    QueryError::parse(format!("@vectorIndex has no algorithm named '{name}'"))
+            // The algorithm is chosen by which block is set, which is also
+            // what the wire envelope does. `alg:` names one directly, for the
+            // default configuration; giving both is fine as long as they agree,
+            // and a disagreement is refused rather than resolved by precedence.
+            let mut algorithm: Option<schema::VectorAlgorithm> = None;
+            for (present, selected) in [
+                (config.flat.is_some(), schema::VectorAlgorithm::Flat),
+                (config.hnsw.is_some(), schema::VectorAlgorithm::Hnsw),
+                (config.ivfpq.is_some(), schema::VectorAlgorithm::IvfPq),
+                (config.ssg.is_some(), schema::VectorAlgorithm::Ssg),
+            ] {
+                if !present {
+                    continue;
+                }
+                if let Some(existing) = algorithm.filter(|existing| *existing != selected) {
+                    return Err(QueryError::parse(format!(
+                        "@index vector configures both {} and {}",
+                        existing.as_str(),
+                        selected.as_str()
+                    )));
+                }
+                algorithm = Some(selected);
+            }
+            if let Some(named) = config.algorithm.as_deref() {
+                let named = schema::VectorAlgorithm::from_sdl_name(named).ok_or_else(|| {
+                    QueryError::parse(format!("@index vector has no algorithm named '{named}'"))
+                })?;
+                if let Some(existing) = algorithm.filter(|existing| *existing != named) {
+                    return Err(QueryError::parse(format!(
+                        "@index vector alg is {} but the {} block is configured",
+                        named.as_str(),
+                        existing.as_str()
+                    )));
+                }
+                algorithm = Some(named);
+            }
+            let algorithm = algorithm.unwrap_or_default();
+
+            // The metric belongs to the algorithm, so it is read from that
+            // algorithm's own block and nowhere else.
+            let hnsw = config.hnsw.clone().unwrap_or_default();
+            let named_metric = match algorithm {
+                schema::VectorAlgorithm::Flat => {
+                    config.flat.as_ref().and_then(|f| f.metric.clone())
+                }
+                schema::VectorAlgorithm::Hnsw => hnsw.metric.clone(),
+                schema::VectorAlgorithm::IvfPq => {
+                    config.ivfpq.as_ref().and_then(|b| b.metric.clone())
+                }
+                schema::VectorAlgorithm::Ssg => config.ssg.as_ref().and_then(|b| b.metric.clone()),
+            };
+            let metric = match named_metric.as_deref() {
+                None => schema::DistanceMetric::default(),
+                Some(name) => schema::DistanceMetric::from_sdl_name(name).ok_or_else(|| {
+                    QueryError::parse(format!("@index vector has no metric named '{name}'"))
                 })?,
             };
 
-            let hnsw = config.hnsw.clone().unwrap_or_default();
-            // The top-level argument applies to every algorithm; the HNSW block
-            // is the older spelling and still works.
-            let metric = match config.metric.as_deref().or(hnsw.metric.as_deref()) {
-                None => schema::DistanceMetric::default(),
-                Some(name) => schema::DistanceMetric::from_sdl_name(name).ok_or_else(|| {
-                    QueryError::parse(format!("@vectorIndex has no metric named '{name}'"))
-                })?,
-            };
             let defaults = schema::HnswParams::default();
 
             indexes.push(
@@ -808,7 +852,9 @@ impl<'a> SdlParser<'a> {
                 .as_vector(schema::VectorIndexDescription {
                     algorithm,
                     metric,
-                    // Zero means an `@embedding` on the field fixes the length.
+                    // Absent leaves this zero, which definition validation
+                    // rejects. Go stopped inferring it from an `@embedding` in
+                    // sourcenetwork/defradb#5188.
                     dimensions: config.dimensions.unwrap_or(0),
                     hnsw: match algorithm {
                         schema::VectorAlgorithm::Hnsw => Some(schema::HnswParams {

--- a/crates/query/src/sdl_parse/directives.rs
+++ b/crates/query/src/sdl_parse/directives.rs
@@ -18,7 +18,6 @@ pub const KNOWN_FIELD_DIRECTIVES: &[&str] = &[
     "embedding",
     "encryptedIndex",
     "fulltext",
-    "vectorIndex",
     "immutable",
     "policy", // Go allows @policy on fields in some contexts
 ];
@@ -37,7 +36,16 @@ pub fn known_directive_arguments(directive_name: &str) -> &'static [&'static str
     match directive_name {
         "primary" => &[],
         "crdt" => &["type"],
-        "index" => &["name", "unique", "direction", "fields", "includes"],
+        "index" => &[
+            "name",
+            "kind",
+            "ordered",
+            "vector",
+            "unique",
+            "direction",
+            "fields",
+            "includes",
+        ],
         "relation" => &["name"],
         "default" => &["value"],
         "constraints" => &["size"],
@@ -48,7 +56,6 @@ pub fn known_directive_arguments(directive_name: &str) -> &'static [&'static str
         "embedding" => &["provider", "model", "url", "fields", "template"],
         "encryptedIndex" => &["type"],
         "fulltext" => &["language", "k1", "b"],
-        "vectorIndex" => &["dimensions", "algorithm", "metric", "HNSW", "IVFPQ", "SSG"],
         "immutable" => &[],
         _ => &[],
     }
@@ -93,19 +100,6 @@ pub fn get_directive_string_list(directive: &Directive<'_, String>, arg_name: &s
             .collect(),
         _ => Vec::new(),
     }
-}
-
-/// Get a non-negative integer argument from a directive.
-///
-/// `None` for an absent argument; `Some(Err)` for one that is present but not a
-/// non-negative integer, because a mistyped parameter is a schema error rather
-/// than something to silently default.
-pub fn get_directive_u32(
-    directive: &Directive<'_, String>,
-    arg_name: &str,
-) -> Option<Result<u32, String>> {
-    let value = get_directive_arg(directive, arg_name)?;
-    Some(directive_u32(arg_name, value))
 }
 
 /// Reads a non-negative integer out of one AST value.
@@ -192,7 +186,7 @@ pub struct ParsedDirectives {
     pub embedding: Option<EmbeddingConfig>,
     /// Full-text search configuration from @fulltext directive
     pub fulltext: Option<FullTextConfig>,
-    /// Vector index configuration from @vectorIndex directive
+    /// Vector index configuration from `@index(vector: {...})`
     pub vector_index: Option<VectorIndexConfig>,
     /// Whether this field is immutable after document creation
     pub immutable: bool,
@@ -206,33 +200,47 @@ pub struct FullTextConfig {
     pub b: Option<f64>,
 }
 
-/// Vector index configuration from the `@vectorIndex` directive.
+/// The `vector` argument of `@index`, which is what selects the vector kind.
 ///
 /// The argument names are Go's, because the SDL is what users and parity tests
-/// see. `dimensions` sits at the top level rather than inside the algorithm
-/// config because it describes the field, not the algorithm, and the algorithm
-/// is chosen by *which* config argument is present.
+/// see. `dimensions` sits here rather than inside the algorithm config because
+/// it describes the field, not the algorithm. `metric` does not: it lives
+/// inside each algorithm's block, where the reference put it, so a client
+/// configuring one algorithm sees only that algorithm's knobs.
 #[derive(Debug, Clone, Default)]
 pub struct VectorIndexConfig {
-    /// Vector length. `None` when an `@embedding` on the same field fixes it.
+    /// Index name from `@index(name:)`. Go's `@vectorIndex` could not name an
+    /// index at all; folding into `@index` gives it one for free.
+    pub name: Option<String>,
+    /// Vector length. Required and greater than zero, matching Go after
+    /// sourcenetwork/defradb#5188, which dropped inferring it from an
+    /// `@embedding`.
     pub dimensions: Option<u32>,
-    /// `None` means HNSW, matching the reference where it is the only value.
+    /// From `alg:`, which selects an algorithm with its default configuration.
+    /// `None` means HNSW, or whichever algorithm block was given.
     pub algorithm: Option<String>,
-    /// How the index ranks. Applies to every algorithm, so it sits here rather
-    /// than inside the HNSW block, which the older form still accepts.
-    pub metric: Option<String>,
-    /// Present when the `IVFPQ` argument was given.
+    /// Present when the `flat` argument was given. Flat has no tuning, so the
+    /// block exists to select the algorithm and to give its metric a home:
+    /// under this grammar the metric lives in the algorithm's block, so an
+    /// algorithm with no block could not be built with anything but cosine.
+    pub flat: Option<FlatConfig>,
+    /// Present when the `ivfpq` argument was given.
     pub ivfpq: Option<IvfPqConfig>,
-    /// Present when the `SSG` argument was given.
+    /// Present when the `ssg` argument was given.
     pub ssg: Option<SsgConfig>,
-    /// Present when the `HNSW` argument was given. Its absence still means
+    /// Present when the `hnsw` argument was given. Its absence still means
     /// HNSW, with defaults.
     pub hnsw: Option<HnswConfig>,
 }
 
-/// The `HNSW` argument of `@vectorIndex`. Every member is optional: an omitted
-/// one keeps the default from `schema`, so the directive and the defaults
-/// cannot drift apart.
+/// The `flat` block, which has only a metric.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FlatConfig {
+    pub metric: Option<String>,
+}
+
+/// The `hnsw` block. Every member is optional: an omitted one keeps the default
+/// from `schema`, so the directive and the defaults cannot drift apart.
 #[derive(Debug, Clone, Default)]
 pub struct HnswConfig {
     pub metric: Option<String>,
@@ -241,8 +249,8 @@ pub struct HnswConfig {
     pub ef_search: Option<u32>,
 }
 
-/// Index configuration from @index directive
-#[derive(Debug, Clone)]
+/// Index configuration from the ordered kind of `@index`.
+#[derive(Debug, Clone, Default)]
 pub struct IndexConfig {
     pub name: Option<String>,
     pub unique: bool,
@@ -258,19 +266,21 @@ pub enum IndexDirection {
     Desc,
 }
 
-/// The `IVFPQ` argument of `@vectorIndex`. Every member is optional; an omitted
-/// one keeps its default, and a zero is derived from the corpus.
+/// The `ivfpq` block. Every member is optional; an omitted one keeps its
+/// default, and a zero is derived from the corpus.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct IvfPqConfig {
+    pub metric: Option<String>,
     pub nlist: Option<u32>,
     pub nprobe: Option<u32>,
     pub m: Option<u32>,
     pub sample_bytes: Option<u32>,
 }
 
-/// The `SSG` argument of `@vectorIndex`.
+/// The `ssg` block.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct SsgConfig {
+    pub metric: Option<String>,
     pub r: Option<u32>,
     pub angle: Option<u32>,
     pub pool: Option<u32>,

--- a/crates/query/src/sdl_parse/fields.rs
+++ b/crates/query/src/sdl_parse/fields.rs
@@ -4,7 +4,9 @@
 //! - `parse_field_directives()`, `check_directive_arguments()`
 //! - `get_bool_with_warning()`, `get_string_with_warning()`, `get_int_with_warning()`
 //! - `parse_type_directives()`, `parse_crdt_directive()`
-//! - `parse_index_directive()`, `parse_includes_argument()`, `parse_default_directive()`
+//! - `parse_index_directive()`, `parse_vector_index_config()`, `parse_default_directive()`
+
+use std::collections::BTreeMap;
 
 use graphql_parser::schema::{Directive, Field};
 use schema::CType;
@@ -48,15 +50,20 @@ impl<'a> SdlParser<'a> {
         for directive in directives {
             let name = directive.name.as_str();
 
-            // Check arguments for all known directives upfront
-            if KNOWN_FIELD_DIRECTIVES.contains(&name) {
+            // Check arguments for all known directives upfront. `@index` is
+            // excluded: it validates its own, and refuses an unknown one
+            // outright, so a warning here would only precede the error.
+            if name != "index" && KNOWN_FIELD_DIRECTIVES.contains(&name) {
                 self.check_directive_arguments(directive, &type_name, Some(field_name));
             }
 
             match name {
                 "primary" => result.is_primary = true,
                 "crdt" => result.crdt_type = Some(self.parse_crdt_directive(directive)?),
-                "index" => result.index = Some(self.parse_index_directive(directive, field_name)?),
+                "index" => match self.parse_index_directive(directive, Some(field_name))? {
+                    ParsedIndex::Ordered(config) => result.index = Some(config),
+                    ParsedIndex::Vector(config) => result.vector_index = Some(config),
+                },
                 "relation" => result.relation_name = get_directive_string(directive, "name"),
                 "default" => {
                     result.default_value =
@@ -91,9 +98,6 @@ impl<'a> SdlParser<'a> {
                     let b =
                         self.get_float_with_warning(directive, "b", &type_name, Some(field_name));
                     result.fulltext = Some(super::directives::FullTextConfig { language, k1, b });
-                }
-                "vectorIndex" => {
-                    result.vector_index = Some(self.parse_vector_index_directive(directive)?);
                 }
                 "immutable" => result.immutable = true,
                 "embedding" => {
@@ -294,43 +298,32 @@ impl<'a> SdlParser<'a> {
         for directive in directives {
             let name = directive.name.as_str();
 
-            // Check arguments for all known directives upfront
-            if KNOWN_TYPE_DIRECTIVES.contains(&name) {
+            // Check arguments for all known directives upfront. `@index` is
+            // excluded for the same reason as at field level: it validates its
+            // own and refuses an unknown one.
+            if name != "index" && KNOWN_TYPE_DIRECTIVES.contains(&name) {
                 self.check_directive_arguments(directive, &type_name, None);
             }
 
             match name {
                 "index" => {
-                    // Parse top-level direction argument (default for all fields)
-                    let default_descending = self
-                        .get_string_with_warning(directive, "direction", &type_name, None)
-                        .as_deref()
-                        .map(|d| matches!(d, "DESC" | "desc" | "Descending"))
-                        .unwrap_or(false);
-
-                    // Try "fields" argument first (simple format: ["name", "age"])
-                    let simple_fields = get_directive_string_list(directive, "fields");
-                    let fields: Vec<(String, bool)> = if !simple_fields.is_empty() {
-                        // Apply default direction to all fields from simple format
-                        simple_fields
-                            .into_iter()
-                            .map(|f| (f, default_descending))
-                            .collect()
-                    } else {
-                        // Try "includes" argument (Go format: [{field: "name", direction: DESC}, ...])
-                        self.parse_includes_argument(directive, default_descending)
+                    // One parser for both levels, as the reference has. A
+                    // type-level index names its fields rather than sitting on
+                    // one, which is the only difference, and `None` here is
+                    // what makes a vector configuration invalid.
+                    let ParsedIndex::Ordered(config) =
+                        self.parse_index_directive(directive, None)?
+                    else {
+                        return Err(QueryError::parse(
+                            "@index vector is only valid on a field definition",
+                        ));
                     };
 
-                    let idx_name = get_directive_string(directive, "name");
-                    let unique = self
-                        .get_bool_with_warning(directive, "unique", &type_name, None)
-                        .unwrap_or(false);
-
-                    if !fields.is_empty() {
+                    if !config.includes.is_empty() {
                         result.indexes.push(CompositeIndex {
-                            fields,
-                            name: idx_name,
-                            unique,
+                            fields: config.includes,
+                            name: config.name,
+                            unique: config.unique,
                         });
                     }
                 }
@@ -426,229 +419,293 @@ impl<'a> SdlParser<'a> {
         }
     }
 
+    /// Reads a field-level `@index`, which carries every index kind.
+    ///
+    /// The kind is selected by which configuration argument is present, exactly
+    /// as the wire's `Kind`/`KindDescription` envelope does: `vector:` means
+    /// vector, `ordered:` or any of the legacy top-level ordered arguments
+    /// means ordered, and `kind:` names one directly. Two selectors that
+    /// disagree are an error rather than a precedence rule, because a
+    /// precedence rule would silently build the index the author did not ask
+    /// for.
     pub(super) fn parse_index_directive(
         &mut self,
         directive: &Directive<'_, String>,
-        field_name: &str,
-    ) -> Result<IndexConfig> {
+        field_name: Option<&str>,
+    ) -> Result<ParsedIndex> {
         let type_name = self.current_type.clone().unwrap_or_default();
-        let name = get_directive_string(directive, "name");
-        let unique = self
-            .get_bool_with_warning(directive, "unique", &type_name, Some(field_name))
-            .unwrap_or(false);
-        let direction = match self
-            .get_string_with_warning(directive, "direction", &type_name, Some(field_name))
-            .as_deref()
-        {
-            Some("DESC") | Some("desc") | Some("Descending") => IndexDirection::Desc,
-            _ => IndexDirection::Asc,
-        };
+        let mut kind: Option<IndexKindSelector> = None;
+        let mut name: Option<String> = None;
+        let mut ordered = OrderedIndexArgs::default();
+        let mut vector: Option<&SchemaValue<'_>> = None;
 
-        // Parse includes for composite indexes
-        // The default direction for included fields is inherited from the top-level direction
-        let default_descending = matches!(direction, IndexDirection::Desc);
-        let includes = self.parse_includes_argument(directive, default_descending);
-
-        Ok(IndexConfig {
-            name,
-            unique,
-            direction,
-            includes,
-        })
-    }
-
-    /// Parse the `includes` argument for composite indexes.
-    ///
-    /// Go format: `@index(includes: [{field: "name"}, {field: "age", direction: DESC}])`
-    /// Returns (field_name, descending) tuples extracted from the objects.
-    ///
-    /// The `default_descending` parameter is used when a field in the includes array
-    /// doesn't specify its own direction. This comes from the top-level `direction`
-    /// argument on the @index directive.
-    pub(super) fn parse_includes_argument(
-        &self,
-        directive: &Directive<'_, String>,
-        default_descending: bool,
-    ) -> Vec<(String, bool)> {
-        let Some(value) = get_directive_arg(directive, "includes") else {
-            return Vec::new();
-        };
-
-        let graphql_parser::schema::Value::List(items) = value else {
-            return Vec::new();
-        };
-
-        items
-            .iter()
-            .filter_map(|item| {
-                // Each item should be an object like {field: "name", direction: DESC}
-                let graphql_parser::schema::Value::Object(obj) = item else {
-                    return None;
-                };
-
-                // Extract field name
-                let field_name = obj.get("field").and_then(|v| match v {
-                    graphql_parser::schema::Value::String(s)
-                    | graphql_parser::schema::Value::Enum(s) => Some(s.clone()),
-                    _ => None,
-                })?;
-
-                // Extract direction (defaults to the top-level direction or ASC)
-                let descending = obj
-                    .get("direction")
-                    .map(|v| match v {
-                        graphql_parser::schema::Value::String(s)
-                        | graphql_parser::schema::Value::Enum(s) => {
-                            matches!(s.as_str(), "DESC" | "desc" | "Descending")
+        for (arg_name, value) in &directive.arguments {
+            match arg_name.as_str() {
+                "name" => {
+                    let (SchemaValue::String(text) | SchemaValue::Enum(text)) = value else {
+                        return Err(QueryError::parse("@index name must be a string"));
+                    };
+                    name = Some(text.clone());
+                }
+                "kind" => {
+                    let (SchemaValue::String(text) | SchemaValue::Enum(text)) = value else {
+                        return Err(QueryError::parse("@index kind must be an index kind"));
+                    };
+                    // `vector` is deliberately not accepted here: a vector index
+                    // needs at least its dimensions, so there is no default
+                    // configuration for `kind:` to select. Refusing it names the
+                    // problem, where accepting it would fail later on a missing
+                    // dimension.
+                    match text.as_str() {
+                        "ordered" => select_index_kind(&mut kind, IndexKindSelector::Ordered)?,
+                        other => {
+                            return Err(QueryError::parse(format!(
+                                "@index has no kind named '{other}'"
+                            )))
                         }
-                        _ => default_descending,
-                    })
-                    .unwrap_or(default_descending);
+                    }
+                }
+                "ordered" => {
+                    select_index_kind(&mut kind, IndexKindSelector::Ordered)?;
+                    let SchemaValue::Object(members) = value else {
+                        return Err(QueryError::parse(
+                            "@index ordered must be an object of parameters",
+                        ));
+                    };
+                    for (member, member_value) in members {
+                        self.read_ordered_index_property(
+                            member,
+                            member_value,
+                            &mut ordered,
+                            &mut kind,
+                            &type_name,
+                            field_name,
+                        )?;
+                    }
+                }
+                "vector" => {
+                    select_index_kind(&mut kind, IndexKindSelector::Vector)?;
+                    vector = Some(value);
+                }
+                other => {
+                    self.read_ordered_index_property(
+                        other,
+                        value,
+                        &mut ordered,
+                        &mut kind,
+                        &type_name,
+                        field_name,
+                    )?;
+                }
+            }
+        }
 
-                Some((field_name, descending))
-            })
-            .collect()
+        if let Some(value) = vector {
+            // A vector index covers exactly one field, so it has no type-level
+            // form. `field_name` being absent is exactly that case.
+            if field_name.is_none() {
+                return Err(QueryError::parse(
+                    "@index vector is only valid on a field definition",
+                ));
+            }
+            let mut config = self.parse_vector_index_config(value)?;
+            config.name = name;
+            return Ok(ParsedIndex::Vector(config));
+        }
+
+        // Resolved here rather than as each argument is read, because an
+        // included field with no direction of its own inherits the directive's,
+        // and `direction:` may be written after `includes:`.
+        let default_descending = matches!(ordered.direction, IndexDirection::Desc);
+        Ok(ParsedIndex::Ordered(IndexConfig {
+            name,
+            unique: ordered.unique,
+            direction: ordered.direction,
+            includes: ordered
+                .includes
+                .into_iter()
+                .map(|(name, descending)| (name, descending.unwrap_or(default_descending)))
+                .collect(),
+        }))
     }
 
-    /// Reads `@vectorIndex(dimensions: Int, HNSW: { ... })`.
+    /// Reads one ordered-index property, from either the nested `ordered:`
+    /// block or a legacy top-level argument.
+    ///
+    /// The name is recognised before the kind is selected, so an unknown
+    /// argument is reported as an unknown argument rather than as a kind
+    /// conflict it only causes incidentally.
+    ///
+    /// Writing the same property from both places is refused: the two forms
+    /// merge, and a merge that silently drops one of two explicit values is
+    /// worse than a parse error.
+    fn read_ordered_index_property(
+        &mut self,
+        name: &str,
+        value: &SchemaValue<'_>,
+        config: &mut OrderedIndexArgs,
+        kind: &mut Option<IndexKindSelector>,
+        type_name: &str,
+        field_name: Option<&str>,
+    ) -> Result<()> {
+        let (written, expected_type) = match name {
+            "unique" => (&mut config.has_unique, "Boolean"),
+            "direction" => (&mut config.has_direction, "Ordering"),
+            "includes" | "fields" => (&mut config.has_includes, "[IndexField]"),
+            other => {
+                return Err(QueryError::parse(format!(
+                    "@index has no argument named '{other}'"
+                )))
+            }
+        };
+        if *written {
+            return Err(QueryError::parse(format!("@index sets '{name}' twice")));
+        }
+        *written = true;
+        select_index_kind(kind, IndexKindSelector::Ordered)?;
+
+        match name {
+            "unique" => match value {
+                SchemaValue::Boolean(unique) => config.unique = *unique,
+                _ => self.warn_index_argument_type(name, expected_type, type_name, field_name),
+            },
+            "direction" => match value {
+                SchemaValue::String(text) | SchemaValue::Enum(text) => {
+                    config.direction = match text.as_str() {
+                        "DESC" | "desc" | "Descending" => IndexDirection::Desc,
+                        _ => IndexDirection::Asc,
+                    };
+                }
+                _ => self.warn_index_argument_type(name, expected_type, type_name, field_name),
+            },
+            _ => config.includes = read_includes_value(value),
+        }
+        Ok(())
+    }
+
+    fn warn_index_argument_type(
+        &mut self,
+        argument_name: &str,
+        expected_type: &str,
+        type_name: &str,
+        field_name: Option<&str>,
+    ) {
+        self.warnings.push(ParseWarning::InvalidArgumentType {
+            directive_name: "index".to_string(),
+            argument_name: argument_name.to_string(),
+            expected_type: expected_type.to_string(),
+            type_name: type_name.to_string(),
+            field_name: field_name.map(str::to_string),
+        });
+    }
+
+    /// Reads the `vector: { ... }` configuration of `@index`.
     ///
     /// An unrecognised member is an error rather than an ignored typo: a
     /// silently dropped `efSearch` would build a differently-shaped index than
     /// the schema asks for, and nothing downstream could tell.
-    pub(super) fn parse_vector_index_directive(
+    ///
+    /// `metric` sits inside each algorithm block rather than beside
+    /// `dimensions`, matching the reference: `dimensions` describes the field,
+    /// while the metric is one of the algorithm's own knobs and an algorithm
+    /// may not rank by every metric.
+    pub(super) fn parse_vector_index_config(
         &self,
-        directive: &graphql_parser::schema::Directive<'_, String>,
+        value: &SchemaValue<'_>,
     ) -> Result<super::directives::VectorIndexConfig> {
-        use super::directives::{directive_u32, get_directive_arg, get_directive_u32, HnswConfig};
+        use super::directives::{directive_u32, FlatConfig, HnswConfig, IvfPqConfig, SsgConfig};
 
-        let dimensions = match get_directive_u32(directive, "dimensions") {
-            Some(Ok(value)) => Some(value),
-            Some(Err(message)) => return Err(QueryError::parse(format!("@vectorIndex {message}"))),
-            None => None,
+        let SchemaValue::Object(members) = value else {
+            return Err(QueryError::parse(
+                "@index vector must be an object of parameters",
+            ));
         };
 
-        let algorithm = match get_directive_arg(directive, "algorithm") {
-            None => None,
-            Some(graphql_parser::schema::Value::String(text))
-            | Some(graphql_parser::schema::Value::Enum(text)) => Some(text.clone()),
-            Some(_) => return Err(QueryError::parse("@vectorIndex algorithm must be a string")),
-        };
-
-        let metric = match get_directive_arg(directive, "metric") {
-            None => None,
-            Some(graphql_parser::schema::Value::String(text))
-            | Some(graphql_parser::schema::Value::Enum(text)) => Some(text.clone()),
-            Some(_) => return Err(QueryError::parse("@vectorIndex metric must be a string")),
-        };
-
-        let hnsw = match get_directive_arg(directive, "HNSW") {
-            None => None,
-            Some(graphql_parser::schema::Value::Object(members)) => {
-                let mut config = HnswConfig::default();
-                for (name, value) in members {
-                    let slot = match name.as_str() {
-                        "metric" => {
-                            config.metric = match value {
-                                graphql_parser::schema::Value::String(text)
-                                | graphql_parser::schema::Value::Enum(text) => Some(text.clone()),
-                                _ => {
-                                    return Err(QueryError::parse(
-                                        "@vectorIndex HNSW metric must be a string",
-                                    ))
-                                }
-                            };
-                            continue;
-                        }
-                        "M" => &mut config.m,
-                        "efConstruction" => &mut config.ef_construction,
-                        "efSearch" => &mut config.ef_search,
-                        other => {
-                            return Err(QueryError::parse(format!(
-                                "@vectorIndex HNSW has no argument named '{other}'"
-                            )))
-                        }
-                    };
-                    *slot =
-                        Some(directive_u32(name, value).map_err(|message| {
-                            QueryError::parse(format!("@vectorIndex {message}"))
-                        })?);
+        let mut config = super::directives::VectorIndexConfig::default();
+        for (member, member_value) in members {
+            match member.as_str() {
+                "dimensions" => {
+                    config.dimensions = Some(
+                        directive_u32("dimensions", member_value)
+                            .map_err(|message| QueryError::parse(format!("@index {message}")))?,
+                    );
                 }
-                Some(config)
-            }
-            Some(_) => {
-                return Err(QueryError::parse(
-                    "@vectorIndex HNSW must be an object of parameters",
-                ))
-            }
-        };
-
-        let ivfpq = match get_directive_arg(directive, "IVFPQ") {
-            None => None,
-            Some(graphql_parser::schema::Value::Object(members)) => {
-                let mut config = super::directives::IvfPqConfig::default();
-                for (name, value) in members {
-                    let slot = match name.as_str() {
-                        "nlist" => &mut config.nlist,
-                        "nprobe" => &mut config.nprobe,
-                        "m" => &mut config.m,
-                        "sampleBytes" => &mut config.sample_bytes,
-                        other => {
-                            return Err(QueryError::parse(format!(
-                                "@vectorIndex IVFPQ has no argument named '{other}'"
-                            )))
-                        }
+                "alg" => {
+                    let (SchemaValue::String(text) | SchemaValue::Enum(text)) = member_value else {
+                        return Err(QueryError::parse("@index vector alg must be an algorithm"));
                     };
-                    *slot =
-                        Some(directive_u32(name, value).map_err(|message| {
-                            QueryError::parse(format!("@vectorIndex {message}"))
-                        })?);
+                    config.algorithm = Some(text.clone());
                 }
-                Some(config)
-            }
-            Some(_) => {
-                return Err(QueryError::parse(
-                    "@vectorIndex IVFPQ must be an object of parameters",
-                ))
-            }
-        };
-
-        let ssg = match get_directive_arg(directive, "SSG") {
-            None => None,
-            Some(graphql_parser::schema::Value::Object(members)) => {
-                let mut config = super::directives::SsgConfig::default();
-                for (name, value) in members {
-                    let slot = match name.as_str() {
-                        "R" => &mut config.r,
-                        "angle" => &mut config.angle,
-                        "pool" => &mut config.pool,
-                        other => {
-                            return Err(QueryError::parse(format!(
-                                "@vectorIndex SSG has no argument named '{other}'"
-                            )))
+                block if block == schema::VectorAlgorithm::Flat.sdl_block() => {
+                    let mut block = FlatConfig::default();
+                    for (name, value) in vector_block(member, member_value)? {
+                        match name.as_str() {
+                            "metric" => block.metric = Some(read_metric(member, value)?),
+                            other => return Err(unknown_vector_member(member, other)),
                         }
-                    };
-                    *slot =
-                        Some(directive_u32(name, value).map_err(|message| {
-                            QueryError::parse(format!("@vectorIndex {message}"))
-                        })?);
+                    }
+                    config.flat = Some(block);
                 }
-                Some(config)
+                block if block == schema::VectorAlgorithm::Hnsw.sdl_block() => {
+                    let mut block = HnswConfig::default();
+                    for (name, value) in vector_block(member, member_value)? {
+                        let slot = match name.as_str() {
+                            "metric" => {
+                                block.metric = Some(read_metric(member, value)?);
+                                continue;
+                            }
+                            "M" => &mut block.m,
+                            "efConstruction" => &mut block.ef_construction,
+                            "efSearch" => &mut block.ef_search,
+                            other => return Err(unknown_vector_member(member, other)),
+                        };
+                        *slot = Some(read_block_u32(name, value)?);
+                    }
+                    config.hnsw = Some(block);
+                }
+                block if block == schema::VectorAlgorithm::IvfPq.sdl_block() => {
+                    let mut block = IvfPqConfig::default();
+                    for (name, value) in vector_block(member, member_value)? {
+                        let slot = match name.as_str() {
+                            "metric" => {
+                                block.metric = Some(read_metric(member, value)?);
+                                continue;
+                            }
+                            "nlist" => &mut block.nlist,
+                            "nprobe" => &mut block.nprobe,
+                            "m" => &mut block.m,
+                            "sampleBytes" => &mut block.sample_bytes,
+                            other => return Err(unknown_vector_member(member, other)),
+                        };
+                        *slot = Some(read_block_u32(name, value)?);
+                    }
+                    config.ivfpq = Some(block);
+                }
+                block if block == schema::VectorAlgorithm::Ssg.sdl_block() => {
+                    let mut block = SsgConfig::default();
+                    for (name, value) in vector_block(member, member_value)? {
+                        let slot = match name.as_str() {
+                            "metric" => {
+                                block.metric = Some(read_metric(member, value)?);
+                                continue;
+                            }
+                            "R" => &mut block.r,
+                            "angle" => &mut block.angle,
+                            "pool" => &mut block.pool,
+                            other => return Err(unknown_vector_member(member, other)),
+                        };
+                        *slot = Some(read_block_u32(name, value)?);
+                    }
+                    config.ssg = Some(block);
+                }
+                other => {
+                    return Err(QueryError::parse(format!(
+                        "@index vector has no argument named '{other}'"
+                    )))
+                }
             }
-            Some(_) => {
-                return Err(QueryError::parse(
-                    "@vectorIndex SSG must be an object of parameters",
-                ))
-            }
-        };
-
-        Ok(super::directives::VectorIndexConfig {
-            dimensions,
-            algorithm,
-            metric,
-            hnsw,
-            ivfpq,
-            ssg,
-        })
+        }
+        Ok(config)
     }
 
     pub(super) fn parse_default_directive(
@@ -823,4 +880,136 @@ impl<'a> SdlParser<'a> {
             ))),
         }
     }
+}
+
+/// A `@index` argument value, aliased because the parser names it constantly.
+type SchemaValue<'a> = graphql_parser::schema::Value<'a, String>;
+
+/// What a `@index` invocation resolves to. One variant per index kind, mirroring
+/// the wire's `Kind` discriminator, so a kind can never be inferred twice from
+/// two different places.
+pub(super) enum ParsedIndex {
+    Ordered(IndexConfig),
+    Vector(super::directives::VectorIndexConfig),
+}
+
+/// The kind an argument selects. Distinct from `schema::IndexKind` because the
+/// selection is a parse-time fact about the directive, not a described index.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IndexKindSelector {
+    Ordered,
+    Vector,
+}
+
+impl IndexKindSelector {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Ordered => "ordered",
+            Self::Vector => "vector",
+        }
+    }
+}
+
+/// Ordered-index arguments as written, before defaults are resolved.
+///
+/// `has_*` record whether a property was *written*, not what it resolved to.
+/// The nested `ordered:` block and the legacy top-level arguments merge, so
+/// setting one property from both places has to be an error rather than a
+/// silent last-writer-wins. `includes` stays unparsed until the directive's
+/// `direction:` is known, since an entry without its own direction inherits it.
+#[derive(Default)]
+struct OrderedIndexArgs {
+    unique: bool,
+    direction: IndexDirection,
+    /// `None` on an entry means it named no direction and inherits the
+    /// directive's, which may be written after `includes:`.
+    includes: Vec<(String, Option<bool>)>,
+    has_unique: bool,
+    has_direction: bool,
+    has_includes: bool,
+}
+
+/// Records the kind an argument selects, refusing a second, different one.
+fn select_index_kind(
+    current: &mut Option<IndexKindSelector>,
+    selected: IndexKindSelector,
+) -> Result<()> {
+    match current {
+        Some(existing) if *existing != selected => Err(QueryError::parse(format!(
+            "@index cannot be both {} and {}",
+            existing.as_str(),
+            selected.as_str()
+        ))),
+        _ => {
+            *current = Some(selected);
+            Ok(())
+        }
+    }
+}
+
+/// The members of one algorithm block, or an error naming the block.
+fn vector_block<'v, 'a>(
+    block: &str,
+    value: &'v SchemaValue<'a>,
+) -> Result<&'v BTreeMap<String, SchemaValue<'a>>> {
+    match value {
+        SchemaValue::Object(members) => Ok(members),
+        _ => Err(QueryError::parse(format!(
+            "@index vector {block} must be an object of parameters"
+        ))),
+    }
+}
+
+fn read_metric(block: &str, value: &SchemaValue<'_>) -> Result<String> {
+    match value {
+        SchemaValue::String(text) | SchemaValue::Enum(text) => Ok(text.clone()),
+        _ => Err(QueryError::parse(format!(
+            "@index vector {block} metric must be a metric"
+        ))),
+    }
+}
+
+fn read_block_u32(name: &str, value: &SchemaValue<'_>) -> Result<u32> {
+    super::directives::directive_u32(name, value)
+        .map_err(|message| QueryError::parse(format!("@index vector {message}")))
+}
+
+fn unknown_vector_member(block: &str, member: &str) -> QueryError {
+    QueryError::parse(format!(
+        "@index vector {block} has no argument named '{member}'"
+    ))
+}
+
+/// Reads an `includes` or `fields` list into (field_name, descending) pairs.
+///
+/// An entry is either the reference's object form, `{field: "name", direction:
+/// DESC}`, or our bare string, which names the field and no direction.
+///
+/// `None` for an entry that named no direction: it inherits the directive's,
+/// which the caller resolves once every argument has been read.
+fn read_includes_value(value: &SchemaValue<'_>) -> Vec<(String, Option<bool>)> {
+    let SchemaValue::List(items) = value else {
+        return Vec::new();
+    };
+
+    items
+        .iter()
+        .filter_map(|item| match item {
+            SchemaValue::String(name) | SchemaValue::Enum(name) => Some((name.clone(), None)),
+            SchemaValue::Object(obj) => {
+                let field_name = obj.get("field").and_then(|v| match v {
+                    SchemaValue::String(s) | SchemaValue::Enum(s) => Some(s.clone()),
+                    _ => None,
+                })?;
+                let descending = obj.get("direction").and_then(|v| match v {
+                    SchemaValue::String(s) | SchemaValue::Enum(s) => {
+                        Some(matches!(s.as_str(), "DESC" | "desc" | "Descending"))
+                    }
+                    _ => None,
+                });
+                Some((field_name, descending))
+            }
+            _ => None,
+        })
+        .collect()
 }

--- a/crates/query/src/sdl_parse/parser_tests.rs
+++ b/crates/query/src/sdl_parse/parser_tests.rs
@@ -1105,31 +1105,20 @@ fn test_unknown_type_directive_emits_warning() {
     }
 }
 
+/// `@index` is deliberately stricter than every other directive: its arguments
+/// decide what gets built, so a dropped one silently builds a different index
+/// than the schema asks for. An unknown argument on `@embedding` or `@policy`
+/// is inert by comparison, and those keep warning.
 #[test]
-fn test_unknown_directive_argument_emits_warning() {
-    let sdl = r#"
-        type User {
-            email: String @index(unique: true, unknownArg: "value")
-        }
-    "#;
-
-    let output = parse_sdl_with_warnings(sdl).unwrap();
-    assert_eq!(output.collections.len(), 1);
-    assert_eq!(output.warnings.len(), 1);
-
-    match &output.warnings[0] {
-        ParseWarning::UnknownDirectiveArgument {
-            directive_name,
-            argument_name,
-            type_name,
-            field_name,
-        } => {
-            assert_eq!(directive_name, "index");
-            assert_eq!(argument_name, "unknownArg");
-            assert_eq!(type_name, "User");
-            assert_eq!(field_name.as_deref(), Some("email"));
-        }
-        other => panic!("expected UnknownDirectiveArgument warning, got {:?}", other),
+fn test_unknown_index_argument_is_refused() {
+    for sdl in [
+        r#"type User { email: String @index(unique: true, unknownArg: "value") }"#,
+        r#"type User @index(includes: [{field: "email"}], unknownArg: "value") { email: String }"#,
+    ] {
+        let error = parse_sdl_with_warnings(sdl)
+            .expect_err("an unknown @index argument must not parse")
+            .to_string();
+        assert!(error.contains("unknownArg"), "{sdl}: {error}");
     }
 }
 
@@ -1615,33 +1604,6 @@ fn test_default_directive_value_rejects_unsupported_field_type() {
     );
 }
 
-#[test]
-fn test_type_level_index_unknown_argument_emits_warning() {
-    let sdl = r#"
-        type User @index(fields: ["name"], unknownArg: "value") {
-            name: String
-        }
-    "#;
-
-    let output = parse_sdl_with_warnings(sdl).unwrap();
-    assert_eq!(output.collections.len(), 1);
-    assert_eq!(output.warnings.len(), 1);
-
-    match &output.warnings[0] {
-        ParseWarning::UnknownDirectiveArgument {
-            directive_name,
-            argument_name,
-            field_name,
-            ..
-        } => {
-            assert_eq!(directive_name, "index");
-            assert_eq!(argument_name, "unknownArg");
-            assert!(field_name.is_none()); // type-level
-        }
-        other => panic!("expected UnknownDirectiveArgument, got {:?}", other),
-    }
-}
-
 // =========================================================================
 // InvalidArgumentType Warning Tests
 // =========================================================================
@@ -1760,22 +1722,61 @@ fn test_field_policy_directive_emits_unimplemented_warning() {
     }
 }
 
+/// `fields` is our shorter spelling of `includes`; both name the same set. Each
+/// parses on its own, and giving both is refused rather than resolved by
+/// precedence, which is what the directive used to do: `fields` won and
+/// `includes` was silently dropped.
 #[test]
-fn test_index_with_includes_argument_no_warning() {
+fn test_fields_and_includes_are_one_argument() {
+    for sdl in [
+        r#"type User @index(fields: ["name", "email"]) { name: String  email: String }"#,
+        r#"type User @index(includes: [{field: "name"}, {field: "email"}]) { name: String  email: String }"#,
+    ] {
+        let output = parse_sdl_with_warnings(sdl).unwrap_or_else(|e| panic!("{sdl}: {e}"));
+        assert!(output.warnings.is_empty(), "{sdl}: {:?}", output.warnings);
+        let fields: Vec<&str> = output.collections[0].indexes[0]
+            .fields
+            .iter()
+            .map(|f| f.name.as_str())
+            .collect();
+        assert_eq!(fields, vec!["name", "email"], "{sdl}");
+    }
+
+    let error = parse_sdl_with_warnings(
+        r#"type User @index(fields: ["name"], includes: ["email"]) { name: String  email: String }"#,
+    )
+    .expect_err("one slot written twice must not parse")
+    .to_string();
+    assert!(error.contains("includes"), "got: {error}");
+}
+
+/// The nested block works at type level too, which is where the reference's own
+/// shared parser puts it.
+#[test]
+fn test_type_level_nested_ordered_configuration() {
     let sdl = r#"
-        type User @index(fields: ["name"], includes: ["email"]) {
+        type User @index(name: "userIndex", ordered: {
+            unique: true,
+            direction: DESC,
+            includes: [{field: "name"}, {field: "age", direction: ASC}]
+        }) {
             name: String
-            email: String
+            age: Int
         }
     "#;
 
-    let output = parse_sdl_with_warnings(sdl).unwrap();
-    assert_eq!(output.collections.len(), 1);
-    // includes is a known argument, should not trigger warning
-    assert!(
-        output.warnings.is_empty(),
-        "includes is a known argument but got warnings: {:?}",
-        output.warnings
+    let collections = parse_sdl(sdl).unwrap();
+    let index = &collections[0].indexes[0];
+    assert_eq!(index.name, "userIndex");
+    assert!(index.resolved_unique());
+    assert_eq!(
+        index
+            .fields
+            .iter()
+            .map(|f| (f.name.as_str(), f.descending))
+            .collect::<Vec<_>>(),
+        vec![("name", true), ("age", false)],
+        "an entry without its own direction inherits the directive's"
     );
 }
 

--- a/crates/query/tests/vector_index_sdl.rs
+++ b/crates/query/tests/vector_index_sdl.rs
@@ -1,5 +1,11 @@
-//! `@vectorIndex` in SDL. The argument names are Go's, because the SDL is the
-//! surface users and parity tests see.
+//! `@index(vector: {...})` in SDL. The argument names are Go's, because the SDL
+//! is the surface users and parity tests see.
+//!
+//! Go folded `@vectorIndex` into `@index` in sourcenetwork/defradb#5188 and
+//! deleted the old directive outright. Neither spelling had shipped in a
+//! release either runtime must honour, so this file tracks the folded grammar
+//! only, and `the_old_directive_is_gone` pins that the old one no longer builds
+//! an index rather than quietly still working.
 
 use query::parse_sdl;
 use schema::{DistanceMetric, IndexKind, VectorAlgorithm};
@@ -18,12 +24,17 @@ fn only_vector(sdl: &str) -> schema::VectorIndexDescription {
     *index.vector().unwrap()
 }
 
-/// Omitting the algorithm config still means HNSW, with defaults.
+// ---------------------------------------------------------------------------
+// The kind selector
+// ---------------------------------------------------------------------------
+
+/// `vector:` is what makes an index a vector index, mirroring the wire envelope
+/// where `Kind` decides and `KindDescription` configures.
 #[test]
-fn a_bare_directive_uses_hnsw_defaults() {
+fn the_vector_argument_selects_the_kind() {
     let vector = only_vector(
         r#"type Doc {
-            embedding: [Float!] @vectorIndex(dimensions: 768)
+            embedding: [Float!] @index(vector: {dimensions: 768})
         }"#,
     );
     assert_eq!(vector.algorithm, VectorAlgorithm::Hnsw);
@@ -36,14 +47,181 @@ fn a_bare_directive_uses_hnsw_defaults() {
     );
 }
 
+/// No `vector:` means ordered, which is what `@index` has always meant.
+#[test]
+fn an_index_without_a_vector_argument_is_ordered() {
+    let collections = collections(r#"type Doc { name: String @index }"#);
+    let index = &collections[0].indexes[0];
+    assert!(!index.is_vector());
+    assert!(matches!(index.kind, None | Some(IndexKind::Ordered(_))));
+}
+
+/// `kind:` names a kind directly, for its default configuration.
+#[test]
+fn the_ordered_kind_can_be_named() {
+    let collections = collections(r#"type Doc { name: String @index(kind: ordered) }"#);
+    let index = &collections[0].indexes[0];
+    assert!(!index.is_vector());
+    assert_eq!(index.fields[0].name, "name");
+}
+
+/// `kind: vector` is refused. A vector index needs at least its dimensions, so
+/// there is no default configuration for `kind:` to select, and Go's
+/// `IndexKind` enum deliberately has no such value.
+#[test]
+fn the_vector_kind_cannot_be_named_without_a_configuration() {
+    let err = parse_sdl(r#"type Doc { e: [Float!] @index(kind: vector) }"#)
+        .expect_err("kind: vector must not parse");
+    assert!(err.to_string().contains("vector"), "got: {err}");
+}
+
+/// A `kind:` that agrees with the configuration block is fine; the two say the
+/// same thing.
+#[test]
+fn a_matching_kind_and_configuration_agree() {
+    let collections = collections(
+        r#"type Doc { name: String @index(kind: ordered, ordered: {direction: DESC}) }"#,
+    );
+    assert!(collections[0].indexes[0].fields[0].descending);
+}
+
+/// Legacy top-level arguments still select ordered, so a schema written before
+/// the fold keeps parsing.
+#[test]
+fn a_matching_kind_and_legacy_configuration_agree() {
+    let collections =
+        collections(r#"type Doc { name: String @index(kind: ordered, unique: true) }"#);
+    assert!(collections[0].indexes[0].resolved_unique());
+}
+
+/// Two selectors that disagree are an error rather than a precedence rule: a
+/// precedence rule would build the index the author did not ask for.
+#[test]
+fn competing_kind_selectors_are_refused() {
+    for sdl in [
+        r#"type Doc { e: [Float!] @index(kind: ordered, vector: {dimensions: 3}) }"#,
+        r#"type Doc { e: [Float!] @index(ordered: {}, vector: {dimensions: 3}) }"#,
+        r#"type Doc { e: [Float!] @index(vector: {dimensions: 3}, unique: false) }"#,
+        r#"type Doc { e: [Float!] @index(vector: {dimensions: 3}, direction: DESC) }"#,
+    ] {
+        assert!(parse_sdl(sdl).is_err(), "should have been refused: {sdl}");
+    }
+}
+
+/// A vector index covers exactly one field, so there is no type-level form.
+#[test]
+fn a_vector_configuration_is_refused_on_a_type() {
+    let err = parse_sdl(
+        r#"type Doc @index(vector: {dimensions: 3}) {
+            embedding: [Float!]
+        }"#,
+    )
+    .expect_err("a type-level vector index must not parse");
+    assert!(err.to_string().contains("field"), "got: {err}");
+}
+
+/// The directive Go deleted. Keeping it parsing would mean carrying a grammar
+/// neither runtime emits.
+#[test]
+fn the_old_directive_is_gone() {
+    let collections = parse_sdl(r#"type Doc { e: [Float!] @vectorIndex(dimensions: 4) }"#)
+        .expect("an unknown directive is a warning, not an error");
+    assert!(
+        !collections[0].indexes.iter().any(|i| i.is_vector()),
+        "@vectorIndex must not build an index"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The ordered configuration
+// ---------------------------------------------------------------------------
+
+/// The nested block and the legacy top-level arguments describe the same index,
+/// so they merge when they do not overlap.
+#[test]
+fn nested_and_legacy_ordered_configurations_merge() {
+    let collections = collections(
+        r#"type Doc { name: String @index(ordered: {unique: true}, direction: DESC) }"#,
+    );
+    let index = &collections[0].indexes[0];
+    assert!(index.resolved_unique());
+    assert!(index.fields[0].descending);
+}
+
+/// Setting one property from both places is an error: a merge that silently
+/// drops one of two explicit values is worse than a parse failure.
+#[test]
+fn a_property_set_twice_is_refused() {
+    for sdl in [
+        r#"type Doc { name: String @index(ordered: {unique: true}, unique: false) }"#,
+        r#"type Doc { name: String @index(ordered: {direction: ASC}, direction: DESC) }"#,
+        r#"type Doc { name: String @index(ordered: {includes: []}, includes: []) }"#,
+    ] {
+        assert!(parse_sdl(sdl).is_err(), "should have been refused: {sdl}");
+    }
+}
+
+/// The nested block carries everything the legacy form does, at type level too:
+/// the reference parses both levels with one function, and so do we.
+#[test]
+fn a_nested_ordered_configuration_is_read_on_a_type() {
+    let collections = collections(
+        r#"type Doc @index(name: "userIndex", ordered: {
+            unique: true,
+            direction: DESC,
+            includes: [{field: "name"}, {field: "age", direction: ASC}]
+        }) {
+            name: String
+            age: Int
+        }"#,
+    );
+    let index = &collections[0].indexes[0];
+    assert_eq!(index.name, "userIndex");
+    assert!(index.resolved_unique());
+    assert_eq!(
+        index
+            .fields
+            .iter()
+            .map(|f| (f.name.as_str(), f.descending))
+            .collect::<Vec<_>>(),
+        vec![("name", true), ("age", false)],
+        "an entry without its own direction inherits the directive's"
+    );
+}
+
+/// An unknown argument is reported as one, not as the kind conflict it also
+/// causes.
+#[test]
+fn an_unknown_argument_names_itself() {
+    let err =
+        parse_sdl(r#"type Doc { e: [Float!] @index(unknown: "x", vector: {dimensions: 3}) }"#)
+            .expect_err("an unknown argument must not parse");
+    assert!(err.to_string().contains("unknown"), "got: {err}");
+}
+
+// ---------------------------------------------------------------------------
+// The vector configuration
+// ---------------------------------------------------------------------------
+
+/// `@index` names the index, which Go's `@vectorIndex` could not do at all.
+#[test]
+fn a_vector_index_can_be_named() {
+    let collections = collections(
+        r#"type Doc {
+            embedding: [Float!] @index(name: "by_face", vector: {dimensions: 512})
+        }"#,
+    );
+    assert_eq!(collections[0].indexes[0].name, "by_face");
+}
+
 #[test]
 fn hnsw_parameters_are_read_by_gos_names() {
     let vector = only_vector(
         r#"type Doc {
-            embedding: [Float!] @vectorIndex(
+            embedding: [Float!] @index(vector: {
                 dimensions: 4,
-                HNSW: { metric: "COSINE", M: 32, efConstruction: 200, efSearch: 100 }
-            )
+                hnsw: {metric: COSINE, M: 32, efConstruction: 200, efSearch: 100}
+            })
         }"#,
     );
     let hnsw = vector.hnsw.expect("HNSW params");
@@ -59,7 +237,7 @@ fn hnsw_parameters_are_read_by_gos_names() {
 fn a_partial_hnsw_config_keeps_the_other_defaults() {
     let vector = only_vector(
         r#"type Doc {
-            embedding: [Float!] @vectorIndex(dimensions: 4, HNSW: { M: 48 })
+            embedding: [Float!] @index(vector: {dimensions: 4, hnsw: {M: 48}})
         }"#,
     );
     let hnsw = vector.hnsw.expect("HNSW params");
@@ -69,15 +247,28 @@ fn a_partial_hnsw_config_keeps_the_other_defaults() {
     );
 }
 
-/// Zero dimensions means an `@embedding` on the field fixes the length.
+/// Omitted dimensions parse as zero and are never inferred. Go dropped
+/// inferring them from an `@embedding` on the same field in
+/// sourcenetwork/defradb#5188; definition validation is what rejects the zero,
+/// so this only pins that nothing fills it in on the way through.
 #[test]
-fn dimensions_may_be_omitted() {
-    let vector = only_vector(
-        r#"type Doc {
-            embedding: [Float!] @vectorIndex
-        }"#,
+fn dimensions_are_never_inferred() {
+    assert_eq!(
+        only_vector(r#"type Doc { e: [Float!] @index(vector: {}) }"#).dimensions,
+        0
     );
-    assert_eq!(vector.dimensions, 0);
+    assert_eq!(
+        only_vector(
+            r#"type Doc {
+                t: String
+                e: [Float32!] @index(vector: {})
+                    @embedding(provider: "openai", model: "m", fields: ["t"])
+            }"#
+        )
+        .dimensions,
+        0,
+        "an @embedding on the field must not supply the length"
+    );
 }
 
 /// The index lands in the collection's one index list, carrying its kind. A
@@ -87,7 +278,7 @@ fn a_vector_index_joins_the_ordinary_index_list() {
     let collections = collections(
         r#"type Doc {
             name: String @index
-            embedding: [Float!] @vectorIndex(dimensions: 8)
+            embedding: [Float!] @index(vector: {dimensions: 8})
         }"#,
     );
     let indexes = &collections[0].indexes;
@@ -110,117 +301,132 @@ fn a_vector_index_joins_the_ordinary_index_list() {
 #[test]
 fn unknown_or_mistyped_arguments_are_refused() {
     for sdl in [
-        r#"type Doc { e: [Float!] @vectorIndex(dimensions: 4, HNSW: { efSarch: 10 }) }"#,
-        r#"type Doc { e: [Float!] @vectorIndex(dimensions: 4, HNSW: { M: "big" }) }"#,
-        r#"type Doc { e: [Float!] @vectorIndex(dimensions: "many") }"#,
-        r#"type Doc { e: [Float!] @vectorIndex(dimensions: 4, HNSW: { metric: "MANHATTAN" }) }"#,
-        r#"type Doc { e: [Float!] @vectorIndex(dimensions: 4, HNSW: 5) }"#,
+        r#"type Doc { e: [Float!] @index(vector: {dimensions: 4, hnsw: {efSarch: 10}}) }"#,
+        r#"type Doc { e: [Float!] @index(vector: {dimensions: 4, hnsw: {M: "big"}}) }"#,
+        r#"type Doc { e: [Float!] @index(vector: {dimensions: "many"}) }"#,
+        r#"type Doc { e: [Float!] @index(vector: {dimensions: 4, hnsw: {metric: MANHATTAN}}) }"#,
+        r#"type Doc { e: [Float!] @index(vector: {dimensions: 4, hnsw: 5}) }"#,
+        r#"type Doc { e: [Float!] @index(vector: {dimensions: 4, unknown: 1}) }"#,
+        r#"type Doc { e: [Float!] @index(vector: {dimensions: 4, IVFFlat: {}}) }"#,
+        r#"type Doc { e: [Float!] @index(vector: 5) }"#,
     ] {
         assert!(parse_sdl(sdl).is_err(), "should have been refused: {sdl}");
     }
 }
 
-/// Every metric the enum carries is spellable in SDL. `EUCLIDEAN` in
-/// particular used to be refused, back when the metric set was smaller than
-/// Go's.
-#[test]
-fn every_metric_is_spellable() {
-    for metric in DistanceMetric::ALL {
-        let sdl = format!(
-            r#"type Doc {{ e: [Float!] @vectorIndex(dimensions: 4, HNSW: {{ metric: "{}" }}) }}"#,
-            metric.as_str()
-        );
-        assert_eq!(only_vector(&sdl).metric, *metric, "{sdl}");
-    }
-}
+// ---------------------------------------------------------------------------
+// Algorithm selection
+// ---------------------------------------------------------------------------
 
 #[test]
 fn the_algorithm_defaults_to_hnsw() {
-    let vector = only_vector(
-        r#"type Doc {
-            embedding: [Float!] @vectorIndex(dimensions: 4)
-        }"#,
-    );
+    let vector = only_vector(r#"type Doc { e: [Float!] @index(vector: {dimensions: 4}) }"#);
     assert_eq!(vector.algorithm, VectorAlgorithm::Hnsw);
     assert!(vector.hnsw.is_some(), "HNSW carries build parameters");
 }
 
+/// `alg:` selects an algorithm with its default configuration, which is what
+/// Go's `alg` enum does.
 #[test]
-fn the_flat_algorithm_is_selectable() {
-    let vector = only_vector(
-        r#"type Doc {
-            embedding: [Float!] @vectorIndex(dimensions: 4, algorithm: "FLAT")
-        }"#,
-    );
-    assert_eq!(vector.algorithm, VectorAlgorithm::Flat);
-    assert_eq!(vector.dimensions, 4);
-    assert!(
-        vector.hnsw.is_none(),
-        "flat has no build parameters, got {:?}",
-        vector.hnsw
-    );
+fn every_algorithm_is_selectable_by_alg() {
+    for algorithm in VectorAlgorithm::ALL {
+        let vector = only_vector(&format!(
+            r#"type Doc {{ e: [Float32!] @index(vector: {{dimensions: 8, alg: {}}}) }}"#,
+            algorithm.as_str()
+        ));
+        assert_eq!(vector.algorithm, *algorithm, "{}", algorithm.as_str());
+    }
 }
 
+/// The block that configures an algorithm also selects it, so `alg:` is only
+/// needed for an algorithm taken with its defaults.
 #[test]
-fn the_algorithm_may_be_written_as_an_enum() {
-    let vector = only_vector(
-        r#"type Doc {
-            embedding: [Float!] @vectorIndex(dimensions: 4, algorithm: FLAT)
-        }"#,
-    );
-    assert_eq!(vector.algorithm, VectorAlgorithm::Flat);
+fn every_algorithm_is_selectable_by_its_block() {
+    for algorithm in VectorAlgorithm::ALL {
+        let vector = only_vector(&format!(
+            r#"type Doc {{ e: [Float32!] @index(vector: {{dimensions: 8, {}: {{}}}}) }}"#,
+            algorithm.sdl_block()
+        ));
+        assert_eq!(vector.algorithm, *algorithm, "{}", algorithm.sdl_block());
+    }
+}
+
+/// `alg:` and a block that disagree are refused rather than resolved by
+/// precedence, exactly as two kind selectors are.
+#[test]
+fn an_alg_that_contradicts_its_block_is_refused() {
+    for sdl in [
+        r#"type Doc { e: [Float!] @index(vector: {dimensions: 8, alg: SSG, hnsw: {M: 4}}) }"#,
+        r#"type Doc { e: [Float!] @index(vector: {dimensions: 8, hnsw: {M: 4}, ivfpq: {nlist: 4}}) }"#,
+    ] {
+        assert!(parse_sdl(sdl).is_err(), "should have been refused: {sdl}");
+    }
 }
 
 #[test]
 fn an_unknown_algorithm_is_refused() {
-    let err = parse_sdl(
-        r#"type Doc {
-            embedding: [Float!] @vectorIndex(dimensions: 4, algorithm: "IVFPQ")
-        }"#,
-    )
-    .expect_err("an unknown algorithm must not parse");
+    let err =
+        parse_sdl(r#"type Doc { e: [Float!] @index(vector: {dimensions: 4, alg: IVFFlat}) }"#)
+            .expect_err("an unknown algorithm must not parse");
     assert!(
-        err.to_string().contains("IVFPQ"),
+        err.to_string().contains("IVFFlat"),
         "the error must name it, got: {err}"
     );
 }
 
+// ---------------------------------------------------------------------------
+// Metrics, which live inside the algorithm's own block
+// ---------------------------------------------------------------------------
+
+/// The metric is one of the algorithm's knobs, where the reference puts it, so
+/// every algorithm's block declares its own.
+///
+/// Every pair parses; a pair the algorithm cannot rank by is rejected later, by
+/// definition validation, which is where the reference rejects it too.
 #[test]
-fn the_dot_metric_is_selectable() {
-    let vector = only_vector(
-        r#"type Doc {
-            embedding: [Float!] @vectorIndex(dimensions: 4, HNSW: { metric: "DOT" })
-        }"#,
-    );
-    assert_eq!(vector.metric, DistanceMetric::Dot);
+fn every_algorithm_block_carries_every_metric() {
+    for algorithm in VectorAlgorithm::ALL {
+        for metric in DistanceMetric::ALL {
+            let sdl = format!(
+                r#"type Doc {{ e: [Float32!] @index(vector: {{dimensions: 8, {}: {{metric: {}}}}}) }}"#,
+                algorithm.sdl_block(),
+                metric.as_str()
+            );
+            let vector = only_vector(&sdl);
+            assert_eq!(
+                (vector.algorithm, vector.metric),
+                (*algorithm, *metric),
+                "{sdl}"
+            );
+        }
+    }
 }
 
+/// The metric has no home outside an algorithm block, so writing it beside
+/// `dimensions` is an unknown argument rather than a silently ignored one.
 #[test]
-fn the_ivfpq_algorithm_is_selectable() {
-    let vector = only_vector(
-        r#"type Doc {
-            embedding: [Float!] @vectorIndex(dimensions: 8, algorithm: "IVF_PQ")
-        }"#,
-    );
-    assert_eq!(vector.algorithm, VectorAlgorithm::IvfPq);
-    assert!(vector.hnsw.is_none(), "IVF-PQ carries no HNSW block");
-    let ivfpq = vector.ivfpq.expect("IVF-PQ params");
-    assert_eq!(ivfpq.nprobe, 8);
-    assert_eq!(ivfpq.nlist, 0, "zero derives nlist from the corpus");
-    assert_eq!(ivfpq.m, 0, "zero derives m from the width");
+fn a_metric_beside_dimensions_is_refused() {
+    let err = parse_sdl(r#"type Doc { e: [Float!] @index(vector: {dimensions: 4, metric: DOT}) }"#)
+        .expect_err("a vector-level metric must not parse");
+    assert!(err.to_string().contains("metric"), "got: {err}");
 }
+
+// ---------------------------------------------------------------------------
+// The divergent algorithms
+// ---------------------------------------------------------------------------
 
 #[test]
 fn ivfpq_parameters_are_read() {
     let vector = only_vector(
         r#"type Doc {
-            embedding: [Float!] @vectorIndex(
+            e: [Float!] @index(vector: {
                 dimensions: 128,
-                algorithm: "IVF_PQ",
-                IVFPQ: { nlist: 256, nprobe: 16, m: 16, sampleBytes: 1048576 }
-            )
+                ivfpq: {nlist: 256, nprobe: 16, m: 16, sampleBytes: 1048576}
+            })
         }"#,
     );
+    assert_eq!(vector.algorithm, VectorAlgorithm::IvfPq);
+    assert!(vector.hnsw.is_none(), "IVF-PQ carries no HNSW block");
     let ivfpq = vector.ivfpq.expect("IVF-PQ params");
     assert_eq!(
         (ivfpq.nlist, ivfpq.nprobe, ivfpq.m, ivfpq.sample_bytes),
@@ -229,125 +435,71 @@ fn ivfpq_parameters_are_read() {
 }
 
 #[test]
-fn an_unknown_ivfpq_argument_is_refused() {
-    let err = parse_sdl(
-        r#"type Doc {
-            embedding: [Float!] @vectorIndex(
-                dimensions: 8, algorithm: "IVF_PQ", IVFPQ: { nlists: 4 }
-            )
-        }"#,
-    )
-    .expect_err("a misspelled argument must not parse");
-    assert!(
-        err.to_string().contains("nlists"),
-        "the error must name it, got: {err}"
-    );
-}
-
-/// An IVFPQ block on an HNSW index is inert rather than an error, the same way
-/// an HNSW block is inert on a flat index.
-#[test]
-fn an_ivfpq_block_on_an_hnsw_index_is_inert() {
-    let vector = only_vector(
-        r#"type Doc {
-            embedding: [Float!] @vectorIndex(dimensions: 8, IVFPQ: { nlist: 4 })
-        }"#,
-    );
-    assert_eq!(vector.algorithm, VectorAlgorithm::Hnsw);
-    assert!(vector.hnsw.is_some());
-    assert!(vector.ivfpq.is_none());
-}
-
-#[test]
-fn the_ssg_algorithm_is_selectable() {
-    let vector = only_vector(
-        r#"type Doc {
-            embedding: [Float!] @vectorIndex(dimensions: 8, algorithm: "SSG")
-        }"#,
-    );
-    assert_eq!(vector.algorithm, VectorAlgorithm::Ssg);
-    assert!(vector.hnsw.is_none());
-    assert!(vector.ivfpq.is_none());
-    let ssg = vector.ssg.expect("SSG params");
-    assert_eq!((ssg.r, ssg.angle, ssg.pool), (50, 60, 100));
+fn ivfpq_defaults_are_kept() {
+    let vector =
+        only_vector(r#"type Doc { e: [Float!] @index(vector: {dimensions: 8, alg: IVF_PQ}) }"#);
+    let ivfpq = vector.ivfpq.expect("IVF-PQ params");
+    assert_eq!(ivfpq.nprobe, 8);
+    assert_eq!(ivfpq.nlist, 0, "zero derives nlist from the corpus");
+    assert_eq!(ivfpq.m, 0, "zero derives m from the width");
 }
 
 #[test]
 fn ssg_parameters_are_read() {
     let vector = only_vector(
         r#"type Doc {
-            embedding: [Float!] @vectorIndex(
-                dimensions: 128, algorithm: "SSG", SSG: { R: 32, angle: 45, pool: 200 }
-            )
+            e: [Float!] @index(vector: {dimensions: 128, ssg: {R: 32, angle: 45, pool: 200}})
         }"#,
     );
+    assert_eq!(vector.algorithm, VectorAlgorithm::Ssg);
     let ssg = vector.ssg.expect("SSG params");
     assert_eq!((ssg.r, ssg.angle, ssg.pool), (32, 45, 200));
 }
 
 #[test]
-fn an_unknown_ssg_argument_is_refused() {
-    let err = parse_sdl(
-        r#"type Doc {
-            embedding: [Float!] @vectorIndex(dimensions: 8, algorithm: "SSG", SSG: { degree: 4 })
-        }"#,
-    )
-    .expect_err("a misspelled argument must not parse");
-    assert!(err.to_string().contains("degree"), "got: {err}");
+fn ssg_defaults_are_kept() {
+    let vector =
+        only_vector(r#"type Doc { e: [Float!] @index(vector: {dimensions: 8, alg: SSG}) }"#);
+    let ssg = vector.ssg.expect("SSG params");
+    assert_eq!((ssg.r, ssg.angle, ssg.pool), (50, 60, 100));
+}
+
+#[test]
+fn flat_carries_no_build_parameters() {
+    let vector =
+        only_vector(r#"type Doc { e: [Float!] @index(vector: {dimensions: 4, alg: FLAT}) }"#);
+    assert_eq!(vector.algorithm, VectorAlgorithm::Flat);
+    assert!(vector.hnsw.is_none());
+    assert!(vector.ivfpq.is_none());
+    assert!(vector.ssg.is_none());
+}
+
+#[test]
+fn an_unknown_block_argument_is_refused() {
+    for (sdl, name) in [
+        (
+            r#"type Doc { e: [Float!] @index(vector: {dimensions: 8, ivfpq: {nlists: 4}}) }"#,
+            "nlists",
+        ),
+        (
+            r#"type Doc { e: [Float!] @index(vector: {dimensions: 8, ssg: {degree: 4}}) }"#,
+            "degree",
+        ),
+        (
+            r#"type Doc { e: [Float!] @index(vector: {dimensions: 8, flat: {nlist: 4}}) }"#,
+            "nlist",
+        ),
+    ] {
+        let err = parse_sdl(sdl).expect_err("a misspelled argument must not parse");
+        assert!(err.to_string().contains(name), "got: {err}");
+    }
 }
 
 /// `[Float32!]` is what an `@embedding` field declares, so it must carry a
 /// vector index as readily as `[Float!]`.
 #[test]
 fn a_float32_field_takes_a_vector_index() {
-    let vector = only_vector(
-        r#"type Doc {
-            embedding: [Float32!] @vectorIndex(dimensions: 8)
-        }"#,
-    );
+    let vector = only_vector(r#"type Doc { e: [Float32!] @index(vector: {dimensions: 8}) }"#);
     assert_eq!(vector.dimensions, 8);
     assert_eq!(vector.algorithm, VectorAlgorithm::Hnsw);
-}
-
-/// Every algorithm the engine builds must be selectable by name in SDL.
-#[test]
-fn every_algorithm_is_selectable_by_name() {
-    for algorithm in VectorAlgorithm::ALL {
-        let vector = only_vector(&format!(
-            r#"type Doc {{ embedding: [Float32!] @vectorIndex(dimensions: 8, algorithm: "{}") }}"#,
-            algorithm.as_str()
-        ));
-        assert_eq!(vector.algorithm, *algorithm, "{}", algorithm.as_str());
-    }
-}
-
-/// The metric is a property of the index, not of HNSW, so every algorithm must
-/// accept it from the top-level argument.
-#[test]
-fn every_algorithm_accepts_every_metric() {
-    for algorithm in VectorAlgorithm::ALL {
-        for metric in DistanceMetric::ALL {
-            let vector = only_vector(&format!(
-                r#"type Doc {{ embedding: [Float32!] @vectorIndex(dimensions: 8, algorithm: "{}", metric: "{}") }}"#,
-                algorithm.as_str(),
-                metric.as_str()
-            ));
-            assert_eq!(
-                (vector.algorithm, vector.metric),
-                (*algorithm, *metric),
-                "{} with {}",
-                algorithm.as_str(),
-                metric.as_str()
-            );
-        }
-    }
-}
-
-/// The older spelling still works, so existing schemas keep parsing.
-#[test]
-fn the_hnsw_block_still_carries_the_metric() {
-    let vector = only_vector(
-        r#"type Doc { embedding: [Float!] @vectorIndex(dimensions: 8, HNSW: { metric: "DOT" }) }"#,
-    );
-    assert_eq!(vector.metric, DistanceMetric::Dot);
 }

--- a/crates/schema/src/definition_validation/global_validators.rs
+++ b/crates/schema/src/definition_validation/global_validators.rs
@@ -368,8 +368,9 @@ pub(super) fn validate_embedding_and_kind_compatible(
     errs
 }
 
-/// A vector index must be built with a metric its algorithm can rank by, and a
-/// field must not carry two vector indexes that disagree about the metric.
+/// A vector index must declare its dimensions, be built with a metric its
+/// algorithm can rank by, and not share a field with another vector index that
+/// disagrees about the metric.
 ///
 /// Without the first the definition is accepted and the failure surfaces on the
 /// first document write, as an index-manager construction error naming an
@@ -392,6 +393,17 @@ pub(super) fn validate_vector_index_metrics(
             let Some(vector) = index.vector() else {
                 continue;
             };
+            // Go required this from sourcenetwork/defradb#5188, which dropped
+            // inferring the length from an `@embedding` on the same field. A
+            // zero-dimension index cannot check a query vector's length, so a
+            // wrong-length query would silently be scored on its shared leading
+            // elements.
+            if vector.dimensions == 0 {
+                errs.push(format!(
+                    "index '{}' must set dimensions greater than zero",
+                    index.name
+                ));
+            }
             if !vector.algorithm.supports_metric(vector.metric) {
                 errs.push(format!(
                     "index '{}' cannot rank by {}: the {} algorithm does not order it",

--- a/crates/schema/src/index.rs
+++ b/crates/schema/src/index.rs
@@ -343,8 +343,8 @@ mod tests {
 /// from the coverage every consumer derives from `ALL`.
 macro_rules! vector_algorithms {
     (
-        $(#[doc = $first_doc:literal])* $first:ident => $first_name:literal,
-        $($(#[doc = $doc:literal])* $variant:ident => $name:literal),+ $(,)?
+        $(#[doc = $first_doc:literal])* $first:ident => $first_name:literal / $first_block:literal,
+        $($(#[doc = $doc:literal])* $variant:ident => $name:literal / $block:literal),+ $(,)?
     ) => {
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
         pub enum VectorAlgorithm {
@@ -367,12 +367,34 @@ macro_rules! vector_algorithms {
             /// than reachable only through its own engine tests.
             pub const ALL: &'static [Self] = &[Self::$first, $(Self::$variant),+];
 
-            /// The name used in `@vectorIndex(algorithm:)` and on the wire.
+            /// The name used in `@index(vector: {alg:})` and on the wire.
             pub fn as_str(self) -> &'static str {
                 match self {
                     Self::$first => $first_name,
                     $(Self::$variant => $name),+
                 }
+            }
+
+            /// The `@index(vector: {...})` block that configures this
+            /// algorithm, and whose presence selects it.
+            ///
+            /// Every algorithm has one even when it has nothing to tune,
+            /// because under this grammar the metric lives inside the block:
+            /// an algorithm with no block could only ever be built with the
+            /// default metric.
+            pub fn sdl_block(self) -> &'static str {
+                match self {
+                    Self::$first => $first_block,
+                    $(Self::$variant => $block),+
+                }
+            }
+
+            /// The algorithm a `@index(vector: {...})` block name selects.
+            pub fn from_sdl_block(block: &str) -> Option<Self> {
+                Self::ALL
+                    .iter()
+                    .copied()
+                    .find(|algorithm| algorithm.sdl_block() == block)
             }
         }
     };
@@ -381,14 +403,14 @@ macro_rules! vector_algorithms {
 // The first entry is the default.
 vector_algorithms! {
     /// Hierarchical Navigable Small World graph.
-    Hnsw => "HNSW",
+    Hnsw => "HNSW" / "hnsw",
     /// Exhaustive scan. Exact, no build parameters, no tuning.
-    Flat => "FLAT",
+    Flat => "FLAT" / "flat",
     /// Coarse lists of product-quantized codes. Approximate and lossy, in
     /// exchange for a code far smaller than the vector it stands for.
-    IvfPq => "IVF_PQ",
+    IvfPq => "IVF_PQ" / "ivfpq",
     /// Satellite System Graph: one flat layer, edges pruned by angle.
-    Ssg => "SSG",
+    Ssg => "SSG" / "ssg",
 }
 
 impl VectorAlgorithm {


### PR DESCRIPTION
> **Stacked PR, part of the #1517 vector-index alignment.**
> Review and merge bottom-up. Each PR is based on the one above it, so each shows only its own commit.
>
> | | PR | based on |
> |---|---|---|
> |  | #1656 feat(schema): add the EUCLIDEAN distance metric | main |
> |  | #1657 fix(query): score SIMILARITY by the target index's metric | #1656 |
> | **this** | **#1658** feat(query): fold @vectorIndex into @index(vector: ...) | #1657 |
> |  | #1659 feat(cli): index create takes Go's --vector JSON flag | #1658 |
>
> Still to come on top of this stack: the rescoped sourcenetwork/defradb#5072 metric argument on `SIMILARITY`, the Go compat baseline bump (#1519), the IVF correctness fixes (#1465, #1462, #1463) and the IVF_FLAT engine (#1516).

Closes #1520. Closes #1471. Part of #1517. Stacked on #1657.

#1471 is closed by the same change: the builder no longer drops an algorithm's parameters (each algorithm reads its own block, and a block belonging to a different algorithm is a conflict error rather than silently ignored), and `metric` is reachable for every algorithm rather than only inside `HNSW`, which is what the `flat:` block exists for.

Go folded `@vectorIndex` into `@index` in sourcenetwork/defradb#5188 (merged 2026-08-29) and deleted the old directive outright. Neither spelling has shipped in a release either runtime must honour, so this is the window to align without deprecation debt. This is our side of it.

## The grammar

```graphql
type User {
  age: Int @index(unique: true)                     # unchanged
  name: String @index(kind: ordered, ordered: {direction: DESC})
  headshot: [Float32!] @index(name: "by_face", vector: {
    dimensions: 512,
    hnsw: {metric: EUCLIDEAN, M: 16, efConstruction: 128, efSearch: 64}
  })
}
```

The kind is selected by which configuration argument is present, mirroring the wire's `Kind`/`KindDescription` envelope that #1518 landed. `vector:` means vector, `ordered:` or any legacy top-level ordered argument means ordered, and `kind:` names one directly.

Two selectors that disagree are refused rather than resolved by precedence, because a precedence rule silently builds the index the author did not ask for. `@index(kind: ordered, vector: {...})`, `@index(ordered: {}, vector: {})` and `@index(vector: {}, unique: false)` are all errors, matching Go's `selectKind`.

`kind: vector` is refused. A vector index needs at least its dimensions, so there is no default configuration for `kind:` to select. Go's `IndexKind` enum has no such value for the same reason, and its test asserts the rejection.

`ordered: {unique, direction, includes}` is the nested form of the three legacy top-level arguments. They merge when they do not overlap, and setting one property from both places is an error rather than last-writer-wins.

A vector configuration on a type-level `@index` is refused: a vector index covers exactly one field.

## Decisions

**Metric placement.** Go put `metric` inside `hnsw:`, not beside `dimensions`. #1520 argued the opposite, since it makes metric unreachable for a second algorithm. We follow Go: `metric` lives in each algorithm's own block, and every algorithm therefore declares one. That includes a new `flat: {metric: ...}` block, which exists purely so the block-less algorithm can still name a metric; without it `FLAT` could only ever be cosine, which it isn't today.

**`alg:` survives as an enum.** #1520 asked for the redundant `algorithm:` string to be deleted. Go kept an `alg` enum for selecting an algorithm with its default configuration, so we keep ours, typed the same way. `alg:` and a block that disagree are refused, exactly as two kind selectors are. Go cannot express that conflict (it has one algorithm); we can, so we do.

**`@vectorIndex` is deleted**, as Go deleted it. `the_old_directive_is_gone` pins that it no longer builds an index rather than quietly still working.

**`dimensions` is mandatory and greater than zero**, as Go made it. The inference from an `@embedding` on the same field is gone. A zero-dimension index cannot check a query vector's length, so a wrong-length query would be scored on its shared leading elements alone: silently wrong rather than approximate.

## Where validation lives

Parsing and validation are split the way Go splits them. The parser reads the grammar; `validate_vector_index_metrics` rejects a zero dimension, an unsupported algorithm/metric pair, and (from #1657) a second vector index on a field with a different metric. That means every creation path is covered, not just SDL, and the tests are split to match: `vector_index_sdl.rs` tests the parser, `vector_index_query_path.rs` tests what `add_schema` refuses.

## Also here

`VectorAlgorithm::sdl_block()` and `from_sdl_block()` come from the `vector_algorithms!` macro, so the block name that selects an algorithm has one definition. The parser matches on it, and the tests build SDL from it, so a new algorithm cannot arrive with a block name only the parser knows.

The `@index` parser is rewritten around a kind selector rather than a flat read of known argument names. An unknown argument is now reported as an unknown argument rather than as the kind conflict it also incidentally causes, matching Go's message.

## Verification

```
cargo test --workspace    every Rust-native test passes
cargo clippy --all --all-targets -- -D warnings    clean
RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p defra-core -p schema -p query -p db -p defra-node    clean
cargo fmt --all --check    clean
```

`crates/query/tests/vector_index_sdl.rs` is rewritten as the parity contract: 32 tests covering every accepted and rejected shape in Go's 5188 test matrix, plus our extra algorithms. `every_algorithm_is_selectable_by_alg`, `every_algorithm_is_selectable_by_its_block` and `every_algorithm_block_carries_every_metric` iterate `VectorAlgorithm::ALL` and `DistanceMetric::ALL`, so a new algorithm or metric enters coverage without an edit.

The `defra-node` algorithm x metric x filter x fetcher matrix runs entirely on the new grammar and still agrees with the exhaustive scan in every cell.
