### PR TITLE
feat(cli): index create takes Go's --vector JSON flag

### DIFF
--- a/crates/cli/src/commands/client/index.rs
+++ b/crates/cli/src/commands/client/index.rs
@@ -44,32 +44,17 @@ pub struct IndexNewArgs {
     #[arg(long)]
     pub unique: bool,
 
-    /// Make a vector index, searchable by SIMILARITY
-    #[arg(long)]
-    pub vector: bool,
-
-    /// Vector length. Omit on an `@embedding` field, where the model fixes it.
-    #[arg(long, requires = "vector")]
-    pub vector_dimensions: Option<u32>,
-
-    /// Vector index algorithm
-    #[arg(
-        long,
-        requires = "vector",
-        default_value = "HNSW",
-        value_parser = algorithm_names()
-    )]
-    pub vector_algorithm: String,
-
-    /// How the index ranks. SIMILARITY ranks by dot product, so only a DOT
-    /// index can serve it; a COSINE index is built but never routed to.
-    #[arg(
-        long,
-        requires = "vector",
-        default_value = "COSINE",
-        value_parser = metric_names()
-    )]
-    pub vector_metric: String,
+    /// Make a vector index (on a single field, never unique). The value is the
+    /// index config as JSON, e.g. '{"Metric":"COSINE","Dimensions":3,"HNSW":{}}'.
+    ///
+    /// Dimensions is the vector length and must be greater than zero. Metric is
+    /// the distance metric, one of COSINE, EUCLIDEAN or DOT, and cannot be
+    /// changed later without dropping and recreating the index. The algorithm
+    /// is chosen by which config block is given, or by "Algorithm"; HNSW is the
+    /// default, and its tuning params (M, EfConstruction, EfSearch) default
+    /// when omitted.
+    #[arg(long, value_name = "JSON")]
+    pub vector: Option<String>,
 }
 
 /// Arguments for index list command
@@ -103,44 +88,33 @@ impl IndexArgs {
     }
 }
 
-/// Accepted `--vector-algorithm` values, taken from the enum so a new engine
-/// becomes selectable without touching the CLI.
-fn algorithm_names() -> clap::builder::PossibleValuesParser {
-    clap::builder::PossibleValuesParser::new(
-        schema::VectorAlgorithm::ALL
-            .iter()
-            .map(|algorithm| algorithm.as_str())
-            .collect::<Vec<_>>(),
-    )
-}
-
-/// Accepted `--vector-metric` values, from the enum for the same reason.
-fn metric_names() -> clap::builder::PossibleValuesParser {
-    clap::builder::PossibleValuesParser::new(
-        schema::DistanceMetric::ALL
-            .iter()
-            .map(|metric| metric.as_str())
-            .collect::<Vec<_>>(),
-    )
-}
-
 impl IndexNewArgs {
     /// The vector configuration this request carries, if any.
+    ///
+    /// Deserialized through the same `schema::VectorIndexDescription` serde the
+    /// wire uses, so the flag cannot accept a shape the API would reject, nor
+    /// drift from it. That is also why the JSON is the reference's spelling
+    /// rather than a friendlier one of our own: a script written against either
+    /// runtime runs on both.
     pub fn vector_description(&self) -> Result<Option<schema::VectorIndexDescription>> {
-        if !self.vector {
+        let Some(json) = self.vector.as_deref() else {
             return Ok(None);
+        };
+        let value: serde_json::Value = serde_json::from_str(json)
+            .map_err(|err| Error::InvalidVectorIndexConfig(err.to_string()))?;
+        // Serde will happily read a struct from a JSON sequence, taking fields
+        // positionally, so `[]` would otherwise become an all-default config
+        // rather than an error. The reference unmarshals into a struct, which
+        // rejects anything but an object, and this is the trust boundary where
+        // that difference is visible.
+        if !value.is_object() {
+            return Err(Error::InvalidVectorIndexConfig(
+                "expected a JSON object".to_string(),
+            ));
         }
-
-        let algorithm = schema::VectorAlgorithm::from_sdl_name(&self.vector_algorithm)
-            .ok_or_else(|| Error::InvalidIdentifier(self.vector_algorithm.clone()))?;
-        let metric = schema::DistanceMetric::from_sdl_name(&self.vector_metric)
-            .ok_or_else(|| Error::InvalidIdentifier(self.vector_metric.clone()))?;
-
-        Ok(Some(schema::VectorIndexDescription::with_defaults(
-            algorithm,
-            metric,
-            self.vector_dimensions.unwrap_or(0),
-        )))
+        serde_json::from_value(value)
+            .map(Some)
+            .map_err(|err| Error::InvalidVectorIndexConfig(err.to_string()))
     }
 
     /// Execute the index new command
@@ -205,67 +179,5 @@ impl IndexDeleteArgs {
             self.name, self.collection
         );
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_index_new_args() {
-        let args = IndexNewArgs {
-            collection: "Users".to_string(),
-            fields: vec!["name".to_string(), "email".to_string()],
-            name: Some("idx_name_email".to_string()),
-            unique: true,
-            vector: false,
-            vector_dimensions: None,
-            vector_algorithm: "HNSW".to_string(),
-            vector_metric: "COSINE".to_string(),
-        };
-        assert_eq!(args.collection, "Users");
-        assert_eq!(args.fields.len(), 2);
-        assert!(args.unique);
-    }
-
-    #[test]
-    fn test_index_new_args_minimal() {
-        let args = IndexNewArgs {
-            collection: "Users".to_string(),
-            fields: vec!["name".to_string()],
-            name: None,
-            unique: false,
-            vector: false,
-            vector_dimensions: None,
-            vector_algorithm: "HNSW".to_string(),
-            vector_metric: "COSINE".to_string(),
-        };
-        assert!(args.name.is_none());
-        assert!(!args.unique);
-    }
-
-    #[test]
-    fn test_index_list_args_all() {
-        let args = IndexListArgs { collection: None };
-        assert!(args.collection.is_none());
-    }
-
-    #[test]
-    fn test_index_list_args_filtered() {
-        let args = IndexListArgs {
-            collection: Some("Users".to_string()),
-        };
-        assert_eq!(args.collection.as_deref(), Some("Users"));
-    }
-
-    #[test]
-    fn test_index_delete_args() {
-        let args = IndexDeleteArgs {
-            collection: "Users".to_string(),
-            name: "idx_name".to_string(),
-        };
-        assert_eq!(args.collection, "Users");
-        assert_eq!(args.name, "idx_name");
     }
 }

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -127,6 +127,9 @@ pub enum Error {
     #[error("invalid identifier: {0}")]
     InvalidIdentifier(String),
 
+    #[error("invalid vector index config: {0}")]
+    InvalidVectorIndexConfig(String),
+
     #[error("operation not permitted whilst development mode is disabled")]
     OperationRequiresDeveloperMode,
 

--- a/crates/cli/src/index_adapter.rs
+++ b/crates/cli/src/index_adapter.rs
@@ -69,10 +69,8 @@ impl<S: Store + 'static> IndexOperations for IndexAdapter<S> {
         let (index_desc, updated_schema) = {
             let systemstore = txn.systemstore().map_err(|e| format!("{}", e))?;
 
-            let kind = match vector {
-                Some(vector) => schema::IndexKind::Vector(vector),
-                None => schema::IndexKind::Ordered(schema::OrderedIndexDescription { unique }),
-            };
+            let kind = IndexManager::requested_kind(&indexed_fields, unique, vector)
+                .map_err(|e| format!("{}", e))?;
             let index_desc = index_manager
                 .create_index_of_kind(
                     &systemstore,

--- a/crates/cli/tests/index_vector_args.rs
+++ b/crates/cli/tests/index_vector_args.rs
@@ -1,11 +1,14 @@
-//! `index new --vector` must produce the same descriptor SDL does.
+//! `index new --vector` takes the index config as JSON, which is Go's flag.
 //!
-//! The CLI could create only ordinary indexes, so a vector index was reachable
-//! from SDL and the HTTP API but not from the command line.
+//! Go's `client index new` grew `--vector '{"Metric":"COSINE","Dimensions":3,
+//! "HNSW":{}}'` in sourcenetwork/defradb#5096. Ours spelled the same request as
+//! bespoke flags, so a script written against Go did not run here. The JSON goes
+//! through the same `schema::VectorIndexDescription` serde the wire uses, so
+//! there is one codec and nothing to keep in sync.
 
 use clap::Parser;
 use cli::commands::client::index::IndexNewArgs;
-use schema::{DistanceMetric, VectorAlgorithm};
+use schema::{DistanceMetric, HnswParams, IvfPqParams, VectorAlgorithm};
 
 #[derive(Parser, Debug)]
 struct Wrapper {
@@ -19,92 +22,124 @@ fn parse(extra: &[&str]) -> IndexNewArgs {
     Wrapper::parse_from(argv).args
 }
 
+fn vector(json: &str) -> schema::VectorIndexDescription {
+    parse(&["--vector", json])
+        .vector_description()
+        .unwrap_or_else(|e| panic!("{json}: {e}"))
+        .expect("--vector means a vector index")
+}
+
 #[test]
 fn without_the_flag_there_is_no_vector_config() {
     assert!(parse(&[]).vector_description().unwrap().is_none());
 }
 
-/// Every algorithm and metric the engine supports must be reachable from the
-/// command line, and the per-algorithm parameter block must be filled for it.
+/// The example from Go's own `--vector` help text has to work verbatim.
 #[test]
-fn every_supported_pair_is_selectable() {
-    for algorithm in VectorAlgorithm::ALL {
-        for metric in DistanceMetric::ALL {
-            if !algorithm.supports_metric(*metric) {
-                continue;
-            }
-            let args = parse(&[
-                "--vector",
-                "--vector-dimensions",
-                "8",
-                "--vector-algorithm",
-                algorithm.as_str(),
-                "--vector-metric",
-                metric.as_str(),
-            ]);
-            let vector = args
-                .vector_description()
-                .expect("a supported pair must build")
-                .expect("--vector means a vector index");
+fn gos_documented_example_parses() {
+    let config = vector(r#"{"Metric":"COSINE","Dimensions":3,"HNSW":{}}"#);
+    assert_eq!(config.algorithm, VectorAlgorithm::Hnsw);
+    assert_eq!(config.metric, DistanceMetric::Cosine);
+    assert_eq!(config.dimensions, 3);
+    assert_eq!(config.hnsw, Some(HnswParams::default()));
+}
 
-            assert_eq!(vector.algorithm, *algorithm);
-            assert_eq!(vector.metric, *metric);
-            assert_eq!(vector.dimensions, 8);
-            assert_eq!(
-                vector.hnsw.is_some(),
-                *algorithm == VectorAlgorithm::Hnsw,
-                "the HNSW block belongs to HNSW alone"
-            );
-        }
+/// Omitted tuning params default rather than zeroing, which is what makes the
+/// terse `"HNSW":{}` in Go's example a usable index.
+#[test]
+fn omitted_hnsw_params_default() {
+    let config = vector(r#"{"Dimensions":8,"HNSW":{"M":32}}"#);
+    let hnsw = config.hnsw.expect("HNSW params");
+    let defaults = HnswParams::default();
+    assert_eq!(hnsw.m, 32);
+    assert_eq!(hnsw.ef_construction, defaults.ef_construction);
+    assert_eq!(hnsw.ef_search, defaults.ef_search);
+}
+
+/// An omitted algorithm and metric take their defaults, so the shortest config
+/// that says anything is just the length.
+#[test]
+fn the_shortest_config_is_the_dimensions() {
+    let config = vector(r#"{"Dimensions":4}"#);
+    assert_eq!(config.algorithm, VectorAlgorithm::default());
+    assert_eq!(config.metric, DistanceMetric::default());
+    assert_eq!(config.dimensions, 4);
+}
+
+/// Every metric is reachable by name, and they are the reference's spellings.
+#[test]
+fn every_metric_is_reachable() {
+    for metric in DistanceMetric::ALL {
+        let config = vector(&format!(
+            r#"{{"Metric":"{}","Dimensions":8}}"#,
+            metric.as_str()
+        ));
+        assert_eq!(config.metric, *metric);
     }
 }
 
-/// Omitted dimensions mean an `@embedding` on the field fixes the length.
+/// Our extra algorithms ride the same JSON rather than a separate flag, so a
+/// Rust-only description is a documented divergence in one field, not a
+/// different command line.
 #[test]
-fn dimensions_may_be_omitted() {
-    let args = parse(&["--vector"]);
-    let vector = args.vector_description().unwrap().unwrap();
-    assert_eq!(vector.dimensions, 0);
-    assert_eq!(vector.algorithm, VectorAlgorithm::default());
+fn every_algorithm_is_reachable() {
+    for algorithm in VectorAlgorithm::ALL {
+        let config = vector(&format!(
+            r#"{{"Algorithm":"{}","Dimensions":8}}"#,
+            algorithm.as_str()
+        ));
+        assert_eq!(config.algorithm, *algorithm, "{}", algorithm.as_str());
+    }
 }
 
-/// The accepted values come from the enums, so an unknown one is refused by the
-/// parser with the valid choices rather than reaching the server.
 #[test]
-fn an_unknown_algorithm_is_refused_by_the_parser() {
-    let error = Wrapper::try_parse_from([
-        "index-new",
-        "--collection",
-        "Note",
-        "--fields",
-        "embedding",
-        "--vector",
-        "--vector-algorithm",
-        "NOT_AN_ENGINE",
-    ])
-    .expect_err("an unknown algorithm must not parse");
-
-    let rendered = error.to_string();
-    assert!(
-        VectorAlgorithm::ALL
-            .iter()
-            .all(|algorithm| rendered.contains(algorithm.as_str())),
-        "the error must list every valid algorithm, got: {rendered}"
+fn a_divergent_algorithm_carries_its_own_params() {
+    let config = vector(r#"{"Algorithm":"IVF_PQ","Dimensions":768,"IVFPQ":{"NList":256,"M":16}}"#);
+    assert_eq!(config.algorithm, VectorAlgorithm::IvfPq);
+    let ivfpq = config.ivfpq.expect("IVF-PQ params");
+    let defaults = IvfPqParams::default();
+    assert_eq!((ivfpq.nlist, ivfpq.m), (256, 16));
+    assert_eq!(
+        ivfpq.nprobe, defaults.nprobe,
+        "an omitted param keeps its default"
     );
 }
 
-/// The tuning flags are meaningless without `--vector`, so asking for one alone
-/// is a usage error rather than a silently ignored argument.
+/// Malformed JSON is a named error rather than a silently ignored flag: a
+/// dropped config would build an ordered index over the vector field.
 #[test]
-fn the_tuning_flags_require_the_vector_flag() {
-    Wrapper::try_parse_from([
-        "index-new",
-        "--collection",
-        "Note",
-        "--fields",
-        "embedding",
-        "--vector-dimensions",
-        "8",
-    ])
-    .expect_err("--vector-dimensions alone must not parse");
+fn malformed_json_is_refused() {
+    for json in [
+        "not json",
+        r#"{"Dimensions":"three"}"#,
+        r#"{"Metric":"MANHATTAN","Dimensions":3}"#,
+        r#"{"Algorithm":"IVFFLAT","Dimensions":3}"#,
+        "[]",
+    ] {
+        let error = parse(&["--vector", json])
+            .vector_description()
+            .expect_err(&format!("must be refused: {json}"))
+            .to_string();
+        assert!(
+            error.contains("invalid vector index config"),
+            "{json}: {error}"
+        );
+    }
+}
+
+/// The flag now takes a value, so it can no longer be given bare. The bespoke
+/// `--vector-algorithm` and friends are gone: one construction path, and one
+/// command line that works on either runtime.
+#[test]
+fn the_flag_requires_its_json_and_the_old_flags_are_gone() {
+    for extra in [
+        vec!["--vector"],
+        vec!["--vector-dimensions", "8"],
+        vec!["--vector-algorithm", "HNSW"],
+        vec!["--vector-metric", "COSINE"],
+    ] {
+        let mut argv = vec!["index-new", "--collection", "Note", "--fields", "embedding"];
+        argv.extend_from_slice(&extra);
+        Wrapper::try_parse_from(argv).expect_err(&format!("{extra:?} must not parse"));
+    }
 }

--- a/crates/db/src/index/manager/mod.rs
+++ b/crates/db/src/index/manager/mod.rs
@@ -12,7 +12,7 @@ use datastore::NamespaceView;
 use document::Document;
 use schema::{
     CollectionVersion, FieldDescription, IndexDescription, IndexKind, IndexedFieldDescription,
-    OrderedIndexDescription,
+    OrderedIndexDescription, VectorIndexDescription,
 };
 use std::collections::HashMap;
 use storage::corekv::Key;
@@ -260,6 +260,38 @@ impl IndexManager {
             schema_fields,
         )
         .await
+    }
+
+    /// The index kind a create-index request asks for.
+    ///
+    /// A vector index covers exactly one field and is never unique, which is
+    /// why [`IndexKind::Vector`] has no `unique` to carry. A request that pairs
+    /// a vector config with `unique`, or with several fields, is therefore
+    /// refused here rather than having one of the two quietly dropped: the
+    /// first would build an index that does not enforce what was asked for, the
+    /// second would index a different column than the request named.
+    ///
+    /// Static because every entry point (the CLI, the HTTP API, and any
+    /// embedder) has to make the same call, and a second copy of this decision
+    /// is a divergence waiting to ship.
+    pub fn requested_kind(
+        fields: &[IndexedFieldDescription],
+        unique: bool,
+        vector: Option<VectorIndexDescription>,
+    ) -> Result<IndexKind> {
+        let Some(vector) = vector else {
+            return Ok(IndexKind::Ordered(OrderedIndexDescription { unique }));
+        };
+        if unique {
+            return Err(Error::Other("vector index cannot be unique".to_string()));
+        }
+        if fields.len() != 1 {
+            return Err(Error::Other(format!(
+                "vector index must be on exactly one field, got {}",
+                fields.len()
+            )));
+        }
+        Ok(IndexKind::Vector(vector))
     }
 
     /// Creates an index of any kind.

--- a/crates/db/tests/index/manager.rs
+++ b/crates/db/tests/index/manager.rs
@@ -1997,3 +1997,68 @@ mod unique_boundaries {
         );
     }
 }
+
+/// A vector index covers exactly one field and is never unique, which is why
+/// `IndexKind::Vector` has no `unique` to carry.
+///
+/// The reference refuses both pairings (`errVectorIndexCannotBeUnique`,
+/// `errVectorIndexRequiresSingleField`); we used to absorb them, building an
+/// index that did not enforce the uniqueness asked for, or one over a different
+/// column than the request named.
+mod requested_kind {
+    use db::index::manager::IndexManager;
+    use schema::{
+        DistanceMetric, IndexKind, IndexedFieldDescription, VectorAlgorithm, VectorIndexDescription,
+    };
+
+    fn field(name: &str) -> IndexedFieldDescription {
+        IndexedFieldDescription {
+            name: name.to_string(),
+            descending: false,
+        }
+    }
+
+    fn vector() -> VectorIndexDescription {
+        VectorIndexDescription::with_defaults(VectorAlgorithm::Hnsw, DistanceMetric::Cosine, 8)
+    }
+
+    #[test]
+    fn no_vector_config_is_an_ordered_index() {
+        for unique in [false, true] {
+            let kind = IndexManager::requested_kind(&[field("name")], unique, None)
+                .expect("an ordered index takes any uniqueness");
+            match kind {
+                IndexKind::Ordered(ordered) => assert_eq!(ordered.unique, unique),
+                other => panic!("expected ordered, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn a_single_field_vector_request_is_a_vector_index() {
+        let kind = IndexManager::requested_kind(&[field("embedding")], false, Some(vector()))
+            .expect("one field and not unique is the valid shape");
+        match kind {
+            IndexKind::Vector(described) => assert_eq!(described, vector()),
+            other => panic!("expected vector, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_unique_vector_request_is_refused() {
+        let error = IndexManager::requested_kind(&[field("embedding")], true, Some(vector()))
+            .expect_err("unique and vector cannot both hold")
+            .to_string();
+        assert!(error.contains("unique"), "got: {error}");
+    }
+
+    #[test]
+    fn a_multi_field_vector_request_is_refused() {
+        for fields in [vec![], vec![field("a"), field("b")]] {
+            let error = IndexManager::requested_kind(&fields, false, Some(vector()))
+                .expect_err("a vector index covers exactly one field")
+                .to_string();
+            assert!(error.contains("exactly one field"), "got: {error}");
+        }
+    }
+}


### PR DESCRIPTION
> **Stacked PR, part of the #1517 vector-index alignment.**
> Review and merge bottom-up. Each PR is based on the one above it, so each shows only its own commit.
>
> | | PR | based on |
> |---|---|---|
> |  | #1656 feat(schema): add the EUCLIDEAN distance metric | main |
> |  | #1657 fix(query): score SIMILARITY by the target index's metric | #1656 |
> |  | #1658 feat(query): fold @vectorIndex into @index(vector: ...) | #1657 |
> | **this** | **#1659** feat(cli): index create takes Go's --vector JSON flag | #1658 |
>
> Still to come on top of this stack: the rescoped sourcenetwork/defradb#5072 metric argument on `SIMILARITY`, the Go compat baseline bump (#1519), the IVF correctness fixes (#1465, #1462, #1463) and the IVF_FLAT engine (#1516).

Closes #1524. Part of #1517. Stacked on #1658.

Go's `client index new` takes `--vector` as the index config JSON (sourcenetwork/defradb#5096, `cli/index_new.go`):

```
defradb client index new --collection Users --fields vec \
  --vector '{"Metric":"COSINE","Dimensions":3,"HNSW":{}}'
```

Ours spelled the same request as a boolean `--vector` plus `--vector-dimensions`, `--vector-algorithm` and `--vector-metric`, so that command line did not run here. Same CLI commands, same behaviour is a parity requirement.

## What changed

`--vector` now takes the JSON, deserialized through the same `schema::VectorIndexDescription` serde the wire uses. One codec: the flag cannot accept a shape the API would reject, and it cannot drift from it. That is also why the JSON keeps the reference's PascalCase spelling rather than a friendlier one of our own.

The three bespoke flags are deleted. There is one way to make a vector index from the command line, and it is the one that works on either runtime. Our extra algorithms ride the same JSON (`{"Algorithm":"IVF_PQ","Dimensions":768,"IVFPQ":{"NList":256}}`), so a Rust-only description is a divergence in one field rather than a different command line.

Malformed JSON is a named error (`invalid vector index config: ...`), matching Go's `NewErrInvalidVectorIndexConfig`. A silently dropped config would build an ordered index over the vector field, which is the failure mode #1518 existed to close.

## Two refusals we were missing

Go rejects a vector index that is unique (`errVectorIndexCannotBeUnique`) or covers more than one field (`errVectorIndexRequiresSingleField`). We absorbed both: `index_adapter.rs` built `IndexKind::Vector(vector)` and simply dropped the `unique` flag, and nothing checked the field count. So `--unique --vector '{...}'` returned success and built an index that did not enforce uniqueness.

Both now live in `IndexManager::requested_kind`, which is the one function every entry point (CLI, HTTP API, embedders) calls to turn a request into a kind. `IndexKind::Vector` has no `unique` to carry, so refusing is the only honest option; a second copy of that decision in each caller is a divergence waiting to ship.

## A serde hole at the flag boundary

`serde` reads a struct from a JSON *sequence*, taking fields positionally, so `--vector '[]'` deserialized into an all-default config instead of failing. Go's `json.Unmarshal` into a struct rejects a non-object. The flag now checks the value is an object before deserializing.

Worth stating plainly: this is fixed at the CLI boundary only. The same serde behaviour applies to every `#[derive(Deserialize)]` struct in the tree, including the HTTP `Vector` field, and that is a wider question than this PR.

## Also here

The `#[cfg(test)] mod tests` in `commands/client/index.rs` is deleted rather than moved. Every test in it constructed a struct literal and asserted the fields it had just set (`assert_eq!(args.collection, "Users")` after `collection: "Users".to_string()`), so none of them could fail while the logic was wrong. The real coverage parses actual argv, and lives in `crates/cli/tests/index_vector_args.rs`.

## Checked while here, no change needed

The HTTP index-create body already matches Go's `NewIndexRequest{Name, Fields, Unique, Vector}` exactly, including per-field `Descending` (`crates/http/src/handlers/index/go_api.rs`), and `crates/http/tests/vector_index_api.rs` already pins the round trip.

## Known gap, not in this PR's scope

Go's `--fields` accepts a per-field order suffix (`--fields name:ASC,age:DESC`). Ours splits on commas and then runs `validate_identifier` on each entry, so `name:DESC` is rejected. That is a separate parity break from the one #1524 describes, and it deserves its own issue rather than riding along here.

## Verification

```
cargo test --workspace    every Rust-native test passes
cargo clippy --all --all-targets -- -D warnings    clean
RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p cli -p db -p schema -p query -p defra-core    clean
cargo fmt --all --check    clean
```

`crates/cli/tests/index_vector_args.rs` is rewritten around the JSON flag: Go's documented example verbatim, defaulting of omitted tuning params, every metric and every algorithm by name from `DistanceMetric::ALL` and `VectorAlgorithm::ALL`, the divergent IVF-PQ params, five malformed inputs, and that the deleted flags no longer parse.

`crates/db/tests/index/manager.rs` covers `requested_kind` across the four shapes: ordered with either uniqueness, single-field vector, unique vector refused, and zero-or-many-field vector refused.
