### PR TITLE
feat(query): warn in GraphQL extensions when a vector index goes unused

### DIFF
--- a/crates/defra-node/tests/vector_index_query_path.rs
+++ b/crates/defra-node/tests/vector_index_query_path.rs
@@ -713,3 +713,121 @@ async fn the_fallback_does_not_duplicate_indexed_documents() {
     );
     assert_eq!(titles.len(), 4, "every document exactly once: {titles:?}");
 }
+
+/// A routed similarity query stays silent: `extensions` must be entirely
+/// absent, not merely an empty warnings list. Explain already says the index
+/// was used; nothing here needs a second channel to repeat that.
+#[tokio::test]
+async fn a_routed_similarity_query_has_no_extensions() {
+    let node = node_with("").await;
+    seed(&node).await;
+
+    let query = similarity_query(&vector_for(3), 5, None);
+    let response = node.execute(&query).await;
+    assert!(!response.has_errors(), "{:?}", response.errors);
+    assert!(
+        response.extensions.is_none(),
+        "a routed query must not carry extensions: {:?}",
+        response.extensions
+    );
+}
+
+/// Without a limit, `route()` never gets far enough to ask for an index, so
+/// the scan falls back to scoring everything. The results are still correct;
+/// only the cost changed, which is exactly what the warning is for.
+#[tokio::test]
+async fn dropping_the_limit_warns_vector_index_unused() {
+    let node = node_with("").await;
+    seed(&node).await;
+
+    let query = format!(
+        r#"{{ Note(order: {{ _alias: {{ sim: DESC }} }}) {{ title tag sim: SIMILARITY(embedding: {{vector: [{}]}}) }} }}"#,
+        render(&vector_for(3))
+    );
+    let response = node.execute(&query).await;
+    assert!(!response.has_errors(), "{:?}", response.errors);
+
+    let extensions = response
+        .extensions
+        .as_ref()
+        .expect("dropping the limit must warn");
+    assert_eq!(extensions.warnings.len(), 1);
+    let warning = &extensions.warnings[0];
+    assert_eq!(warning.code, "VECTOR_INDEX_UNUSED");
+    let detail = warning.detail.as_ref().expect("detail");
+    assert_eq!(detail["reason"], "noLimit");
+    assert_eq!(detail["field"], "embedding");
+
+    let rows = response.data.as_ref().unwrap()["Note"]
+        .as_array()
+        .expect("Note array")
+        .clone();
+    assert_eq!(rows.len(), CORPUS, "no limit means every document");
+    let scores: Vec<f64> = rows
+        .iter()
+        .map(|row| row["sim"].as_f64().expect("sim"))
+        .collect();
+    assert!(
+        scores.windows(2).all(|pair| pair[0] >= pair[1]),
+        "rows are not ordered by similarity: {scores:?}"
+    );
+}
+
+/// Same shape as `dropping_the_limit_warns_vector_index_unused`, but the
+/// defect is the order direction instead of the missing limit.
+#[tokio::test]
+async fn ascending_order_warns_vector_index_unused() {
+    let node = node_with("").await;
+    seed(&node).await;
+
+    let query = format!(
+        r#"{{ Note(order: {{ _alias: {{ sim: ASC }} }}, limit: 5) {{ title tag sim: SIMILARITY(embedding: {{vector: [{}]}}) }} }}"#,
+        render(&vector_for(3))
+    );
+    let response = node.execute(&query).await;
+    assert!(!response.has_errors(), "{:?}", response.errors);
+
+    let extensions = response
+        .extensions
+        .as_ref()
+        .expect("ascending order must warn");
+    let warning = &extensions.warnings[0];
+    assert_eq!(warning.code, "VECTOR_INDEX_UNUSED");
+    let detail = warning.detail.as_ref().expect("detail");
+    assert_eq!(detail["reason"], "notOrderedBySimilarityDesc");
+    assert_eq!(detail["field"], "embedding");
+}
+
+/// The precision condition: a field with no vector index never warns, however
+/// the query is shaped. Written with the limit removed, the one shape that
+/// *would* warn if this field had an index (see
+/// `dropping_the_limit_warns_vector_index_unused`).
+#[tokio::test]
+async fn a_field_without_a_vector_index_never_warns() {
+    let node = EmbeddedNode::builder().build().await.unwrap();
+    node.add_schema(&format!(
+        "type Note {{ title: String  tag: String  embedding: [Float32!] @index(vector: {{dimensions: {DIMENSIONS}}})  plainEmbedding: [Float32!] }}"
+    ))
+    .await
+    .expect("add schema with an unindexed vector field");
+
+    for index in 0..3 {
+        let mutation = format!(
+            r#"mutation {{ create_Note(input: {{ title: "note-{index}", tag: "even", plainEmbedding: [{}] }}) {{ _docID }} }}"#,
+            render(&vector_for(index))
+        );
+        query_data(&node, &mutation, "seed").await;
+    }
+
+    let query = format!(
+        r#"{{ Note(order: {{ _alias: {{ sim: DESC }} }}) {{ title sim: SIMILARITY(plainEmbedding: {{vector: [{}]}}) }} }}"#,
+        render(&vector_for(0))
+    );
+    let response = node.execute(&query).await;
+    assert!(!response.has_errors(), "{:?}", response.errors);
+    assert!(
+        response.extensions.is_none(),
+        "a similarity query on an unindexed field must never warn: {:?}",
+        response.extensions
+    );
+}

--- a/crates/query/src/executor.rs
+++ b/crates/query/src/executor.rs
@@ -90,6 +90,11 @@ pub struct QueryResponse {
     /// Errors that occurred during execution.
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub errors: Vec<QueryResponseError>,
+
+    /// Extra information about a request that worked, such as warnings.
+    /// Absent when there is nothing to report, so existing responses do not change.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub extensions: Option<GqlExtensions>,
 }
 
 impl QueryResponse {
@@ -98,6 +103,7 @@ impl QueryResponse {
         Self {
             data: Some(data),
             errors: Vec::new(),
+            extensions: None,
         }
     }
 
@@ -106,6 +112,7 @@ impl QueryResponse {
         Self {
             data: None,
             errors: vec![err.into()],
+            extensions: None,
         }
     }
 
@@ -114,6 +121,7 @@ impl QueryResponse {
         Self {
             data: Some(data),
             errors,
+            extensions: None,
         }
     }
 
@@ -133,7 +141,43 @@ impl QueryResponse {
             && self.errors.len() == 1
             && self.errors[0].code() == Some(TXN_CONFLICT_ERROR_CODE)
     }
+
+    /// Attach warnings, dropping the member entirely when there are none so an
+    /// empty `extensions` is never serialized.
+    pub fn with_warnings(mut self, warnings: Vec<GqlWarning>) -> Self {
+        if !warnings.is_empty() {
+            self.extensions = Some(GqlExtensions { warnings });
+        }
+        self
+    }
 }
+
+/// Sits next to `data` and `errors` in a response. Holds anything that is
+/// neither a result nor an error. A client skips what it does not recognise.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct GqlExtensions {
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub warnings: Vec<GqlWarning>,
+}
+
+/// Something that happened during a request that still worked.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GqlWarning {
+    /// Names the warning. Clients match on this, so it does not change once released.
+    pub code: String,
+    /// Explains the warning to a person. The wording can change, so do not read it in code.
+    pub message: String,
+    /// Values belonging to this warning. Sent to the client and possibly logged,
+    /// so no secrets, keys, or counts that reveal documents the caller cannot see.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub detail: Option<serde_json::Map<String, JsonValue>>,
+}
+
+/// A similarity query read the whole collection even though the field it scored
+/// has a vector index. The results are correct, but the query costs more as the
+/// collection grows. The `reason` detail says which part of the query shape
+/// ruled the index out.
+pub const WARNING_CODE_VECTOR_INDEX_UNUSED: &str = "VECTOR_INDEX_UNUSED";
 
 /// GraphQL error extensions exposed to clients.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/query/src/planner/builder/mod.rs
+++ b/crates/query/src/planner/builder/mod.rs
@@ -23,11 +23,13 @@ use schema::CollectionVersion;
 use tracing::{debug, instrument};
 
 use crate::error::{QueryError, Result};
+use crate::executor::GqlWarning;
 use crate::fetcher::DocFetcher;
 use crate::limits::QueryLimits;
 use crate::mapper::{Requestable, Select};
 use crate::plan::{IndexScanNode, PermissionFilterNode, SEFilterNode, ScanNode, SelectNode};
 use crate::planner::index_selection::IndexScanParams;
+use crate::planner::vector_routing;
 use crate::planner::PlanNode;
 
 /// Maximum allowed nesting depth for nested queries (0-indexed).
@@ -50,6 +52,8 @@ pub struct PlanResult {
     /// with a relation selection (e.g., both `_count(published: {})` and `published(limit: 2)`).
     /// Maps: aggregate_output_name -> (relation_field_name, internal_key)
     pub aggregate_internal_keys: HashMap<String, (String, String)>,
+    /// Warnings raised while planning, for the response's `extensions` member.
+    pub warnings: Vec<GqlWarning>,
 }
 
 impl PlanResult {
@@ -269,16 +273,29 @@ impl Planner {
             || is_complex_filter
             || (self.acp.is_some() && collection.policy.is_some());
 
-        let vector_route = self
-            .fetcher
-            .as_ref()
-            .filter(|_| !rows_rejected_above_the_scan)
-            .filter(|fetcher| fetcher.supports_vector_search())
-            .and_then(|_| {
-                match crate::planner::vector_routing::route(
-                    &crate::planner::vector_routing::similarity_query(select),
-                    &collection.indexes,
-                ) {
+        let mut warnings: Vec<GqlWarning> = Vec::new();
+
+        let sim_query = vector_routing::similarity_query(select);
+        let warning_field =
+            vector_routing::first_indexed_similarity(&sim_query.similarities, &collection.indexes);
+
+        let vector_route = if let Some(ref fetcher) = self.fetcher {
+            if rows_rejected_above_the_scan {
+                if let Some(field) = warning_field {
+                    warnings.push(vector_routing::vector_index_unused_warning_for_filter(
+                        field,
+                    ));
+                }
+                None
+            } else if !fetcher.supports_vector_search() {
+                if let Some(field) = warning_field {
+                    warnings.push(
+                        vector_routing::vector_index_unused_warning_for_unsupported_fetcher(field),
+                    );
+                }
+                None
+            } else {
+                match vector_routing::route(&sim_query, &collection.indexes) {
                     Ok(route) => Some(route),
                     Err(reason) => {
                         debug!(
@@ -286,10 +303,20 @@ impl Planner {
                             ?reason,
                             "vector routing declined"
                         );
+                        if let Some(field) = warning_field {
+                            if let Some(warning) =
+                                vector_routing::vector_index_unused_warning(&reason, field)
+                            {
+                                warnings.push(warning);
+                            }
+                        }
                         None
                     }
                 }
-            });
+            }
+        } else {
+            None
+        };
 
         // Check if an index can be used for the filter or ordering.
         // Index selection works for both pre-loaded docs and fetcher-based loading.
@@ -643,6 +670,7 @@ impl Planner {
             index_scan,
             ordering_only_fields,
             aggregate_internal_keys,
+            warnings,
         })
     }
 

--- a/crates/query/src/planner/cached_view_builder.rs
+++ b/crates/query/src/planner/cached_view_builder.rs
@@ -44,6 +44,7 @@ impl Planner {
             index_scan: None,
             ordering_only_fields: Vec::new(),
             aggregate_internal_keys: HashMap::new(),
+            warnings: Vec::new(),
         })
     }
 }

--- a/crates/query/src/planner/vector_routing.rs
+++ b/crates/query/src/planner/vector_routing.rs
@@ -10,8 +10,10 @@
 //! `exclude_doc_ids` into a filter on essentially every call, and under Go's
 //! rule it could never be routed at all.
 
+use crate::executor::{GqlWarning, WARNING_CODE_VECTOR_INDEX_UNUSED};
 use crate::mapper::{OrderDirection, Requestable, Select};
 use schema::{DistanceMetric, IndexDescription, VectorIndexDescription};
+use serde_json::Value as JsonValue;
 
 /// What a routable query resolved to.
 #[derive(Debug, Clone, PartialEq)]
@@ -47,6 +49,22 @@ pub enum NotRouted {
     /// The query vector's length does not match the index's declared
     /// dimensions. Scoring it would silently use the shared prefix only.
     DimensionMismatch { expected: u32, actual: usize },
+}
+
+impl NotRouted {
+    /// The `reason` detail of a `VECTOR_INDEX_UNUSED` warning. Clients match on
+    /// these, so they do not change once released. The first four are the
+    /// reference's spellings; the last two are ours, for shapes it does not check.
+    pub fn reason(&self) -> &'static str {
+        match self {
+            NotRouted::NoLimit => "noLimit",
+            NotRouted::NotOneSimilarity => "multipleSimilarityFields",
+            NotRouted::NotOrderedBySimilarity => "notOrderedBySimilarityDesc",
+            NotRouted::NoVectorIndex => "noVectorIndex",
+            NotRouted::ShowDeleted => "showDeleted",
+            NotRouted::DimensionMismatch { .. } => "dimensionMismatch",
+        }
+    }
 }
 
 /// The query shape the decision is made from.
@@ -182,6 +200,63 @@ pub fn route(
         query_vector: similarity.vector.clone(),
         k: limit.saturating_add(query.offset),
     })
+}
+
+/// The warning a declined routing raises, or `None` when there is nothing worth
+/// saying.
+///
+/// `NoVectorIndex` produces nothing: a query scoring an unindexed field has no
+/// index to miss, so warning about it would be noise on every ordinary
+/// similarity query. That precision condition is the whole design; steady-state
+/// noise has to be zero or the channel gets ignored.
+pub fn vector_index_unused_warning(reason: &NotRouted, field: &str) -> Option<GqlWarning> {
+    if matches!(reason, NotRouted::NoVectorIndex) {
+        return None;
+    }
+    Some(build_warning(reason.reason(), field))
+}
+
+/// The `VECTOR_INDEX_UNUSED` warning for a query whose filter the vector index
+/// path cannot serve, which keeps it from ever reaching `route()`. Go's own
+/// planner calls this shape `filter`.
+pub fn vector_index_unused_warning_for_filter(field: &str) -> GqlWarning {
+    build_warning("filter", field)
+}
+
+/// The `VECTOR_INDEX_UNUSED` warning for a fetcher that does not support
+/// vector search, which keeps the query from ever reaching `route()`. Ours:
+/// the reference has no fetcher abstraction to decline through.
+pub fn vector_index_unused_warning_for_unsupported_fetcher(field: &str) -> GqlWarning {
+    build_warning("unsupportedFetcher", field)
+}
+
+fn build_warning(reason: &str, field: &str) -> GqlWarning {
+    let mut detail = serde_json::Map::new();
+    detail.insert("field".to_string(), JsonValue::String(field.to_string()));
+    detail.insert("reason".to_string(), JsonValue::String(reason.to_string()));
+    GqlWarning {
+        code: WARNING_CODE_VECTOR_INDEX_UNUSED.to_string(),
+        message: format!(
+            "similarity query on field '{field}' did not use the vector index and read the whole collection"
+        ),
+        detail: Some(detail),
+    }
+}
+
+/// The first entry in `similarities` whose field has a vector index, or `None`
+/// when none do (including when `similarities` is empty).
+///
+/// This is the field a `VECTOR_INDEX_UNUSED` warning names: a field without an
+/// index has no index to have missed, so nothing about it is worth reporting,
+/// however the rest of the query is shaped.
+pub fn first_indexed_similarity<'a>(
+    similarities: &'a [SimilarityField],
+    indexes: &[IndexDescription],
+) -> Option<&'a str> {
+    similarities
+        .iter()
+        .find(|field| vector_index_on(indexes, &field.target_field).is_some())
+        .map(|field| field.target_field.as_str())
 }
 
 /// The metric a `SIMILARITY` on `field_name` is scored by.

--- a/crates/query/src/planner/view_builder.rs
+++ b/crates/query/src/planner/view_builder.rs
@@ -256,6 +256,7 @@ impl Planner {
             index_scan: None,
             ordering_only_fields: Vec::new(),
             aggregate_internal_keys: HashMap::new(),
+            warnings: source_plan_result.warnings,
         })
     }
 }

--- a/crates/query/src/runner/executor.rs
+++ b/crates/query/src/runner/executor.rs
@@ -10,7 +10,7 @@ use acp::nac::NodePermission;
 use identity::Did;
 
 use crate::error::{Result, TransactionError};
-use crate::executor::{QueryExecutor, QueryRequest, QueryResponse, QueryResponseError};
+use crate::executor::{GqlWarning, QueryExecutor, QueryRequest, QueryResponse, QueryResponseError};
 use crate::query_parse::{parse_request_with_limits, validate_parsed_operation, ParsedOperation};
 use crate::txn::{GetTransactionResult, TransactionHandle, TransactionRegistry};
 
@@ -131,6 +131,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
                         locations: None,
                         extensions: None,
                     }],
+                    extensions: None,
                 };
             }
         };
@@ -180,6 +181,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
                     locations: None,
                     extensions: None,
                 }],
+                extensions: None,
             };
         }
 
@@ -195,6 +197,8 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
         let acting_identity = creator_did
             .clone()
             .or_else(defra_core::current_identity::get_effective_identity);
+
+        let mut warnings: Vec<GqlWarning> = Vec::new();
 
         // Route to appropriate handler based on operation type
         // Pass identity and variables through for ACP permission checks and variable substitution
@@ -219,8 +223,13 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
                         )
                         .await
                     } else {
-                        self.execute_selects_internal(selects, self.fetcher.as_ref(), identity)
-                            .await
+                        self.execute_selects_internal(
+                            selects,
+                            self.fetcher.as_ref(),
+                            identity,
+                            &mut warnings,
+                        )
+                        .await
                     }
                 }
                 ParsedOperation::Mutation {
@@ -280,7 +289,9 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
             Ok(data) => QueryResponse {
                 data: Some(data),
                 errors: vec![],
-            },
+                extensions: None,
+            }
+            .with_warnings(warnings),
             Err(e) => {
                 tracing::error!(
                     query = %request.query,
@@ -290,7 +301,9 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
                 QueryResponse {
                     data: None,
                     errors: vec![QueryResponseError::from_query_error(e)],
+                    extensions: None,
                 }
+                .with_warnings(warnings)
             }
         }
     }
@@ -346,6 +359,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
                         locations: None,
                         extensions: None,
                     }],
+                    extensions: None,
                 };
             }
         };
@@ -371,6 +385,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
                         locations: None,
                         extensions: None,
                     }],
+                    extensions: None,
                 };
             }
         }
@@ -382,6 +397,8 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
 
         // Resolve effective identity: request identity takes precedence over default
         let identity = self.resolve_identity(request.identity);
+
+        let mut warnings: Vec<GqlWarning> = Vec::new();
 
         // Route to appropriate handler based on operation type
         let execution = async {
@@ -406,8 +423,13 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
                         )
                         .await
                     } else {
-                        self.execute_selects_internal(selects, fetcher.as_ref(), identity)
-                            .await
+                        self.execute_selects_internal(
+                            selects,
+                            fetcher.as_ref(),
+                            identity,
+                            &mut warnings,
+                        )
+                        .await
                     }
                 }
                 ParsedOperation::Mutation { explain, .. } => {
@@ -493,7 +515,9 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
             Ok(data) => QueryResponse {
                 data: Some(data),
                 errors: vec![],
-            },
+                extensions: None,
+            }
+            .with_warnings(warnings),
             Err(e) => {
                 tracing::error!(
                     query = %request.query,
@@ -504,7 +528,9 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
                 QueryResponse {
                     data: None,
                     errors: vec![QueryResponseError::from_query_error(e)],
+                    extensions: None,
                 }
+                .with_warnings(warnings)
             }
         }
     }

--- a/crates/query/src/runner/mutation_inputs.rs
+++ b/crates/query/src/runner/mutation_inputs.rs
@@ -31,8 +31,9 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         select.document_mapping = mapping;
         select.show_deleted = show_deleted;
 
+        let mut warnings = Vec::new();
         let result = self
-            .execute_select_internal(&select, self.fetcher.as_ref(), None)
+            .execute_select_internal(&select, self.fetcher.as_ref(), None, &mut warnings)
             .await?;
         let items = result.as_array().ok_or_else(|| {
             crate::error::QueryError::internal("filtered document selection returned a non-list")

--- a/crates/query/src/runner/query/aggregate.rs
+++ b/crates/query/src/runner/query/aggregate.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 
 use crate::document::{documents_to_plan_docs, DocumentMapping};
 use crate::error::{QueryError, Result};
+use crate::executor::GqlWarning;
 use crate::mapper::{Requestable, Select};
 use crate::planner::{Doc, Planner};
 use crate::txn::TransactionRegistry;
@@ -253,6 +254,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         select: &Select,
         fetcher: &dyn DocFetcher,
         identity: Option<Did>,
+        warnings: &mut Vec<GqlWarning>,
     ) -> Result<JsonValue> {
         use crate::mapper::AggregateType;
 
@@ -338,6 +340,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             planner = planner.with_lens_store(lens_store.clone());
         }
         let plan_result = planner.plan_with_index_info(&filter_select)?;
+        warnings.extend(plan_result.warnings);
         let mut plan = plan_result.plan;
         let mapping = plan.document_map().clone();
 

--- a/crates/query/src/runner/query/mod.rs
+++ b/crates/query/src/runner/query/mod.rs
@@ -13,6 +13,7 @@ use serde_json::{Map, Value as JsonValue};
 use tracing::instrument;
 
 use crate::error::Result;
+use crate::executor::GqlWarning;
 use crate::mapper::Select;
 use crate::query_parse::parse_query_with_limits;
 use crate::txn::TransactionRegistry;
@@ -77,10 +78,11 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         let selects = parse_query_with_limits(query, variables, self.query_limits)?;
 
         let mut results = Map::new();
+        let mut warnings = Vec::new();
 
         for select in selects {
             let result = self
-                .execute_select_internal(&select, fetcher, caller_identity.clone())
+                .execute_select_internal(&select, fetcher, caller_identity.clone(), &mut warnings)
                 .await?;
             let key = if select.is_cursor {
                 select
@@ -101,7 +103,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
     /// Execute already-parsed Select operations with a specific fetcher and identity.
     #[instrument(
         name = "query.execute",
-        skip(self, selects, fetcher, caller_identity),
+        skip(self, selects, fetcher, caller_identity, warnings),
         fields(select_count = selects.len())
     )]
     pub(crate) async fn execute_selects_internal(
@@ -109,12 +111,13 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         selects: Vec<Select>,
         fetcher: &dyn DocFetcher,
         caller_identity: Option<Did>,
+        warnings: &mut Vec<GqlWarning>,
     ) -> Result<JsonValue> {
         let mut results = Map::new();
 
         for select in selects {
             let result = self
-                .execute_select_internal(&select, fetcher, caller_identity.clone())
+                .execute_select_internal(&select, fetcher, caller_identity.clone(), warnings)
                 .await?;
             let key = if select.is_cursor {
                 select

--- a/crates/query/src/runner/query/nested.rs
+++ b/crates/query/src/runner/query/nested.rs
@@ -9,6 +9,7 @@ use tracing::{debug, instrument};
 use web_time::Instant;
 
 use crate::error::Result;
+use crate::executor::GqlWarning;
 use crate::mapper::{Requestable, Select};
 use crate::planner::Planner;
 use crate::txn::TransactionRegistry;
@@ -35,6 +36,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         select: &Select,
         fetcher: &dyn DocFetcher,
         identity: Option<Did>,
+        warnings: &mut Vec<GqlWarning>,
     ) -> Result<JsonValue> {
         let mut profile = NestedQueryProfile::default();
 
@@ -75,6 +77,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         }
         let plan_result = planner.plan_with_index_info(select)?;
         profile.plan_build_elapsed = plan_build_start.elapsed();
+        warnings.extend(plan_result.warnings);
         let mut plan = plan_result.plan;
         let ordering_only_fields = plan_result.ordering_only_fields;
         let aggregate_internal_keys = plan_result.aggregate_internal_keys;

--- a/crates/query/src/runner/query/select.rs
+++ b/crates/query/src/runner/query/select.rs
@@ -5,6 +5,7 @@ use identity::Did;
 use serde_json::{Map, Value as JsonValue};
 
 use crate::error::{QueryError, Result};
+use crate::executor::GqlWarning;
 use crate::mapper::{Filter, Requestable, Select};
 use crate::planner::index_selection::{can_be_ordered_by_index, can_or_filter_use_index};
 use crate::txn::TransactionRegistry;
@@ -19,6 +20,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         select: &Select,
         fetcher: &dyn DocFetcher,
         caller_identity: Option<Did>,
+        warnings: &mut Vec<GqlWarning>,
     ) -> Result<JsonValue> {
         // Handle encrypted search queries (encrypted_<Collection>)
         if select.is_encrypted {
@@ -58,7 +60,13 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         // For queries with _version, execute documents first then add version data
         if version_selection.is_some() {
             return self
-                .execute_query_with_version(select, fetcher, caller_identity, version_selection)
+                .execute_query_with_version(
+                    select,
+                    fetcher,
+                    caller_identity,
+                    version_selection,
+                    warnings,
+                )
                 .await;
         }
 
@@ -149,7 +157,12 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             if aggregate_filter_has_relations {
                 // Use planner path to join relation data before filtering
                 return self
-                    .execute_top_level_aggregate_with_planner(select, fetcher, caller_identity)
+                    .execute_top_level_aggregate_with_planner(
+                        select,
+                        fetcher,
+                        caller_identity,
+                        warnings,
+                    )
                     .await;
             } else {
                 return self
@@ -302,7 +315,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
 
         if needs_planner {
             // Use the Planner for queries with nested selections (joins) or relation filters.
-            self.execute_nested_select_with_planner(select, fetcher, caller_identity)
+            self.execute_nested_select_with_planner(select, fetcher, caller_identity, warnings)
                 .await
         } else {
             // Use the optimized path for simple queries

--- a/crates/query/src/runner/version.rs
+++ b/crates/query/src/runner/version.rs
@@ -12,6 +12,7 @@ use serde_json::Value as JsonValue;
 use std::collections::HashSet;
 
 use crate::error::{QueryError, Result};
+use crate::executor::GqlWarning;
 use crate::mapper::{Requestable, Select};
 use crate::txn::TransactionRegistry;
 
@@ -278,6 +279,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         fetcher: &dyn DocFetcher,
         caller_identity: Option<Did>,
         version_selection: Option<&Select>,
+        warnings: &mut Vec<GqlWarning>,
     ) -> Result<JsonValue> {
         // Get collection schema
         let collection = self.get_collection(&select.collection_name).await?;
@@ -347,6 +349,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                 &select_without_version,
                 fetcher,
                 caller_identity,
+                warnings,
             )
             .await?
         } else {

--- a/crates/query/tests/vector_index_warnings.rs
+++ b/crates/query/tests/vector_index_warnings.rs
@@ -1,0 +1,100 @@
+//! The `VECTOR_INDEX_UNUSED` warning: which `NotRouted` reasons produce it, and
+//! how it serializes into a `QueryResponse`'s `extensions`.
+
+use query::executor::QueryResponse;
+use query::planner::vector_routing::{vector_index_unused_warning, NotRouted};
+
+fn all_not_routed_variants() -> [NotRouted; 6] {
+    [
+        NotRouted::NoLimit,
+        NotRouted::NotOneSimilarity,
+        NotRouted::NotOrderedBySimilarity,
+        NotRouted::NoVectorIndex,
+        NotRouted::ShowDeleted,
+        NotRouted::DimensionMismatch {
+            expected: 4,
+            actual: 2,
+        },
+    ]
+}
+
+/// An exhaustive match: a new `NotRouted` variant fails to compile here before
+/// it can ship without a reason string.
+#[test]
+fn every_not_routed_variant_maps_to_its_reason_string() {
+    for variant in all_not_routed_variants() {
+        let expected = match variant {
+            NotRouted::NoLimit => "noLimit",
+            NotRouted::NotOneSimilarity => "multipleSimilarityFields",
+            NotRouted::NotOrderedBySimilarity => "notOrderedBySimilarityDesc",
+            NotRouted::NoVectorIndex => "noVectorIndex",
+            NotRouted::ShowDeleted => "showDeleted",
+            NotRouted::DimensionMismatch { .. } => "dimensionMismatch",
+        };
+        assert_eq!(variant.reason(), expected);
+    }
+}
+
+#[test]
+fn vector_index_unused_warning_is_none_only_for_no_vector_index() {
+    for variant in all_not_routed_variants() {
+        let warning = vector_index_unused_warning(&variant, "embedding");
+        assert_eq!(
+            warning.is_none(),
+            variant == NotRouted::NoVectorIndex,
+            "{variant:?}"
+        );
+    }
+}
+
+#[test]
+fn vector_index_unused_warning_has_the_exact_shape() {
+    let warning =
+        vector_index_unused_warning(&NotRouted::NoLimit, "embedding").expect("NoLimit must warn");
+    assert_eq!(
+        serde_json::to_value(&warning).unwrap(),
+        serde_json::json!({
+            "code": "VECTOR_INDEX_UNUSED",
+            "message": "similarity query on field 'embedding' did not use the vector index and read the whole collection",
+            "detail": {
+                "field": "embedding",
+                "reason": "noLimit",
+            },
+        })
+    );
+}
+
+#[test]
+fn empty_extensions_are_omitted_from_the_response() {
+    let response =
+        QueryResponse::success(serde_json::json!({"Note": []})).with_warnings(Vec::new());
+    let value = serde_json::to_value(&response).unwrap();
+    assert!(
+        value.as_object().unwrap().get("extensions").is_none(),
+        "{value:#}"
+    );
+}
+
+#[test]
+fn a_response_with_one_warning_serializes_with_extensions() {
+    let warning = vector_index_unused_warning(&NotRouted::NoLimit, "embedding").unwrap();
+    let response =
+        QueryResponse::success(serde_json::json!({"Note": []})).with_warnings(vec![warning]);
+
+    assert_eq!(
+        serde_json::to_value(&response).unwrap(),
+        serde_json::json!({
+            "data": {"Note": []},
+            "extensions": {
+                "warnings": [{
+                    "code": "VECTOR_INDEX_UNUSED",
+                    "message": "similarity query on field 'embedding' did not use the vector index and read the whole collection",
+                    "detail": {
+                        "field": "embedding",
+                        "reason": "noLimit",
+                    },
+                }],
+            },
+        })
+    );
+}


### PR DESCRIPTION
Closes #1523. Part of #1517. Stacked on #1659.

A query that scores an indexed field but misses the routed shape returns correct results while scanning and scoring the whole collection. It works in testing and falls over at scale, and nothing told the user why. `NotRouted` (`crates/query/src/planner/vector_routing.rs`) already enumerated every miss reason and was written as diagnostics; it had zero consumers.

Go shipped the same channel in sourcenetwork/defradb#5189 (merged 2026-09-01), so this follows its shape rather than the one #1523 proposed. The differences are worth naming because the issue is now out of date:

| #1523 proposed | Go shipped, and this PR |
|---|---|
| code `VECTOR_INDEX_NOT_USED` | `VECTOR_INDEX_UNUSED` |
| `reason` and `field` at the top level of the warning | inside a `detail` map, beside a human-readable `message` |
| a `hint` telling the user how to rewrite the query | no hint |

A query that warns must warn identically on both runtimes, so Go's spelling wins on every one of those.

## The shape

```json
{"data": {...},
 "extensions": {"warnings": [{
   "code": "VECTOR_INDEX_UNUSED",
   "message": "similarity query on field 'embedding' did not use the vector index and read the whole collection",
   "detail": {"field": "embedding", "reason": "noLimit"}}]}}
```

`extensions` is left out entirely when there is nothing to report, so existing responses do not change.

## The precision condition is the design

A similarity query on a field with no vector index warns about nothing. That is the whole point: an annotate-style query over an unindexed field is not a mistake, and warning about it would put a warning on the majority of similarity queries until the channel got ignored. Steady-state noise has to be zero.

The routed case is also silent. Explain already reports the index it used.

## Reasons

The first four are Go's spellings; a query that warns has to warn the same way on both runtimes.

| reason | when |
|---|---|
| `noLimit` | no limit, so there is no `k` to ask for |
| `multipleSimilarityFields` | more than one similarity field, so which drives the search is ambiguous |
| `notOrderedBySimilarityDesc` | not ordered by that similarity alone, descending |
| `filter` | a filter the index path cannot serve |
| `showDeleted` | the query wants deleted documents; the index holds only live ones |
| `dimensionMismatch` | the query vector's length does not match the index's declared dimensions |
| `unsupportedFetcher` | the fetcher in use cannot drive a vector search |

The last three are ours. Go does not check for them, and silence would be a false green on a query that reads the whole collection.

Note that `filter` means something narrower here than in Go. Go refuses every filtered KNN (sourcenetwork/defradb#5071); our routing serves filtered queries by over-fetch widening, so we only reach this reason for the shapes that reject rows above the scan (a relation filter, a complex filter, or an ACP policy on the collection), where the scan cannot widen because the rejection is invisible to it.

## How it reaches the response

Go carries an accumulator on the request context, because "warnings come from the planner and the fetchers, far below the code that builds the response". Rust has no ambient context here. There is a `thread_local!` pattern in the tree (`defra_core::current_identity`) that would be the direct analogue, but it silently drops values if a future migrates threads mid-request, and a diagnostic channel that quietly loses entries is worse than one that is explicit.

So the warnings ride on `PlanResult`, which `plan_with_index_info` already returns and which already carries three other non-row outputs, and the runner threads a `&mut Vec<GqlWarning>` up to the response. `&mut Vec<_>` is `Send`, needs no interior mutability and no lock, and these futures must stay `Send` on non-wasm.

Two sites previously constructed a fresh `PlanResult` and discarded the inner plan's diagnostics (`planner/view_builder.rs`, `planner/cached_view_builder.rs`). They now propagate warnings, so a query against a view is not silently exempt.

## Verification

```
cargo test --workspace                             every Rust-native test passes
cargo clippy --all --all-targets -- -D warnings    clean
cargo fmt --all --check                            clean
```

`crates/query/tests/vector_index_warnings.rs`, 5 tests: every `NotRouted` variant maps to its documented reason (enumerated, so a new variant cannot be added without one); `vector_index_unused_warning` returns `None` only for `NoVectorIndex`; the warning's code, message and detail match a literal expected value including the exact message text; a response with no warnings omits `extensions` entirely; a response with one serializes the full shape.

`crates/defra-node/tests/vector_index_query_path.rs`, 4 new tests end to end through `EmbeddedNode`:

- `a_routed_similarity_query_has_no_extensions`. The routed case stays silent.
- `dropping_the_limit_warns_vector_index_unused`. One warning, `detail.reason == "noLimit"`, `detail.field == "embedding"`, and the results are still correct.
- `ascending_order_warns_vector_index_unused`. `detail.reason == "notOrderedBySimilarityDesc"`.
- `a_field_without_a_vector_index_never_warns`. Written with the limit removed, so the shape would warn if an index existed. This is the precision condition and it is the test that matters most in the file.
