### PR TITLE
feat(query): optional metric argument on SIMILARITY

### DIFF
--- a/crates/defra-node/tests/vector_index_query_path.rs
+++ b/crates/defra-node/tests/vector_index_query_path.rs
@@ -77,6 +77,15 @@ fn similarity_query(vector: &[f64], limit: usize, filter: Option<&str>) -> Strin
     )
 }
 
+/// Same shape as `similarity_query`, with a `metric` argument alongside the
+/// vector.
+fn similarity_query_with_metric(vector: &[f64], limit: usize, metric: &str) -> String {
+    format!(
+        r#"{{ Note(order: {{ _alias: {{ sim: DESC }} }}, limit: {limit}) {{ title tag sim: SIMILARITY(embedding: {{vector: [{}], metric: {metric}}}) }} }}"#,
+        render(vector)
+    )
+}
+
 /// Sum a counter across every node of an execute-explain tree.
 fn total(explain: &Value, counter: &str) -> u64 {
     match explain {
@@ -798,6 +807,86 @@ async fn ascending_order_warns_vector_index_unused() {
     assert_eq!(detail["field"], "embedding");
 }
 
+/// A metric no index on the field carries must still answer correctly: the
+/// query falls back to a full scan scored by the metric it named, and warns
+/// that the vector index went unused rather than silently ranking by the
+/// index's own metric instead.
+#[tokio::test]
+async fn a_metric_no_index_carries_scans_and_warns() {
+    let node = EmbeddedNode::builder().build().await.unwrap();
+    node.add_schema(&format!(
+        "type Note {{ title: String  tag: String  embedding: [Float32!] @index(vector: {{dimensions: {DIMENSIONS}, hnsw: {{metric: COSINE}}}}) }}"
+    ))
+    .await
+    .expect("add cosine schema");
+    seed(&node).await;
+
+    let query = similarity_query_with_metric(&vector_for(3), 5, "DOT");
+    let explain = query_data(
+        &node,
+        &format!("query @explain(type: execute) {query}"),
+        "metric mismatch explain",
+    )
+    .await;
+    assert_eq!(
+        vector_index(&explain),
+        None,
+        "a metric no index carries must not be served by the index\n{explain:#}"
+    );
+
+    let response = node.execute(&query).await;
+    assert!(!response.has_errors(), "{:?}", response.errors);
+
+    let extensions = response
+        .extensions
+        .as_ref()
+        .expect("a metric mismatch must warn");
+    assert_eq!(extensions.warnings.len(), 1);
+    let warning = &extensions.warnings[0];
+    assert_eq!(warning.code, "VECTOR_INDEX_UNUSED");
+    let detail = warning.detail.as_ref().expect("detail");
+    assert_eq!(detail["reason"], "metricMismatch");
+    assert_eq!(detail["field"], "embedding");
+
+    let rows = response.data.as_ref().unwrap()["Note"]
+        .as_array()
+        .expect("Note array")
+        .clone();
+    assert_eq!(rows.len(), 5, "the scan must still fill the page");
+    let titles: Vec<&str> = rows
+        .iter()
+        .filter_map(|row| row["title"].as_str())
+        .collect();
+    let scores: Vec<f64> = rows
+        .iter()
+        .map(|row| row["sim"].as_f64().expect("sim"))
+        .collect();
+    assert!(
+        scores.windows(2).all(|pair| pair[0] >= pair[1]),
+        "rows are not ordered by similarity: {scores:?}"
+    );
+
+    // The exhaustive answer under the same named metric, computed without a
+    // limit so no index can narrow it: the scanned page must be its top slice.
+    let exhaustive = query_data(
+        &node,
+        &similarity_query_with_metric(&vector_for(3), CORPUS, "DOT"),
+        "exhaustive dot scores",
+    )
+    .await;
+    let exhaustive_rows = exhaustive["Note"].as_array().expect("Note array");
+    let expected_titles: Vec<&str> = exhaustive_rows
+        .iter()
+        .filter_map(|row| row["title"].as_str())
+        .take(5)
+        .collect();
+
+    assert_eq!(
+        titles, expected_titles,
+        "the scanned page must be the exhaustive DOT-scored page"
+    );
+}
+
 /// The precision condition: a field with no vector index never warns, however
 /// the query is shaped. Written with the limit removed, the one shape that
 /// *would* warn if this field had an index (see
@@ -829,5 +918,112 @@ async fn a_field_without_a_vector_index_never_warns() {
         response.extensions.is_none(),
         "a similarity query on an unindexed field must never warn: {:?}",
         response.extensions
+    );
+}
+
+/// Two vector indexes on one field, and a query that says which it means.
+///
+/// This is the whole point of the `metric` argument, and it was unreachable
+/// from SDL until a repeated `@index` on a field stopped overwriting: the
+/// parser kept the last directive, so a field could never carry two indexes and
+/// there was nothing for the argument to choose between. Each metric must reach
+/// its own index, and the routed page must be the exhaustive page for that
+/// metric, not for the other one.
+#[tokio::test]
+async fn a_named_metric_reaches_its_own_index_among_several() {
+    let node = EmbeddedNode::builder().build().await.unwrap();
+    node.add_schema(&format!(
+        "type Note {{ title: String  tag: String  embedding: [Float32!] \
+         @index(name: \"by_cosine\", vector: {{dimensions: {DIMENSIONS}, hnsw: {{metric: COSINE}}}}) \
+         @index(name: \"by_dot\", vector: {{dimensions: {DIMENSIONS}, hnsw: {{metric: DOT}}}}) }}"
+    ))
+    .await
+    .expect("two vector indexes on one field");
+    seed(&node).await;
+
+    let probe = vector_for(3);
+    for (metric, index_name) in [("COSINE", "Note_by_cosine"), ("DOT", "Note_by_dot")] {
+        let query = format!(
+            r#"{{ Note(order: {{ _alias: {{ sim: DESC }} }}, limit: 5) {{ title sim: SIMILARITY(embedding: {{vector: [{}], metric: {metric}}}) }} }}"#,
+            render(&probe)
+        );
+
+        let explain = query_data(
+            &node,
+            &format!("query @explain(type: execute) {query}"),
+            metric,
+        )
+        .await;
+        let served = vector_index(&explain)
+            .unwrap_or_else(|| panic!("{metric}: no vector index served the scan\n{explain:#}"));
+        assert!(
+            served.contains(index_name) || served.contains(metric.to_lowercase().as_str()),
+            "{metric}: served by {served}, not the index built with that metric"
+        );
+
+        let routed = query_data(&node, &query, metric).await;
+        let rows = routed["Note"].as_array().expect("Note array");
+        assert_eq!(rows.len(), 5, "{metric}");
+        let titles: Vec<&str> = rows.iter().filter_map(|r| r["title"].as_str()).collect();
+
+        // Unlimited, so nothing narrows it: the answer the routed page must
+        // reproduce, scored by the metric this query named.
+        let all = query_data(
+            &node,
+            &format!(
+                r#"{{ Note(order: {{_alias: {{sim: DESC}}}}, limit: {CORPUS}) {{ title sim: SIMILARITY(embedding: {{vector: [{}], metric: {metric}}}) }} }}"#,
+                render(&probe)
+            ),
+            metric,
+        )
+        .await;
+        let expected: Vec<&str> = all["Note"]
+            .as_array()
+            .expect("Note array")
+            .iter()
+            .filter_map(|r| r["title"].as_str())
+            .take(5)
+            .collect();
+        assert_eq!(
+            titles, expected,
+            "{metric}: routed page differs from the exhaustive one"
+        );
+    }
+}
+
+/// Naming no metric when the field carries several is ambiguous, so the query
+/// declines to route and says so rather than letting index order decide the
+/// results.
+#[tokio::test]
+async fn several_indexes_without_a_metric_warn_ambiguous() {
+    let node = EmbeddedNode::builder().build().await.unwrap();
+    node.add_schema(&format!(
+        "type Note {{ title: String  tag: String  embedding: [Float32!] \
+         @index(name: \"by_cosine\", vector: {{dimensions: {DIMENSIONS}, hnsw: {{metric: COSINE}}}}) \
+         @index(name: \"by_dot\", vector: {{dimensions: {DIMENSIONS}, hnsw: {{metric: DOT}}}}) }}"
+    ))
+    .await
+    .expect("two vector indexes on one field");
+    seed(&node).await;
+
+    let query = similarity_query(&vector_for(3), 5, None);
+    let response = node.execute(&query).await;
+    assert!(!response.has_errors(), "{:?}", response.errors);
+
+    let extensions = response
+        .extensions
+        .as_ref()
+        .expect("an ambiguous metric must warn");
+    let detail = extensions.warnings[0].detail.as_ref().expect("detail");
+    assert_eq!(detail["reason"], "ambiguousMetric");
+    assert_eq!(detail["field"], "embedding");
+
+    assert_eq!(
+        response.data.as_ref().unwrap()["Note"]
+            .as_array()
+            .expect("Note array")
+            .len(),
+        5,
+        "declining to route must still fill the page"
     );
 }

--- a/crates/query/src/mapper/types.rs
+++ b/crates/query/src/mapper/types.rs
@@ -202,6 +202,10 @@ pub struct Similarity {
     pub vector: Vec<f64>,
     /// Optional alias for output
     pub alias: Option<String>,
+    /// The metric named by the query, selecting among several vector indexes on
+    /// the field. `None` means the field's only index, or cosine when it has
+    /// none.
+    pub metric: Option<schema::DistanceMetric>,
 }
 
 impl Similarity {
@@ -210,11 +214,17 @@ impl Similarity {
             target_field: target_field.into(),
             vector,
             alias: None,
+            metric: None,
         }
     }
 
     pub fn with_alias(mut self, alias: impl Into<String>) -> Self {
         self.alias = Some(alias.into());
+        self
+    }
+
+    pub fn with_metric(mut self, metric: schema::DistanceMetric) -> Self {
+        self.metric = Some(metric);
         self
     }
 

--- a/crates/query/src/planner/aggregates.rs
+++ b/crates/query/src/planner/aggregates.rs
@@ -56,8 +56,12 @@ impl Planner {
                     field_index,
                     similarity_index,
                     sim.vector.clone(),
-                    crate::planner::vector_routing::scoring_metric(indexes, &sim.target_field)
-                        .engine_metric(),
+                    crate::planner::vector_routing::scoring_metric(
+                        indexes,
+                        &sim.target_field,
+                        sim.metric,
+                    )
+                    .engine_metric(),
                 ));
             }
         }

--- a/crates/query/src/planner/vector_routing.rs
+++ b/crates/query/src/planner/vector_routing.rs
@@ -49,12 +49,20 @@ pub enum NotRouted {
     /// The query vector's length does not match the index's declared
     /// dimensions. Scoring it would silently use the shared prefix only.
     DimensionMismatch { expected: u32, actual: usize },
+    /// Several vector indexes on the field and no metric named to choose
+    /// between them: which one answered would silently decide the results
+    /// rather than just the cost.
+    AmbiguousMetric,
+    /// The query named a metric no vector index on the field was built with, so
+    /// none of them ranks the way this query scores.
+    MetricMismatch { requested: DistanceMetric },
 }
 
 impl NotRouted {
     /// The `reason` detail of a `VECTOR_INDEX_UNUSED` warning. Clients match on
     /// these, so they do not change once released. The first four are the
-    /// reference's spellings; the last two are ours, for shapes it does not check.
+    /// reference's spellings; the last four are ours, for shapes it does not
+    /// check.
     pub fn reason(&self) -> &'static str {
         match self {
             NotRouted::NoLimit => "noLimit",
@@ -63,6 +71,8 @@ impl NotRouted {
             NotRouted::NoVectorIndex => "noVectorIndex",
             NotRouted::ShowDeleted => "showDeleted",
             NotRouted::DimensionMismatch { .. } => "dimensionMismatch",
+            NotRouted::AmbiguousMetric => "ambiguousMetric",
+            NotRouted::MetricMismatch { .. } => "metricMismatch",
         }
     }
 }
@@ -99,6 +109,10 @@ pub struct SimilarityField {
     /// otherwise. An alias-ordered query is therefore the same shape here as a
     /// directly-ordered one.
     pub output_name: String,
+    /// The metric named by the query, selecting among several vector indexes on
+    /// the field. `None` means the field's only index, or cosine when it has
+    /// none.
+    pub metric: Option<DistanceMetric>,
 }
 
 /// The single order-by key of a routable query.
@@ -130,6 +144,7 @@ pub fn similarity_query(select: &Select) -> SimilarityQuery {
                     target_field: similarity.target_field.clone(),
                     vector: similarity.vector.clone(),
                     output_name: similarity.output_name().to_string(),
+                    metric: similarity.metric,
                 }),
                 _ => None,
             })
@@ -175,7 +190,7 @@ pub fn route(
     }
 
     let (index_id, vector) =
-        vector_index_on(indexes, &similarity.target_field).ok_or(NotRouted::NoVectorIndex)?;
+        vector_index_for(indexes, &similarity.target_field, similarity.metric)?;
 
     // A wrong-length query would be scored on its shared leading elements
     // only, which is silently wrong rather than merely approximate. Zero
@@ -187,13 +202,6 @@ pub fn route(
             actual: similarity.vector.len(),
         });
     }
-
-    // No metric check: `SimilarityNode` scores by whatever metric this index
-    // was built with (see `scoring_metric`), so the index's nearest neighbours
-    // are the query's highest scorers whichever metric that is. A collection
-    // cannot carry two vector indexes on one field with different metrics, so
-    // the metric the scan would use and the metric the index ranks by are the
-    // same one by construction.
 
     Ok(VectorRoute {
         index_id,
@@ -255,33 +263,80 @@ pub fn first_indexed_similarity<'a>(
 ) -> Option<&'a str> {
     similarities
         .iter()
-        .find(|field| vector_index_on(indexes, &field.target_field).is_some())
+        .find(|field| !vector_indexes_on(indexes, &field.target_field).is_empty())
         .map(|field| field.target_field.as_str())
 }
 
 /// The metric a `SIMILARITY` on `field_name` is scored by.
 ///
-/// The field's vector index metric, or cosine when it has no vector index,
-/// matching the reference. Routing and the unrouted scan both resolve through
-/// here, so the ranking a query gets does not depend on whether the index was
-/// used.
-pub fn scoring_metric(indexes: &[IndexDescription], field_name: &str) -> DistanceMetric {
-    vector_index_on(indexes, field_name)
+/// The metric the query names, when it names one, whether or not the field
+/// carries an index built with it: an unindexed or mismatched field still
+/// scores by what the query asked for. Otherwise the field's vector index
+/// metric, or cosine when it has none, matching the reference. A field
+/// carrying several indexes and no named metric scores by the first, since
+/// scoring has to produce something and routing has already declined for that
+/// shape. Routing and the unrouted scan both resolve through here, so the
+/// ranking a query gets does not depend on whether the index was used.
+pub fn scoring_metric(
+    indexes: &[IndexDescription],
+    field_name: &str,
+    requested: Option<DistanceMetric>,
+) -> DistanceMetric {
+    if let Some(metric) = requested {
+        return metric;
+    }
+    vector_indexes_on(indexes, field_name)
+        .first()
         .map(|(_, vector)| vector.metric)
         .unwrap_or_default()
 }
 
-/// The vector index over `field_name`, if a collection has one.
-fn vector_index_on(
+/// The vector index that answers a `SIMILARITY` on `field_name` under
+/// `requested`.
+///
+/// With no metric named, the field's only index answers; a field carrying
+/// several is ambiguous, since which one answered would silently decide the
+/// results rather than just the cost. With one named, the index built with that
+/// metric answers, and no such index is a mismatch rather than a fallback.
+pub fn vector_index_for(
     indexes: &[IndexDescription],
     field_name: &str,
-) -> Option<(u32, VectorIndexDescription)> {
-    indexes.iter().find_map(|index| {
-        let vector = index.vector()?;
-        let indexes_field = index
-            .fields
-            .first()
-            .is_some_and(|field| field.name == field_name);
-        indexes_field.then_some((index.id, *vector))
-    })
+    requested: Option<DistanceMetric>,
+) -> Result<(u32, VectorIndexDescription), NotRouted> {
+    let candidates = vector_indexes_on(indexes, field_name);
+
+    match requested {
+        Some(metric) => candidates
+            .iter()
+            .find(|(_, vector)| vector.metric == metric)
+            .copied()
+            .ok_or(if candidates.is_empty() {
+                NotRouted::NoVectorIndex
+            } else {
+                NotRouted::MetricMismatch { requested: metric }
+            }),
+        None => match candidates.as_slice() {
+            [] => Err(NotRouted::NoVectorIndex),
+            [only] => Ok(*only),
+            _ => Err(NotRouted::AmbiguousMetric),
+        },
+    }
+}
+
+/// Every vector index on `field_name`, in index order.
+fn vector_indexes_on(
+    indexes: &[IndexDescription],
+    field_name: &str,
+) -> Vec<(u32, VectorIndexDescription)> {
+    indexes
+        .iter()
+        .filter_map(|index| {
+            let vector = index.vector()?;
+            let indexes_field = index
+                .fields
+                .first()
+                .is_some_and(|field| field.name == field_name);
+            indexes_field.then_some((index.id, *vector))
+        })
+        .collect()
 }

--- a/crates/query/src/query_parse/mutations.rs
+++ b/crates/query/src/query_parse/mutations.rs
@@ -432,9 +432,11 @@ pub(super) fn parse_bm25_field(
 
 /// Parse a _similarity field from a GraphQL query.
 ///
-/// Format: `_similarity(fieldName: {vector: [1, 2, 3]})`
+/// Format: `_similarity(fieldName: {vector: [1, 2, 3], metric: COSINE})`
 /// The argument name is the target field containing the document's vector.
-/// The value is an object with a `vector` key containing the query vector.
+/// The value is an object with a `vector` key containing the query vector, and
+/// an optional `metric` key selecting among several vector indexes on that
+/// field.
 pub(super) fn parse_similarity_field(
     field: &Field<'_, String>,
     variables: Option<&HashMap<String, JsonValue>>,
@@ -445,13 +447,15 @@ pub(super) fn parse_similarity_field(
 
     let (target_field, value) = &field.arguments[0];
 
-    // Parse the value: {vector: [1, 2, 3]}
-    let vector = match value {
+    // Parse the value: {vector: [1, 2, 3], metric: COSINE}
+    let (vector, metric) = match value {
         Value::Object(obj) => {
             let vec_value = obj.get("vector").ok_or_else(|| {
                 QueryError::parse("_similarity argument must contain a 'vector' key")
             })?;
-            parse_vector_value(vec_value, variables)?
+            let vector = parse_vector_value(vec_value, variables)?;
+            let metric = obj.get("metric").map(parse_metric_value).transpose()?;
+            (vector, metric)
         }
         Value::Variable(var_name) => {
             let vars = variables.ok_or_else(|| {
@@ -464,7 +468,9 @@ pub(super) fn parse_similarity_field(
                 let vec_val = obj.get("vector").ok_or_else(|| {
                     QueryError::parse("_similarity variable must contain a 'vector' key")
                 })?;
-                parse_json_vector(vec_val)?
+                let vector = parse_json_vector(vec_val)?;
+                let metric = obj.get("metric").map(parse_json_metric).transpose()?;
+                (vector, metric)
             } else {
                 return Err(QueryError::parse("_similarity variable must be an object"));
             }
@@ -476,7 +482,35 @@ pub(super) fn parse_similarity_field(
         }
     };
 
-    Ok(Similarity::new(target_field.clone(), vector))
+    let mut similarity = Similarity::new(target_field.clone(), vector);
+    if let Some(metric) = metric {
+        similarity = similarity.with_metric(metric);
+    }
+    Ok(similarity)
+}
+
+/// Resolve a `metric` name to the `DistanceMetric` it names.
+fn resolve_metric(name: &str) -> Result<schema::DistanceMetric> {
+    schema::DistanceMetric::from_sdl_name(name)
+        .ok_or_else(|| QueryError::parse(format!("_similarity has no metric named '{name}'")))
+}
+
+/// Parse a `metric` value from a GraphQL argument literal.
+fn parse_metric_value(value: &Value<'_, String>) -> Result<schema::DistanceMetric> {
+    match value {
+        Value::String(name) | Value::Enum(name) => resolve_metric(name),
+        _ => Err(QueryError::parse(
+            "_similarity 'metric' must be a string or enum value",
+        )),
+    }
+}
+
+/// Parse a `metric` value from a JSON variable.
+fn parse_json_metric(value: &JsonValue) -> Result<schema::DistanceMetric> {
+    match value {
+        JsonValue::String(name) => resolve_metric(name),
+        _ => Err(QueryError::parse("_similarity 'metric' must be a string")),
+    }
 }
 
 /// Parse a vector value from a GraphQL list literal.

--- a/crates/query/src/runner/introspection/aggregates.rs
+++ b/crates/query/src/runner/introspection/aggregates.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 pub(super) fn build_aggregate_types_for_collection(
     collection: &CollectionVersion,
     id_to_name: &HashMap<String, String>,
-) -> Vec<InputObject> {
+) -> Vec<Type> {
     let coll_name = &collection.name;
     let mut types = Vec::new();
 
@@ -23,14 +23,14 @@ pub(super) fn build_aggregate_types_for_collection(
         ))
         .field(InputValue::new("limit", TypeRef::named("Int")))
         .field(InputValue::new("offset", TypeRef::named("Int")));
-    types.push(count_selector);
+    types.push(count_selector.into());
 
     // {Collection}___version__CountSelector: limit, offset
     let version_count_selector =
         InputObject::new(format!("{}___version__CountSelector", coll_name))
             .field(InputValue::new("limit", TypeRef::named("Int")))
             .field(InputValue::new("offset", TypeRef::named("Int")));
-    types.push(version_count_selector);
+    types.push(version_count_selector.into());
 
     // {Collection}__NumericSelector: field, filter, limit, offset, order
     // Build numeric fields enum
@@ -52,7 +52,7 @@ pub(super) fn build_aggregate_types_for_collection(
             "order",
             TypeRef::named_list(format!("{}OrderArg", coll_name)),
         ));
-    types.push(numeric_selector);
+    types.push(numeric_selector.into());
 
     // Per-field selectors for inline arrays
     for field in &collection.fields {
@@ -81,7 +81,7 @@ pub(super) fn build_aggregate_types_for_collection(
                     .field(InputValue::new("filter", TypeRef::named(filter_type)))
                     .field(InputValue::new("limit", TypeRef::named("Int")))
                     .field(InputValue::new("offset", TypeRef::named("Int")));
-            types.push(inline_count);
+            types.push(inline_count.into());
 
             // Numeric arrays also get NumericSelector
             let is_numeric = matches!(
@@ -100,7 +100,7 @@ pub(super) fn build_aggregate_types_for_collection(
                         .field(InputValue::new("limit", TypeRef::named("Int")))
                         .field(InputValue::new("offset", TypeRef::named("Int")))
                         .field(InputValue::new("order", TypeRef::named("Ordering")));
-                types.push(inline_numeric);
+                types.push(inline_numeric.into());
             }
         }
     }
@@ -127,13 +127,14 @@ pub(super) fn build_aggregate_types_for_collection(
                         ))
                         .field(InputValue::new("limit", TypeRef::named("Int")))
                         .field(InputValue::new("offset", TypeRef::named("Int")));
-                types.push(rel_count);
+                types.push(rel_count.into());
             }
             _ => {}
         }
     }
 
     // Similarity selectors for numeric array fields
+    let mut metric_enum_registered = false;
     for field in &collection.fields {
         if let FieldKind::ScalarArray(arr) = &field.kind {
             let is_numeric = matches!(
@@ -161,13 +162,35 @@ pub(super) fn build_aggregate_types_for_collection(
                         .field(InputValue::new(
                             "vector",
                             TypeRef::named_nn_list_nn(vector_type),
+                        ))
+                        .field(InputValue::new(
+                            "metric",
+                            TypeRef::named("VectorDistanceMetric"),
                         ));
-                types.push(similarity_selector);
+                types.push(similarity_selector.into());
+
+                if !metric_enum_registered {
+                    types.push(vector_distance_metric_enum().into());
+                    metric_enum_registered = true;
+                }
             }
         }
     }
 
     types
+}
+
+/// The `VectorDistanceMetric` enum backing `metric` on every `SimilaritySelector`.
+///
+/// Go's name, so a query written against either runtime introspects the same
+/// type. Built from `DistanceMetric::ALL`, so a new metric appears here without
+/// another edit.
+fn vector_distance_metric_enum() -> Enum {
+    let mut enum_type = Enum::new("VectorDistanceMetric");
+    for metric in schema::DistanceMetric::ALL {
+        enum_type = enum_type.item(EnumItem::new(metric.as_str()));
+    }
+    enum_type
 }
 
 /// Build the numeric fields enum for a collection (used by NumericSelector).

--- a/crates/query/src/sdl_parse/builder.rs
+++ b/crates/query/src/sdl_parse/builder.rs
@@ -552,8 +552,9 @@ impl<'a> SdlParser<'a> {
                 }
             }
 
-            // Handle field-level @index directive
-            if let Some(ref idx_config) = parsed_field.directives.index {
+            // Handle field-level @index directives, of which a field may carry
+            // several.
+            for idx_config in &parsed_field.directives.index {
                 // Build fields list based on includes
                 // For relation fields (non-array), Go DefraDB stores indexes on the FK field
                 // (_fieldID) rather than the relation field name.
@@ -768,135 +769,136 @@ impl<'a> SdlParser<'a> {
         // so a collection definition carries one list whichever runtime wrote
         // it.
         for field in &type_def.fields {
-            let Some(config) = field.directives.vector_index.as_ref() else {
-                continue;
-            };
-            let name = config.name.clone().unwrap_or_else(|| {
-                generate_index_name(&type_def.name, &field.name, &existing_index_names)
-            });
-            existing_index_names.push(name.clone());
-            index_id_counter += 1;
+            for config in &field.directives.vector_index {
+                let name = config.name.clone().unwrap_or_else(|| {
+                    generate_index_name(&type_def.name, &field.name, &existing_index_names)
+                });
+                existing_index_names.push(name.clone());
+                index_id_counter += 1;
 
-            // The algorithm is chosen by which block is set, which is also
-            // what the wire envelope does. `alg:` names one directly, for the
-            // default configuration; giving both is fine as long as they agree,
-            // and a disagreement is refused rather than resolved by precedence.
-            let mut algorithm: Option<schema::VectorAlgorithm> = None;
-            for (present, selected) in [
-                (config.flat.is_some(), schema::VectorAlgorithm::Flat),
-                (config.hnsw.is_some(), schema::VectorAlgorithm::Hnsw),
-                (config.ivfpq.is_some(), schema::VectorAlgorithm::IvfPq),
-                (config.ssg.is_some(), schema::VectorAlgorithm::Ssg),
-            ] {
-                if !present {
-                    continue;
+                // The algorithm is chosen by which block is set, which is also
+                // what the wire envelope does. `alg:` names one directly, for the
+                // default configuration; giving both is fine as long as they agree,
+                // and a disagreement is refused rather than resolved by precedence.
+                let mut algorithm: Option<schema::VectorAlgorithm> = None;
+                for (present, selected) in [
+                    (config.flat.is_some(), schema::VectorAlgorithm::Flat),
+                    (config.hnsw.is_some(), schema::VectorAlgorithm::Hnsw),
+                    (config.ivfpq.is_some(), schema::VectorAlgorithm::IvfPq),
+                    (config.ssg.is_some(), schema::VectorAlgorithm::Ssg),
+                ] {
+                    if !present {
+                        continue;
+                    }
+                    if let Some(existing) = algorithm.filter(|existing| *existing != selected) {
+                        return Err(QueryError::parse(format!(
+                            "@index vector configures both {} and {}",
+                            existing.as_str(),
+                            selected.as_str()
+                        )));
+                    }
+                    algorithm = Some(selected);
                 }
-                if let Some(existing) = algorithm.filter(|existing| *existing != selected) {
-                    return Err(QueryError::parse(format!(
-                        "@index vector configures both {} and {}",
-                        existing.as_str(),
-                        selected.as_str()
-                    )));
+                if let Some(named) = config.algorithm.as_deref() {
+                    let named = schema::VectorAlgorithm::from_sdl_name(named).ok_or_else(|| {
+                        QueryError::parse(format!("@index vector has no algorithm named '{named}'"))
+                    })?;
+                    if let Some(existing) = algorithm.filter(|existing| *existing != named) {
+                        return Err(QueryError::parse(format!(
+                            "@index vector alg is {} but the {} block is configured",
+                            named.as_str(),
+                            existing.as_str()
+                        )));
+                    }
+                    algorithm = Some(named);
                 }
-                algorithm = Some(selected);
+                let algorithm = algorithm.unwrap_or_default();
+
+                // The metric belongs to the algorithm, so it is read from that
+                // algorithm's own block and nowhere else.
+                let hnsw = config.hnsw.clone().unwrap_or_default();
+                let named_metric = match algorithm {
+                    schema::VectorAlgorithm::Flat => {
+                        config.flat.as_ref().and_then(|f| f.metric.clone())
+                    }
+                    schema::VectorAlgorithm::Hnsw => hnsw.metric.clone(),
+                    schema::VectorAlgorithm::IvfPq => {
+                        config.ivfpq.as_ref().and_then(|b| b.metric.clone())
+                    }
+                    schema::VectorAlgorithm::Ssg => {
+                        config.ssg.as_ref().and_then(|b| b.metric.clone())
+                    }
+                };
+                let metric = match named_metric.as_deref() {
+                    None => schema::DistanceMetric::default(),
+                    Some(name) => schema::DistanceMetric::from_sdl_name(name).ok_or_else(|| {
+                        QueryError::parse(format!("@index vector has no metric named '{name}'"))
+                    })?,
+                };
+
+                let defaults = schema::HnswParams::default();
+
+                indexes.push(
+                    IndexDescription {
+                        name,
+                        id: index_id_counter,
+                        fields: vec![IndexedFieldDescription {
+                            name: field.name.clone(),
+                            descending: false,
+                        }],
+                        unique: false,
+                        kind: None,
+                        auto_generated: false,
+                    }
+                    .as_vector(schema::VectorIndexDescription {
+                        algorithm,
+                        metric,
+                        // Absent leaves this zero, which definition validation
+                        // rejects. Go stopped inferring it from an `@embedding` in
+                        // sourcenetwork/defradb#5188.
+                        dimensions: config.dimensions.unwrap_or(0),
+                        hnsw: match algorithm {
+                            schema::VectorAlgorithm::Hnsw => Some(schema::HnswParams {
+                                m: hnsw.m.unwrap_or(defaults.m),
+                                ef_construction: hnsw
+                                    .ef_construction
+                                    .unwrap_or(defaults.ef_construction),
+                                ef_search: hnsw.ef_search.unwrap_or(defaults.ef_search),
+                            }),
+                            schema::VectorAlgorithm::Flat
+                            | schema::VectorAlgorithm::IvfPq
+                            | schema::VectorAlgorithm::Ssg => None,
+                        },
+                        ivfpq: match algorithm {
+                            schema::VectorAlgorithm::IvfPq => {
+                                let ivfpq = config.ivfpq.clone().unwrap_or_default();
+                                let defaults = schema::IvfPqParams::default();
+                                Some(schema::IvfPqParams {
+                                    nlist: ivfpq.nlist.unwrap_or(defaults.nlist),
+                                    nprobe: ivfpq.nprobe.unwrap_or(defaults.nprobe),
+                                    m: ivfpq.m.unwrap_or(defaults.m),
+                                    sample_bytes: ivfpq
+                                        .sample_bytes
+                                        .map_or(defaults.sample_bytes, u64::from),
+                                })
+                            }
+                            _ => None,
+                        },
+                        ssg: match algorithm {
+                            schema::VectorAlgorithm::Ssg => {
+                                let ssg = config.ssg.clone().unwrap_or_default();
+                                let defaults = schema::SsgParams::default();
+                                Some(schema::SsgParams {
+                                    r: ssg.r.unwrap_or(defaults.r),
+                                    angle: ssg.angle.unwrap_or(defaults.angle),
+                                    pool: ssg.pool.unwrap_or(defaults.pool),
+                                })
+                            }
+                            _ => None,
+                        },
+                    }),
+                );
             }
-            if let Some(named) = config.algorithm.as_deref() {
-                let named = schema::VectorAlgorithm::from_sdl_name(named).ok_or_else(|| {
-                    QueryError::parse(format!("@index vector has no algorithm named '{named}'"))
-                })?;
-                if let Some(existing) = algorithm.filter(|existing| *existing != named) {
-                    return Err(QueryError::parse(format!(
-                        "@index vector alg is {} but the {} block is configured",
-                        named.as_str(),
-                        existing.as_str()
-                    )));
-                }
-                algorithm = Some(named);
-            }
-            let algorithm = algorithm.unwrap_or_default();
-
-            // The metric belongs to the algorithm, so it is read from that
-            // algorithm's own block and nowhere else.
-            let hnsw = config.hnsw.clone().unwrap_or_default();
-            let named_metric = match algorithm {
-                schema::VectorAlgorithm::Flat => {
-                    config.flat.as_ref().and_then(|f| f.metric.clone())
-                }
-                schema::VectorAlgorithm::Hnsw => hnsw.metric.clone(),
-                schema::VectorAlgorithm::IvfPq => {
-                    config.ivfpq.as_ref().and_then(|b| b.metric.clone())
-                }
-                schema::VectorAlgorithm::Ssg => config.ssg.as_ref().and_then(|b| b.metric.clone()),
-            };
-            let metric = match named_metric.as_deref() {
-                None => schema::DistanceMetric::default(),
-                Some(name) => schema::DistanceMetric::from_sdl_name(name).ok_or_else(|| {
-                    QueryError::parse(format!("@index vector has no metric named '{name}'"))
-                })?,
-            };
-
-            let defaults = schema::HnswParams::default();
-
-            indexes.push(
-                IndexDescription {
-                    name,
-                    id: index_id_counter,
-                    fields: vec![IndexedFieldDescription {
-                        name: field.name.clone(),
-                        descending: false,
-                    }],
-                    unique: false,
-                    kind: None,
-                    auto_generated: false,
-                }
-                .as_vector(schema::VectorIndexDescription {
-                    algorithm,
-                    metric,
-                    // Absent leaves this zero, which definition validation
-                    // rejects. Go stopped inferring it from an `@embedding` in
-                    // sourcenetwork/defradb#5188.
-                    dimensions: config.dimensions.unwrap_or(0),
-                    hnsw: match algorithm {
-                        schema::VectorAlgorithm::Hnsw => Some(schema::HnswParams {
-                            m: hnsw.m.unwrap_or(defaults.m),
-                            ef_construction: hnsw
-                                .ef_construction
-                                .unwrap_or(defaults.ef_construction),
-                            ef_search: hnsw.ef_search.unwrap_or(defaults.ef_search),
-                        }),
-                        schema::VectorAlgorithm::Flat
-                        | schema::VectorAlgorithm::IvfPq
-                        | schema::VectorAlgorithm::Ssg => None,
-                    },
-                    ivfpq: match algorithm {
-                        schema::VectorAlgorithm::IvfPq => {
-                            let ivfpq = config.ivfpq.clone().unwrap_or_default();
-                            let defaults = schema::IvfPqParams::default();
-                            Some(schema::IvfPqParams {
-                                nlist: ivfpq.nlist.unwrap_or(defaults.nlist),
-                                nprobe: ivfpq.nprobe.unwrap_or(defaults.nprobe),
-                                m: ivfpq.m.unwrap_or(defaults.m),
-                                sample_bytes: ivfpq
-                                    .sample_bytes
-                                    .map_or(defaults.sample_bytes, u64::from),
-                            })
-                        }
-                        _ => None,
-                    },
-                    ssg: match algorithm {
-                        schema::VectorAlgorithm::Ssg => {
-                            let ssg = config.ssg.clone().unwrap_or_default();
-                            let defaults = schema::SsgParams::default();
-                            Some(schema::SsgParams {
-                                r: ssg.r.unwrap_or(defaults.r),
-                                angle: ssg.angle.unwrap_or(defaults.angle),
-                                pool: ssg.pool.unwrap_or(defaults.pool),
-                            })
-                        }
-                        _ => None,
-                    },
-                }),
-            );
         }
 
         // Build full-text indexes from @fulltext directives

--- a/crates/query/src/sdl_parse/directives.rs
+++ b/crates/query/src/sdl_parse/directives.rs
@@ -172,8 +172,11 @@ pub struct ParsedDirectives {
     pub is_primary: bool,
     /// CRDT type override (default is LwwRegister)
     pub crdt_type: Option<CType>,
-    /// Index configuration
-    pub index: Option<IndexConfig>,
+    /// Ordered index configurations, one per `@index` on the field.
+    ///
+    /// A list because the reference appends every `@index` directive it finds
+    /// on a field rather than keeping one, so a field can carry several.
+    pub index: Vec<IndexConfig>,
     /// Explicit relation name from @relation directive
     pub relation_name: Option<String>,
     /// Default value from @default directive
@@ -186,8 +189,10 @@ pub struct ParsedDirectives {
     pub embedding: Option<EmbeddingConfig>,
     /// Full-text search configuration from @fulltext directive
     pub fulltext: Option<FullTextConfig>,
-    /// Vector index configuration from `@index(vector: {...})`
-    pub vector_index: Option<VectorIndexConfig>,
+    /// Vector index configurations, one per `@index(vector: {...})` on the
+    /// field. Several are how a field carries indexes of different metrics,
+    /// which is what a query's `metric` argument then chooses between.
+    pub vector_index: Vec<VectorIndexConfig>,
     /// Whether this field is immutable after document creation
     pub immutable: bool,
 }

--- a/crates/query/src/sdl_parse/fields.rs
+++ b/crates/query/src/sdl_parse/fields.rs
@@ -61,8 +61,8 @@ impl<'a> SdlParser<'a> {
                 "primary" => result.is_primary = true,
                 "crdt" => result.crdt_type = Some(self.parse_crdt_directive(directive)?),
                 "index" => match self.parse_index_directive(directive, Some(field_name))? {
-                    ParsedIndex::Ordered(config) => result.index = Some(config),
-                    ParsedIndex::Vector(config) => result.vector_index = Some(config),
+                    ParsedIndex::Ordered(config) => result.index.push(config),
+                    ParsedIndex::Vector(config) => result.vector_index.push(config),
                 },
                 "relation" => result.relation_name = get_directive_string(directive, "name"),
                 "default" => {

--- a/crates/query/tests/vector_index_sdl.rs
+++ b/crates/query/tests/vector_index_sdl.rs
@@ -314,6 +314,50 @@ fn unknown_or_mistyped_arguments_are_refused() {
     }
 }
 
+/// A field carries as many indexes as it has `@index` directives. The reference
+/// appends every one it finds rather than keeping the last, and two vector
+/// indexes of different metrics on one field is precisely what a query's
+/// `metric` argument exists to choose between: without this the argument has
+/// nothing to disambiguate.
+#[test]
+fn a_field_takes_more_than_one_index() {
+    let collections = collections(
+        r#"type Doc {
+            embedding: [Float32!]
+                @index(name: "by_cosine", vector: {dimensions: 8, hnsw: {metric: COSINE}})
+                @index(name: "by_euclidean", vector: {dimensions: 8, hnsw: {metric: EUCLIDEAN}})
+        }"#,
+    );
+    let indexes = &collections[0].indexes;
+    assert_eq!(indexes.len(), 2, "both directives must build an index");
+    assert_ne!(indexes[0].id, indexes[1].id, "ids must not collide");
+
+    let by_name = |name: &str| {
+        indexes
+            .iter()
+            .find(|index| index.name == name)
+            .and_then(|index| index.vector())
+            .unwrap_or_else(|| panic!("no vector index named {name}"))
+            .metric
+    };
+    assert_eq!(by_name("by_cosine"), DistanceMetric::Cosine);
+    assert_eq!(by_name("by_euclidean"), DistanceMetric::Euclidean);
+}
+
+/// The same, mixing kinds: an ordered index and a vector index on one field.
+#[test]
+fn a_field_takes_an_ordered_and_a_vector_index() {
+    let collections = collections(
+        r#"type Doc {
+            embedding: [Float32!] @index @index(vector: {dimensions: 8})
+        }"#,
+    );
+    let indexes = &collections[0].indexes;
+    assert_eq!(indexes.len(), 2);
+    assert_eq!(indexes.iter().filter(|i| i.is_vector()).count(), 1);
+    assert_eq!(indexes.iter().filter(|i| !i.is_vector()).count(), 1);
+}
+
 // ---------------------------------------------------------------------------
 // Algorithm selection
 // ---------------------------------------------------------------------------

--- a/crates/query/tests/vector_index_warnings.rs
+++ b/crates/query/tests/vector_index_warnings.rs
@@ -3,8 +3,9 @@
 
 use query::executor::QueryResponse;
 use query::planner::vector_routing::{vector_index_unused_warning, NotRouted};
+use schema::DistanceMetric;
 
-fn all_not_routed_variants() -> [NotRouted; 6] {
+fn all_not_routed_variants() -> [NotRouted; 8] {
     [
         NotRouted::NoLimit,
         NotRouted::NotOneSimilarity,
@@ -14,6 +15,10 @@ fn all_not_routed_variants() -> [NotRouted; 6] {
         NotRouted::DimensionMismatch {
             expected: 4,
             actual: 2,
+        },
+        NotRouted::AmbiguousMetric,
+        NotRouted::MetricMismatch {
+            requested: DistanceMetric::Dot,
         },
     ]
 }
@@ -30,6 +35,8 @@ fn every_not_routed_variant_maps_to_its_reason_string() {
             NotRouted::NoVectorIndex => "noVectorIndex",
             NotRouted::ShowDeleted => "showDeleted",
             NotRouted::DimensionMismatch { .. } => "dimensionMismatch",
+            NotRouted::AmbiguousMetric => "ambiguousMetric",
+            NotRouted::MetricMismatch { .. } => "metricMismatch",
         };
         assert_eq!(variant.reason(), expected);
     }

--- a/crates/query/tests/vector_routing.rs
+++ b/crates/query/tests/vector_routing.rs
@@ -45,7 +45,32 @@ fn similarity(field: &str, output_name: &str) -> SimilarityField {
         target_field: field.to_string(),
         vector: vec![1.0, 0.0, 0.0, 0.0],
         output_name: output_name.to_string(),
+        metric: None,
     }
+}
+
+/// A vector index built with a chosen metric, so a field can carry several
+/// that disagree.
+fn vector_index_with_metric(id: u32, field: &str, metric: DistanceMetric) -> IndexDescription {
+    IndexDescription {
+        name: format!("by_{field}_{}", metric.as_str()),
+        id,
+        fields: vec![IndexedFieldDescription {
+            name: field.to_string(),
+            descending: false,
+        }],
+        unique: false,
+        kind: None,
+        auto_generated: false,
+    }
+    .as_vector(VectorIndexDescription {
+        algorithm: VectorAlgorithm::Hnsw,
+        metric,
+        dimensions: DIMENSIONS,
+        hnsw: Some(HnswParams::default()),
+        ivfpq: None,
+        ssg: None,
+    })
 }
 
 fn order(field: &str, descending: bool) -> Option<OrderKey> {
@@ -292,20 +317,104 @@ fn the_scoring_metric_follows_the_field_index() {
         vector_index(9, "embedding", DIMENSIONS),
     ];
 
-    assert_eq!(scoring_metric(&indexes, "embedding"), DistanceMetric::Dot);
     assert_eq!(
-        scoring_metric(&indexes, "title"),
+        scoring_metric(&indexes, "embedding", None),
+        DistanceMetric::Dot
+    );
+    assert_eq!(
+        scoring_metric(&indexes, "title", None),
         DistanceMetric::Cosine,
         "an ordered index is not a vector index"
     );
     assert_eq!(
-        scoring_metric(&indexes, "unindexed"),
+        scoring_metric(&indexes, "unindexed", None),
         DistanceMetric::Cosine,
         "an unindexed field scores as cosine"
     );
     assert_eq!(
-        scoring_metric(&[], "embedding"),
+        scoring_metric(&[], "embedding", None),
         DistanceMetric::Cosine,
         "a collection with no indexes at all scores as cosine"
+    );
+    assert_eq!(
+        scoring_metric(&[], "embedding", Some(DistanceMetric::Dot)),
+        DistanceMetric::Dot,
+        "a named metric scores by what the query asked for, even on an \
+         unindexed field"
+    );
+}
+
+/// With one index on the field, that index is the only candidate whatever
+/// metric it was built with, so no metric needs naming.
+#[test]
+fn a_single_index_routes_without_a_named_metric() {
+    for metric in DistanceMetric::ALL {
+        let indexes = [vector_index_with_metric(7, "embedding", *metric)];
+        let route = route(&routable(), &indexes)
+            .unwrap_or_else(|e| panic!("{metric:?} with a single index must route: {e:?}"));
+        assert_eq!(route.index_id, 7);
+    }
+}
+
+/// Two indexes and no named metric: which one would answer is ambiguous, so
+/// routing declines rather than silently picking one.
+#[test]
+fn several_indexes_without_a_named_metric_do_not_route() {
+    let indexes = [
+        vector_index_with_metric(1, "embedding", DistanceMetric::Cosine),
+        vector_index_with_metric(2, "embedding", DistanceMetric::Dot),
+    ];
+    assert_eq!(
+        route(&routable(), &indexes),
+        Err(NotRouted::AmbiguousMetric)
+    );
+}
+
+/// With a metric named, the index built with that metric answers, whichever
+/// index carries it.
+#[test]
+fn a_named_metric_selects_its_own_index_among_several() {
+    let indexes = [
+        vector_index_with_metric(1, "embedding", DistanceMetric::Cosine),
+        vector_index_with_metric(2, "embedding", DistanceMetric::Dot),
+    ];
+
+    for (metric, expected_id) in [(DistanceMetric::Cosine, 1), (DistanceMetric::Dot, 2)] {
+        let query = SimilarityQuery {
+            similarities: vec![SimilarityField {
+                metric: Some(metric),
+                ..similarity("embedding", "SIMILARITY")
+            }],
+            ..routable()
+        };
+        assert_eq!(
+            route(&query, &indexes).unwrap().index_id,
+            expected_id,
+            "{metric:?} should select index {expected_id}"
+        );
+    }
+}
+
+/// Naming a metric no index on the field carries is a mismatch: it does not
+/// fall back to whatever the field does have.
+#[test]
+fn a_metric_no_index_carries_does_not_route() {
+    let indexes = [vector_index_with_metric(
+        7,
+        "embedding",
+        DistanceMetric::Cosine,
+    )];
+    let query = SimilarityQuery {
+        similarities: vec![SimilarityField {
+            metric: Some(DistanceMetric::Dot),
+            ..similarity("embedding", "SIMILARITY")
+        }],
+        ..routable()
+    };
+    assert_eq!(
+        route(&query, &indexes),
+        Err(NotRouted::MetricMismatch {
+            requested: DistanceMetric::Dot
+        })
     );
 }

--- a/crates/schema/src/definition_validation/global_validators.rs
+++ b/crates/schema/src/definition_validation/global_validators.rs
@@ -2,7 +2,7 @@
 
 use super::helpers::*;
 use super::DefinitionState;
-use crate::{DistanceMetric, FieldKind, ScalarKind, ORPHAN_COLLECTION_ID};
+use crate::{FieldKind, ScalarKind, ORPHAN_COLLECTION_ID};
 
 fn format_relation_kind(kind: &FieldKind) -> String {
     let (name, is_array) = match kind {
@@ -368,27 +368,24 @@ pub(super) fn validate_embedding_and_kind_compatible(
     errs
 }
 
-/// A vector index must declare its dimensions, be built with a metric its
-/// algorithm can rank by, and not share a field with another vector index that
-/// disagrees about the metric.
+/// A vector index must declare its dimensions and be built with a metric its
+/// algorithm can rank by.
 ///
-/// Without the first the definition is accepted and the failure surfaces on the
+/// Without this the definition is accepted and the failure surfaces on the
 /// first document write, as an index-manager construction error naming an
 /// engine the schema author never mentioned.
 ///
-/// The second is what makes "the field's metric" a single value. A `SIMILARITY`
-/// selection scores by the metric the field's index declares, and the planner
-/// takes the first vector index it finds, so two metrics on one field would
-/// make the ranking depend on index order rather than on the query. Changing a
-/// metric means dropping the index and creating it again, because a graph is
-/// not merely searched by its metric, it is built by it.
+/// A field may carry several vector indexes, including several with the same
+/// metric: this used to be refused because the planner took the first vector
+/// index it found on a field, so two metrics there would make the ranking
+/// depend on index order rather than on the query. A query can now name the
+/// metric it means (sourcenetwork/defradb#5072), which is what unblocks this.
 pub(super) fn validate_vector_index_metrics(
     new_state: &DefinitionState,
     _old_state: &DefinitionState,
 ) -> Vec<String> {
     let mut errs = Vec::new();
     for col in &new_state.collections {
-        let mut metric_by_field: Vec<(&str, DistanceMetric, &str)> = Vec::new();
         for index in &col.indexes {
             let Some(vector) = index.vector() else {
                 continue;
@@ -411,29 +408,6 @@ pub(super) fn validate_vector_index_metrics(
                     vector.metric.as_str(),
                     vector.algorithm.as_str()
                 ));
-            }
-
-            let Some(field) = index.fields.first() else {
-                continue;
-            };
-            match metric_by_field
-                .iter()
-                .find(|(name, _, _)| *name == field.name)
-            {
-                Some((_, existing, existing_index)) if *existing != vector.metric => {
-                    errs.push(format!(
-                        "field '{}' already has a vector index '{}' with distance metric {}; \
-                         drop it and create it again to index with {}",
-                        field.name,
-                        existing_index,
-                        existing.as_str(),
-                        vector.metric.as_str()
-                    ));
-                }
-                Some(_) => {}
-                None => {
-                    metric_by_field.push((&field.name, vector.metric, &index.name));
-                }
             }
         }
     }


### PR DESCRIPTION
Part of #1517. Stacked on #1663. Supersedes #1521 and #1522.

Upstream rescoped sourcenetwork/defradb#5072. The dedicated nearest-neighbour argument it originally proposed was declined by the Go team as not enabling anything the existing shape cannot express, and what survived is the part that unblocks something real: an optional metric alongside the vector, so a field can carry more than one vector index and a query can say which it means.

That makes this PR the whole query-surface slice of the epic. #1521 (the `nearest:` argument) and #1522 (a `DISTANCE` field succeeding `SIMILARITY`) are both surfaces upstream has moved away from, so neither is implemented here; building them would be exactly the deprecation debt this epic exists to avoid.

## The shape

```graphql
User(order: {_alias: {d: DESC}}, limit: 10) {
  d: SIMILARITY(embedding: {vector: [0.1, 0.8], metric: EUCLIDEAN})
}
```

`metric` is optional and sits beside `vector` in the same field-keyed object, so nothing about the existing spelling changes.

## Selection rules

`vector_index_for` is the one place a `SIMILARITY` resolves to an index:

| field has | query names | result |
|---|---|---|
| no vector index | anything | scan, scored by the named metric or cosine |
| one index | nothing | that index |
| one index | its metric | that index |
| several | nothing | declines, reason `ambiguousMetric` |
| several | one of their metrics | the index built with it |
| any | a metric none carries | declines, reason `metricMismatch` |

Declining is a warning, not an error: the results stay correct, they just cost a scan. Both new reasons ride the `VECTOR_INDEX_UNUSED` channel #1663 added.

An unindexed field still scores by the metric the query named. Naming `EUCLIDEAN` on a field with no index is an ordinary annotate query, not a mistake, so it is answered rather than refused.

## The restriction this lifts

`validate_vector_index_metrics` refused a second vector index on a field with a different metric, which I added in #1657 to match Go's `validateNoConflictingVectorIndexMetric`. Go added it because its planner takes the first vector index it finds, so which one answered would silently decide the results rather than just the cost. A query can now name the metric it means, so the restriction goes.

Worth stating plainly: no test in the tree asserted that refusal. The validator's conflict path was reachable only from hand-built `IndexDescription` lists, never from SDL, for the reason below.

## Repeated `@index`, which is why the argument was unreachable

`ParsedDirectives` held `index: Option<IndexConfig>` and `vector_index: Option<VectorIndexConfig>`, both singular, and each `@index` directive on a field overwrote the last. So two `@index` directives on one field silently built one index, and a field could never carry the two indexes this argument exists to choose between: the feature was shipped but unreachable from SDL.

The reference appends (`internal/request/graphql/schema/collection.go`, `indexes = append(indexes, index)` per directive), so this is a parity bug rather than a design choice. Both slots are now `Vec`, and the two consumers in `sdl_parse/builder.rs` iterate.

## Introspection

`SimilaritySelector` gains a `metric` field typed `VectorDistanceMetric`, the enum built from `DistanceMetric::ALL` so a new metric appears without another edit. The type name is Go's, so a query written against either runtime introspects the same type. The enum is registered once per schema even when several fields reference it.

## Verification

```
cargo test --workspace                             every Rust-native test passes
cargo clippy --all --all-targets -- -D warnings    clean
RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p query -p schema -p defra-node    clean
cargo fmt --all --check                            clean
```

`crates/query/tests/vector_routing.rs` covers the selection table above, including that every algorithm and metric pair routes when it is the field's only index, and that each of two metrics selects its own `index_id`.

`crates/query/tests/vector_index_sdl.rs` gains `a_field_takes_more_than_one_index` and `a_field_takes_an_ordered_and_a_vector_index`, which are what pin the repeated-directive fix.

`crates/defra-node/tests/vector_index_query_path.rs` proves the capability reaches the production read path rather than just the routing decision:

- `a_named_metric_reaches_its_own_index_among_several`. Two indexes on one field; each metric's query is served by the index built with that metric (asserted from the execute-explain's `vectorIndex`), and its routed page equals the exhaustive page scored by that same metric, not the other one.
- `several_indexes_without_a_metric_warn_ambiguous`. No metric named, so it declines with `ambiguousMetric` and still fills the page.
- `a_metric_no_index_carries_scans_and_warns`. Scans, answers correctly, warns `metricMismatch`.

## Wire compatibility

Upstream has not landed its 5072 PR yet, so the argument name is coordinated with the issue's own wording ("an optional metric alongside the vector") rather than with merged code. If upstream lands a different spelling, this is the surface to reconcile before either runtime releases it.
