### PR TITLE
fix(db): remove the stale inverted-list entry when a vector moves lists

### DIFF
--- a/crates/db/src/index/vector/engine/ivfpq/mod.rs
+++ b/crates/db/src/index/vector/engine/ivfpq/mod.rs
@@ -133,15 +133,39 @@ impl<S: VectorNodeStore> VectorIndexEngine for IvfPq<S> {
 
     /// The vector is always stored, trained or not: it is what a rebuild reads
     /// and what keeps the index exact until one happens.
+    ///
+    /// Re-inserting under an id that already has one is an update, and its list
+    /// assignment can move. The previous entry has to go with it: a list holds
+    /// the code of whatever vector was assigned to it, so a stale one returns
+    /// the document a second time, ranked by an embedding it no longer has.
     async fn insert<E: Element>(&mut self, id: NodeId, vector: &[E]) -> Result<()> {
+        let trained = self.trained().await?;
+
+        // Read before the write, because `staging.insert` overwrites the node
+        // and the old vector is what names the list to clear.
+        let previous = match trained {
+            Some(_) => self.store().get_node(id).await?,
+            None => None,
+        };
+
         self.staging.insert(id, vector).await?;
 
-        if let Some(state) = self.trained().await? {
+        if let Some(state) = trained {
             let stored =
                 self.store().get_node(id).await?.ok_or_else(|| {
                     Error::Other("vector index: a just-stored node is gone".into())
                 })?;
             let (list, code) = self.assign(&state, &stored.vector).await?;
+
+            if let Some(previous) = previous {
+                let (previous_list, _) = self.assign(&state, &previous.vector).await?;
+                if previous_list != list {
+                    self.store_mut()
+                        .delete_aux(codec::LIST, &codec::list_key(previous_list, id))
+                        .await?;
+                }
+            }
+
             self.store_mut()
                 .put_aux(codec::LIST, &codec::list_key(list, id), &code)
                 .await?;

--- a/crates/db/src/index/vector/kv_store.rs
+++ b/crates/db/src/index/vector/kv_store.rs
@@ -154,6 +154,12 @@ impl<T: Reader + Writer + MaybeSend> VectorNodeStore for KvNodeStore<'_, T> {
         Ok(())
     }
 
+    async fn delete_aux(&mut self, kind: u8, key: &[u8]) -> Result<()> {
+        let full = self.aux_key(kind, key);
+        self.txn.delete(&full).await?;
+        Ok(())
+    }
+
     /// Streams one kind's entries, holding one at a time. The prefix stops at
     /// this epoch's discriminator, so a scan cannot reach the graph or another
     /// kind.

--- a/crates/db/src/index/vector/store/memory.rs
+++ b/crates/db/src/index/vector/store/memory.rs
@@ -80,6 +80,11 @@ impl VectorNodeStore for MemoryNodeStore {
         Ok(())
     }
 
+    async fn delete_aux(&mut self, kind: u8, key: &[u8]) -> Result<()> {
+        self.aux.remove(&(kind, key.to_vec()));
+        Ok(())
+    }
+
     /// A range over the ordered map, not a full scan: an inverted-list probe
     /// is a prefix lookup and must cost what the prefix holds, not what the
     /// index holds.

--- a/crates/db/src/index/vector/store/mod.rs
+++ b/crates/db/src/index/vector/store/mod.rs
@@ -98,6 +98,14 @@ pub trait VectorNodeStore: MaybeSendSync {
 
     async fn put_aux(&mut self, kind: u8, key: &[u8], value: &[u8]) -> Result<()>;
 
+    /// Removes one entry, if it is there. Absent is not an error: a caller
+    /// clearing an entry it is not sure exists is the normal case.
+    ///
+    /// Without this a partitioned kind can only ever add, so a vector that
+    /// moves between lists leaves its old entry behind to be found by a later
+    /// probe.
+    async fn delete_aux(&mut self, kind: u8, key: &[u8]) -> Result<()>;
+
     /// Visits every entry of `kind` whose key starts with `key_prefix`, in key
     /// order, one at a time.
     async fn iterate_aux<F>(&self, kind: u8, key_prefix: &[u8], visit: F) -> Result<()>

--- a/crates/db/tests/vector/ivfpq_engine.rs
+++ b/crates/db/tests/vector/ivfpq_engine.rs
@@ -282,3 +282,68 @@ async fn k_zero_returns_nothing() {
         .unwrap()
         .is_empty());
 }
+
+/// Updating a vector moves it between inverted lists, and the entry under its
+/// previous list has to go with it.
+///
+/// A list holds the code of whatever vector was assigned to it, so a stale
+/// entry is not merely a duplicate: probing both lists pushes the same id twice
+/// with two different distances, and one of them ranks the document by an
+/// embedding it no longer has. The liveness check filters tombstones only, so
+/// nothing downstream catches it.
+#[tokio::test]
+async fn updating_a_vector_leaves_no_entry_in_its_previous_list() {
+    let mut corpus = crate::support::Corpus::new(SEED ^ 0x444);
+    let vectors = corpus.clustered(400, DIMENSIONS, 8, 0.1);
+    let mut index = filled(8, 8, &vectors).await;
+    index.build().await.unwrap();
+
+    // Move document 1 onto a far-away cluster's vector, which is what puts it
+    // in a different list from the one it was built into. Probing everything,
+    // so a surviving stale entry has nowhere to hide.
+    let moved_to = vectors[399].clone();
+    index.insert(NodeId(1), &moved_to).await.unwrap();
+
+    let hits = index.search(moved_to.as_slice(), 400, None).await.unwrap();
+    let appearances = hits.iter().filter(|n| n.id == NodeId(1)).count();
+    assert_eq!(
+        appearances,
+        1,
+        "document 1 appears {appearances} times after moving lists: {:?}",
+        hits.iter().map(|n| n.id.0).collect::<Vec<_>>()
+    );
+
+    // And it must rank by where it moved to, not by where it was. It now holds
+    // document 400's vector exactly, so the two tie for nearest; which of a tie
+    // comes first is IVF-PQ's tie-break, not this fix's business.
+    let best_distance = hits.first().expect("a non-empty result").distance;
+    let moved = hits
+        .iter()
+        .find(|n| n.id == NodeId(1))
+        .expect("the updated document must still rank");
+    assert!(
+        (moved.distance - best_distance).abs() <= f64::EPSILON,
+        "the updated document ranks at {} rather than its new vector's {best_distance}",
+        moved.distance
+    );
+}
+
+/// The same, when the vector is replaced by one that lands in the *same* list.
+/// Nothing should be removed, and the document must still appear exactly once.
+#[tokio::test]
+async fn updating_within_one_list_keeps_the_document() {
+    let mut corpus = crate::support::Corpus::new(SEED ^ 0x555);
+    let vectors = corpus.clustered(400, DIMENSIONS, 8, 0.1);
+    let mut index = filled(8, 8, &vectors).await;
+    index.build().await.unwrap();
+
+    let nudged: Vec<f32> = vectors[0].iter().map(|value| value + 0.001).collect();
+    index.insert(NodeId(1), &nudged).await.unwrap();
+
+    let hits = index.search(nudged.as_slice(), 400, None).await.unwrap();
+    assert_eq!(
+        hits.iter().filter(|n| n.id == NodeId(1)).count(),
+        1,
+        "document 1 must appear exactly once"
+    );
+}

--- a/crates/db/tests/vector/ssg_vs_hnsw.rs
+++ b/crates/db/tests/vector/ssg_vs_hnsw.rs
@@ -87,6 +87,10 @@ impl<S: VectorNodeStore> VectorNodeStore for Counting<S> {
         self.inner.put_aux(kind, key, value).await
     }
 
+    async fn delete_aux(&mut self, kind: u8, key: &[u8]) -> Result<()> {
+        self.inner.delete_aux(kind, key).await
+    }
+
     async fn iterate_aux<F>(&self, kind: u8, key_prefix: &[u8], visit: F) -> Result<()>
     where
         F: FnMut(&[u8], &[u8]) -> Result<()> + MaybeSend,

--- a/crates/db/tests/vector/vector_engine.rs
+++ b/crates/db/tests/vector/vector_engine.rs
@@ -96,6 +96,10 @@ impl<S: VectorNodeStore> VectorNodeStore for Counting<S> {
         self.inner.put_aux(kind, key, value).await
     }
 
+    async fn delete_aux(&mut self, kind: u8, key: &[u8]) -> Result<()> {
+        self.inner.delete_aux(kind, key).await
+    }
+
     async fn iterate_aux<F>(&self, kind: u8, key_prefix: &[u8], visit: F) -> Result<()>
     where
         F: FnMut(&[u8], &[u8]) -> Result<()> + MaybeSend,

--- a/crates/db/tests/vector/vector_kv_cost.rs
+++ b/crates/db/tests/vector/vector_kv_cost.rs
@@ -106,6 +106,10 @@ impl<S: VectorNodeStore> VectorNodeStore for Counting<S> {
         self.inner.put_aux(kind, key, value).await
     }
 
+    async fn delete_aux(&mut self, kind: u8, key: &[u8]) -> Result<()> {
+        self.inner.delete_aux(kind, key).await
+    }
+
     async fn iterate_aux<F>(&self, kind: u8, key_prefix: &[u8], visit: F) -> Result<()>
     where
         F: FnMut(&[u8], &[u8]) -> Result<()> + MaybeSend,

--- a/crates/db/tests/vector/vector_recall_baseline.rs
+++ b/crates/db/tests/vector/vector_recall_baseline.rs
@@ -148,6 +148,10 @@ impl<S: VectorNodeStore> VectorNodeStore for Counting<S> {
         self.inner.put_aux(kind, key, value).await
     }
 
+    async fn delete_aux(&mut self, kind: u8, key: &[u8]) -> Result<()> {
+        self.inner.delete_aux(kind, key).await
+    }
+
     async fn iterate_aux<F>(&self, kind: u8, key_prefix: &[u8], visit: F) -> Result<()>
     where
         F: FnMut(&[u8], &[u8]) -> Result<()> + MaybeSend,


### PR DESCRIPTION
Closes #1465. Part of #1517. Stacked on #1667.

`IvfPq::insert` wrote the new inverted-list entry and never removed the document's entry under its previous list. Document 7 is assigned to list 3, then updated so its nearest centroid becomes list 9: `insert` writes `(LIST, key(9, 7))` and leaves `(LIST, key(3, 7))` in place, still holding the old code.

That is worse than a duplicate. A list holds the code of whatever vector was assigned to it, so a query probing both lists pushes `NodeId(7)` twice with two different distances, and one of them ranks the document by an embedding it no longer has. The liveness check in `search_lists` filters tombstones only, so nothing downstream catches it.

## The port change

`VectorNodeStore` had `get_aux`, `put_aux` and `iterate_aux` and no way to remove one entry, so a partitioned kind could only ever add. `delete_aux` joins them, implemented on both stores (`KvNodeStore` deletes the namespaced key, `MemoryNodeStore` removes from its ordered map) and forwarded by the `Counting` wrappers the cost tests use. Absent is not an error: a caller clearing an entry it is not sure exists is the normal case.

## The fix

`insert` now reads the node before `staging.insert` overwrites it, because the old vector is what names the list to clear. If the index is trained and the new assignment differs from the old one, the previous entry is deleted before the new one is written. An assignment that does not move writes in place, as before, and nothing is removed.

The read is only taken when the index is trained, so the untrained staging path costs exactly what it did.

## This is a prerequisite, not a detour

IVF_FLAT (#1516) has the same staged shape and would inherit the same defect, and for it the consequence is worse: its list entries hold the full vector rather than a code, so a stale entry returns a live document ranked at a distance it no longer has, with no quantization error to hide behind. #1516 says so explicitly, which is why this lands first.

## Verification

```
cargo test -p db                                   every binary ok, 0 failed
cargo clippy --all --all-targets -- -D warnings    clean
cargo fmt --all --check                            clean
```

Two new tests in `crates/db/tests/vector/ivfpq_engine.rs`:

- `updating_a_vector_leaves_no_entry_in_its_previous_list`. Moves document 1 onto a far cluster's vector, probes every list so a survivor has nowhere to hide, and asserts it appears exactly once. On the old code it appears twice. It also asserts the document now ranks at its new vector's distance rather than its old one.
- `updating_within_one_list_keeps_the_document`. The complement: a nudge that stays in the same list must remove nothing and still return the document exactly once.

The first test deliberately stops short of asserting which of a tie ranks first. Document 1 ends up holding document 400's vector exactly, so the two tie, and which one wins is IVF-PQ's tie-break order, which is #1469 and not this change.
