### PR TITLE
fix(db): clear the whole vector epoch keyspace, aux space included

### DIFF
--- a/crates/db/src/index/vector/kv_store.rs
+++ b/crates/db/src/index/vector/kv_store.rs
@@ -7,7 +7,7 @@
 use bytes::Bytes;
 use defra_core::thread_bounds::MaybeSend;
 use storage::corekv::{IterOptions, Key, Reader, Writer};
-use storage::keys::datastore::{VectorAuxKey, VectorIndexKey};
+use storage::keys::datastore::{vector_epoch_prefix, VectorAuxKey, VectorIndexKey};
 
 use super::codec::{decode_meta, decode_node, encode_meta, encode_node};
 use super::store::{Meta, Node, NodeId, VectorNodeStore};
@@ -59,18 +59,34 @@ impl<'txn, T> KvNodeStore<'txn, T> {
     fn node_prefix(&self) -> Vec<u8> {
         VectorIndexKey::node_prefix(self.collection_short_id, self.index_id, self.epoch).bytes()
     }
+
+    /// Every key of this build: nodes, meta, and every aux kind beside them.
+    fn epoch_prefix(&self) -> Vec<u8> {
+        vector_epoch_prefix(self.collection_short_id, self.index_id, self.epoch)
+    }
 }
 
 impl<T: Reader + Writer + MaybeSend> KvNodeStore<'_, T> {
     /// Removes every key of this epoch, in batches, so the memory held is
     /// bounded by the batch size rather than by the number of nodes.
+    ///
+    /// The scan is over the whole epoch prefix rather than the node prefix,
+    /// which is what makes "every key" true: the aux space holds a partitioned
+    /// kind's centroids, codebooks and inverted lists, and a graph kind's
+    /// adjacency, and none of it is under the node prefix. Leaving it behind
+    /// corrupts a reindex, because a surviving trained-state marker makes the
+    /// engine append to lists built from centroids that are gone, and leaks the
+    /// whole aux keyspace on a drop, because nothing else ever removes it.
+    ///
+    /// Prefix rather than a per-kind sweep so a kind added later is covered
+    /// without anyone remembering to add it here.
     pub async fn clear(&mut self) -> Result<()> {
         loop {
             let mut batch = Vec::new();
             {
                 let mut iter = self
                     .txn
-                    .iterator(IterOptions::default().with_prefix(self.node_prefix()))
+                    .iterator(IterOptions::default().with_prefix(self.epoch_prefix()))
                     .await?;
                 while let Some(pair) = iter.next().await? {
                     batch.push(pair.key);
@@ -86,7 +102,6 @@ impl<T: Reader + Writer + MaybeSend> KvNodeStore<'_, T> {
                 self.txn.delete(&key).await?;
             }
         }
-        self.txn.delete(&self.meta_key()).await?;
         Ok(())
     }
 }

--- a/crates/db/tests/vector/vector_kv_store.rs
+++ b/crates/db/tests/vector/vector_kv_store.rs
@@ -375,6 +375,7 @@ async fn clearing_an_epoch_leaves_its_neighbours_alone() {
         })
         .await
         .unwrap();
+        kv.put_aux(b's', b"key", b"value").await.unwrap();
     }
 
     KvNodeStore::new(&mut txn, COLLECTION, INDEX, EPOCH)
@@ -393,8 +394,17 @@ async fn clearing_an_epoch_leaves_its_neighbours_alone() {
     .unwrap();
     assert_eq!(count, 0, "the cleared epoch still has nodes");
 
+    assert!(
+        kv.get_aux(b's', b"key").await.unwrap().is_none(),
+        "the cleared epoch kept its aux entry"
+    );
+
     let survivor = KvNodeStore::new(&mut txn, COLLECTION, INDEX, EPOCH + 1);
     assert!(survivor.get_meta().await.unwrap().is_some());
+    assert!(
+        survivor.get_aux(b's', b"key").await.unwrap().is_some(),
+        "the next epoch's aux entry was cleared with the previous one"
+    );
     let mut count = 0;
     survivor
         .iterate_nodes(|_| {
@@ -425,4 +435,71 @@ async fn a_corrupt_stored_value_is_an_error() {
         kv.iterate_nodes(|_| Ok(())).await,
         Err(Error::Other(_))
     ));
+}
+
+/// `clear` has to remove every key of the epoch, which includes the aux space
+/// beside the graph.
+///
+/// It used to scan the node prefix only and then delete the meta key, so a
+/// partitioned kind's centroids, codebooks, inverted lists and trained-state
+/// marker all survived. That has two consequences and neither is quiet: a
+/// reindex re-inserts into lists built from centroids that are gone, because
+/// the surviving state marker says the index is trained; and a dropped index
+/// leaks its whole aux keyspace, because nothing else ever removes it.
+#[tokio::test]
+async fn clear_removes_the_aux_space_too() {
+    let store = RegolithStore::in_memory().unwrap();
+
+    // Kinds an engine actually uses, plus one nobody uses yet: the sweep is by
+    // prefix, so a kind added later must be covered without being listed here.
+    const KINDS: [u8; 4] = *b"sckz";
+
+    {
+        let mut txn = txn(&store).await;
+        let mut kv = KvNodeStore::new(&mut txn, COLLECTION, INDEX, EPOCH);
+        kv.put_node(Node::new(NodeId(1), vec![1.0, 0.0], 0))
+            .await
+            .unwrap();
+        kv.put_meta(Meta {
+            entry_point: NodeId(1),
+            top_layer: 0,
+        })
+        .await
+        .unwrap();
+        for kind in KINDS {
+            kv.put_aux(kind, b"key", b"value").await.unwrap();
+        }
+        txn.commit().await.unwrap();
+    }
+
+    {
+        let mut txn = txn(&store).await;
+        let kv = KvNodeStore::new(&mut txn, COLLECTION, INDEX, EPOCH);
+        for kind in KINDS {
+            assert!(
+                kv.get_aux(kind, b"key").await.unwrap().is_some(),
+                "kind {} was not written",
+                kind as char
+            );
+        }
+    }
+
+    {
+        let mut txn = txn(&store).await;
+        let mut kv = KvNodeStore::new(&mut txn, COLLECTION, INDEX, EPOCH);
+        kv.clear().await.unwrap();
+        txn.commit().await.unwrap();
+    }
+
+    let mut txn = txn(&store).await;
+    let kv = KvNodeStore::new(&mut txn, COLLECTION, INDEX, EPOCH);
+    assert!(kv.get_node(NodeId(1)).await.unwrap().is_none(), "node kept");
+    assert!(kv.get_meta().await.unwrap().is_none(), "meta kept");
+    for kind in KINDS {
+        assert!(
+            kv.get_aux(kind, b"key").await.unwrap().is_none(),
+            "aux kind {} survived the clear",
+            kind as char
+        );
+    }
 }

--- a/crates/storage/src/keys/datastore/vector_index_key.rs
+++ b/crates/storage/src/keys/datastore/vector_index_key.rs
@@ -77,6 +77,16 @@ impl VectorIndexKey {
     }
 }
 
+/// `/<collShortID>/<indexID>/<epoch>/`, shared by every key of one build of one
+/// index: its nodes, its meta key, and every aux kind beside them.
+///
+/// Public because it is the only prefix that covers all of them, and dropping a
+/// build means dropping all of them. Enumerating the kinds instead would leak
+/// whichever kind an engine added last.
+pub fn vector_epoch_prefix(collection_short_id: u32, index_id: u32, epoch: u32) -> Vec<u8> {
+    epoch_prefix(collection_short_id, index_id, epoch)
+}
+
 /// `/<collShortID>/<indexID>/<epoch>/`, shared by every key in this space.
 fn epoch_prefix(collection_short_id: u32, index_id: u32, epoch: u32) -> Vec<u8> {
     let mut buf = vec![SEPARATOR];


### PR DESCRIPTION
Closes #1462. Part of #1517. Stacked on #1668.

`KvNodeStore::clear` scanned the node prefix and then deleted the meta key. Its doc comment claimed it "removes every key of this epoch", which was not true: the aux space beside the graph holds a partitioned kind's centroids, codebooks, inverted lists and trained-state marker, and a graph kind's adjacency, and none of that is under the node prefix.

`VectorIndex::remove_all` is both the reindex path and the drop-index path, so this had two consequences.

**Reindex corrupted the index.** Nodes and meta went, but the surviving `STATE` marker meant `IvfPq::trained()` still returned a state. Backfill then re-inserted into inverted lists built from centroids that were gone, and a probe returned documents ranked by codes for vectors that no longer existed.

**Drop leaked permanently.** Nothing else ever removes centroid, codebook, list or adjacency keys, so they outlived the index that wrote them.

## The fix

Every key of one build of one index shares `/<collShortID>/<indexID>/<epoch>/`: its nodes, its meta key, and every aux kind beside them. `clear` now sweeps that prefix, which is what makes "every key of this epoch" true.

A prefix sweep rather than a per-kind loop, deliberately. Enumerating kinds would leak whichever kind an engine adds next, and the whole point of the aux space is that a kind adds a concept without a port change. The batching is unchanged, so the memory held is still bounded by the batch rather than by the corpus.

`vector_epoch_prefix` is exported from `storage::keys::datastore` because it is the only prefix that covers all of it, and the existing `node_prefix` deliberately does not.

## Why this is a prerequisite

IVF_FLAT (#1516) stores the full vector in each list entry rather than a code, so under this defect its aux keyspace is a second complete copy of the corpus. A leaked one on reindex or drop leaks the entire corpus again, not a set of codes. #1516 names this as load-bearing, which is why it lands first.

## Verification

```
cargo test -p db -p storage                        every binary ok, 0 failed
cargo clippy --all --all-targets -- -D warnings    clean
cargo fmt --all --check                            clean
```

`clear_removes_the_aux_space_too` writes a node, a meta key and four aux kinds, clears, and asserts none survive. The fourth kind is one no engine uses: the sweep is by prefix, so a kind added later must be covered without being listed in the test.

`clearing_an_epoch_leaves_its_neighbours_alone` already existed and covered nodes and meta across two epochs; it is extended to cover an aux entry in each, so the sweep is shown to be confined to its own build rather than merely thorough. Extending it beat adding a near-duplicate.

Both tests were checked against the old behaviour, reproduced exactly (node-prefix scan plus the explicit meta delete): both fail there, with `aux kind s survived the clear` and `the cleared epoch kept its aux entry`, and pass on the fix. They are regression tests rather than tests that pass either way.
