### PR TITLE
fix(db): train vector indexes from the production write path

### DIFF
--- a/crates/db/src/index/manager/index_type.rs
+++ b/crates/db/src/index/manager/index_type.rs
@@ -130,6 +130,15 @@ impl IndexType {
         }
     }
 
+    /// Gives a vector index one chance to train and build, if it should. A
+    /// no-op for every other index kind, which has nothing to train.
+    pub async fn build_if_needed<T: Reader + Writer + MaybeSend>(&self, txn: &mut T) -> Result<()> {
+        match self {
+            IndexType::Simple(_) | IndexType::Unique(_) | IndexType::FullText(_) => Ok(()),
+            IndexType::Vector(idx) => idx.build_if_needed(txn).await,
+        }
+    }
+
     /// RemoveAll removes all entries for this index.
     pub async fn remove_all<T: Reader + Writer + MaybeSend>(&self, txn: &mut T) -> Result<()> {
         match self {

--- a/crates/db/src/index/manager/mod.rs
+++ b/crates/db/src/index/manager/mod.rs
@@ -484,6 +484,14 @@ impl IndexManager {
             indexed_count += 1;
         }
 
+        // One chance to build here, rather than leaving a vector index to
+        // notice on its own: the loop above would otherwise ask the same
+        // per-write question for every document a bulk load lands at once.
+        index
+            .build_if_needed(&mut mutable_datastore)
+            .await
+            .map_err(Error::Storage)?;
+
         Ok(BulkIndexResult {
             indexed: indexed_count,
             skipped: skipped_count,

--- a/crates/db/src/index/vector/engine/ann/engine.rs
+++ b/crates/db/src/index/vector/engine/ann/engine.rs
@@ -53,6 +53,22 @@ pub trait VectorIndexEngine: MaybeSendSync {
     /// Removes `id`, returning whether this call was the one that did it.
     async fn delete(&mut self, id: NodeId) -> Result<bool>;
 
+    /// Whether enough has accumulated that building would pay for itself.
+    ///
+    /// Defaulted false: a kind with nothing to train is never asked to build,
+    /// and adding a kind does not mean remembering to answer this.
+    async fn should_build(&self) -> Result<bool> {
+        Ok(false)
+    }
+
+    /// Train and rebuild from what is stored.
+    ///
+    /// Called only when [`should_build`](Self::should_build) says so. Defaulted
+    /// to a no-op for the same reason.
+    async fn build(&mut self) -> Result<()> {
+        Ok(())
+    }
+
     /// Up to `k` nearest live nodes to `query`, nearest first.
     ///
     /// Takes any element width, for the same reason [`insert`](Self::insert)

--- a/crates/db/src/index/vector/engine/dispatch.rs
+++ b/crates/db/src/index/vector/engine/dispatch.rs
@@ -47,6 +47,18 @@ impl<S: VectorNodeStore> VectorIndexEngine for Engine<S> {
         dispatch!(self, e => e.delete(id).await)
     }
 
+    async fn should_build(&self) -> Result<bool> {
+        dispatch!(self, e => e.should_build().await)
+    }
+
+    async fn build(&mut self) -> Result<()> {
+        // Method resolution prefers IvfPq's and Ssg's own inherent `build`,
+        // which return their kind's report, over this trait method; `map`
+        // discards it uniformly across every arm rather than the macro having
+        // to special-case the two kinds that build something.
+        dispatch!(self, e => e.build().await.map(|_| ()))
+    }
+
     async fn search_where<E: Element, A: Admit>(
         &self,
         query: &[E],

--- a/crates/db/src/index/vector/engine/ivfpq/build.rs
+++ b/crates/db/src/index/vector/engine/ivfpq/build.rs
@@ -29,13 +29,46 @@ impl<S: VectorNodeStore> IvfPq<S> {
         Ok(count)
     }
 
+    /// Whether at least `wanted` live vectors are stored, counting no further.
+    ///
+    /// The count is bounded by what the question needs rather than by the
+    /// corpus, so asking it on every write costs a constant rather than a scan.
+    /// `iterate_nodes` stops as soon as the visitor returns an error, so the
+    /// visitor becomes that stop signal itself once `wanted` is reached; `count`
+    /// having reached `wanted` is what distinguishes the signal from a real
+    /// failure the store raised on its own.
+    pub async fn live_count_at_least(&self, wanted: u64) -> Result<bool> {
+        if wanted == 0 {
+            return Ok(true);
+        }
+        let mut count = 0u64;
+        match self
+            .store()
+            .iterate_nodes(|_| {
+                count += 1;
+                if count < wanted {
+                    Ok(())
+                } else {
+                    Err(Error::Other(
+                        "vector index: live_count_at_least stopped early".into(),
+                    ))
+                }
+            })
+            .await
+        {
+            Ok(()) => Ok(false),
+            Err(_) if count >= wanted => Ok(true),
+            Err(err) => Err(err),
+        }
+    }
+
     /// Whether there are enough vectors to fit the configured lists.
     pub async fn should_build(&self) -> Result<bool> {
         if self.is_trained().await? {
             return Ok(false);
         }
-        let live = self.live_count().await?;
-        Ok(live >= self.params().train_threshold(live).max(1))
+        self.live_count_at_least(self.params().resolved_train_threshold())
+            .await
     }
 
     /// Trains from a byte-bounded sample and writes centroids, codebooks and

--- a/crates/db/src/index/vector/engine/ivfpq/mod.rs
+++ b/crates/db/src/index/vector/engine/ivfpq/mod.rs
@@ -179,6 +179,14 @@ impl<S: VectorNodeStore> VectorIndexEngine for IvfPq<S> {
         self.staging.delete(id).await
     }
 
+    async fn should_build(&self) -> Result<bool> {
+        self.should_build().await
+    }
+
+    async fn build(&mut self) -> Result<()> {
+        self.build().await.map(|_| ())
+    }
+
     async fn search_where<E: Element, A: Admit>(
         &self,
         query: &[E],

--- a/crates/db/src/index/vector/engine/ivfpq/params.rs
+++ b/crates/db/src/index/vector/engine/ivfpq/params.rs
@@ -76,8 +76,19 @@ impl IvfPqParams {
             .unwrap_or(1)
     }
 
-    /// Vectors needed before training fires.
-    pub fn train_threshold(&self, corpus: u64) -> u64 {
-        u64::from(self.resolved_nlist(corpus)) * u64::from(TRAIN_PER_LIST)
+    /// Vectors needed before training fires, with no dependency on the count
+    /// being asked about.
+    ///
+    /// An explicit `nlist` already makes [`resolved_nlist`](Self::resolved_nlist)
+    /// a constant, so the threshold is just `nlist * TRAIN_PER_LIST`. A derived
+    /// `nlist` (`nlist == 0`) makes it `4*sqrt(corpus)*TRAIN_PER_LIST`, so the
+    /// point it crosses solves `corpus == 4*sqrt(corpus)*TRAIN_PER_LIST`, whose
+    /// positive root is the fixed `16*TRAIN_PER_LIST^2`, independent of corpus.
+    pub fn resolved_train_threshold(&self) -> u64 {
+        if self.nlist > 0 {
+            u64::from(self.nlist.min(MAX_NLIST)) * u64::from(TRAIN_PER_LIST)
+        } else {
+            16 * u64::from(TRAIN_PER_LIST) * u64::from(TRAIN_PER_LIST)
+        }
     }
 }

--- a/crates/db/src/index/vector/engine/ssg/build.rs
+++ b/crates/db/src/index/vector/engine/ssg/build.rs
@@ -6,6 +6,7 @@ use super::codec::{self, BuiltState};
 use super::Ssg;
 use crate::index::error::{Error, Result};
 use crate::index::vector::engine::ann::{Candidate, EdgeSelector};
+use crate::index::vector::engine::ivfpq::TRAIN_PER_LIST;
 use crate::index::vector::engine::select::Angular;
 use crate::index::vector::store::{NodeId, VectorNodeStore};
 
@@ -20,6 +21,66 @@ pub struct SsgBuildReport {
 }
 
 impl<S: VectorNodeStore> Ssg<S> {
+    /// Vectors held, tombstones excluded.
+    pub async fn live_count(&self) -> Result<u64> {
+        let mut count = 0u64;
+        self.store()
+            .iterate_nodes(|_| {
+                count += 1;
+                Ok(())
+            })
+            .await?;
+        Ok(count)
+    }
+
+    /// Whether at least `wanted` live vectors are stored, counting no further.
+    ///
+    /// The count is bounded by what the question needs rather than by the
+    /// corpus, so asking it on every write costs a constant rather than a scan.
+    /// See [`IvfPq::live_count_at_least`](super::super::ivfpq::IvfPq::live_count_at_least)
+    /// for why returning an error from the visitor is what stops the walk early.
+    pub async fn live_count_at_least(&self, wanted: u64) -> Result<bool> {
+        if wanted == 0 {
+            return Ok(true);
+        }
+        let mut count = 0u64;
+        match self
+            .store()
+            .iterate_nodes(|_| {
+                count += 1;
+                if count < wanted {
+                    Ok(())
+                } else {
+                    Err(Error::Other(
+                        "vector index: live_count_at_least stopped early".into(),
+                    ))
+                }
+            })
+            .await
+        {
+            Ok(()) => Ok(false),
+            Err(_) if count >= wanted => Ok(true),
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Whether there are enough nodes for a build to be worth it.
+    ///
+    /// SSG's own parameters (`r`, `angle`, `pool`) are all fixed by
+    /// configuration and none scale with the corpus, so unlike IVF-PQ's
+    /// `nlist` none of them implies a threshold on their own. This borrows
+    /// IVF-PQ's rule instead, substituting `r` for `nlist`: both are the
+    /// structural fan-out a build commits to (coarse lists there, edges per
+    /// node here), so the same `TRAIN_PER_LIST` per-unit minimum applies,
+    /// giving `r * TRAIN_PER_LIST` live nodes before a build pays for itself.
+    pub async fn should_build(&self) -> Result<bool> {
+        if self.is_built().await? {
+            return Ok(false);
+        }
+        let wanted = u64::from(self.params().r) * u64::from(TRAIN_PER_LIST);
+        self.live_count_at_least(wanted).await
+    }
+
     /// Prunes every node's layer-0 neighbours by angle, then repairs
     /// connectivity so no node is stranded.
     ///

--- a/crates/db/src/index/vector/engine/ssg/mod.rs
+++ b/crates/db/src/index/vector/engine/ssg/mod.rs
@@ -114,6 +114,14 @@ impl<S: VectorNodeStore> VectorIndexEngine for Ssg<S> {
         self.staging.delete(id).await
     }
 
+    async fn should_build(&self) -> Result<bool> {
+        self.should_build().await
+    }
+
+    async fn build(&mut self) -> Result<()> {
+        self.build().await.map(|_| ())
+    }
+
     async fn search_where<E: Element, A: Admit>(
         &self,
         query: &[E],

--- a/crates/db/src/index/vector/index.rs
+++ b/crates/db/src/index/vector/index.rs
@@ -153,6 +153,21 @@ impl VectorIndex {
         })
     }
 
+    /// Gives the engine one chance to train and build, if it judges enough has
+    /// accumulated. Called after a bulk load lands a whole corpus at once,
+    /// where asking on every write the way [`save`](Self::save) does would
+    /// repeat the same question for every document instead of once at the end.
+    pub async fn build_if_needed<T: Reader + Writer + MaybeSend>(
+        &self,
+        txn: &mut T,
+    ) -> storage::corekv::Result<()> {
+        let mut engine = self.engine(txn).map_err(into_storage)?;
+        if engine.should_build().await.map_err(into_storage)? {
+            engine.build().await.map_err(into_storage)?;
+        }
+        Ok(())
+    }
+
     /// The vector a document contributes, if any.
     ///
     /// `None` means the document is simply not in the index, which is the same
@@ -263,7 +278,14 @@ impl CollectionIndex for VectorIndex {
             Indexable::Wide(v) => engine.insert(id, v).await,
             Indexable::Integral(v) => engine.insert(id, v).await,
         }
-        .map_err(into_storage)
+        .map_err(into_storage)?;
+
+        // Once built, `should_build`'s trained/built check is an O(1) aux
+        // lookup, so this costs one extra read per write and nothing else.
+        if engine.should_build().await.map_err(into_storage)? {
+            engine.build().await.map_err(into_storage)?;
+        }
+        Ok(())
     }
 
     /// Re-inserting under the same id replaces the node's vector and rebuilds

--- a/crates/db/tests/vector/ivfpq_engine.rs
+++ b/crates/db/tests/vector/ivfpq_engine.rs
@@ -5,6 +5,7 @@ use db::index::vector::engine::ann::VectorIndexEngine;
 use db::index::vector::engine::flat::Flat;
 use db::index::vector::engine::ivfpq::IvfPq;
 use db::index::vector::engine::ivfpq::IvfPqParams;
+use db::index::vector::engine::ivfpq::TRAIN_PER_LIST;
 use db::index::vector::store::MemoryNodeStore;
 use db::index::vector::store::NodeId;
 use defra_core::vector::Metric;
@@ -346,4 +347,64 @@ async fn updating_within_one_list_keeps_the_document() {
         1,
         "document 1 must appear exactly once"
     );
+}
+
+#[tokio::test]
+async fn should_build_is_false_on_an_empty_index() {
+    let index = index(8, 8);
+    assert!(!index.should_build().await.unwrap());
+}
+
+#[tokio::test]
+async fn should_build_is_false_once_built() {
+    let mut corpus = crate::support::Corpus::new(SEED ^ 0x777);
+    let vectors = corpus.vectors(400, DIMENSIONS);
+    let mut index = filled(8, 8, &vectors).await;
+    index.build().await.unwrap();
+
+    assert!(!index.should_build().await.unwrap());
+}
+
+/// The regression #1463 closes: crossing the threshold must make
+/// `should_build` answer `true`, or nothing downstream ever trains the index.
+#[tokio::test]
+async fn should_build_becomes_true_once_the_threshold_is_crossed() {
+    let threshold = 4u64 * u64::from(TRAIN_PER_LIST);
+    let mut corpus = crate::support::Corpus::new(SEED ^ 0x888);
+    let vectors = corpus.vectors(threshold as usize, DIMENSIONS);
+    let mut index = index(4, 4);
+
+    for (i, vector) in vectors.iter().take(threshold as usize - 1).enumerate() {
+        index.insert(NodeId(i as u64 + 1), vector).await.unwrap();
+    }
+    assert!(
+        !index.should_build().await.unwrap(),
+        "one short of the threshold"
+    );
+
+    index
+        .insert(NodeId(threshold), &vectors[threshold as usize - 1])
+        .await
+        .unwrap();
+    assert!(index.should_build().await.unwrap(), "at the threshold");
+}
+
+/// `live_count_at_least` must answer exactly what a full count would, at
+/// targets on both sides of the true count.
+#[tokio::test]
+async fn live_count_at_least_agrees_with_live_count() {
+    let mut corpus = crate::support::Corpus::new(SEED ^ 0x999);
+    let vectors = corpus.vectors(150, DIMENSIONS);
+    let index = filled(8, 8, &vectors).await;
+
+    let true_count = index.live_count().await.unwrap();
+    assert_eq!(true_count, 150);
+
+    for target in [0u64, 1, 50, 149, 150, 151, 500] {
+        assert_eq!(
+            index.live_count_at_least(target).await.unwrap(),
+            true_count >= target,
+            "target={target}, true_count={true_count}"
+        );
+    }
 }

--- a/crates/db/tests/vector/main.rs
+++ b/crates/db/tests/vector/main.rs
@@ -22,3 +22,4 @@ mod vector_kv_cost;
 mod vector_kv_store;
 mod vector_recall_baseline;
 mod vector_recall_gate;
+mod vector_train_trigger;

--- a/crates/db/tests/vector/ssg_engine.rs
+++ b/crates/db/tests/vector/ssg_engine.rs
@@ -3,6 +3,7 @@
 use db::index::vector::engine::ann::EngineKind;
 use db::index::vector::engine::ann::VectorIndexEngine;
 use db::index::vector::engine::flat::Flat;
+use db::index::vector::engine::ivfpq::TRAIN_PER_LIST;
 use db::index::vector::engine::ssg::Ssg;
 use db::index::vector::engine::ssg::SsgParams;
 use db::index::vector::params::Params;
@@ -292,4 +293,68 @@ async fn a_document_written_after_the_build_is_searchable() {
         hits.iter().any(|n| n.id == NodeId(9_999)),
         "the late document was not found: {hits:?}"
     );
+}
+
+#[tokio::test]
+async fn should_build_is_false_on_an_empty_index() {
+    let index = index(SsgParams::default());
+    assert!(!index.should_build().await.unwrap());
+}
+
+#[tokio::test]
+async fn should_build_is_false_once_built() {
+    let mut corpus = crate::support::Corpus::new(SEED ^ 0xAA);
+    let vectors = corpus.clustered(300, DIMENSIONS, 8, 0.2);
+    let mut index = filled(SsgParams::default(), &vectors).await;
+    index.build().await.unwrap();
+
+    assert!(!index.should_build().await.unwrap());
+}
+
+/// The regression #1463 closes, mirrored from the IVF-PQ engine: crossing the
+/// threshold must make `should_build` answer `true`.
+#[tokio::test]
+async fn should_build_becomes_true_once_the_threshold_is_crossed() {
+    let params = SsgParams {
+        r: 8,
+        ..SsgParams::default()
+    };
+    let threshold = 8u64 * u64::from(TRAIN_PER_LIST);
+    let mut corpus = crate::support::Corpus::new(SEED ^ 0xBB);
+    let vectors = corpus.clustered(threshold as usize, DIMENSIONS, 8, 0.2);
+    let mut index = index(params);
+
+    for (i, vector) in vectors.iter().take(threshold as usize - 1).enumerate() {
+        index.insert(NodeId(i as u64 + 1), vector).await.unwrap();
+    }
+    assert!(
+        !index.should_build().await.unwrap(),
+        "one short of the threshold"
+    );
+
+    index
+        .insert(NodeId(threshold), &vectors[threshold as usize - 1])
+        .await
+        .unwrap();
+    assert!(index.should_build().await.unwrap(), "at the threshold");
+}
+
+/// `live_count_at_least` must answer exactly what a full count would, at
+/// targets on both sides of the true count.
+#[tokio::test]
+async fn live_count_at_least_agrees_with_live_count() {
+    let mut corpus = crate::support::Corpus::new(SEED ^ 0xCC);
+    let vectors = corpus.clustered(150, DIMENSIONS, 8, 0.2);
+    let index = filled(SsgParams::default(), &vectors).await;
+
+    let true_count = index.live_count().await.unwrap();
+    assert_eq!(true_count, 150);
+
+    for target in [0u64, 1, 50, 149, 150, 151, 500] {
+        assert_eq!(
+            index.live_count_at_least(target).await.unwrap(),
+            true_count >= target,
+            "target={target}, true_count={true_count}"
+        );
+    }
 }

--- a/crates/db/tests/vector/vector_train_trigger.rs
+++ b/crates/db/tests/vector/vector_train_trigger.rs
@@ -1,0 +1,317 @@
+//! #1463: a schema selecting a trainable algorithm must actually train once
+//! the corpus warrants it, through the production write paths, not only when
+//! a test calls `build()` directly.
+
+use db::database::DB;
+use db::index::manager::IndexManager;
+use db::index::manager::SliceSource;
+use db::index::vector::engine::ivfpq::IvfPq;
+use db::index::vector::engine::ivfpq::IvfPqParams;
+use db::index::vector::engine::ivfpq::TRAIN_PER_LIST;
+use db::index::vector::index::VectorIndex;
+use db::index::vector::kv_store::KvNodeStore;
+use db::index::vector::store::NodeId;
+use defra_core::thread_bounds::MaybeSend;
+use defra_core::vector::Metric;
+use document::Document;
+use document::NormalValue;
+use schema::CollectionVersion;
+use schema::DistanceMetric;
+use schema::FieldDescription;
+use schema::FieldKind;
+use schema::IndexDescription;
+use schema::IndexKind;
+use schema::IndexedFieldDescription;
+use schema::VectorAlgorithm;
+use schema::VectorIndexDescription;
+use storage::corekv::Reader;
+use storage::corekv::Store;
+use storage::corekv::Txn;
+use storage::corekv::Writer;
+use storage::index::CollectionIndex;
+use storage::RegolithStore;
+
+const COLLECTION: u32 = 71;
+const INDEX_ID: u32 = 5;
+const DIMENSIONS: u32 = 16;
+const NLIST: u32 = 8;
+const SEED: u64 = 0x1463_1463;
+
+fn ivfpq_vector_description() -> VectorIndexDescription {
+    VectorIndexDescription {
+        algorithm: VectorAlgorithm::IvfPq,
+        metric: DistanceMetric::Cosine,
+        dimensions: DIMENSIONS,
+        hnsw: None,
+        ivfpq: Some(schema::IvfPqParams {
+            nlist: NLIST,
+            nprobe: NLIST,
+            m: 4,
+            ..schema::IvfPqParams::default()
+        }),
+        ssg: None,
+    }
+}
+
+fn hnsw_vector_description() -> VectorIndexDescription {
+    VectorIndexDescription {
+        algorithm: VectorAlgorithm::Hnsw,
+        metric: DistanceMetric::Cosine,
+        dimensions: DIMENSIONS,
+        hnsw: Some(schema::HnswParams::default()),
+        ivfpq: None,
+        ssg: None,
+    }
+}
+
+fn description(id: u32, vector: VectorIndexDescription) -> IndexDescription {
+    IndexDescription {
+        name: "by_embedding".to_string(),
+        id,
+        fields: vec![IndexedFieldDescription {
+            name: "embedding".to_string(),
+            descending: false,
+        }],
+        unique: false,
+        kind: None,
+        auto_generated: false,
+    }
+    .as_vector(vector)
+}
+
+fn schema() -> CollectionVersion {
+    CollectionVersion::new(
+        "docs",
+        "v1",
+        "col-docs",
+        vec![
+            FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+            FieldDescription::new("2", "embedding", FieldKind::float64_array()),
+        ],
+    )
+}
+
+async fn txn(store: &RegolithStore) -> Box<dyn Txn> {
+    store.new_txn(false).await.unwrap()
+}
+
+fn wide(vector: &[f32]) -> Vec<NormalValue> {
+    vec![NormalValue::Float64Array(
+        vector.iter().map(|x| *x as f64).collect(),
+    )]
+}
+
+fn document(vector: &[f32]) -> Document {
+    let mut doc = Document::new();
+    doc.set(
+        "embedding",
+        NormalValue::Float64Array(vector.iter().map(|x| *x as f64).collect()),
+    );
+    doc
+}
+
+/// Reads trained state directly off whatever transaction wrote it: a raw
+/// store transaction for the direct-save path, a `NamespaceView` for the
+/// manager path. `is_trained` needs none of `IvfPq`'s own configuration, only
+/// the store location, so any valid params construct a throwaway reader.
+async fn is_trained<T: Reader + Writer + MaybeSend>(txn: &mut T, index_id: u32) -> bool {
+    let kv = KvNodeStore::new(txn, COLLECTION, index_id, 0);
+    let engine = IvfPq::try_new(kv, Metric::Cosine, IvfPqParams::default(), 0).unwrap();
+    engine.is_trained().await.unwrap()
+}
+
+/// How many of `sample` find themselves in their own top 5, through a fresh
+/// read transaction.
+async fn self_match_count(
+    store: &RegolithStore,
+    index: &VectorIndex,
+    vectors: &[Vec<f32>],
+    sample: &[usize],
+) -> usize {
+    let mut read = txn(store).await;
+    let mut found = 0usize;
+    for &i in sample {
+        let hits = index
+            .search(&mut read, vectors[i].as_slice(), 5, None)
+            .await
+            .unwrap();
+        if hits.iter().any(|h| h.id == NodeId(i as u64 + 1)) {
+            found += 1;
+        }
+    }
+    found
+}
+
+/// The regression #1463 closes: an IVF-PQ description must end up trained
+/// through ordinary document writes, with nothing in this test calling
+/// `build()`. Searches stay correct on both sides of the threshold, so
+/// crossing it is not observable as a wrong answer.
+#[tokio::test]
+async fn training_triggers_through_vector_index_save() {
+    let threshold = u64::from(NLIST) * u64::from(TRAIN_PER_LIST);
+    let below = threshold as usize - 12;
+    let corpus_size = threshold as usize + 88;
+
+    let store = RegolithStore::in_memory().unwrap();
+    let index = VectorIndex::try_new(
+        COLLECTION,
+        description(INDEX_ID, ivfpq_vector_description()),
+    )
+    .unwrap();
+
+    let mut corpus = crate::support::Corpus::new(SEED ^ 0x01);
+    let vectors = corpus.clustered(corpus_size, DIMENSIONS as usize, 8, 0.1);
+
+    let mut write = txn(&store).await;
+    for (i, vector) in vectors[..below].iter().enumerate() {
+        index
+            .save(&mut write, i as u64 + 1, &wide(vector))
+            .await
+            .unwrap();
+    }
+    write.commit().await.unwrap();
+
+    let mut read = txn(&store).await;
+    assert!(
+        !is_trained(&mut read, INDEX_ID).await,
+        "must not train before the threshold"
+    );
+    let hits = index
+        .search(&mut read, vectors[3].as_slice(), 1, None)
+        .await
+        .unwrap();
+    assert_eq!(
+        hits[0].id,
+        NodeId(4),
+        "an untrained index is an exact scan, so a vector must find itself first"
+    );
+
+    let mut write = txn(&store).await;
+    for (i, vector) in vectors[below..].iter().enumerate() {
+        index
+            .save(&mut write, (below + i) as u64 + 1, &wide(vector))
+            .await
+            .unwrap();
+    }
+    write.commit().await.unwrap();
+
+    let mut read = txn(&store).await;
+    assert!(
+        is_trained(&mut read, INDEX_ID).await,
+        "#1463: no test call to build() here, so the write path must trigger it"
+    );
+
+    let sample = [0usize, 100, 250, 350, corpus_size - 1];
+    let found = self_match_count(&store, &index, &vectors, &sample).await;
+    assert!(
+        found >= 4,
+        "a trained index must still find most vectors' own documents: {found}/{}",
+        sample.len()
+    );
+}
+
+/// The same regression, through the index manager's bulk backfill path.
+#[tokio::test]
+async fn training_triggers_through_bulk_index_from() {
+    let threshold = u64::from(NLIST) * u64::from(TRAIN_PER_LIST);
+    let corpus_size = threshold as usize + 88;
+
+    let mut corpus = crate::support::Corpus::new(SEED ^ 0x02);
+    let vectors = corpus.clustered(corpus_size, DIMENSIONS as usize, 8, 0.1);
+    let documents: Vec<(u64, Document)> = vectors
+        .iter()
+        .enumerate()
+        .map(|(i, v)| (i as u64 + 1, document(v)))
+        .collect();
+
+    let store = RegolithStore::in_memory().unwrap();
+    let db = DB::new(store.clone()).unwrap();
+    let txn = db.new_txn(false).await.unwrap();
+    let datastore = txn.datastore().unwrap();
+
+    let mut manager = IndexManager::new(COLLECTION);
+    let desc = manager
+        .create_index_of_kind(
+            &datastore,
+            "docs",
+            "by_embedding".to_string(),
+            vec![IndexedFieldDescription {
+                name: "embedding".to_string(),
+                descending: false,
+            }],
+            IndexKind::Vector(ivfpq_vector_description()),
+            &schema().fields,
+        )
+        .await
+        .unwrap();
+
+    let mut source = SliceSource::new(&documents);
+    let result = manager
+        .bulk_index_from(&datastore, "by_embedding", &mut source, &schema())
+        .await
+        .unwrap();
+    assert_eq!(result.indexed, documents.len());
+
+    // A commit refuses while any `NamespaceView` still references the shared
+    // transaction, so this must go before it.
+    drop(datastore);
+    txn.commit().await.unwrap();
+
+    let read_txn = db.new_txn(false).await.unwrap();
+    let mut read_datastore = read_txn.datastore().unwrap();
+    assert!(
+        is_trained(&mut read_datastore, desc.id).await,
+        "#1463: no test call to build() here, so bulk_index_from must trigger it"
+    );
+}
+
+/// HNSW has nothing to train, so it must never observably "build", and must
+/// keep answering correctly across the same corpus size that trains IVF-PQ.
+#[tokio::test]
+async fn hnsw_never_builds_and_keeps_answering() {
+    let threshold = u64::from(NLIST) * u64::from(TRAIN_PER_LIST);
+    let below = threshold as usize - 12;
+    let corpus_size = threshold as usize + 88;
+
+    let store = RegolithStore::in_memory().unwrap();
+    let index =
+        VectorIndex::try_new(COLLECTION, description(INDEX_ID, hnsw_vector_description())).unwrap();
+
+    let mut corpus = crate::support::Corpus::new(SEED ^ 0x03);
+    let vectors = corpus.clustered(corpus_size, DIMENSIONS as usize, 8, 0.1);
+
+    let mut write = txn(&store).await;
+    for (i, vector) in vectors[..below].iter().enumerate() {
+        index
+            .save(&mut write, i as u64 + 1, &wide(vector))
+            .await
+            .unwrap();
+    }
+    write.commit().await.unwrap();
+
+    let early_sample = [0usize, 50, below - 1];
+    let found = self_match_count(&store, &index, &vectors, &early_sample).await;
+    assert_eq!(
+        found,
+        early_sample.len(),
+        "HNSW recall dropped below the IVF-PQ threshold size: {found}/{}",
+        early_sample.len()
+    );
+
+    let mut write = txn(&store).await;
+    for (i, vector) in vectors[below..].iter().enumerate() {
+        index
+            .save(&mut write, (below + i) as u64 + 1, &wide(vector))
+            .await
+            .unwrap();
+    }
+    write.commit().await.unwrap();
+
+    let late_sample = [0usize, 100, 250, 350, corpus_size - 1];
+    let found = self_match_count(&store, &index, &vectors, &late_sample).await;
+    assert!(
+        found >= 4,
+        "HNSW recall dropped past the IVF-PQ threshold size: {found}/{}",
+        late_sample.len()
+    );
+}


### PR DESCRIPTION
Closes #1463. Part of #1517. Stacked on #1669.

`IvfPq::should_build()`/`build()` and `Ssg::build()` had no caller outside tests and benches. A repo-wide grep for `should_build` returned its own definition and nothing else.

So a schema selecting `IVF_PQ` or `SSG` got an index that stayed permanently in its exact-scan staging mode: `insert` delegated to the staging `Flat`, nothing ever asked the engine to train, and every query did a linear scan rather than the coarse-list probe or pruned graph that was requested. The selected algorithm was silently not the algorithm that ran. The engines could train; nothing in production asked them to.

## The lifecycle belongs on the trait

`VectorIndexEngine` gains `should_build` and `build`, both defaulted to "nothing to do". That is why `Hnsw` and `Flat` implement neither: a kind with nothing to train is never asked, and adding a kind does not mean remembering to answer. `IvfPq` and `Ssg` implement them by delegating to their inherent versions.

`Ssg` had `is_built()` but no `should_build()`, so it gains one. Its params (`r`, `angle`, `pool`) do not scale with corpus size the way `nlist` does, so there is no threshold implied by them directly; it borrows IVF-PQ's rule with `r` in `nlist`'s place, both being the structural fan-out a build commits to. That choice is written down in the doc comment rather than left to be inferred.

## The check had to stop being a scan

`should_build` called `live_count()`, which iterates everything stored. Asked on every write, that is quadratic over the ramp to the threshold.

It does not need the count, only whether the count has reached the threshold, and that threshold is a constant in both configurations. With an explicit `nlist`, `resolved_nlist` is constant. With `nlist == 0` it derives `4 * sqrt(corpus)`, and `live >= 4 * sqrt(live) * TRAIN_PER_LIST` reduces to `live >= 16 * TRAIN_PER_LIST^2`, also constant. `IvfPqParams::train_threshold(corpus)` is therefore replaced by a corpus-free `resolved_train_threshold()`; the old one took `corpus` only to resolve a derived `nlist`, which is exactly the value this no longer computes, and it had no other caller.

`live_count_at_least(wanted)` counts and stops as soon as the target is reached, using the visitor's existing early-exit contract. `live_count()` is untouched and still backs `build()`.

## Measured, not asserted

An instrumented store counting visits, run as a scratch test:

| state | live | threshold | result | visits |
|---|---|---|---|---|
| untrained | 100 | 156 | false | 100 |
| untrained | 200 | 156 | true | 156 |
| trained | 200 | 156 | false | 0 |

A trained index costs one aux lookup and nothing else, which is what makes the per-write check affordable. An untrained one stops at the threshold rather than reading the corpus: 156 visits against 200 live entries is the early exit working, not a full scan with a counter on top.

## Where it is called

`VectorIndex::save`, after the insert succeeds, so an index trains as soon as ordinary writes carry it past the threshold. And `IndexManager::bulk_index_from` once after the drain loop, which is the backfill and reindex path where a whole corpus arrives at once and the per-write question would otherwise be asked thousands of times.

`IndexType::build_if_needed` is the narrowest route the manager needed: it matches the vector variant and is a no-op for every other kind, so `CollectionIndex` does not grow a vector-specific method. A build failure propagates like any other error from those paths rather than being swallowed.

## Verification

```
cargo test -p db                                   169 vector tests, 0 failed; every binary ok
cargo clippy --all --all-targets -- -D warnings    clean
cargo fmt --all --check                            clean
```

`crates/db/tests/vector/vector_train_trigger.rs` is the regression test: it inserts past the threshold through the real `CollectionIndex::save` path and through `bulk_index_from`, and asserts the index reports itself trained afterwards without the test ever calling `build()`. An `HNSW` description writes the same corpus, never builds, and answers throughout. Searches before and after the automatic build both return correct results, so crossing the threshold is not observable as a wrong answer.

The tests were checked against the defect: reverting just the two call sites, keeping the rest of the change, fails both training tests and leaves the HNSW one passing.

`ivfpq_engine.rs` and `ssg_engine.rs` each gain `should_build` coverage (empty, built, threshold crossed) and a check that `live_count_at_least` agrees with `live_count` at seven targets either side of the true count.
