### PR TITLE
feat(db): add the IVF_FLAT engine on a shared IVF coarse quantizer

### DIFF
--- a/benches/benches/common/vector.rs
+++ b/benches/benches/common/vector.rs
@@ -5,6 +5,7 @@
 use db::index::vector::engine::ann::VectorIndexEngine;
 use db::index::vector::engine::flat::Flat;
 use db::index::vector::engine::hnsw::Hnsw;
+use db::index::vector::engine::ivfflat::{IvfFlat, IvfFlatParams};
 use db::index::vector::engine::ivfpq::{IvfPq, IvfPqParams};
 use db::index::vector::engine::ssg::{Ssg, SsgParams};
 use db::index::vector::params::{Params, DEFAULT_M};
@@ -78,6 +79,7 @@ pub enum Kind {
     Flat,
     Hnsw,
     IvfPq,
+    IvfFlat,
     Ssg,
 }
 
@@ -87,6 +89,7 @@ impl Kind {
             Kind::Flat => "flat",
             Kind::Hnsw => "hnsw",
             Kind::IvfPq => "ivfpq",
+            Kind::IvfFlat => "ivfflat",
             Kind::Ssg => "ssg",
         }
     }
@@ -94,17 +97,24 @@ impl Kind {
     /// The kinds that build a structure after the fact, and therefore have a
     /// second state to measure.
     pub fn is_batch_built(self) -> bool {
-        matches!(self, Kind::IvfPq | Kind::Ssg)
+        matches!(self, Kind::IvfPq | Kind::IvfFlat | Kind::Ssg)
     }
 }
 
-pub const ALL_KINDS: [Kind; 4] = [Kind::Flat, Kind::Hnsw, Kind::IvfPq, Kind::Ssg];
+pub const ALL_KINDS: [Kind; 5] = [
+    Kind::Flat,
+    Kind::Hnsw,
+    Kind::IvfPq,
+    Kind::IvfFlat,
+    Kind::Ssg,
+];
 
 #[derive(Clone)]
 pub enum Index {
     Flat(Flat<MemoryNodeStore>),
     Hnsw(Hnsw<MemoryNodeStore>),
     IvfPq(IvfPq<MemoryNodeStore>),
+    IvfFlat(IvfFlat<MemoryNodeStore>),
     Ssg(Ssg<MemoryNodeStore>),
 }
 
@@ -114,6 +124,7 @@ macro_rules! on_index {
             Index::Flat($index) => $call,
             Index::Hnsw($index) => $call,
             Index::IvfPq($index) => $call,
+            Index::IvfFlat($index) => $call,
             Index::Ssg($index) => $call,
         }
     };
@@ -142,6 +153,10 @@ impl Index {
                     SEED,
                 )
                 .expect("cosine is rankable by squared distance"),
+            ),
+            Kind::IvfFlat => Index::IvfFlat(
+                IvfFlat::try_new(store, metric, IvfFlatParams::default(), SEED)
+                    .expect("cosine or euclidean partitions soundly"),
             ),
             Kind::Ssg => Index::Ssg(
                 Ssg::try_new(
@@ -184,6 +199,9 @@ impl Index {
         match self {
             Index::IvfPq(index) => {
                 index.build().await.expect("ivf-pq build");
+            }
+            Index::IvfFlat(index) => {
+                index.build().await.expect("ivf_flat build");
             }
             Index::Ssg(index) => {
                 index.build().await.expect("ssg build");

--- a/crates/cli/tests/index_vector_args.rs
+++ b/crates/cli/tests/index_vector_args.rs
@@ -8,7 +8,7 @@
 
 use clap::Parser;
 use cli::commands::client::index::IndexNewArgs;
-use schema::{DistanceMetric, HnswParams, IvfPqParams, VectorAlgorithm};
+use schema::{DistanceMetric, HnswParams, IvfFlatParams, IvfPqParams, VectorAlgorithm};
 
 #[derive(Parser, Debug)]
 struct Wrapper {
@@ -101,6 +101,22 @@ fn a_divergent_algorithm_carries_its_own_params() {
     assert_eq!((ivfpq.nlist, ivfpq.m), (256, 16));
     assert_eq!(
         ivfpq.nprobe, defaults.nprobe,
+        "an omitted param keeps its default"
+    );
+}
+
+/// IVF_FLAT is a second divergent algorithm, and its block has no `M`: a list
+/// holds the full vector, so there is nothing to quantize.
+#[test]
+fn ivfflat_carries_its_own_params() {
+    let config =
+        vector(r#"{"Algorithm":"IVF_FLAT","Dimensions":768,"IVFFLAT":{"NList":128,"NProbe":16}}"#);
+    assert_eq!(config.algorithm, VectorAlgorithm::IvfFlat);
+    let ivfflat = config.ivfflat.expect("IVF_FLAT params");
+    let defaults = IvfFlatParams::default();
+    assert_eq!((ivfflat.nlist, ivfflat.nprobe), (128, 16));
+    assert_eq!(
+        ivfflat.sample_bytes, defaults.sample_bytes,
         "an omitted param keeps its default"
     );
 }

--- a/crates/db/src/index/vector/engine/ann/engine_kind.rs
+++ b/crates/db/src/index/vector/engine/ann/engine_kind.rs
@@ -14,6 +14,9 @@ pub enum EngineKind {
     Flat,
     /// Coarse lists of product-quantized codes.
     IvfPq,
+    /// Coarse lists of full-precision vectors: the same partitioning as
+    /// `IvfPq`, with nothing compressed.
+    IvfFlat,
     /// Satellite System Graph: one flat, angle-pruned layer.
     Ssg,
 }
@@ -24,6 +27,7 @@ impl EngineKind {
             EngineKind::Hnsw => "HNSW",
             EngineKind::Flat => "FLAT",
             EngineKind::IvfPq => "IVF_PQ",
+            EngineKind::IvfFlat => "IVF_FLAT",
             EngineKind::Ssg => "SSG",
         }
     }

--- a/crates/db/src/index/vector/engine/dispatch.rs
+++ b/crates/db/src/index/vector/engine/dispatch.rs
@@ -7,6 +7,7 @@
 use super::ann::{Admit, EngineKind, Neighbor, VectorIndexEngine};
 use super::flat::Flat;
 use super::hnsw::Hnsw;
+use super::ivfflat::IvfFlat;
 use super::ivfpq::IvfPq;
 use super::ssg::Ssg;
 use crate::index::error::Result;
@@ -18,6 +19,7 @@ pub enum Engine<S> {
     Hnsw(Hnsw<S>),
     Flat(Flat<S>),
     IvfPq(IvfPq<S>),
+    IvfFlat(IvfFlat<S>),
     Ssg(Ssg<S>),
 }
 
@@ -27,6 +29,7 @@ macro_rules! dispatch {
             Engine::Hnsw($engine) => $call,
             Engine::Flat($engine) => $call,
             Engine::IvfPq($engine) => $call,
+            Engine::IvfFlat($engine) => $call,
             Engine::Ssg($engine) => $call,
         }
     };
@@ -52,10 +55,10 @@ impl<S: VectorNodeStore> VectorIndexEngine for Engine<S> {
     }
 
     async fn build(&mut self) -> Result<()> {
-        // Method resolution prefers IvfPq's and Ssg's own inherent `build`,
-        // which return their kind's report, over this trait method; `map`
-        // discards it uniformly across every arm rather than the macro having
-        // to special-case the two kinds that build something.
+        // Method resolution prefers IvfPq's, IvfFlat's and Ssg's own inherent
+        // `build`, which return their kind's report, over this trait method;
+        // `map` discards it uniformly across every arm rather than the macro
+        // having to special-case the kinds that build something.
         dispatch!(self, e => e.build().await.map(|_| ()))
     }
 

--- a/crates/db/src/index/vector/engine/ivf/codec.rs
+++ b/crates/db/src/index/vector/engine/ivf/codec.rs
@@ -1,0 +1,141 @@
+//! Encoding shared by every coarse-quantized engine: centroids, inverted-list
+//! keys, and the marker that a coarse build has completed.
+
+use crate::index::error::{Error, Result};
+use crate::index::vector::engine::ann::Centroids;
+use crate::index::vector::store::{NodeId, VectorNodeStore};
+
+pub const CENTROID: u8 = b'c';
+pub const LIST: u8 = b'l';
+pub const STATE: u8 = b's';
+
+const STATE_VERSION: u8 = 1;
+
+pub fn encode_vector(values: &[f32]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(values.len() * 4);
+    for value in values {
+        out.extend_from_slice(&value.to_le_bytes());
+    }
+    out
+}
+
+pub fn decode_vector(bytes: &[u8]) -> Result<Vec<f32>> {
+    if !bytes.len().is_multiple_of(4) {
+        return Err(Error::Other(
+            "vector index: a stored vector is ragged".into(),
+        ));
+    }
+    Ok(bytes
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .map(|&c| f32::from_le_bytes(c))
+        .collect())
+}
+
+pub fn encode_centroids(centroids: &Centroids) -> Vec<u8> {
+    let mut out = Vec::with_capacity(8 + centroids.values.len() * 4);
+    out.extend_from_slice(&(centroids.k as u32).to_le_bytes());
+    out.extend_from_slice(&(centroids.dimensions as u32).to_le_bytes());
+    out.extend_from_slice(&encode_vector(&centroids.values));
+    out
+}
+
+pub fn decode_centroids(bytes: &[u8]) -> Result<Centroids> {
+    if bytes.len() < 8 {
+        return Err(Error::Other("vector index: a codebook is truncated".into()));
+    }
+    let k = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as usize;
+    let dimensions = u32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]) as usize;
+    let values = decode_vector(&bytes[8..])?;
+    if k * dimensions != values.len() {
+        return Err(Error::Other(
+            "vector index: a codebook's shape disagrees with its payload".into(),
+        ));
+    }
+    Ok(Centroids {
+        k,
+        dimensions,
+        values,
+    })
+}
+
+/// `listID || nodeID`, both big-endian so a prefix scan of a list is contiguous
+/// and ordered.
+pub fn list_key(list: u32, node: NodeId) -> Vec<u8> {
+    let mut key = Vec::with_capacity(12);
+    key.extend_from_slice(&list.to_be_bytes());
+    key.extend_from_slice(&node.0.to_be_bytes());
+    key
+}
+
+pub fn list_prefix(list: u32) -> Vec<u8> {
+    list.to_be_bytes().to_vec()
+}
+
+pub fn node_from_list_key(key: &[u8]) -> Result<NodeId> {
+    if key.len() < 12 {
+        return Err(Error::Other("vector index: a list key is truncated".into()));
+    }
+    let mut id = [0u8; 8];
+    id.copy_from_slice(&key[4..12]);
+    Ok(NodeId(u64::from_be_bytes(id)))
+}
+
+/// What a coarse build needs before it reads anything else: the number of
+/// centroids and the vector width.
+///
+/// IVF-PQ's own trained state additionally carries `m`, the subquantizer
+/// count, so it keeps a wider struct and its own codec in `ivfpq::codec`
+/// rather than growing this one with a field that means nothing to IVF_FLAT;
+/// changing this shape would also change IVF-PQ's on-disk encoding and stop an
+/// index trained before this split from decoding. IVF_FLAT has nothing beyond
+/// `nlist` and `dimensions`, so it uses this state directly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TrainedState {
+    pub nlist: u32,
+    pub dimensions: u32,
+}
+
+pub fn encode_state(state: &TrainedState) -> Vec<u8> {
+    let mut out = Vec::with_capacity(9);
+    out.push(STATE_VERSION);
+    out.extend_from_slice(&state.nlist.to_le_bytes());
+    out.extend_from_slice(&state.dimensions.to_le_bytes());
+    out
+}
+
+pub fn decode_state(bytes: &[u8]) -> Result<TrainedState> {
+    if bytes.len() != 9 || bytes[0] != STATE_VERSION {
+        return Err(Error::Other(
+            "vector index: unsupported trained-state encoding".into(),
+        ));
+    }
+    let read =
+        |at: usize| u32::from_le_bytes([bytes[at], bytes[at + 1], bytes[at + 2], bytes[at + 3]]);
+    Ok(TrainedState {
+        nlist: read(1),
+        dimensions: read(5),
+    })
+}
+
+/// Loads every centroid a build wrote, in order, from `state`.
+pub async fn load_centroids<S: VectorNodeStore>(
+    store: &S,
+    nlist: u32,
+    dimensions: u32,
+) -> Result<Centroids> {
+    let mut values = Vec::with_capacity(nlist as usize * dimensions as usize);
+    for index in 0..nlist {
+        let bytes = store
+            .get_aux(CENTROID, &index.to_be_bytes())
+            .await?
+            .ok_or_else(|| Error::Other(format!("vector index: centroid {index} is missing")))?;
+        values.extend_from_slice(&decode_vector(&bytes)?);
+    }
+    Ok(Centroids {
+        k: nlist as usize,
+        dimensions: dimensions as usize,
+        values,
+    })
+}

--- a/crates/db/src/index/vector/engine/ivf/mod.rs
+++ b/crates/db/src/index/vector/engine/ivf/mod.rs
@@ -1,0 +1,21 @@
+//! The coarse quantizer IVF-PQ and IVF_FLAT both partition through: centroid
+//! training over a byte-bounded sample, the inverted-list key layout, and
+//! ranking centroids for probing. Neither is PQ-specific, so a fix here
+//! covers both engines instead of two copies that can drift apart.
+//!
+//! What stays out: the residual pass and codebook training are IVF-PQ's own
+//! (`ivfpq::build`), and the trained-state marker is per-engine, because
+//! IVF-PQ's carries `m` and IVF_FLAT's does not (see [`TrainedState`]).
+
+mod codec;
+mod probe;
+mod train;
+
+pub use codec::{
+    decode_centroids, decode_state, decode_vector, encode_centroids, encode_state, encode_vector,
+    list_key, list_prefix, load_centroids, node_from_list_key, TrainedState, CENTROID, LIST, STATE,
+};
+pub use probe::probe_lists;
+pub use train::{
+    fit_centroids, resolved_nlist, resolved_train_threshold, MAX_NLIST, TRAIN_PER_LIST,
+};

--- a/crates/db/src/index/vector/engine/ivf/probe.rs
+++ b/crates/db/src/index/vector/engine/ivf/probe.rs
@@ -1,0 +1,39 @@
+//! Ranking centroids for probing: which lists a query actually scans.
+
+use crate::index::vector::engine::ann::Centroids;
+use defra_core::vector::Metric;
+
+/// The lists a query probes, nearest centroid first.
+///
+/// Always ranked by squared Euclidean distance over the centroids, whatever
+/// the engine's configured metric: the coarse step is a partitioning
+/// heuristic, not the ranking itself, and centroids are trained over vectors
+/// already prepared the way that metric requires (normalized, under cosine).
+///
+/// `effort` overrides the configured `nprobe` the way `ef_search` does for a
+/// graph; `None` takes the configured value. Either way the result holds at
+/// least one list and never more than exist.
+pub fn probe_lists(
+    query: &[f32],
+    centroids: &Centroids,
+    configured_nprobe: usize,
+    effort: Option<usize>,
+) -> Vec<usize> {
+    let nprobe = effort
+        .map(|e| e.max(1))
+        .unwrap_or(configured_nprobe)
+        .min(centroids.k)
+        .max(1);
+
+    let mut lists: Vec<(usize, f64)> = (0..centroids.k)
+        .map(|index| {
+            (
+                index,
+                Metric::Euclidean.distance(query, centroids.get(index)),
+            )
+        })
+        .collect();
+    lists.sort_by(|a, b| a.1.total_cmp(&b.1));
+    lists.truncate(nprobe);
+    lists.into_iter().map(|(index, _)| index).collect()
+}

--- a/crates/db/src/index/vector/engine/ivf/train.rs
+++ b/crates/db/src/index/vector/engine/ivf/train.rs
@@ -1,0 +1,56 @@
+//! Centroid training and the corpus-derived parameters both IVF engines
+//! resolve the same way.
+
+use crate::index::error::{Error, Result};
+use crate::index::vector::engine::ann::{Centroids, Clusterer};
+use crate::index::vector::quantize::KMeans;
+
+/// FAISS's stated minimum for a usable k-means fit. Below `TRAIN_PER_LIST *
+/// nlist` vectors an index stays exact rather than training on too little.
+pub const TRAIN_PER_LIST: u32 = 39;
+
+pub const MAX_NLIST: u32 = 65_536;
+
+/// `4*sqrt(n)` is the usual starting point: lists stay large enough to train
+/// and small enough that probing a few is much cheaper than a scan.
+pub fn resolved_nlist(explicit: u32, corpus: u64) -> u32 {
+    if explicit > 0 {
+        return explicit.min(MAX_NLIST);
+    }
+    let derived = 4.0 * (corpus as f64).sqrt();
+    (derived as u32).clamp(1, MAX_NLIST)
+}
+
+/// Vectors needed before training fires, with no dependency on the count
+/// being asked about.
+///
+/// An explicit `nlist` already makes [`resolved_nlist`] a constant, so the
+/// threshold is just `nlist * TRAIN_PER_LIST`. A derived `nlist`
+/// (`explicit_nlist == 0`) makes it `4*sqrt(corpus)*TRAIN_PER_LIST`, so the
+/// point it crosses solves `corpus == 4*sqrt(corpus)*TRAIN_PER_LIST`, whose
+/// positive root is the fixed `16*TRAIN_PER_LIST^2`, independent of corpus.
+pub fn resolved_train_threshold(explicit_nlist: u32) -> u64 {
+    if explicit_nlist > 0 {
+        u64::from(explicit_nlist.min(MAX_NLIST)) * u64::from(TRAIN_PER_LIST)
+    } else {
+        16 * u64::from(TRAIN_PER_LIST) * u64::from(TRAIN_PER_LIST)
+    }
+}
+
+/// Fits `nlist` centroids over `sample`, a flat `n * dimensions` buffer,
+/// failing rather than handing back a coarse quantizer with nothing in it.
+pub fn fit_centroids(
+    sample: &[f32],
+    dimensions: usize,
+    nlist: usize,
+    seed: u64,
+) -> Result<Centroids> {
+    let clusterer = KMeans::new(seed);
+    let (coarse, _) = clusterer.fit(sample, dimensions, nlist);
+    if coarse.k == 0 {
+        return Err(Error::Other(
+            "vector index: the training sample produced no centroids".into(),
+        ));
+    }
+    Ok(coarse)
+}

--- a/crates/db/src/index/vector/engine/ivfflat/build.rs
+++ b/crates/db/src/index/vector/engine/ivfflat/build.rs
@@ -1,11 +1,10 @@
 //! Training and the build that follows it.
 
-use super::codec::{self, TrainedState};
-use super::IvfPq;
+use super::IvfFlat;
 use crate::index::error::{Error, Result};
-use crate::index::vector::engine::ann::{Centroids, Quantizer, Sampler};
-use crate::index::vector::engine::ivf;
-use crate::index::vector::quantize::{KMeans, ProductQuantizer, Reservoir};
+use crate::index::vector::engine::ann::Sampler;
+use crate::index::vector::engine::ivf::{self, TrainedState};
+use crate::index::vector::quantize::Reservoir;
 use crate::index::vector::store::{NodeId, VectorNodeStore};
 
 /// What a build did, so a caller can report it rather than guess.
@@ -17,7 +16,7 @@ pub struct BuildReport {
     pub state: TrainedState,
 }
 
-impl<S: VectorNodeStore> IvfPq<S> {
+impl<S: VectorNodeStore> IvfFlat<S> {
     /// Vectors held, tombstones excluded.
     pub async fn live_count(&self) -> Result<u64> {
         let mut count = 0u64;
@@ -32,12 +31,9 @@ impl<S: VectorNodeStore> IvfPq<S> {
 
     /// Whether at least `wanted` live vectors are stored, counting no further.
     ///
-    /// The count is bounded by what the question needs rather than by the
-    /// corpus, so asking it on every write costs a constant rather than a scan.
-    /// `iterate_nodes` stops as soon as the visitor returns an error, so the
-    /// visitor becomes that stop signal itself once `wanted` is reached; `count`
-    /// having reached `wanted` is what distinguishes the signal from a real
-    /// failure the store raised on its own.
+    /// See [`IvfPq::live_count_at_least`](super::super::ivfpq::IvfPq::live_count_at_least)
+    /// for why returning an error from the visitor is what stops the walk
+    /// early.
     pub async fn live_count_at_least(&self, wanted: u64) -> Result<bool> {
         if wanted == 0 {
             return Ok(true);
@@ -72,23 +68,28 @@ impl<S: VectorNodeStore> IvfPq<S> {
             .await
     }
 
-    /// Trains from a byte-bounded sample and writes centroids, codebooks and
-    /// inverted lists.
+    /// Trains from a byte-bounded sample and writes centroids and inverted
+    /// lists. Cheaper to build than IVF-PQ: one k-means fit, no residual
+    /// pass, no codebook training, no quantizer round trip.
     ///
-    /// Two streaming passes over the nodes and nothing else resident: the
-    /// sample, the centroids and the codebooks, each bounded by configuration
-    /// rather than by the corpus.
+    /// Only the list assignment travels between the read pass that computes
+    /// it and the write pass that stores it, never the vector: at
+    /// `dimensions` in the hundreds that is the difference between a few
+    /// bytes per document and a second corpus resident in memory. The vector
+    /// itself is re-read from the node it is already durable in, the same
+    /// read `insert` does on an update; reading and writing the store cannot
+    /// interleave in one pass in any case, since a write needs `&mut` access
+    /// the read's borrow is still holding.
     pub async fn build(&mut self) -> Result<BuildReport> {
         let live = self.live_count().await?;
         if live == 0 {
             return Err(Error::Other(
-                "vector index: nothing to train an IVF-PQ build on".into(),
+                "vector index: nothing to train an IVF_FLAT build on".into(),
             ));
         }
 
         let dimensions = self.first_width().await?;
         let nlist = self.params().resolved_nlist(live);
-        let m = self.params().resolved_m(dimensions);
 
         let mut reservoir =
             Reservoir::new(dimensions, self.params().sample_bytes as usize, self.seed());
@@ -103,53 +104,46 @@ impl<S: VectorNodeStore> IvfPq<S> {
         let sample_bytes = reservoir.resident_bytes();
         let coarse =
             ivf::fit_centroids(reservoir.as_flat(), dimensions, nlist as usize, self.seed())?;
-
-        let residuals = residuals_of(reservoir.as_flat(), dimensions, &coarse);
-        let clusterer = KMeans::new(self.seed());
-        let quantizer = ProductQuantizer::train(&clusterer, &residuals, dimensions, m)?;
-        drop(residuals);
+        drop(reservoir);
 
         for index in 0..coarse.k {
-            let bytes = codec::encode_vector(coarse.get(index));
+            let bytes = ivf::encode_vector(coarse.get(index));
             self.store_mut()
-                .put_aux(codec::CENTROID, &(index as u32).to_be_bytes(), &bytes)
-                .await?;
-        }
-        for (sub, book) in quantizer.books().iter().enumerate() {
-            let bytes = codec::encode_centroids(book);
-            self.store_mut()
-                .put_aux(codec::CODEBOOK, &(sub as u32).to_be_bytes(), &bytes)
+                .put_aux(ivf::CENTROID, &(index as u32).to_be_bytes(), &bytes)
                 .await?;
         }
 
         let state = TrainedState {
             nlist: coarse.k as u32,
-            m: quantizer.m() as u32,
             dimensions: dimensions as u32,
         };
 
-        let mut assignments: Vec<(u32, NodeId, Vec<u8>)> = Vec::new();
-        let mut code = vec![0u8; quantizer.code_len()];
-        let mut residual = vec![0.0f32; dimensions];
+        let mut assignments: Vec<(u32, NodeId)> = Vec::new();
         self.store()
             .iterate_nodes(|node| {
                 let (list, _) = coarse.nearest(&node.vector);
-                subtract_into(&node.vector, coarse.get(list), &mut residual);
-                quantizer.encode(&residual, &mut code);
-                assignments.push((list as u32, node.id, code.clone()));
+                assignments.push((list as u32, node.id));
                 Ok(())
             })
             .await?;
 
         let indexed = assignments.len() as u64;
-        for (list, id, code) in assignments {
+        for (list, id) in assignments {
+            let node =
+                self.store().get_node(id).await?.ok_or_else(|| {
+                    Error::Other("vector index: a just-sampled node is gone".into())
+                })?;
             self.store_mut()
-                .put_aux(codec::LIST, &codec::list_key(list, id), &code)
+                .put_aux(
+                    ivf::LIST,
+                    &ivf::list_key(list, id),
+                    &ivf::encode_vector(&node.vector),
+                )
                 .await?;
         }
 
         self.store_mut()
-            .put_aux(codec::STATE, b"", &codec::encode_state(&state))
+            .put_aux(ivf::STATE, b"", &ivf::encode_state(&state))
             .await?;
 
         Ok(BuildReport {
@@ -160,23 +154,11 @@ impl<S: VectorNodeStore> IvfPq<S> {
         })
     }
 
-    /// The list a vector belongs to, and its code.
-    pub(super) async fn assign(
-        &self,
-        state: &TrainedState,
-        vector: &[f32],
-    ) -> Result<(u32, Vec<u8>)> {
-        let (coarse, quantizer) = self.trained_parts(state).await?;
-        let (list, _) = coarse.nearest(vector);
-        let mut residual = vec![0.0f32; state.dimensions as usize];
-        subtract_into(vector, coarse.get(list), &mut residual);
-        let mut code = vec![0u8; quantizer.code_len()];
-        quantizer.encode(&residual, &mut code);
-        Ok((list as u32, code))
-    }
-
-    pub(super) async fn load_coarse_centroids(&self, state: &TrainedState) -> Result<Centroids> {
-        ivf::load_centroids(self.store(), state.nlist, state.dimensions).await
+    /// The list a vector belongs to.
+    pub(super) async fn assign(&self, state: &TrainedState, vector: &[f32]) -> Result<u32> {
+        let centroids = self.trained_centroids(state).await?;
+        let (list, _) = centroids.nearest(vector);
+        Ok(list as u32)
     }
 
     async fn first_width(&self) -> Result<usize> {
@@ -196,22 +178,4 @@ impl<S: VectorNodeStore> IvfPq<S> {
         }
         Ok(width)
     }
-}
-
-fn subtract_into(vector: &[f32], centroid: &[f32], out: &mut [f32]) {
-    for (slot, (v, c)) in out.iter_mut().zip(vector.iter().zip(centroid)) {
-        *slot = v - c;
-    }
-}
-
-fn residuals_of(sample: &[f32], dimensions: usize, coarse: &Centroids) -> Vec<f32> {
-    let mut residuals = vec![0.0f32; sample.len()];
-    for (point, slot) in sample
-        .chunks_exact(dimensions)
-        .zip(residuals.chunks_exact_mut(dimensions))
-    {
-        let (nearest, _) = coarse.nearest(point);
-        subtract_into(point, coarse.get(nearest), slot);
-    }
-    residuals
 }

--- a/crates/db/src/index/vector/engine/ivfflat/mod.rs
+++ b/crates/db/src/index/vector/engine/ivfflat/mod.rs
@@ -1,0 +1,205 @@
+//! IVF_FLAT: coarse lists of full-precision vectors.
+//!
+//! The same partitioning [`ivfpq`](super::ivfpq) uses, with nothing
+//! compressed: a list holds the full vector rather than a product-quantized
+//! code, so inside the probed lists the ranking is exactly
+//! [`Flat`]'s. The only recall loss is a true neighbour sitting in an
+//! unprobed list; there is no quantization error at all, which is what makes
+//! `nprobe == nlist` byte-identical to `Flat`, ties included.
+//!
+//! A list entry is `encode_vector(&node.vector)`: `4 * dimensions` extra
+//! bytes per document, alongside the node itself, so a probe is one
+//! contiguous scan that yields id and vector together and feeds the SIMD
+//! kernel directly, rather than a random read per candidate. That second copy
+//! of the corpus is the cost this layout trades for the scan staying
+//! sequential; said here rather than left as a disk-usage surprise.
+//!
+//! An index accepts writes from the first document and answers them exactly
+//! by exhaustive scan, exactly as [`Flat`] does, because that is what it is
+//! until it has enough vectors to fit centroids. Once the threshold is
+//! reached it trains from a byte-bounded sample, writes centroids and
+//! inverted lists, and answers from those instead.
+
+mod build;
+mod params;
+mod search;
+
+pub use build::BuildReport;
+pub use params::{IvfFlatParams, DEFAULT_NPROBE, DEFAULT_SAMPLE_BYTES, MAX_NLIST, TRAIN_PER_LIST};
+
+use crate::index::error::{Error, Result};
+use crate::index::vector::engine::ann::{
+    Admit, Centroids, EngineKind, Neighbor, VectorIndexEngine,
+};
+use crate::index::vector::engine::flat::Flat;
+use crate::index::vector::engine::ivf::{self, TrainedState};
+use crate::index::vector::store::{NodeId, VectorNodeStore};
+use defra_core::vector::{Element, Metric};
+use std::sync::OnceLock;
+
+/// A coarse-partitioned index whose lists hold full-precision vectors.
+#[derive(Debug, Clone)]
+pub struct IvfFlat<S> {
+    staging: Flat<S>,
+    metric: Metric,
+    params: IvfFlatParams,
+    seed: u64,
+    /// Centroids are fixed once trained, and decoding them costs more than
+    /// scanning the lists they route to. Loaded once per engine.
+    trained_cache: OnceLock<Centroids>,
+}
+
+impl<S: VectorNodeStore> IvfFlat<S> {
+    /// Fails for a metric the coarse partitioning cannot serve, rather than
+    /// quietly ranking on a heuristic that costs recall in a way no test on a
+    /// cosine corpus would catch.
+    ///
+    /// Only the *coarse* step is restricted: the scan inside a probed list
+    /// ranks by the real metric at full precision, whatever it is. The
+    /// partitioning itself is squared Euclidean over the centroids, which is
+    /// the metric that distance *is*, so `EUCLIDEAN` shares cells with it by
+    /// construction; under cosine it is sound too, because vectors are
+    /// normalized on insert (`|a-b|^2 = 2 - 2a.b`). A magnitude-sensitive
+    /// metric like `DOT` does not share cells with nearest-neighbour search
+    /// under L2 at all, so it stays refused until that is measured, mirroring
+    /// exactly which metrics IVF-PQ's own `try_new` refuses.
+    pub fn try_new(store: S, metric: Metric, params: IvfFlatParams, seed: u64) -> Result<Self> {
+        params.validate()?;
+        if metric != Metric::Cosine && metric != Metric::Euclidean {
+            return Err(Error::Other(format!(
+                "IVF_FLAT partitions lists by centroid distance, which does not share cells \
+                 with {metric:?}"
+            )));
+        }
+        Ok(Self {
+            staging: Flat::new(store, metric),
+            metric,
+            params,
+            seed,
+            trained_cache: OnceLock::new(),
+        })
+    }
+
+    pub fn store(&self) -> &S {
+        self.staging.store()
+    }
+
+    pub fn store_mut(&mut self) -> &mut S {
+        self.staging.store_mut()
+    }
+
+    pub fn params(&self) -> IvfFlatParams {
+        self.params
+    }
+
+    pub fn metric(&self) -> Metric {
+        self.metric
+    }
+
+    pub fn seed(&self) -> u64 {
+        self.seed
+    }
+
+    /// The trained state, or `None` while the index is still exact.
+    pub async fn trained(&self) -> Result<Option<TrainedState>> {
+        match self.store().get_aux(ivf::STATE, b"").await? {
+            Some(bytes) => ivf::decode_state(&bytes).map(Some),
+            None => Ok(None),
+        }
+    }
+
+    pub async fn is_trained(&self) -> Result<bool> {
+        Ok(self.trained().await?.is_some())
+    }
+
+    /// The coarse centroids, decoded once.
+    pub(super) async fn trained_centroids(&self, state: &TrainedState) -> Result<&Centroids> {
+        if let Some(centroids) = self.trained_cache.get() {
+            return Ok(centroids);
+        }
+        let centroids = ivf::load_centroids(self.store(), state.nlist, state.dimensions).await?;
+        Ok(self.trained_cache.get_or_init(|| centroids))
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl<S: VectorNodeStore> VectorIndexEngine for IvfFlat<S> {
+    fn kind(&self) -> EngineKind {
+        EngineKind::IvfFlat
+    }
+
+    /// The vector is always stored, trained or not: it is what a rebuild reads
+    /// and what keeps the index exact until one happens.
+    ///
+    /// Re-inserting under an id that already has one is an update, and its
+    /// list assignment can move. The previous entry has to go with it: a list
+    /// holds the vector of whatever was assigned to it, so a stale one
+    /// returns the document a second time, ranked at a distance it no longer
+    /// has.
+    async fn insert<E: Element>(&mut self, id: NodeId, vector: &[E]) -> Result<()> {
+        let trained = self.trained().await?;
+
+        // Read before the write, because `staging.insert` overwrites the node
+        // and the old vector is what names the list to clear.
+        let previous = match trained {
+            Some(_) => self.store().get_node(id).await?,
+            None => None,
+        };
+
+        self.staging.insert(id, vector).await?;
+
+        if let Some(state) = trained {
+            let stored =
+                self.store().get_node(id).await?.ok_or_else(|| {
+                    Error::Other("vector index: a just-stored node is gone".into())
+                })?;
+            let list = self.assign(&state, &stored.vector).await?;
+
+            if let Some(previous) = previous {
+                let previous_list = self.assign(&state, &previous.vector).await?;
+                if previous_list != list {
+                    self.store_mut()
+                        .delete_aux(ivf::LIST, &ivf::list_key(previous_list, id))
+                        .await?;
+                }
+            }
+
+            self.store_mut()
+                .put_aux(
+                    ivf::LIST,
+                    &ivf::list_key(list, id),
+                    &ivf::encode_vector(&stored.vector),
+                )
+                .await?;
+        }
+        Ok(())
+    }
+
+    /// Tombstones the node. Its list entry stays and is skipped on the scan,
+    /// the same way the graph kinds skip a tombstone.
+    async fn delete(&mut self, id: NodeId) -> Result<bool> {
+        self.staging.delete(id).await
+    }
+
+    async fn should_build(&self) -> Result<bool> {
+        self.should_build().await
+    }
+
+    async fn build(&mut self) -> Result<()> {
+        self.build().await.map(|_| ())
+    }
+
+    async fn search_where<E: Element, A: Admit>(
+        &self,
+        query: &[E],
+        k: usize,
+        effort: Option<usize>,
+        admit: &A,
+    ) -> Result<Vec<Neighbor>> {
+        match self.trained().await? {
+            None => self.staging.search_where(query, k, effort, admit).await,
+            Some(state) => self.search_lists(&state, query, k, effort, admit).await,
+        }
+    }
+}

--- a/crates/db/src/index/vector/engine/ivfflat/params.rs
+++ b/crates/db/src/index/vector/engine/ivfflat/params.rs
@@ -1,4 +1,4 @@
-//! IVF-PQ build and search parameters.
+//! IVF_FLAT build and search parameters.
 
 pub use crate::index::vector::engine::ivf::{MAX_NLIST, TRAIN_PER_LIST};
 
@@ -6,36 +6,32 @@ use crate::index::error::{Error, Result};
 use crate::index::vector::engine::ivf;
 
 pub const DEFAULT_NPROBE: u32 = 8;
-pub const DEFAULT_NBITS: u32 = 8;
 pub const DEFAULT_SAMPLE_BYTES: u64 = 128 << 20;
 
-pub const MAX_M: u32 = 4_096;
-
-/// `0` means derive from the corpus: `nlist` from its size, `m` from the width.
+/// `0` means derive `nlist` from the corpus, matching
+/// [`IvfPqParams`](crate::index::vector::engine::ivfpq::IvfPqParams). There is
+/// no `m`: a list holds the full vector, so there is nothing to quantize.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct IvfPqParams {
+pub struct IvfFlatParams {
     pub nlist: u32,
     pub nprobe: u32,
-    pub m: u32,
     pub sample_bytes: u64,
 }
 
-impl Default for IvfPqParams {
+impl Default for IvfFlatParams {
     fn default() -> Self {
         Self {
             nlist: 0,
             nprobe: DEFAULT_NPROBE,
-            m: 0,
             sample_bytes: DEFAULT_SAMPLE_BYTES,
         }
     }
 }
 
-impl IvfPqParams {
+impl IvfFlatParams {
     pub fn validate(&self) -> Result<()> {
         for (name, value, max) in [
             ("nlist", self.nlist, MAX_NLIST),
-            ("m", self.m, MAX_M),
             ("nprobe", self.nprobe, MAX_NLIST),
         ] {
             if value > max {
@@ -56,19 +52,6 @@ impl IvfPqParams {
     /// train and small enough that probing a few is much cheaper than a scan.
     pub fn resolved_nlist(&self, corpus: u64) -> u32 {
         ivf::resolved_nlist(self.nlist, corpus)
-    }
-
-    /// The largest `m` that divides the width and keeps subvectors at least 2
-    /// wide, capped so a code stays small against the vector it replaces.
-    pub fn resolved_m(&self, dimensions: usize) -> usize {
-        if self.m > 0 {
-            return (self.m as usize).min(dimensions.max(1));
-        }
-        let target = (dimensions / 8).clamp(1, MAX_M as usize);
-        (1..=target)
-            .rev()
-            .find(|m| dimensions.is_multiple_of(*m))
-            .unwrap_or(1)
     }
 
     /// Vectors needed before training fires. See

--- a/crates/db/src/index/vector/engine/ivfflat/search.rs
+++ b/crates/db/src/index/vector/engine/ivfflat/search.rs
@@ -1,0 +1,105 @@
+//! Probing lists and scanning full-precision vectors.
+
+use std::collections::BinaryHeap;
+
+use super::IvfFlat;
+use crate::index::error::Result;
+use crate::index::vector::engine::ann::{Admit, Neighbor};
+use crate::index::vector::engine::ivf::{self, TrainedState};
+use crate::index::vector::store::{NodeId, VectorNodeStore};
+use defra_core::vector::Element;
+
+impl<S: VectorNodeStore> IvfFlat<S> {
+    pub(super) async fn search_lists<E: Element, A: Admit>(
+        &self,
+        state: &TrainedState,
+        query: &[E],
+        k: usize,
+        effort: Option<usize>,
+        admit: &A,
+    ) -> Result<Vec<Neighbor>> {
+        if k == 0 {
+            return Ok(Vec::new());
+        }
+
+        let query = self.metric().prepare(query);
+        let metric = self.metric();
+
+        let centroids = self.trained_centroids(state).await?;
+        let lists = ivf::probe_lists(
+            query.as_slice(),
+            centroids,
+            self.params().nprobe as usize,
+            effort,
+        );
+
+        // A max-heap of size k: the worst of the current best is on top, so a
+        // new candidate is one comparison and at most one pop, exactly as
+        // `Flat` scores its own scan.
+        let mut best: BinaryHeap<Ranked> = BinaryHeap::with_capacity(k + 1);
+        for list in lists {
+            self.store()
+                .iterate_aux(ivf::LIST, &ivf::list_prefix(list as u32), |key, value| {
+                    let id = ivf::node_from_list_key(key)?;
+                    if !admit.admits(id) {
+                        return Ok(());
+                    }
+                    let vector = ivf::decode_vector(value)?;
+                    let distance = metric.distance_stored(query.as_slice(), &vector);
+                    best.push(Ranked { id, distance });
+                    if best.len() > k {
+                        best.pop();
+                    }
+                    Ok(())
+                })
+                .await?;
+        }
+
+        // A tombstoned document keeps its list entry, so liveness is checked
+        // once on the survivors rather than on every candidate.
+        let ranked: Vec<Ranked> = best.into_sorted_vec();
+        let mut out = Vec::with_capacity(ranked.len());
+        for candidate in ranked {
+            let live = self
+                .store()
+                .get_node(candidate.id)
+                .await?
+                .is_some_and(|node| !node.deleted);
+            if live {
+                out.push(Neighbor {
+                    id: candidate.id,
+                    distance: candidate.distance,
+                });
+            }
+        }
+        Ok(out)
+    }
+}
+
+/// Farthest on top, so the heap drops its worst; ties break by ascending id.
+/// This has to agree with [`Flat`](crate::index::vector::engine::flat::Flat)
+/// and [`Hnsw`](crate::index::vector::engine::hnsw::Hnsw), because IVF_FLAT is
+/// differentially tested against `Flat` at `nprobe == nlist`. IVF-PQ
+/// tie-breaks the other way (#1469); that is its own bug to fix, not this
+/// engine's to inherit.
+#[derive(Debug, PartialEq)]
+struct Ranked {
+    id: NodeId,
+    distance: f64,
+}
+
+impl Eq for Ranked {}
+
+impl Ord for Ranked {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.distance
+            .total_cmp(&other.distance)
+            .then_with(|| self.id.cmp(&other.id))
+    }
+}
+
+impl PartialOrd for Ranked {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}

--- a/crates/db/src/index/vector/engine/ivfpq/codec.rs
+++ b/crates/db/src/index/vector/engine/ivfpq/codec.rs
@@ -1,88 +1,24 @@
-//! Encoding for the entries IVF-PQ keeps beside its nodes.
+//! IVF-PQ's own trained-state marker, on top of the coarse codec both IVF
+//! engines share.
+
+pub use crate::index::vector::engine::ivf::{
+    decode_centroids, encode_centroids, encode_vector, list_key, list_prefix, node_from_list_key,
+    CENTROID, LIST, STATE,
+};
 
 use crate::index::error::{Error, Result};
-use crate::index::vector::engine::ann::Centroids;
-use crate::index::vector::store::NodeId;
 
-pub const CENTROID: u8 = b'c';
 pub const CODEBOOK: u8 = b'b';
-pub const LIST: u8 = b'l';
-pub const STATE: u8 = b's';
 
 const STATE_VERSION: u8 = 1;
 
-pub fn encode_vector(values: &[f32]) -> Vec<u8> {
-    let mut out = Vec::with_capacity(values.len() * 4);
-    for value in values {
-        out.extend_from_slice(&value.to_le_bytes());
-    }
-    out
-}
-
-pub fn decode_vector(bytes: &[u8]) -> Result<Vec<f32>> {
-    if !bytes.len().is_multiple_of(4) {
-        return Err(Error::Other(
-            "vector index: a stored vector is ragged".into(),
-        ));
-    }
-    Ok(bytes
-        .as_chunks::<4>()
-        .0
-        .iter()
-        .map(|&c| f32::from_le_bytes(c))
-        .collect())
-}
-
-pub fn encode_centroids(centroids: &Centroids) -> Vec<u8> {
-    let mut out = Vec::with_capacity(8 + centroids.values.len() * 4);
-    out.extend_from_slice(&(centroids.k as u32).to_le_bytes());
-    out.extend_from_slice(&(centroids.dimensions as u32).to_le_bytes());
-    out.extend_from_slice(&encode_vector(&centroids.values));
-    out
-}
-
-pub fn decode_centroids(bytes: &[u8]) -> Result<Centroids> {
-    if bytes.len() < 8 {
-        return Err(Error::Other("vector index: a codebook is truncated".into()));
-    }
-    let k = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as usize;
-    let dimensions = u32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]) as usize;
-    let values = decode_vector(&bytes[8..])?;
-    if k * dimensions != values.len() {
-        return Err(Error::Other(
-            "vector index: a codebook's shape disagrees with its payload".into(),
-        ));
-    }
-    Ok(Centroids {
-        k,
-        dimensions,
-        values,
-    })
-}
-
-/// `listID || nodeID`, both big-endian so a prefix scan of a list is contiguous
-/// and ordered.
-pub fn list_key(list: u32, node: NodeId) -> Vec<u8> {
-    let mut key = Vec::with_capacity(12);
-    key.extend_from_slice(&list.to_be_bytes());
-    key.extend_from_slice(&node.0.to_be_bytes());
-    key
-}
-
-pub fn list_prefix(list: u32) -> Vec<u8> {
-    list.to_be_bytes().to_vec()
-}
-
-pub fn node_from_list_key(key: &[u8]) -> Result<NodeId> {
-    if key.len() < 12 {
-        return Err(Error::Other("vector index: a list key is truncated".into()));
-    }
-    let mut id = [0u8; 8];
-    id.copy_from_slice(&key[4..12]);
-    Ok(NodeId(u64::from_be_bytes(id)))
-}
-
-/// What a trained index needs to answer before it reads anything else.
+/// What a trained IVF-PQ index needs before it reads anything else.
+///
+/// Carries `m`, the subquantizer count, on top of the coarse `nlist` and
+/// `dimensions` the shared [`ivf`](crate::index::vector::engine::ivf) module's
+/// own `TrainedState` holds. IVF_FLAT has no `m`, so it uses that shared state
+/// directly instead of this wider one; this stays its own type and its own
+/// 13-byte encoding so an index trained before this split keeps decoding.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TrainedState {
     pub nlist: u32,

--- a/crates/db/src/index/vector/engine/ivfpq/search.rs
+++ b/crates/db/src/index/vector/engine/ivfpq/search.rs
@@ -6,8 +6,9 @@ use super::codec::{self, TrainedState};
 use super::IvfPq;
 use crate::index::error::Result;
 use crate::index::vector::engine::ann::{Admit, Neighbor, Quantizer};
+use crate::index::vector::engine::ivf;
 use crate::index::vector::store::{NodeId, VectorNodeStore};
-use defra_core::vector::{Element, Metric};
+use defra_core::vector::Element;
 
 impl<S: VectorNodeStore> IvfPq<S> {
     pub(super) async fn search_lists<E: Element, A: Admit>(
@@ -27,27 +28,17 @@ impl<S: VectorNodeStore> IvfPq<S> {
         let (coarse, quantizer) = self.trained_parts(state).await?;
 
         // `effort` overrides nprobe the way ef_search does for a graph.
-        let nprobe = effort
-            .map(|e| e.max(1))
-            .unwrap_or(self.params().nprobe as usize)
-            .min(coarse.k)
-            .max(1);
-
-        let mut lists: Vec<(usize, f64)> = (0..coarse.k)
-            .map(|index| {
-                (
-                    index,
-                    Metric::Euclidean.distance(query.as_slice(), coarse.get(index)),
-                )
-            })
-            .collect();
-        lists.sort_by(|a, b| a.1.total_cmp(&b.1));
-        lists.truncate(nprobe);
+        let lists = ivf::probe_lists(
+            query.as_slice(),
+            coarse,
+            self.params().nprobe as usize,
+            effort,
+        );
 
         let mut best: BinaryHeap<Ranked> = BinaryHeap::with_capacity(k + 1);
         let mut residual = vec![0.0f32; state.dimensions as usize];
 
-        for (list, _) in lists {
+        for list in lists {
             for (slot, (q, c)) in residual.iter_mut().zip(query.iter().zip(coarse.get(list))) {
                 *slot = q - c;
             }

--- a/crates/db/src/index/vector/engine/mod.rs
+++ b/crates/db/src/index/vector/engine/mod.rs
@@ -10,6 +10,8 @@ pub mod ann;
 pub mod dispatch;
 pub mod flat;
 pub mod hnsw;
+pub mod ivf;
+pub mod ivfflat;
 pub mod ivfpq;
 pub mod select;
 pub mod ssg;

--- a/crates/db/src/index/vector/index.rs
+++ b/crates/db/src/index/vector/index.rs
@@ -14,6 +14,7 @@ use super::engine::ann::{Admit, Neighbor, VectorIndexEngine};
 use super::engine::dispatch::Engine;
 use super::engine::flat::Flat;
 use super::engine::hnsw::Hnsw;
+use super::engine::ivfflat::{IvfFlat, IvfFlatParams};
 use super::engine::ivfpq::{IvfPq, IvfPqParams};
 use super::engine::ssg::{Ssg, SsgParams};
 use super::kv_store::KvNodeStore;
@@ -35,6 +36,7 @@ pub struct VectorIndex {
     vector: VectorIndexDescription,
     params: Params,
     ivfpq: IvfPqParams,
+    ivfflat: IvfFlatParams,
     ssg: SsgParams,
     metric: Metric,
     seed: u64,
@@ -66,6 +68,13 @@ impl VectorIndex {
             sample_bytes: configured.sample_bytes,
         };
 
+        let configured = vector.ivfflat.unwrap_or_default();
+        let ivfflat = IvfFlatParams {
+            nlist: configured.nlist,
+            nprobe: configured.nprobe,
+            sample_bytes: configured.sample_bytes,
+        };
+
         let configured = vector.ssg.unwrap_or_default();
         let ssg = SsgParams {
             r: configured.r,
@@ -83,6 +92,9 @@ impl VectorIndex {
         if vector.algorithm == VectorAlgorithm::IvfPq {
             IvfPq::try_new(super::store::MemoryNodeStore::new(), metric, ivfpq, 0)?;
         }
+        if vector.algorithm == VectorAlgorithm::IvfFlat {
+            IvfFlat::try_new(super::store::MemoryNodeStore::new(), metric, ivfflat, 0)?;
+        }
 
         Ok(Self {
             collection_short_id,
@@ -93,6 +105,7 @@ impl VectorIndex {
             vector,
             params,
             ivfpq,
+            ivfflat,
             ssg,
             metric,
         })
@@ -143,6 +156,12 @@ impl VectorIndex {
             VectorAlgorithm::IvfPq => {
                 Engine::IvfPq(IvfPq::try_new(store, self.metric, self.ivfpq, self.seed)?)
             }
+            VectorAlgorithm::IvfFlat => Engine::IvfFlat(IvfFlat::try_new(
+                store,
+                self.metric,
+                self.ivfflat,
+                self.seed,
+            )?),
             VectorAlgorithm::Ssg => Engine::Ssg(Ssg::try_new(
                 store,
                 self.metric,

--- a/crates/db/tests/common/schema.rs
+++ b/crates/db/tests/common/schema.rs
@@ -56,6 +56,7 @@ pub fn vector_kind() -> IndexKind {
         dimensions: DIMENSIONS,
         hnsw: Some(HnswParams::default()),
         ivfpq: None,
+        ivfflat: None,
         ssg: None,
     })
 }

--- a/crates/db/tests/read/lookup.rs
+++ b/crates/db/tests/read/lookup.rs
@@ -52,6 +52,7 @@ fn schema() -> CollectionVersion {
         dimensions: DIMENSIONS,
         hnsw: Some(HnswParams::default()),
         ivfpq: None,
+        ivfflat: None,
         ssg: None,
     })];
     version

--- a/crates/db/tests/vector/ivfflat_engine.rs
+++ b/crates/db/tests/vector/ivfflat_engine.rs
@@ -1,0 +1,450 @@
+//! The IVF_FLAT engine and its train-on-threshold lifecycle.
+
+use db::index::vector::engine::ann::EngineKind;
+use db::index::vector::engine::ann::VectorIndexEngine;
+use db::index::vector::engine::flat::Flat;
+use db::index::vector::engine::ivfflat::IvfFlat;
+use db::index::vector::engine::ivfflat::IvfFlatParams;
+use db::index::vector::engine::ivfflat::TRAIN_PER_LIST;
+use db::index::vector::store::MemoryNodeStore;
+use db::index::vector::store::NodeId;
+use defra_core::vector::Metric;
+
+const SEED: u64 = 0x1F4A_7F1A;
+const DIMENSIONS: usize = 16;
+
+fn params(nlist: u32, nprobe: u32) -> IvfFlatParams {
+    IvfFlatParams {
+        nlist,
+        nprobe,
+        ..IvfFlatParams::default()
+    }
+}
+
+fn index(nlist: u32, nprobe: u32) -> IvfFlat<MemoryNodeStore> {
+    IvfFlat::try_new(
+        MemoryNodeStore::new(),
+        Metric::Cosine,
+        params(nlist, nprobe),
+        SEED,
+    )
+    .expect("cosine partitions soundly")
+}
+
+async fn filled(nlist: u32, nprobe: u32, vectors: &[Vec<f32>]) -> IvfFlat<MemoryNodeStore> {
+    let mut index = index(nlist, nprobe);
+    for (i, vector) in vectors.iter().enumerate() {
+        index.insert(NodeId(i as u64 + 1), vector).await.unwrap();
+    }
+    index
+}
+
+async fn exact(vectors: &[Vec<f32>], query: &[f32], k: usize) -> Vec<u64> {
+    let mut flat = Flat::new(MemoryNodeStore::new(), Metric::Cosine);
+    for (i, vector) in vectors.iter().enumerate() {
+        flat.insert(NodeId(i as u64 + 1), vector).await.unwrap();
+    }
+    flat.search(query, k, None)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|n| n.id.0)
+        .collect()
+}
+
+#[tokio::test]
+async fn the_kind_is_reported() {
+    assert_eq!(index(4, 2).kind(), EngineKind::IvfFlat);
+}
+
+/// The coarse step partitions by centroid distance, which shares cells with
+/// squared Euclidean by construction and with cosine because vectors are
+/// normalized on insert. A metric that does neither, like a raw dot product,
+/// is refused rather than silently partitioned by a heuristic that would cost
+/// recall in a way no test on a cosine corpus would catch.
+#[test]
+fn a_metric_the_coarse_step_cannot_share_cells_with_is_refused() {
+    assert!(IvfFlat::try_new(
+        MemoryNodeStore::new(),
+        Metric::NegativeDot,
+        IvfFlatParams::default(),
+        SEED
+    )
+    .is_err());
+    assert!(IvfFlat::try_new(
+        MemoryNodeStore::new(),
+        Metric::Cosine,
+        IvfFlatParams::default(),
+        SEED
+    )
+    .is_ok());
+    assert!(IvfFlat::try_new(
+        MemoryNodeStore::new(),
+        Metric::Euclidean,
+        IvfFlatParams::default(),
+        SEED
+    )
+    .is_ok());
+}
+
+/// Before training the index is exact, because it is a flat scan.
+#[tokio::test]
+async fn an_untrained_index_answers_exactly() {
+    let mut corpus = crate::support::Corpus::new(SEED);
+    let vectors = corpus.vectors(120, DIMENSIONS);
+    let index = filled(8, 4, &vectors).await;
+
+    assert!(!index.is_trained().await.unwrap());
+
+    let query = &vectors[5];
+    let got: Vec<u64> = index
+        .search(query.as_slice(), 10, None)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|n| n.id.0)
+        .collect();
+    assert_eq!(got, exact(&vectors, query, 10).await);
+}
+
+#[tokio::test]
+async fn building_marks_the_index_trained() {
+    let mut corpus = crate::support::Corpus::new(SEED);
+    let vectors = corpus.vectors(400, DIMENSIONS);
+    let mut index = filled(8, 8, &vectors).await;
+
+    let report = index.build().await.unwrap();
+    assert_eq!(report.indexed, 400);
+    assert_eq!(report.state.dimensions, DIMENSIONS as u32);
+    assert_eq!(report.state.nlist, 8);
+    assert!(report.sampled > 0);
+    assert!(index.is_trained().await.unwrap());
+}
+
+/// Probing every list makes the scan exhaustive, and IVF_FLAT has no
+/// compression at all, so this must be **exactly** `Flat`, not merely close.
+/// The randomized, property-tested version of this claim lives in
+/// `ivfflat_exactness.rs`; this is the single-fixture sanity check.
+#[tokio::test]
+async fn a_trained_index_is_exact_when_every_list_is_probed() {
+    let mut corpus = crate::support::Corpus::new(SEED ^ 0xABC);
+    let vectors = corpus.clustered(600, DIMENSIONS, 12, 0.12);
+    let mut index = filled(12, 12, &vectors).await;
+    index.build().await.unwrap();
+
+    for i in 0..20 {
+        let query = &vectors[i * 7];
+        let got: Vec<u64> = index
+            .search(query.as_slice(), 10, None)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|n| n.id.0)
+            .collect();
+        assert_eq!(got, exact(&vectors, query, 10).await, "query {i}");
+    }
+}
+
+/// A vector's own document must come back first: there is no quantization to
+/// blame if it does not.
+#[tokio::test]
+async fn a_corpus_vector_finds_itself() {
+    let mut corpus = crate::support::Corpus::new(SEED ^ 0xDEF);
+    let vectors = corpus.clustered(500, DIMENSIONS, 10, 0.1);
+    let mut index = filled(10, 10, &vectors).await;
+    index.build().await.unwrap();
+
+    for i in [0usize, 37, 111, 250, 400] {
+        let hits = index.search(vectors[i].as_slice(), 5, None).await.unwrap();
+        assert_eq!(
+            hits.first().map(|n| n.id),
+            Some(NodeId(i as u64 + 1)),
+            "vector {i} did not find itself first"
+        );
+    }
+}
+
+/// Writes after a build must be searchable, or the index silently stops
+/// covering new documents.
+#[tokio::test]
+async fn a_document_written_after_the_build_is_searchable() {
+    let mut corpus = crate::support::Corpus::new(SEED ^ 0x111);
+    let vectors = corpus.clustered(400, DIMENSIONS, 8, 0.1);
+    let mut index = filled(8, 8, &vectors).await;
+    index.build().await.unwrap();
+
+    let late = vectors[3].clone();
+    index.insert(NodeId(9_999), &late).await.unwrap();
+
+    let hits = index.search(late.as_slice(), 10, None).await.unwrap();
+    assert!(
+        hits.iter().any(|n| n.id == NodeId(9_999)),
+        "the late document was not found: {hits:?}"
+    );
+}
+
+#[tokio::test]
+async fn a_deleted_document_stops_ranking() {
+    let mut corpus = crate::support::Corpus::new(SEED ^ 0x222);
+    let vectors = corpus.clustered(400, DIMENSIONS, 8, 0.1);
+    let mut index = filled(8, 8, &vectors).await;
+    index.build().await.unwrap();
+
+    assert!(index.delete(NodeId(1)).await.unwrap());
+    let hits = index.search(vectors[0].as_slice(), 10, None).await.unwrap();
+    assert!(
+        !hits.iter().any(|n| n.id == NodeId(1)),
+        "a deleted document ranked: {hits:?}"
+    );
+}
+
+/// `Admit` is trait-level, so it must work here exactly as it does for a
+/// graph, as long as every list is probed.
+#[tokio::test]
+async fn a_filter_excludes_without_shortening_the_answer() {
+    let mut corpus = crate::support::Corpus::new(SEED ^ 0x333);
+    let vectors = corpus.clustered(500, DIMENSIONS, 10, 0.1);
+    let mut index = filled(10, 10, &vectors).await;
+    index.build().await.unwrap();
+
+    let admit = |id: NodeId| id.0.is_multiple_of(2);
+    let hits = index
+        .search_where(vectors[9].as_slice(), 8, None, &admit)
+        .await
+        .unwrap();
+
+    assert!(
+        hits.iter().all(|n| n.id.0.is_multiple_of(2)),
+        "a filter leaked"
+    );
+    assert_eq!(hits.len(), 8, "the filter shortened the answer");
+}
+
+/// A selective filter narrows what a *graph* search may return, but a graph
+/// keeps walking until it fills `k` or exhausts the structure. An inverted
+/// list has no such widening: its candidates are exactly the entries of the
+/// lists that were probed, so a filter selective enough to exhaust those
+/// entries returns fewer than `k`, even though `k` admitted documents exist
+/// elsewhere in the corpus. That is an honest limitation of the scan being
+/// bounded to `nprobe` lists, not a bug.
+#[tokio::test]
+async fn a_selective_filter_can_return_fewer_than_k_when_the_probed_lists_run_out() {
+    let mut corpus = crate::support::Corpus::new(SEED ^ 0x9A9A);
+    let vectors = corpus.clustered(600, DIMENSIONS, 16, 0.1);
+    let mut index = filled(16, 1, &vectors).await;
+    index.build().await.unwrap();
+
+    let query = vectors[0].clone();
+    let probed_list_size = index
+        .search(query.as_slice(), vectors.len(), None)
+        .await
+        .unwrap()
+        .len();
+    assert!(
+        probed_list_size < vectors.len(),
+        "test setup: nprobe=1 of 16 lists must not cover the whole corpus, got {probed_list_size}"
+    );
+
+    // Admits every live document, so a graph walk (or a wider probe) would
+    // trivially return k; only the single probed list's own size bounds this
+    // scan.
+    let k = probed_list_size + 50;
+    assert!(
+        k <= vectors.len(),
+        "test setup: k must stay inside the corpus"
+    );
+    let hits = index
+        .search_where(query.as_slice(), k, None, &|_: NodeId| true)
+        .await
+        .unwrap();
+
+    assert!(
+        hits.len() < k,
+        "expected fewer than k={k} hits bounded by the probed list's {probed_list_size} \
+         entries, got {}",
+        hits.len()
+    );
+}
+
+#[tokio::test]
+async fn results_are_ordered_nearest_first() {
+    let mut corpus = crate::support::Corpus::new(SEED ^ 0x444);
+    let vectors = corpus.clustered(400, DIMENSIONS, 8, 0.1);
+    let mut index = filled(8, 8, &vectors).await;
+    index.build().await.unwrap();
+
+    let hits = index.search(vectors[2].as_slice(), 10, None).await.unwrap();
+    assert!(hits.windows(2).all(|w| w[0].distance <= w[1].distance));
+}
+
+/// Probing more lists can only look at more candidates, so recall must not
+/// fall as nprobe rises.
+#[tokio::test]
+async fn recall_does_not_fall_as_nprobe_rises() {
+    let mut corpus = crate::support::Corpus::new(SEED ^ 0x555);
+    let vectors = corpus.clustered(600, DIMENSIONS, 16, 0.1);
+    let query = vectors[13].clone();
+    let want = exact(&vectors, &query, 10).await;
+
+    let mut previous = 0usize;
+    for nprobe in [1usize, 2, 4, 8, 16] {
+        let mut index = filled(16, nprobe as u32, &vectors).await;
+        index.build().await.unwrap();
+        let got: Vec<u64> = index
+            .search(query.as_slice(), 10, None)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|n| n.id.0)
+            .collect();
+        let hit = got.iter().filter(|id| want.contains(id)).count();
+        assert!(
+            hit + 1 >= previous,
+            "recall fell at nprobe={nprobe}: {hit} after {previous}"
+        );
+        previous = hit;
+    }
+}
+
+#[tokio::test]
+async fn an_empty_index_builds_no_state() {
+    let mut index = index(4, 2);
+    assert!(index.build().await.is_err());
+    assert!(!index.is_trained().await.unwrap());
+}
+
+#[tokio::test]
+async fn k_zero_returns_nothing() {
+    let mut corpus = crate::support::Corpus::new(SEED ^ 0x666);
+    let vectors = corpus.vectors(200, DIMENSIONS);
+    let mut index = filled(4, 4, &vectors).await;
+    index.build().await.unwrap();
+    assert!(index
+        .search(vectors[0].as_slice(), 0, None)
+        .await
+        .unwrap()
+        .is_empty());
+}
+
+/// Updating a vector moves it between inverted lists, and the entry under its
+/// previous list has to go with it.
+///
+/// A list holds the vector of whatever was assigned to it, so a stale entry
+/// is not merely a duplicate: probing both lists pushes the same id twice
+/// with two different distances, and one of them ranks the document by an
+/// embedding it no longer has. The liveness check filters tombstones only, so
+/// nothing downstream catches it.
+#[tokio::test]
+async fn updating_a_vector_leaves_no_entry_in_its_previous_list() {
+    let mut corpus = crate::support::Corpus::new(SEED ^ 0x444);
+    let vectors = corpus.clustered(400, DIMENSIONS, 8, 0.1);
+    let mut index = filled(8, 8, &vectors).await;
+    index.build().await.unwrap();
+
+    // Move document 1 onto document 400's own vector exactly, which is what
+    // puts it in a different list from the one it was built into and, unlike
+    // IVF-PQ's lossy code, ties it byte-for-byte with document 400. Probing
+    // everything, so a surviving stale entry has nowhere to hide.
+    let moved_to = vectors[399].clone();
+    index.insert(NodeId(1), &moved_to).await.unwrap();
+
+    let hits = index.search(moved_to.as_slice(), 400, None).await.unwrap();
+    let appearances = hits.iter().filter(|n| n.id == NodeId(1)).count();
+    assert_eq!(
+        appearances,
+        1,
+        "document 1 appears {appearances} times after moving lists: {:?}",
+        hits.iter().map(|n| n.id.0).collect::<Vec<_>>()
+    );
+
+    // It now holds document 400's vector exactly, at full precision, so the
+    // two are an exact tie; IVF_FLAT ties break the same way `Flat` does, on
+    // ascending id, so document 1 must sort ahead of document 400.
+    assert_eq!(hits[0].id, NodeId(1), "the tie must break to the lower id");
+    assert_eq!(hits[1].id, NodeId(400));
+    assert_eq!(
+        hits[0].distance, hits[1].distance,
+        "an identical vector must rank at an identical distance, exactly"
+    );
+}
+
+/// The same, when the vector is replaced by one that lands in the *same*
+/// list. Nothing should be removed, and the document must still appear
+/// exactly once.
+#[tokio::test]
+async fn updating_within_one_list_keeps_the_document() {
+    let mut corpus = crate::support::Corpus::new(SEED ^ 0x555);
+    let vectors = corpus.clustered(400, DIMENSIONS, 8, 0.1);
+    let mut index = filled(8, 8, &vectors).await;
+    index.build().await.unwrap();
+
+    let nudged: Vec<f32> = vectors[0].iter().map(|value| value + 0.001).collect();
+    index.insert(NodeId(1), &nudged).await.unwrap();
+
+    let hits = index.search(nudged.as_slice(), 400, None).await.unwrap();
+    assert_eq!(
+        hits.iter().filter(|n| n.id == NodeId(1)).count(),
+        1,
+        "document 1 must appear exactly once"
+    );
+}
+
+#[tokio::test]
+async fn should_build_is_false_on_an_empty_index() {
+    let index = index(8, 8);
+    assert!(!index.should_build().await.unwrap());
+}
+
+#[tokio::test]
+async fn should_build_is_false_once_built() {
+    let mut corpus = crate::support::Corpus::new(SEED ^ 0x777);
+    let vectors = corpus.vectors(400, DIMENSIONS);
+    let mut index = filled(8, 8, &vectors).await;
+    index.build().await.unwrap();
+
+    assert!(!index.should_build().await.unwrap());
+}
+
+/// Mirrors #1463's regression for IVF-PQ: crossing the threshold must make
+/// `should_build` answer `true`, or nothing downstream ever trains the index.
+#[tokio::test]
+async fn should_build_becomes_true_once_the_threshold_is_crossed() {
+    let threshold = 4u64 * u64::from(TRAIN_PER_LIST);
+    let mut corpus = crate::support::Corpus::new(SEED ^ 0x888);
+    let vectors = corpus.vectors(threshold as usize, DIMENSIONS);
+    let mut index = index(4, 4);
+
+    for (i, vector) in vectors.iter().take(threshold as usize - 1).enumerate() {
+        index.insert(NodeId(i as u64 + 1), vector).await.unwrap();
+    }
+    assert!(
+        !index.should_build().await.unwrap(),
+        "one short of the threshold"
+    );
+
+    index
+        .insert(NodeId(threshold), &vectors[threshold as usize - 1])
+        .await
+        .unwrap();
+    assert!(index.should_build().await.unwrap(), "at the threshold");
+}
+
+/// `live_count_at_least` must answer exactly what a full count would, at
+/// targets on both sides of the true count.
+#[tokio::test]
+async fn live_count_at_least_agrees_with_live_count() {
+    let mut corpus = crate::support::Corpus::new(SEED ^ 0x999);
+    let vectors = corpus.vectors(150, DIMENSIONS);
+    let index = filled(8, 8, &vectors).await;
+
+    let true_count = index.live_count().await.unwrap();
+    assert_eq!(true_count, 150);
+
+    for target in [0u64, 1, 50, 149, 150, 151, 500] {
+        assert_eq!(
+            index.live_count_at_least(target).await.unwrap(),
+            true_count >= target,
+            "target={target}, true_count={true_count}"
+        );
+    }
+}

--- a/crates/db/tests/vector/ivfflat_exactness.rs
+++ b/crates/db/tests/vector/ivfflat_exactness.rs
@@ -1,0 +1,141 @@
+//! The IVF_FLAT acceptance property: at `nprobe == nlist`, the scan is exact.
+//!
+//! There is no quantization in this engine at all, so probing every list
+//! makes it identical to [`Flat`], not merely close: same ids, same
+//! distances, same order, ties included. Any divergence here is a bug in the
+//! scan, not a recall tradeoff, which is why it gets its own file rather than
+//! one assertion inside `ivfflat_engine.rs`. Checked over several randomized
+//! corpus shapes rather than one fixture, mirroring how the rest of this
+//! suite varies seeds instead of reaching for `proptest`.
+//!
+//! That byte-identical claim holds for a *live* corpus. With tombstones
+//! present it narrows to a subset: `iterate_aux`'s visitor is synchronous, so
+//! a candidate's liveness can only be checked once the per-list scan hands
+//! control back, after the top-k heap has already filled on raw distance.
+//! IVF-PQ's `search_lists` has the identical shape for the identical reason.
+//! A heap slot a dead entry wins is a slot a live one further out never gets
+//! to compete for, so the surviving hits can be fewer than `k` even when `k`
+//! live documents exist in the probed lists; what stays provably true is that
+//! every survivor is one `Flat` would also return, at the same distance.
+
+use db::index::vector::engine::ann::VectorIndexEngine;
+use db::index::vector::engine::flat::Flat;
+use db::index::vector::engine::ivfflat::IvfFlat;
+use db::index::vector::engine::ivfflat::IvfFlatParams;
+use db::index::vector::store::MemoryNodeStore;
+use db::index::vector::store::NodeId;
+use defra_core::vector::Metric;
+
+async fn built(nlist: u32, seed: u64, vectors: &[Vec<f32>]) -> IvfFlat<MemoryNodeStore> {
+    let params = IvfFlatParams {
+        nlist,
+        nprobe: nlist,
+        ..IvfFlatParams::default()
+    };
+    let mut index = IvfFlat::try_new(MemoryNodeStore::new(), Metric::Cosine, params, seed)
+        .expect("cosine partitions soundly");
+    for (i, vector) in vectors.iter().enumerate() {
+        index.insert(NodeId(i as u64 + 1), vector).await.unwrap();
+    }
+    index.build().await.unwrap();
+    index
+}
+
+async fn flat_of(vectors: &[Vec<f32>]) -> Flat<MemoryNodeStore> {
+    let mut flat = Flat::new(MemoryNodeStore::new(), Metric::Cosine);
+    for (i, vector) in vectors.iter().enumerate() {
+        flat.insert(NodeId(i as u64 + 1), vector).await.unwrap();
+    }
+    flat
+}
+
+/// `(seed, corpus, dimensions, clusters, nlist, k)`. Deliberately varied
+/// shapes: `nlist` above, below and equal to the true cluster count, a
+/// single-list corpus, and a single-document corpus, so a bug that only shows
+/// up when a list is empty or when `nlist` does not match reality cannot hide
+/// behind one lucky configuration.
+const CASES: &[(u64, usize, usize, usize, u32, usize)] = &[
+    (0x0001, 200, 8, 5, 5, 10),
+    (0x0002, 500, 16, 12, 12, 10),
+    (0x0003, 300, 4, 3, 7, 5),
+    (0x0004, 150, 32, 6, 6, 20),
+    (0x0005, 1, 8, 1, 1, 5),
+    (0x0006, 64, 8, 1, 1, 10),
+    (0x0007, 800, 16, 20, 3, 15),
+];
+
+#[tokio::test]
+async fn nprobe_equal_to_nlist_matches_flat_exactly() {
+    for &(seed, count, dimensions, clusters, nlist, k) in CASES {
+        let mut corpus = crate::support::Corpus::new(seed);
+        let vectors = corpus.clustered(count, dimensions, clusters, 0.15);
+
+        let index = built(nlist, seed ^ 0xF1A7, &vectors).await;
+        let flat = flat_of(&vectors).await;
+
+        let mut queries = crate::support::Corpus::new(seed ^ 0xC0FF_EE00);
+        for q in 0..25 {
+            let query = queries.vector(dimensions);
+            let from_ivf = index.search(query.as_slice(), k, None).await.unwrap();
+            let from_flat = flat.search(query.as_slice(), k, None).await.unwrap();
+            assert_eq!(
+                from_ivf, from_flat,
+                "seed={seed:#x} count={count} dims={dimensions} clusters={clusters} \
+                 nlist={nlist} query={q}: ids, distances or order diverged from Flat"
+            );
+
+            // And a corpus vector itself, so a tie against its own bucket-mate
+            // is exercised, not only a random unseen query.
+            let self_query = &vectors[q % vectors.len()];
+            let from_ivf = index.search(self_query.as_slice(), k, None).await.unwrap();
+            let from_flat = flat.search(self_query.as_slice(), k, None).await.unwrap();
+            assert_eq!(
+                from_ivf, from_flat,
+                "seed={seed:#x} corpus-vector query {q}: ids, distances or order diverged"
+            );
+        }
+    }
+}
+
+/// A deleted document must never come back, and every document IVF_FLAT does
+/// return must be one `Flat` would also return, at the identical distance:
+/// the strongest claim that holds once tombstones are in play, proved in the
+/// module doc above. Full list equality is not that claim; see
+/// `ivfflat_engine::a_selective_filter_can_return_fewer_than_k_when_the_probed_lists_run_out`
+/// for the same "fewer than k survives" shape under a filter instead of a
+/// delete.
+#[tokio::test]
+async fn deletes_never_resurrect_and_every_survivor_matches_flat() {
+    for &(seed, count, dimensions, clusters, nlist, k) in CASES {
+        let mut corpus = crate::support::Corpus::new(seed ^ 0x5EED);
+        let vectors = corpus.clustered(count, dimensions, clusters, 0.15);
+
+        let mut index = built(nlist, seed ^ 0xF1A7, &vectors).await;
+        let mut flat = flat_of(&vectors).await;
+
+        let deleted: std::collections::HashSet<u64> =
+            (1..=vectors.len() as u64).step_by(3).collect();
+        for &id in &deleted {
+            index.delete(NodeId(id)).await.unwrap();
+            flat.delete(NodeId(id)).await.unwrap();
+        }
+
+        let mut queries = crate::support::Corpus::new(seed ^ 0xBEEF);
+        for _ in 0..10 {
+            let query = queries.vector(dimensions);
+            let from_ivf = index.search(query.as_slice(), k, None).await.unwrap();
+            let from_flat = flat.search(query.as_slice(), k, None).await.unwrap();
+
+            assert!(from_ivf.len() <= k, "seed={seed:#x}: returned more than k");
+            assert!(
+                from_ivf.iter().all(|hit| !deleted.contains(&hit.id.0)),
+                "seed={seed:#x}: a deleted document was returned: {from_ivf:?}"
+            );
+            assert!(
+                from_ivf.iter().all(|hit| from_flat.contains(hit)),
+                "seed={seed:#x}: IVF_FLAT returned a hit Flat would not: \
+                 ivf={from_ivf:?} flat={from_flat:?}"
+            );
+        }
+    }
+}

--- a/crates/db/tests/vector/ivfflat_recall_gate.rs
+++ b/crates/db/tests/vector/ivfflat_recall_gate.rs
@@ -1,0 +1,221 @@
+//! The IVF_FLAT recall target: a regression gate on a named distribution.
+//!
+//! Scoped deliberately. These thresholds hold for the synthetic clustered
+//! corpus below and say nothing about a real embedding corpus, which has
+//! never been measured here. What they catch is the index getting worse than
+//! it is today.
+//!
+//! Unlike `ivfpq_recall_gate.rs` there is no quantization error to isolate:
+//! every recall lost here is a true neighbour sitting in an unprobed list, so
+//! `nprobe == nlist` is not a loose target but an exact one, proven generally
+//! in `ivfflat_exactness.rs` and echoed here as a floor on this corpus.
+
+use db::index::vector::engine::ann::VectorIndexEngine;
+use db::index::vector::engine::flat::Flat;
+use db::index::vector::engine::hnsw::Hnsw;
+use db::index::vector::engine::ivfflat::IvfFlat;
+use db::index::vector::engine::ivfflat::IvfFlatParams;
+use db::index::vector::engine::ivfpq::IvfPq;
+use db::index::vector::engine::ivfpq::IvfPqParams;
+use db::index::vector::params::Params;
+use db::index::vector::params::DEFAULT_EF_SEARCH;
+use db::index::vector::params::DEFAULT_M;
+use db::index::vector::store::MemoryNodeStore;
+use db::index::vector::store::NodeId;
+use defra_core::vector::Metric;
+
+const SEED: u64 = 0x09C0_F1A7;
+const K: usize = 10;
+const QUERIES: usize = 12;
+const DIMENSIONS: usize = 16;
+
+struct Measured {
+    recall: f64,
+}
+
+async fn oracle(vectors: &[Vec<f32>]) -> Flat<MemoryNodeStore> {
+    let mut flat = Flat::new(MemoryNodeStore::new(), Metric::Cosine);
+    for (i, vector) in vectors.iter().enumerate() {
+        flat.insert(NodeId(i as u64 + 1), vector).await.unwrap();
+    }
+    flat
+}
+
+async fn exact(flat: &Flat<MemoryNodeStore>, query: &[f32]) -> Vec<u64> {
+    flat.search(query, K, None)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|n| n.id.0)
+        .collect()
+}
+
+async fn measure(nprobe: u32) -> Measured {
+    let mut corpus = crate::support::Corpus::new(SEED);
+    let vectors = corpus.clustered(600, DIMENSIONS, 8, 0.4);
+    let queries = corpus.vectors(QUERIES, DIMENSIONS);
+
+    let mut index = IvfFlat::try_new(
+        MemoryNodeStore::new(),
+        Metric::Cosine,
+        IvfFlatParams {
+            nlist: 8,
+            nprobe,
+            ..IvfFlatParams::default()
+        },
+        SEED,
+    )
+    .unwrap();
+    for (i, vector) in vectors.iter().enumerate() {
+        index.insert(NodeId(i as u64 + 1), vector).await.unwrap();
+    }
+    index.build().await.unwrap();
+
+    // Built once, not per query: the oracle is the same for every one of them.
+    let flat = oracle(&vectors).await;
+    let (mut hit, mut total) = (0usize, 0usize);
+    for query in &queries {
+        let want = exact(&flat, query).await;
+        let got = index.search(query.as_slice(), K, None).await.unwrap();
+        hit += got.iter().filter(|n| want.contains(&n.id.0)).count();
+        total += want.len();
+    }
+
+    Measured {
+        recall: hit as f64 / total as f64,
+    }
+}
+
+/// Every list probed, so the scan is exhaustive and there is no partial-probe
+/// error left at all: this must be a perfect recall against the same oracle,
+/// on this corpus, not merely a high one.
+#[tokio::test]
+async fn probing_every_list_matches_the_oracle_exactly() {
+    let m = measure(8).await;
+    println!("nprobe=8 (of 8): recall@10={:.4}", m.recall);
+    assert_eq!(
+        m.recall, 1.0,
+        "full probe must be exact, recall@10 was {:.4}",
+        m.recall
+    );
+}
+
+/// One list probed: most of the loss is the coarse step missing a neighbour
+/// it never scanned. A floor, so a broken probe ordering is caught.
+#[tokio::test]
+async fn a_single_probe_still_finds_most_neighbours() {
+    let m = measure(1).await;
+    println!("nprobe=1 (of 8): recall@10={:.4}", m.recall);
+    assert!(m.recall >= 0.55, "recall@10 fell to {:.4}", m.recall);
+}
+
+/// Probing more lists can only see more candidates.
+#[tokio::test]
+async fn recall_rises_with_nprobe() {
+    let one = measure(1).await.recall;
+    let half = measure(4).await.recall;
+    let all = measure(8).await.recall;
+    assert!(
+        half >= one,
+        "probing half the lists ({half:.4}) was worse than one ({one:.4})"
+    );
+    assert!(
+        all >= half,
+        "probing every list ({all:.4}) was worse than half ({half:.4})"
+    );
+}
+
+/// Recall at each engine's own default settings, on one shared corpus: what
+/// #1516 asks the PR to report rather than assume. Not a regression gate
+/// (each engine already has its own), just the comparison written down.
+///
+/// Every parameter left at `default()`: `nlist` and `m` derive from the
+/// corpus, `nprobe` is `DEFAULT_NPROBE`, `ef_search` is `DEFAULT_EF_SEARCH`.
+#[tokio::test]
+async fn recall_against_ivfpq_and_hnsw_at_default_settings() {
+    const COUNT: usize = 2_000;
+    const DIMS: usize = 32;
+    const CLUSTERS: usize = 40;
+    const COMPARE_SEED: u64 = 0x9E37_79B9;
+
+    let mut corpus = crate::support::Corpus::new(COMPARE_SEED);
+    let vectors = corpus.clustered(COUNT, DIMS, CLUSTERS, 0.15);
+
+    let flat = oracle(&vectors).await;
+
+    let mut ivfflat = IvfFlat::try_new(
+        MemoryNodeStore::new(),
+        Metric::Cosine,
+        IvfFlatParams::default(),
+        COMPARE_SEED,
+    )
+    .unwrap();
+    let mut ivfpq = IvfPq::try_new(
+        MemoryNodeStore::new(),
+        Metric::Cosine,
+        IvfPqParams::default(),
+        COMPARE_SEED,
+    )
+    .unwrap();
+    let mut hnsw = Hnsw::new(
+        MemoryNodeStore::new(),
+        Metric::Cosine,
+        Params::new(DEFAULT_M),
+        COMPARE_SEED,
+    );
+    for (i, vector) in vectors.iter().enumerate() {
+        let id = NodeId(i as u64 + 1);
+        ivfflat.insert(id, vector).await.unwrap();
+        ivfpq.insert(id, vector).await.unwrap();
+        hnsw.insert(id, vector).await.unwrap();
+    }
+    ivfflat.build().await.unwrap();
+    ivfpq.build().await.unwrap();
+
+    let mut queries = crate::support::Corpus::new(COMPARE_SEED ^ 0xFFFF);
+    let (mut hit_ivfflat, mut hit_ivfpq, mut hit_hnsw, mut total) =
+        (0usize, 0usize, 0usize, 0usize);
+    for _ in 0..QUERIES {
+        let query = queries.vector(DIMS);
+        let want = exact(&flat, &query).await;
+
+        let from_ivfflat = ivfflat.search(&query, K, None).await.unwrap();
+        let from_ivfpq = ivfpq.search(&query, K, None).await.unwrap();
+        let from_hnsw = hnsw
+            .search(&query, K, Some(DEFAULT_EF_SEARCH))
+            .await
+            .unwrap();
+
+        hit_ivfflat += from_ivfflat
+            .iter()
+            .filter(|n| want.contains(&n.id.0))
+            .count();
+        hit_ivfpq += from_ivfpq.iter().filter(|n| want.contains(&n.id.0)).count();
+        hit_hnsw += from_hnsw.iter().filter(|n| want.contains(&n.id.0)).count();
+        total += want.len();
+    }
+
+    let recall_ivfflat = hit_ivfflat as f64 / total as f64;
+    let recall_ivfpq = hit_ivfpq as f64 / total as f64;
+    let recall_hnsw = hit_hnsw as f64 / total as f64;
+
+    println!(
+        "corpus: clustered N={COUNT} d={DIMS} clusters={CLUSTERS}, defaults, recall@{K}:\n\
+         \x20 IVF_FLAT (nlist={}, nprobe={}) = {recall_ivfflat:.4}\n\
+         \x20 IVF_PQ   (nlist={}, nprobe={}, m={}) = {recall_ivfpq:.4}\n\
+         \x20 HNSW     (m={DEFAULT_M}, ef_search={DEFAULT_EF_SEARCH}) = {recall_hnsw:.4}",
+        IvfFlatParams::default().resolved_nlist(COUNT as u64),
+        IvfFlatParams::default().nprobe,
+        IvfPqParams::default().resolved_nlist(COUNT as u64),
+        IvfPqParams::default().nprobe,
+        IvfPqParams::default().resolved_m(DIMS),
+    );
+
+    // A floor, not a race: IVF_FLAT has no quantization error, so it must not
+    // be the worst of the three on the same corpus at default settings.
+    assert!(
+        recall_ivfflat >= recall_ivfpq - 0.02,
+        "IVF_FLAT ({recall_ivfflat:.4}) fell meaningfully behind IVF_PQ ({recall_ivfpq:.4}) \
+         despite paying no quantization error"
+    );
+}

--- a/crates/db/tests/vector/main.rs
+++ b/crates/db/tests/vector/main.rs
@@ -1,6 +1,9 @@
 //! Vector index engines, quantization and recall gates.
 
 mod edge_selection;
+mod ivfflat_engine;
+mod ivfflat_exactness;
+mod ivfflat_recall_gate;
 mod ivfpq_engine;
 mod ivfpq_recall_baseline;
 mod ivfpq_recall_gate;

--- a/crates/db/tests/vector/vector_collection_index.rs
+++ b/crates/db/tests/vector/vector_collection_index.rs
@@ -1,6 +1,7 @@
 //! The vector index seen through `CollectionIndex`: what a document write does
 //! to the graph.
 
+use db::index::vector::engine::ivf;
 use db::index::vector::index::VectorIndex;
 use db::index::vector::kv_store::KvNodeStore;
 use db::index::vector::store::NodeId;
@@ -10,6 +11,7 @@ use schema::DistanceMetric;
 use schema::HnswParams;
 use schema::IndexDescription;
 use schema::IndexedFieldDescription;
+use schema::IvfFlatParams;
 use schema::VectorAlgorithm;
 use schema::VectorIndexDescription;
 use storage::corekv::Store;
@@ -27,6 +29,7 @@ fn vector_config(dimensions: u32) -> VectorIndexDescription {
         dimensions,
         hnsw: Some(HnswParams::default()),
         ivfpq: None,
+        ivfflat: None,
         ssg: None,
     }
 }
@@ -321,6 +324,95 @@ async fn dropping_the_index_removes_every_key() {
         kv.get_meta().await.unwrap(),
         None,
         "the meta key must go too"
+    );
+}
+
+/// IVF_FLAT's aux keyspace is a second full copy of the corpus, since a list
+/// entry holds the vector rather than a small code, so leaking it on drop
+/// would leak the whole corpus again rather than a handful of centroids.
+/// `remove_all` must clear it completely once trained, not only while the
+/// index is still a staging `Flat`.
+#[tokio::test]
+async fn dropping_a_trained_ivfflat_index_removes_every_key() {
+    let store = RegolithStore::in_memory().unwrap();
+    let desc = IndexDescription {
+        name: "by_embedding".to_string(),
+        id: 9,
+        fields: vec![IndexedFieldDescription {
+            name: "embedding".to_string(),
+            descending: false,
+        }],
+        unique: false,
+        kind: None,
+        auto_generated: false,
+    }
+    .as_vector(VectorIndexDescription {
+        algorithm: VectorAlgorithm::IvfFlat,
+        metric: DistanceMetric::Cosine,
+        dimensions: DIMENSIONS,
+        hnsw: None,
+        ivfpq: None,
+        ivfflat: Some(IvfFlatParams {
+            nlist: 4,
+            nprobe: 4,
+            ..IvfFlatParams::default()
+        }),
+        ssg: None,
+    });
+    let index = VectorIndex::try_new(COLLECTION, desc).expect("a valid IVF_FLAT description");
+
+    let mut corpus = crate::support::Corpus::new(0x1F_1A7);
+    let vectors = corpus.vectors(200, DIMENSIONS as usize);
+
+    let mut write = txn(&store).await;
+    for (i, vector) in vectors.iter().enumerate() {
+        let widened: Vec<f64> = vector.iter().map(|x| *x as f64).collect();
+        index
+            .save(&mut write, i as u64 + 1, &wide(&widened))
+            .await
+            .unwrap();
+    }
+    write.commit().await.unwrap();
+    assert_eq!(live_ids(&store, &index).await.len(), 200);
+
+    // The index must actually have trained, or this test proves nothing about
+    // the trained aux keyspace at all.
+    let mut read = txn(&store).await;
+    let kv = KvNodeStore::new(&mut read, COLLECTION, 9, 0);
+    assert!(
+        kv.get_aux(ivf::STATE, b"").await.unwrap().is_some(),
+        "test setup: 200 documents must be enough to cross the training threshold"
+    );
+
+    let mut write = txn(&store).await;
+    index.remove_all(&mut write).await.unwrap();
+    write.commit().await.unwrap();
+
+    assert!(live_ids(&store, &index).await.is_empty());
+    let mut read = txn(&store).await;
+    let kv = KvNodeStore::new(&mut read, COLLECTION, 9, 0);
+    assert_eq!(kv.get_meta().await.unwrap(), None);
+    assert!(
+        kv.get_aux(ivf::STATE, b"").await.unwrap().is_none(),
+        "the trained-state marker must go"
+    );
+    assert!(
+        kv.get_aux(ivf::CENTROID, &0u32.to_be_bytes())
+            .await
+            .unwrap()
+            .is_none(),
+        "a centroid must go"
+    );
+    let mut list_entries = 0;
+    kv.iterate_aux(ivf::LIST, b"", |_, _| {
+        list_entries += 1;
+        Ok(())
+    })
+    .await
+    .unwrap();
+    assert_eq!(
+        list_entries, 0,
+        "the inverted lists, the full-vector copy, must go"
     );
 }
 

--- a/crates/db/tests/vector/vector_distance_metrics.rs
+++ b/crates/db/tests/vector/vector_distance_metrics.rs
@@ -45,6 +45,7 @@ fn index(metric: DistanceMetric) -> VectorIndex {
         dimensions: 2,
         hnsw: Some(HnswParams::default()),
         ivfpq: None,
+        ivfflat: None,
         ssg: None,
     });
     VectorIndex::try_new(COLLECTION, desc).expect("a valid vector description")

--- a/crates/db/tests/vector/vector_engine.rs
+++ b/crates/db/tests/vector/vector_engine.rs
@@ -23,6 +23,8 @@ use db::index::vector::engine::ann::VectorIndexEngine;
 use db::index::vector::engine::flat::Flat;
 use db::index::vector::engine::hnsw::Hnsw;
 use db::index::vector::engine::hnsw::LevelSampler;
+use db::index::vector::engine::ivfflat::IvfFlat;
+use db::index::vector::engine::ivfflat::IvfFlatParams;
 use db::index::vector::params::Params;
 use db::index::vector::params::DEFAULT_EF_CONSTRUCTION;
 use db::index::vector::params::DEFAULT_EF_SEARCH;
@@ -261,11 +263,11 @@ async fn recall_against_an_exact_scan_is_recorded() {
     );
 }
 
-/// Both kinds must be usable through the trait alone, with no knowledge of
-/// which one is behind it. A trait one type implements is a guess; this is what
-/// makes it an abstraction.
+/// Every kind exercised here must be usable through the trait alone, with no
+/// knowledge of which one is behind it. A trait one type implements is a
+/// guess; this is what makes it an abstraction.
 #[tokio::test]
-async fn both_kinds_satisfy_the_engine_trait() {
+async fn every_exercised_kind_satisfies_the_engine_trait() {
     async fn exercise<E: VectorIndexEngine>(
         engine: &mut E,
         vectors: &[Vec<f32>],
@@ -339,6 +341,21 @@ async fn both_kinds_satisfy_the_engine_trait() {
         &mut Flat::new(MemoryNodeStore::new(), Metric::Cosine),
         &vectors,
         EngineKind::Flat,
+    )
+    .await;
+    // Below the train threshold, so this exercises the staging path: an
+    // IvfFlat that never builds must behave exactly like Flat, which is the
+    // same contract IvfPq and Ssg's own staging paths carry.
+    exercise(
+        &mut IvfFlat::try_new(
+            MemoryNodeStore::new(),
+            Metric::Cosine,
+            IvfFlatParams::default(),
+            GRAPH_SEED,
+        )
+        .expect("cosine partitions soundly"),
+        &vectors,
+        EngineKind::IvfFlat,
     )
     .await;
 }

--- a/crates/db/tests/vector/vector_flat_algorithm.rs
+++ b/crates/db/tests/vector/vector_flat_algorithm.rs
@@ -39,6 +39,7 @@ fn description(algorithm: VectorAlgorithm, hnsw: Option<HnswParams>) -> IndexDes
         dimensions: DIMENSIONS,
         hnsw,
         ivfpq: None,
+        ivfflat: None,
         ssg: None,
     })
 }
@@ -216,6 +217,7 @@ async fn the_ivfpq_algorithm_is_selectable() {
             m: 4,
             ..schema::IvfPqParams::default()
         }),
+        ivfflat: None,
         ssg: None,
     });
     let index = VectorIndex::try_new(COLLECTION, desc).expect("a valid IVF-PQ description");
@@ -262,6 +264,7 @@ fn an_ivfpq_index_with_an_unrankable_metric_is_refused() {
             dimensions: DIMENSIONS,
             hnsw: None,
             ivfpq: Some(schema::IvfPqParams::default()),
+            ivfflat: None,
             ssg: None,
         });
     let err = VectorIndex::try_new(COLLECTION, desc).unwrap_err();
@@ -280,6 +283,7 @@ async fn the_ssg_algorithm_is_selectable() {
         dimensions: DIMENSIONS,
         hnsw: None,
         ivfpq: None,
+        ivfflat: None,
         ssg: Some(schema::SsgParams::default()),
     });
     let index = VectorIndex::try_new(COLLECTION, desc).expect("a valid SSG description");
@@ -314,6 +318,7 @@ fn out_of_range_ssg_parameters_are_refused() {
         dimensions: DIMENSIONS,
         hnsw: None,
         ivfpq: None,
+        ivfflat: None,
         ssg: Some(schema::SsgParams {
             angle: 200,
             ..schema::SsgParams::default()

--- a/crates/db/tests/vector/vector_kv_built_state.rs
+++ b/crates/db/tests/vector/vector_kv_built_state.rs
@@ -5,6 +5,8 @@
 //! trained structures actually persist rather than that the algorithm works.
 
 use db::index::vector::engine::ann::VectorIndexEngine;
+use db::index::vector::engine::ivfflat::IvfFlat;
+use db::index::vector::engine::ivfflat::IvfFlatParams;
 use db::index::vector::engine::ivfpq::IvfPq;
 use db::index::vector::engine::ivfpq::IvfPqParams;
 use db::index::vector::engine::ssg::Ssg;
@@ -76,6 +78,57 @@ async fn ivfpq_training_survives_a_commit() {
         .unwrap();
     assert_eq!(hits.len(), 5);
     assert_eq!(hits[0].id, NodeId(4), "a vector is nearest itself");
+}
+
+/// The same, for IVF_FLAT: trained state, centroids and list entries (full
+/// vectors, not codes) must survive a commit, or a reopened index silently
+/// answers from its staging path forever.
+#[tokio::test]
+async fn ivfflat_training_survives_a_commit() {
+    let backing = RegolithStore::in_memory().unwrap();
+    let vectors = corpus(400);
+    let params = IvfFlatParams {
+        nlist: 8,
+        nprobe: 8,
+        ..IvfFlatParams::default()
+    };
+
+    let mut write = txn(&backing).await;
+    {
+        let store = KvNodeStore::new(&mut write, COLLECTION, INDEX + 3, 0);
+        let mut index = IvfFlat::try_new(store, Metric::Cosine, params, SEED).unwrap();
+        for (i, vector) in vectors.iter().enumerate() {
+            index.insert(NodeId(i as u64 + 1), vector).await.unwrap();
+        }
+        assert!(!index.is_trained().await.unwrap());
+        let report = index.build().await.unwrap();
+        assert_eq!(report.indexed, 400);
+    }
+    write.commit().await.unwrap();
+
+    let mut read = txn(&backing).await;
+    let store = KvNodeStore::new(&mut read, COLLECTION, INDEX + 3, 0);
+    let reopened = IvfFlat::try_new(store, Metric::Cosine, params, SEED).unwrap();
+
+    let state = reopened
+        .trained()
+        .await
+        .unwrap()
+        .expect("the trained state must have been persisted");
+    assert_eq!(state.nlist, 8);
+    assert_eq!(state.dimensions, DIMENSIONS as u32);
+
+    let hits = reopened
+        .search(vectors[3].as_slice(), 5, None)
+        .await
+        .unwrap();
+    assert_eq!(hits.len(), 5);
+    assert_eq!(hits[0].id, NodeId(4), "a vector is nearest itself");
+    assert!(
+        hits[0].distance < 1e-6,
+        "a reopened index must still rank a vector against itself at ~0, got {}",
+        hits[0].distance
+    );
 }
 
 #[tokio::test]

--- a/crates/db/tests/vector/vector_kv_cost.rs
+++ b/crates/db/tests/vector/vector_kv_cost.rs
@@ -13,7 +13,10 @@ use crate::support::CORPUS_SEED;
 use crate::support::GRAPH_SEED;
 use crate::support::QUERY_SEED;
 use db::index::error::Result;
+use db::index::vector::engine::ann::VectorIndexEngine;
 use db::index::vector::engine::hnsw::Hnsw;
+use db::index::vector::engine::ivfflat::IvfFlat;
+use db::index::vector::engine::ivfflat::IvfFlatParams;
 use db::index::vector::kv_store::KvNodeStore;
 use db::index::vector::params::Params;
 use db::index::vector::params::DEFAULT_M;
@@ -31,7 +34,7 @@ use storage::corekv::Store;
 use storage::corekv::Txn;
 use storage::RegolithStore;
 
-/// Counts every key read and write reaching the store.
+/// Counts every key read and write reaching the store, node and aux alike.
 #[derive(Debug, Default)]
 struct Counting<S> {
     inner: S,
@@ -40,6 +43,13 @@ struct Counting<S> {
     /// Distinct keys read, so a repeat read of the same node is visible
     /// separately from a genuinely new one.
     distinct: Mutex<HashSet<u64>>,
+    /// Entries handed to an `iterate_aux` visitor: what a list scan actually
+    /// touches, as opposed to the number of `iterate_aux` calls (one per
+    /// probed list) or the corpus size.
+    aux_entries_visited: AtomicUsize,
+    /// Largest single value handed to `put_aux`, so a build's per-write cost
+    /// can be checked against one vector's width rather than assumed.
+    max_aux_write_bytes: AtomicUsize,
 }
 
 impl<S> Counting<S> {
@@ -49,6 +59,8 @@ impl<S> Counting<S> {
             reads: AtomicUsize::new(0),
             writes: AtomicUsize::new(0),
             distinct: Mutex::new(HashSet::new()),
+            aux_entries_visited: AtomicUsize::new(0),
+            max_aux_write_bytes: AtomicUsize::new(0),
         }
     }
 
@@ -64,6 +76,15 @@ impl<S> Counting<S> {
             self.reads.swap(0, Ordering::Relaxed),
             self.writes.swap(0, Ordering::Relaxed),
             distinct,
+        )
+    }
+
+    /// Aux entries visited, and the largest single write, since the last
+    /// call.
+    fn take_aux(&self) -> (usize, usize) {
+        (
+            self.aux_entries_visited.swap(0, Ordering::Relaxed),
+            self.max_aux_write_bytes.swap(0, Ordering::Relaxed),
         )
     }
 }
@@ -99,22 +120,33 @@ impl<S: VectorNodeStore> VectorNodeStore for Counting<S> {
     }
 
     async fn get_aux(&self, kind: u8, key: &[u8]) -> Result<Option<bytes::Bytes>> {
+        self.reads.fetch_add(1, Ordering::Relaxed);
         self.inner.get_aux(kind, key).await
     }
 
     async fn put_aux(&mut self, kind: u8, key: &[u8], value: &[u8]) -> Result<()> {
+        self.writes.fetch_add(1, Ordering::Relaxed);
+        self.max_aux_write_bytes
+            .fetch_max(value.len(), Ordering::Relaxed);
         self.inner.put_aux(kind, key, value).await
     }
 
     async fn delete_aux(&mut self, kind: u8, key: &[u8]) -> Result<()> {
+        self.writes.fetch_add(1, Ordering::Relaxed);
         self.inner.delete_aux(kind, key).await
     }
 
-    async fn iterate_aux<F>(&self, kind: u8, key_prefix: &[u8], visit: F) -> Result<()>
+    async fn iterate_aux<F>(&self, kind: u8, key_prefix: &[u8], mut visit: F) -> Result<()>
     where
         F: FnMut(&[u8], &[u8]) -> Result<()> + MaybeSend,
     {
-        self.inner.iterate_aux(kind, key_prefix, visit).await
+        let entries = &self.aux_entries_visited;
+        self.inner
+            .iterate_aux(kind, key_prefix, |key, value| {
+                entries.fetch_add(1, Ordering::Relaxed);
+                visit(key, value)
+            })
+            .await
     }
 }
 
@@ -180,5 +212,164 @@ async fn cost_against_a_kv_store() {
                 insert_reads as f64 / count as f64,
             );
         }
+    }
+}
+
+/// IVF_FLAT's build cost: whether it holds anything sized by the corpus.
+///
+/// The structure passed between the read pass that computes a document's list
+/// and the write pass that stores it is `(u32, NodeId)`, never the vector
+/// itself; the vector is re-read from the node it is already durable in. That
+/// is checked two ways rather than assumed: the number of aux writes a build
+/// performs is exactly `nlist` centroids plus one list entry per document
+/// plus one state marker (linear in the corpus, never more), and no single
+/// write handed to the store ever exceeds one vector's encoded width, at any
+/// corpus size or dimension.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "measurement; run with --ignored --nocapture"]
+async fn ivfflat_build_holds_nothing_corpus_sized() {
+    println!(
+        "{:>7} {:>4} {:>6} {:>12} {:>12} {:>14} {:>14}",
+        "N", "dim", "nlist", "expect_writes", "writes", "max_write(B)", "vector(B)"
+    );
+
+    for (count, dimensions, nlist) in [(200usize, 16usize, 8u32), (2_000, 16, 32), (2_000, 256, 32)]
+    {
+        let mut corpus = Corpus::new(CORPUS_SEED);
+        let vectors = corpus.vectors(count, dimensions);
+
+        let store = RegolithStore::in_memory().unwrap();
+        let mut write: Box<dyn Txn> = store.new_txn(false).await.unwrap();
+        let params = IvfFlatParams {
+            nlist,
+            nprobe: nlist,
+            ..IvfFlatParams::default()
+        };
+        let mut index = IvfFlat::try_new(
+            Counting::new(KvNodeStore::new(&mut write, 1, 1, 0)),
+            Metric::Cosine,
+            params,
+            GRAPH_SEED,
+        )
+        .unwrap();
+        for (i, vector) in vectors.iter().enumerate() {
+            index.insert(NodeId(i as u64 + 1), vector).await.unwrap();
+        }
+        // Discard the insert phase's own counts: only the build matters here.
+        index.store().take();
+        index.store().take_aux();
+
+        let report = index.build().await.unwrap();
+        let (_reads, actual_writes, _distinct) = index.store().take();
+        let (_visited, max_write) = index.store().take_aux();
+
+        let expected_writes = report.state.nlist as usize + report.indexed as usize + 1;
+        let one_vector_bytes = dimensions * 4;
+
+        println!(
+            "{count:>7} {dimensions:>4} {nlist:>6} {expected_writes:>12} {actual_writes:>12} \
+             {max_write:>14} {one_vector_bytes:>14}"
+        );
+        assert_eq!(
+            actual_writes, expected_writes,
+            "build performed {actual_writes} aux writes, expected exactly \
+             nlist + corpus + 1 = {expected_writes}: a build is not linear in the corpus"
+        );
+        assert_eq!(
+            max_write, one_vector_bytes,
+            "the largest single aux write was {max_write}B, expected exactly one \
+             encoded vector ({one_vector_bytes}B): some write scaled with the corpus"
+        );
+    }
+}
+
+/// IVF_FLAT's search cost: whether a probe reads only the lists it probed,
+/// rather than assuming it from the design.
+///
+/// The entries an `iterate_aux` scan hands to its visitor during a search are
+/// counted directly. Probing every list must visit exactly one entry per live
+/// document, since every document lives in exactly one list; probing fewer
+/// must visit strictly fewer than the whole corpus, or the entire premise of
+/// probing a handful of lists instead of scanning everything does not hold.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "measurement; run with --ignored --nocapture"]
+async fn ivfflat_search_reads_only_the_probed_lists() {
+    const COUNT: usize = 3_000;
+    const DIMENSIONS: usize = 32;
+    const NLIST: u32 = 24;
+    const K: usize = 10;
+    const QUERIES: usize = 30;
+
+    let mut corpus = Corpus::new(CORPUS_SEED);
+    let vectors = corpus.vectors(COUNT, DIMENSIONS);
+
+    let store = RegolithStore::in_memory().unwrap();
+    let mut write: Box<dyn Txn> = store.new_txn(false).await.unwrap();
+    {
+        let params = IvfFlatParams {
+            nlist: NLIST,
+            nprobe: NLIST,
+            ..IvfFlatParams::default()
+        };
+        let mut index = IvfFlat::try_new(
+            KvNodeStore::new(&mut write, 2, 2, 0),
+            Metric::Cosine,
+            params,
+            GRAPH_SEED,
+        )
+        .unwrap();
+        for (i, vector) in vectors.iter().enumerate() {
+            index.insert(NodeId(i as u64 + 1), vector).await.unwrap();
+        }
+        index.build().await.unwrap();
+    }
+    write.commit().await.unwrap();
+
+    println!("{:>6} {:>12} {:>10}", "nprobe", "visited/q", "of_corpus");
+
+    for nprobe in [1u32, 4, 12, NLIST] {
+        let mut read: Box<dyn Txn> = store.new_txn(false).await.unwrap();
+        let params = IvfFlatParams {
+            nlist: NLIST,
+            nprobe,
+            ..IvfFlatParams::default()
+        };
+        let index = IvfFlat::try_new(
+            Counting::new(KvNodeStore::new(&mut read, 2, 2, 0)),
+            Metric::Cosine,
+            params,
+            GRAPH_SEED,
+        )
+        .unwrap();
+
+        let mut queries = Corpus::new(QUERY_SEED);
+        let mut visited_total = 0usize;
+        for _ in 0..QUERIES {
+            let query = queries.vector(DIMENSIONS);
+            index.store().take_aux();
+            let hits = index.search(&query, K, None).await.unwrap();
+            assert!(!hits.is_empty(), "nprobe={nprobe}: an empty answer");
+
+            let (visited, _) = index.store().take_aux();
+            if nprobe >= NLIST {
+                assert_eq!(
+                    visited, COUNT,
+                    "probing every list must visit exactly one entry per live document"
+                );
+            } else {
+                assert!(
+                    visited < COUNT,
+                    "nprobe={nprobe} visited {visited} of {COUNT}: the probe did not narrow \
+                     the scan below the whole corpus"
+                );
+            }
+            visited_total += visited;
+        }
+
+        let visited_per_query = visited_total as f64 / QUERIES as f64;
+        println!(
+            "{nprobe:>6} {visited_per_query:>12.1} {:>9.1}%",
+            100.0 * visited_per_query / COUNT as f64
+        );
     }
 }

--- a/crates/db/tests/vector/vector_train_trigger.rs
+++ b/crates/db/tests/vector/vector_train_trigger.rs
@@ -49,6 +49,7 @@ fn ivfpq_vector_description() -> VectorIndexDescription {
             m: 4,
             ..schema::IvfPqParams::default()
         }),
+        ivfflat: None,
         ssg: None,
     }
 }
@@ -60,6 +61,7 @@ fn hnsw_vector_description() -> VectorIndexDescription {
         dimensions: DIMENSIONS,
         hnsw: Some(schema::HnswParams::default()),
         ivfpq: None,
+        ivfflat: None,
         ssg: None,
     }
 }

--- a/crates/http/tests/vector_index_api.rs
+++ b/crates/http/tests/vector_index_api.rs
@@ -55,6 +55,7 @@ fn the_response_reports_the_kind() {
             dimensions: 4,
             hnsw: Some(HnswParams::default()),
             ivfpq: None,
+            ivfflat: None,
             ssg: None,
         }),
     };

--- a/crates/query/src/sdl_parse/builder.rs
+++ b/crates/query/src/sdl_parse/builder.rs
@@ -785,6 +785,7 @@ impl<'a> SdlParser<'a> {
                     (config.flat.is_some(), schema::VectorAlgorithm::Flat),
                     (config.hnsw.is_some(), schema::VectorAlgorithm::Hnsw),
                     (config.ivfpq.is_some(), schema::VectorAlgorithm::IvfPq),
+                    (config.ivfflat.is_some(), schema::VectorAlgorithm::IvfFlat),
                     (config.ssg.is_some(), schema::VectorAlgorithm::Ssg),
                 ] {
                     if !present {
@@ -824,6 +825,9 @@ impl<'a> SdlParser<'a> {
                     schema::VectorAlgorithm::Hnsw => hnsw.metric.clone(),
                     schema::VectorAlgorithm::IvfPq => {
                         config.ivfpq.as_ref().and_then(|b| b.metric.clone())
+                    }
+                    schema::VectorAlgorithm::IvfFlat => {
+                        config.ivfflat.as_ref().and_then(|b| b.metric.clone())
                     }
                     schema::VectorAlgorithm::Ssg => {
                         config.ssg.as_ref().and_then(|b| b.metric.clone())
@@ -867,6 +871,7 @@ impl<'a> SdlParser<'a> {
                             }),
                             schema::VectorAlgorithm::Flat
                             | schema::VectorAlgorithm::IvfPq
+                            | schema::VectorAlgorithm::IvfFlat
                             | schema::VectorAlgorithm::Ssg => None,
                         },
                         ivfpq: match algorithm {
@@ -878,6 +883,20 @@ impl<'a> SdlParser<'a> {
                                     nprobe: ivfpq.nprobe.unwrap_or(defaults.nprobe),
                                     m: ivfpq.m.unwrap_or(defaults.m),
                                     sample_bytes: ivfpq
+                                        .sample_bytes
+                                        .map_or(defaults.sample_bytes, u64::from),
+                                })
+                            }
+                            _ => None,
+                        },
+                        ivfflat: match algorithm {
+                            schema::VectorAlgorithm::IvfFlat => {
+                                let ivfflat = config.ivfflat.clone().unwrap_or_default();
+                                let defaults = schema::IvfFlatParams::default();
+                                Some(schema::IvfFlatParams {
+                                    nlist: ivfflat.nlist.unwrap_or(defaults.nlist),
+                                    nprobe: ivfflat.nprobe.unwrap_or(defaults.nprobe),
+                                    sample_bytes: ivfflat
                                         .sample_bytes
                                         .map_or(defaults.sample_bytes, u64::from),
                                 })

--- a/crates/query/src/sdl_parse/directives.rs
+++ b/crates/query/src/sdl_parse/directives.rs
@@ -231,6 +231,8 @@ pub struct VectorIndexConfig {
     pub flat: Option<FlatConfig>,
     /// Present when the `ivfpq` argument was given.
     pub ivfpq: Option<IvfPqConfig>,
+    /// Present when the `ivfflat` argument was given.
+    pub ivfflat: Option<IvfFlatConfig>,
     /// Present when the `ssg` argument was given.
     pub ssg: Option<SsgConfig>,
     /// Present when the `hnsw` argument was given. Its absence still means
@@ -279,6 +281,17 @@ pub struct IvfPqConfig {
     pub nlist: Option<u32>,
     pub nprobe: Option<u32>,
     pub m: Option<u32>,
+    pub sample_bytes: Option<u32>,
+}
+
+/// The `ivfflat` block. Every member is optional; an omitted one keeps its
+/// default, and a zero is derived from the corpus. No `m`: a list holds the
+/// full vector, so there is nothing to quantize.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct IvfFlatConfig {
+    pub metric: Option<String>,
+    pub nlist: Option<u32>,
+    pub nprobe: Option<u32>,
     pub sample_bytes: Option<u32>,
 }
 

--- a/crates/query/src/sdl_parse/fields.rs
+++ b/crates/query/src/sdl_parse/fields.rs
@@ -62,7 +62,7 @@ impl<'a> SdlParser<'a> {
                 "crdt" => result.crdt_type = Some(self.parse_crdt_directive(directive)?),
                 "index" => match self.parse_index_directive(directive, Some(field_name))? {
                     ParsedIndex::Ordered(config) => result.index.push(config),
-                    ParsedIndex::Vector(config) => result.vector_index.push(config),
+                    ParsedIndex::Vector(config) => result.vector_index.push(*config),
                 },
                 "relation" => result.relation_name = get_directive_string(directive, "name"),
                 "default" => {
@@ -510,7 +510,7 @@ impl<'a> SdlParser<'a> {
             }
             let mut config = self.parse_vector_index_config(value)?;
             config.name = name;
-            return Ok(ParsedIndex::Vector(config));
+            return Ok(ParsedIndex::Vector(Box::new(config)));
         }
 
         // Resolved here rather than as each argument is read, because an
@@ -613,7 +613,9 @@ impl<'a> SdlParser<'a> {
         &self,
         value: &SchemaValue<'_>,
     ) -> Result<super::directives::VectorIndexConfig> {
-        use super::directives::{directive_u32, FlatConfig, HnswConfig, IvfPqConfig, SsgConfig};
+        use super::directives::{
+            directive_u32, FlatConfig, HnswConfig, IvfFlatConfig, IvfPqConfig, SsgConfig,
+        };
 
         let SchemaValue::Object(members) = value else {
             return Err(QueryError::parse(
@@ -680,6 +682,23 @@ impl<'a> SdlParser<'a> {
                         *slot = Some(read_block_u32(name, value)?);
                     }
                     config.ivfpq = Some(block);
+                }
+                block if block == schema::VectorAlgorithm::IvfFlat.sdl_block() => {
+                    let mut block = IvfFlatConfig::default();
+                    for (name, value) in vector_block(member, member_value)? {
+                        let slot = match name.as_str() {
+                            "metric" => {
+                                block.metric = Some(read_metric(member, value)?);
+                                continue;
+                            }
+                            "nlist" => &mut block.nlist,
+                            "nprobe" => &mut block.nprobe,
+                            "sampleBytes" => &mut block.sample_bytes,
+                            other => return Err(unknown_vector_member(member, other)),
+                        };
+                        *slot = Some(read_block_u32(name, value)?);
+                    }
+                    config.ivfflat = Some(block);
                 }
                 block if block == schema::VectorAlgorithm::Ssg.sdl_block() => {
                     let mut block = SsgConfig::default();
@@ -890,7 +909,10 @@ type SchemaValue<'a> = graphql_parser::schema::Value<'a, String>;
 /// two different places.
 pub(super) enum ParsedIndex {
     Ordered(IndexConfig),
-    Vector(super::directives::VectorIndexConfig),
+    // Boxed: `VectorIndexConfig` carries one optional config block per
+    // algorithm, and `IvfFlatConfig` pushed it past clippy's size-difference
+    // threshold against `IndexConfig`, the enum's other, much smaller variant.
+    Vector(Box<super::directives::VectorIndexConfig>),
 }
 
 /// The kind an argument selects. Distinct from `schema::IndexKind` because the

--- a/crates/query/tests/vector_index_sdl.rs
+++ b/crates/query/tests/vector_index_sdl.rs
@@ -489,6 +489,34 @@ fn ivfpq_defaults_are_kept() {
 }
 
 #[test]
+fn ivfflat_parameters_are_read() {
+    let vector = only_vector(
+        r#"type Doc {
+            e: [Float!] @index(vector: {
+                dimensions: 128,
+                ivfflat: {nlist: 256, nprobe: 16, sampleBytes: 1048576}
+            })
+        }"#,
+    );
+    assert_eq!(vector.algorithm, VectorAlgorithm::IvfFlat);
+    assert!(vector.hnsw.is_none(), "IVF_FLAT carries no HNSW block");
+    let ivfflat = vector.ivfflat.expect("IVF_FLAT params");
+    assert_eq!(
+        (ivfflat.nlist, ivfflat.nprobe, ivfflat.sample_bytes),
+        (256, 16, 1_048_576)
+    );
+}
+
+#[test]
+fn ivfflat_defaults_are_kept() {
+    let vector =
+        only_vector(r#"type Doc { e: [Float!] @index(vector: {dimensions: 8, alg: IVF_FLAT}) }"#);
+    let ivfflat = vector.ivfflat.expect("IVF_FLAT params");
+    assert_eq!(ivfflat.nprobe, 8);
+    assert_eq!(ivfflat.nlist, 0, "zero derives nlist from the corpus");
+}
+
+#[test]
 fn ssg_parameters_are_read() {
     let vector = only_vector(
         r#"type Doc {
@@ -515,6 +543,7 @@ fn flat_carries_no_build_parameters() {
     assert_eq!(vector.algorithm, VectorAlgorithm::Flat);
     assert!(vector.hnsw.is_none());
     assert!(vector.ivfpq.is_none());
+    assert!(vector.ivfflat.is_none());
     assert!(vector.ssg.is_none());
 }
 
@@ -532,6 +561,10 @@ fn an_unknown_block_argument_is_refused() {
         (
             r#"type Doc { e: [Float!] @index(vector: {dimensions: 8, flat: {nlist: 4}}) }"#,
             "nlist",
+        ),
+        (
+            r#"type Doc { e: [Float!] @index(vector: {dimensions: 8, ivfflat: {m: 4}}) }"#,
+            "m",
         ),
     ] {
         let err = parse_sdl(sdl).expect_err("a misspelled argument must not parse");

--- a/crates/query/tests/vector_routing.rs
+++ b/crates/query/tests/vector_routing.rs
@@ -30,6 +30,7 @@ fn vector_index(id: u32, field: &str, dimensions: u32) -> IndexDescription {
         dimensions,
         hnsw: Some(HnswParams::default()),
         ivfpq: None,
+        ivfflat: None,
         ssg: None,
     })
 }
@@ -69,6 +70,7 @@ fn vector_index_with_metric(id: u32, field: &str, metric: DistanceMetric) -> Ind
         dimensions: DIMENSIONS,
         hnsw: Some(HnswParams::default()),
         ivfpq: None,
+        ivfflat: None,
         ssg: None,
     })
 }

--- a/crates/query/tests/vector_routing_hybrid.rs
+++ b/crates/query/tests/vector_routing_hybrid.rs
@@ -30,6 +30,7 @@ fn vector_index() -> Vec<IndexDescription> {
         dimensions: VECTOR.len() as u32,
         hnsw: Some(HnswParams::default()),
         ivfpq: None,
+        ivfflat: None,
         ssg: None,
     })]
 }

--- a/crates/schema/src/index.rs
+++ b/crates/schema/src/index.rs
@@ -409,6 +409,10 @@ vector_algorithms! {
     /// Coarse lists of product-quantized codes. Approximate and lossy, in
     /// exchange for a code far smaller than the vector it stands for.
     IvfPq => "IVF_PQ" / "ivfpq",
+    /// Coarse lists of full-precision vectors: the same partitioning as
+    /// `IvfPq`, with nothing compressed, so inside a probed list the ranking
+    /// is exact.
+    IvfFlat => "IVF_FLAT" / "ivfflat",
     /// Satellite System Graph: one flat layer, edges pruned by angle.
     Ssg => "SSG" / "ssg",
 }
@@ -434,11 +438,18 @@ impl VectorAlgorithm {
     /// inherent there, but the quantized path has no measured recall for it, so
     /// it stays refused rather than shipped unmeasured.
     ///
+    /// IVF_FLAT has no ADC: it ranks a probed list at full precision, in
+    /// whatever metric was asked for. What is restricted is the *coarse*
+    /// step, which partitions by centroid distance and is sound only when
+    /// vectors are normalized, as cosine does on insert. `DOT` would silently
+    /// cost recall in a way no cosine-corpus test would catch, so it stays
+    /// refused for the same reason IVF-PQ's `EUCLIDEAN` does: unmeasured.
+    ///
     /// Refused when the definition is written rather than when the first
     /// document is indexed.
     pub fn supports_metric(self, metric: DistanceMetric) -> bool {
         match self {
-            Self::IvfPq => metric == DistanceMetric::Cosine,
+            Self::IvfPq | Self::IvfFlat => metric == DistanceMetric::Cosine,
             Self::Hnsw | Self::Flat | Self::Ssg => true,
         }
     }
@@ -563,6 +574,9 @@ pub struct VectorIndexDescription {
     /// Present when `algorithm` is IVF_PQ.
     #[serde(rename = "IVFPQ", default, skip_serializing_if = "Option::is_none")]
     pub ivfpq: Option<IvfPqParams>,
+    /// Present when `algorithm` is IVF_FLAT.
+    #[serde(rename = "IVFFLAT", default, skip_serializing_if = "Option::is_none")]
+    pub ivfflat: Option<IvfFlatParams>,
     /// Present when `algorithm` is SSG.
     #[serde(rename = "SSG", default, skip_serializing_if = "Option::is_none")]
     pub ssg: Option<SsgParams>,
@@ -643,6 +657,42 @@ impl Default for IvfPqParams {
     }
 }
 
+/// IVF_FLAT build and search parameters.
+///
+/// `0` means derive `nlist` from the corpus, matching [`IvfPqParams`]. There
+/// is no `m`: a list holds the full vector rather than a quantized code, so
+/// there is nothing to quantize.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IvfFlatParams {
+    /// Coarse centroids, and therefore inverted lists.
+    #[serde(rename = "NList", default)]
+    pub nlist: u32,
+    /// Lists probed per query.
+    #[serde(rename = "NProbe", default = "default_ivfflat_nprobe")]
+    pub nprobe: u32,
+    /// Cap on the resident training sample.
+    #[serde(rename = "SampleBytes", default = "default_ivfflat_sample_bytes")]
+    pub sample_bytes: u64,
+}
+
+fn default_ivfflat_nprobe() -> u32 {
+    8
+}
+
+fn default_ivfflat_sample_bytes() -> u64 {
+    128 << 20
+}
+
+impl Default for IvfFlatParams {
+    fn default() -> Self {
+        Self {
+            nlist: 0,
+            nprobe: default_ivfflat_nprobe(),
+            sample_bytes: default_ivfflat_sample_bytes(),
+        }
+    }
+}
+
 impl VectorIndexDescription {
     /// A description carrying the chosen algorithm's default parameters.
     ///
@@ -660,6 +710,7 @@ impl VectorIndexDescription {
             dimensions,
             hnsw: matches!(algorithm, VectorAlgorithm::Hnsw).then(HnswParams::default),
             ivfpq: matches!(algorithm, VectorAlgorithm::IvfPq).then(IvfPqParams::default),
+            ivfflat: matches!(algorithm, VectorAlgorithm::IvfFlat).then(IvfFlatParams::default),
             ssg: matches!(algorithm, VectorAlgorithm::Ssg).then(SsgParams::default),
         }
     }

--- a/crates/schema/src/lib.rs
+++ b/crates/schema/src/lib.rs
@@ -38,7 +38,7 @@ pub use field::FieldDescription;
 pub use field_kind::{FieldKind, ScalarArrayKind, ScalarKind};
 pub use index::{
     DistanceMetric, EncryptedIndexDescription, EncryptedIndexType, FullTextIndexDescription,
-    HnswParams, IndexDescription, IndexKind, IndexedFieldDescription, IvfPqParams,
+    HnswParams, IndexDescription, IndexKind, IndexedFieldDescription, IvfFlatParams, IvfPqParams,
     OrderedIndexDescription, SsgParams, VectorAlgorithm, VectorIndexDescription,
 };
 pub use policy::PolicyDescription;

--- a/crates/schema/tests/index_kind_tests.rs
+++ b/crates/schema/tests/index_kind_tests.rs
@@ -3,8 +3,8 @@
 
 use proptest::prelude::*;
 use schema::{
-    DistanceMetric, HnswParams, IndexDescription, IndexKind, IvfPqParams, OrderedIndexDescription,
-    SsgParams, VectorAlgorithm, VectorIndexDescription,
+    DistanceMetric, HnswParams, IndexDescription, IndexKind, IvfFlatParams, IvfPqParams,
+    OrderedIndexDescription, SsgParams, VectorAlgorithm, VectorIndexDescription,
 };
 
 fn vector_description() -> VectorIndexDescription {
@@ -14,6 +14,7 @@ fn vector_description() -> VectorIndexDescription {
         dimensions: 768,
         hnsw: Some(HnswParams::default()),
         ivfpq: None,
+        ivfflat: None,
         ssg: None,
     }
 }
@@ -148,6 +149,7 @@ fn index_kinds() -> impl Strategy<Value = IndexKind> {
         Just(VectorAlgorithm::Hnsw),
         Just(VectorAlgorithm::Flat),
         Just(VectorAlgorithm::IvfPq),
+        Just(VectorAlgorithm::IvfFlat),
         Just(VectorAlgorithm::Ssg),
     ];
     let metrics = prop_oneof![Just(DistanceMetric::Cosine), Just(DistanceMetric::Dot)];
@@ -168,6 +170,13 @@ fn index_kinds() -> impl Strategy<Value = IndexKind> {
             },
         ),
     );
+    let ivfflat = prop::option::of((any::<u32>(), any::<u32>(), any::<u64>()).prop_map(
+        |(nlist, nprobe, sample_bytes)| IvfFlatParams {
+            nlist,
+            nprobe,
+            sample_bytes,
+        },
+    ));
     let ssg = prop::option::of(
         (any::<u32>(), any::<u32>(), any::<u32>()).prop_map(|(r, angle, pool)| SsgParams {
             r,
@@ -178,14 +187,15 @@ fn index_kinds() -> impl Strategy<Value = IndexKind> {
 
     prop_oneof![
         any::<bool>().prop_map(|unique| IndexKind::Ordered(OrderedIndexDescription { unique })),
-        (algorithms, metrics, any::<u32>(), hnsw, ivfpq, ssg).prop_map(
-            |(algorithm, metric, dimensions, hnsw, ivfpq, ssg)| {
+        (algorithms, metrics, any::<u32>(), hnsw, ivfpq, ivfflat, ssg).prop_map(
+            |(algorithm, metric, dimensions, hnsw, ivfpq, ivfflat, ssg)| {
                 IndexKind::Vector(VectorIndexDescription {
                     algorithm,
                     metric,
                     dimensions,
                     hnsw,
                     ivfpq,
+                    ivfflat,
                     ssg,
                 })
             }

--- a/crates/schema/tests/index_wire_shape.rs
+++ b/crates/schema/tests/index_wire_shape.rs
@@ -43,6 +43,7 @@ fn vector() -> VectorIndexDescription {
             ef_search: 64,
         }),
         ivfpq: None,
+        ivfflat: None,
         ssg: None,
     }
 }
@@ -416,4 +417,71 @@ fn ssg_is_an_algorithm_go_cannot_parse() {
 
     let back: IndexDescription = serde_json::from_value(json).unwrap();
     assert_eq!(back.vector().and_then(|v| v.ssg).map(|p| p.r), Some(32));
+}
+
+/// `IVF_FLAT` is the fifth divergence, and its parameter block has no `M`:
+/// a list holds the full vector, so there is nothing to quantize.
+#[test]
+fn ivfflat_is_an_algorithm_go_cannot_parse() {
+    use schema::IvfFlatParams;
+
+    assert!(!VectorAlgorithm::IvfFlat.is_go_compatible());
+    assert_eq!(
+        serde_json::to_value(VectorAlgorithm::IvfFlat).unwrap(),
+        json!("IVF_FLAT")
+    );
+
+    let desc = IndexDescription::new("i")
+        .as_vector(VectorIndexDescription {
+            algorithm: VectorAlgorithm::IvfFlat,
+            hnsw: None,
+            ivfflat: Some(IvfFlatParams {
+                nlist: 64,
+                nprobe: 12,
+                sample_bytes: 1 << 20,
+            }),
+            ..vector()
+        })
+        .normalized();
+
+    let json = serde_json::to_value(&desc).unwrap();
+    assert_eq!(json["KindDescription"]["Algorithm"], json!("IVF_FLAT"));
+    assert_eq!(
+        json["KindDescription"]["IVFFLAT"],
+        json!({"NList": 64, "NProbe": 12, "SampleBytes": 1_048_576})
+    );
+    assert!(!json["KindDescription"]
+        .as_object()
+        .unwrap()
+        .contains_key("HNSW"));
+    assert!(
+        !json["KindDescription"]
+            .as_object()
+            .unwrap()
+            .contains_key("M"),
+        "IVF_FLAT has no M to quantize with"
+    );
+
+    let back: IndexDescription = serde_json::from_value(json).unwrap();
+    assert_eq!(
+        back.vector().map(|v| v.algorithm),
+        Some(VectorAlgorithm::IvfFlat)
+    );
+    assert_eq!(
+        back.vector().and_then(|v| v.ivfflat).map(|p| p.nlist),
+        Some(64)
+    );
+}
+
+/// An HNSW description must not grow an IVFFLAT key either, mirroring the
+/// existing IVFPQ check: every Go-compatible definition stays free of every
+/// Rust-only algorithm's block.
+#[test]
+fn an_hnsw_description_carries_no_ivfflat_key() {
+    let json =
+        serde_json::to_value(IndexDescription::new("i").as_vector(vector()).normalized()).unwrap();
+    assert_eq!(
+        keys(&json["KindDescription"]),
+        ["Algorithm", "Dimensions", "HNSW", "Metric"]
+    );
 }


### PR DESCRIPTION
Closes #1516. Part of #1517. Stacked on #1670.

IVF-PQ was the only partitioned engine here, and it buys its speed with product quantization: the codes it scans are lossy, ADC ranks by squared L2 only, and it therefore refuses every metric but cosine. IVF_FLAT is the same partitioning with no compression, so a list holds the full-precision vector and the ranking inside the probed lists is exactly Flat's. It is the point between Flat (exact, linear in the corpus) and IVF-PQ (approximate, lossy, small) that most corpora want, and it is what pgvector ships as its default.

## The coarse half is now shared, not copied

`engine/ivf/` holds what two engines must agree on: the list key encoding, the vector codec, centroid training from a byte-bounded sample, and the centroid ranking that picks which lists to probe. IVF-PQ moves onto it in this same change rather than IVF_FLAT getting a copy with the PQ lines deleted, which is the divergence-waiting-to-ship shape the issue calls out: every open IVF bug would otherwise need fixing twice.

`ivfpq/codec.rs` drops from 115 lines to 51, keeping only its own `TrainedState` (which carries `m`, where the shared one does not) and that state's codec. The encoded form is byte-identical, so an index trained before this change still decodes; the golden-byte tests in `vector_kv_store.rs` pass unchanged.

## The list entry is the vector

`put_aux(LIST, list_key(list, id), encode_vector(&vector))`. One contiguous prefix scan per probed list yields id and vector together and feeds the SIMD kernel directly.

That costs a second copy of every vector, `4 * dimensions` bytes per document, so a 768-dimension corpus pays about 3 KiB per document twice. Said out loud in the module doc rather than discovered as a disk-usage surprise. It is the FAISS and pgvector layout, and the alternative (an empty list entry plus a random read per candidate) throws away the entire reason the list layout exists.

## Measured, not asserted

Same synthetic clustered corpus (N=2000, d=32, 40 clusters), default settings:

| engine | settings | recall |
|---|---|---|
| HNSW | m=16, ef_search=64 | 1.0000 |
| **IVF_FLAT** | nlist=178, nprobe=8 | **0.9750** |
| IVF-PQ | nlist=178, nprobe=8, m=4 | 0.7000 |

That gap is the whole point: same partitioning, same probe count, and the only difference is that IVF_FLAT scans real vectors where IVF-PQ scans codes.

These thresholds hold for this distribution and say nothing about a real embedding corpus, which is the same fence `ivfpq_recall_gate.rs` puts around its own numbers.

**Search reads only the probed lists.** Measured with an aux-visit counter, not assumed: at nlist=24, nprobe=1 visits 4.3% of the corpus per query, and nprobe=24 visits exactly 100.0% (3000/3000).

**Build holds nothing corpus-sized.** The intermediate buffer holds `(u32, NodeId)` pairs and never a vector; aux writes are exactly `nlist + corpus + 1` at every size tested (200 and 2000 documents at 16 and 256 dimensions), and the largest single write is one encoded vector (64 B and 1024 B respectively). That is an operation-count and write-size proof rather than a byte-level memory measurement, since there is no allocator-tracking infrastructure here; stated plainly rather than implied.

## The acceptance criterion

**At `nprobe == nlist`, IVF_FLAT returns exactly what `Flat` returns**: same ids, same distances, same order, ties included. Property-tested over seven corpus shapes at fifty queries each, comparing the whole `Vec<Neighbor>` rather than a summary. Any divergence there is a bug in the scan, not a recall tradeoff, which is why it is the criterion.

Tie-breaking therefore follows `Flat` and `Hnsw`, on ascending `NodeId`. IVF-PQ tie-breaks the other way; that is #1469 and is deliberately untouched here.

## Two things worth calling out

**A test that claimed too much.** The first version of the tombstone case asserted byte-identity to `Flat` after deletes. That is not true and cannot be: `iterate_aux`'s visitor is synchronous, so liveness is checked only after the top-k heap has filled (the same shape IVF-PQ already has), and a heap slot won by a tombstoned entry can starve a live one further out. The weaker true property is asserted instead, that every surviving hit is one `Flat` would also return at the same distance, with the reason in the module doc.

**Metrics.** `VectorAlgorithm::supports_metric` accepts cosine only, refusing at description-creation time exactly as IVF-PQ does. The coarse step is L2 over centroids, which is sound under cosine because vectors are normalized on insert; under `DOT` it is not, and shipping that without a measured MIPS recall number would be an unmeasured claim. The engine constructor accepts cosine and euclidean, mirroring `IvfPq::try_new` rather than inventing a new asymmetry.

## Wiring

`EngineKind::IvfFlat`, the dispatch arm, `VectorAlgorithm::IvfFlat => "IVF_FLAT" / "ivfflat"`, `IvfFlatParams` with `#[serde(rename = "IVFFLAT")]` through the wire envelope, an `ivfflat:` SDL block, the construction arm with the same construct-and-discard validation IVF-PQ gets, and the fifth kind in the benches. `is_go_compatible()` stays false: Go has only HNSW, so this is a deliberate wire divergence exactly as `IVF_PQ`, `SSG` and `FLAT` already are, and a description carrying it is not parseable by a Go node.

HTTP and WASM needed no change; both are generic over `schema::VectorIndexDescription`.

## Verification

```
cargo test -p db -p schema -p query -p cli    0 failures; db's vector suite 197 passed
cargo clippy --all --all-targets -- -D warnings    clean
cargo fmt --all --check                            clean
```

One real lint fired during the work: `clippy::large_enum_variant` on `ParsedIndex` once `VectorIndexConfig` grew past the threshold, fixed by boxing the vector variant.

## Known, not fixed here

`crates/query/src/sdl_parse/fields.rs` was already 1015 lines before this change and is 1037 after the new block's match arm. Restructuring it affects every directive kind in the file and is a larger decision than this change should make unasked. `crates/schema/src/index.rs` and `sdl_parse/builder.rs` grew modestly on already-oversized files for the same reason.
