### PR TITLE
fix(cli,db): re-push SE artifacts when retrying a replicator

### DIFF
--- a/crates/cli/src/commands/start/server_p2p/iroh.rs
+++ b/crates/cli/src/commands/start/server_p2p/iroh.rs
@@ -356,11 +356,13 @@ impl Node {
 
         let failure_recorder_task =
             defra_p2p_adapter::spawn_failure_recorder(store.clone(), failure_rx);
+        let se_repusher: Arc<dyn db::merge::SeArtifactRepusher> =
+            replication.broadcast_mutator.clone();
         let retry_loop_task = defra_p2p_adapter::spawn_retry_loop(
             store.clone(),
             transport.clone(),
             doc_pusher.clone(),
-            None,
+            Some(se_repusher),
         );
 
         let restore_peerstore = storage::stores::Peerstore::new(store);

--- a/crates/cli/src/commands/start/server_p2p/libp2p.rs
+++ b/crates/cli/src/commands/start/server_p2p/libp2p.rs
@@ -367,11 +367,13 @@ impl Node {
 
         let failure_recorder_task =
             defra_p2p_adapter::spawn_failure_recorder(store.clone(), failure_rx);
+        let se_repusher: Arc<dyn db::merge::SeArtifactRepusher> =
+            replication.broadcast_mutator.clone();
         let retry_loop_task = defra_p2p_adapter::spawn_retry_loop(
             store.clone(),
             p2p::Libp2pTransport::new(handle.clone()),
             doc_pusher.clone(),
-            None,
+            Some(se_repusher),
         );
 
         let restore_peerstore = storage::stores::Peerstore::new(store);

--- a/crates/db/src/merge/broadcast_mutator/mod.rs
+++ b/crates/db/src/merge/broadcast_mutator/mod.rs
@@ -190,6 +190,27 @@ impl<S: Store + 'static, B: Blockstore + 'static, T: P2PTransport> SeArtifactRep
     for BroadcastMutator<S, B, T>
 {
     async fn regenerate_and_push_se_artifacts(&self, collection_id: &str, doc_id: &str) {
+        // Durable retry markers may be doc-scoped with no collection id; resolve
+        // it from the document the same way `retry_doc` does.
+        let resolved_collection_id;
+        let collection_id = if collection_id.is_empty() {
+            resolved_collection_id =
+                match crate::merge::push_docs_common::resolve_collection_id_for_doc(
+                    &self.db, doc_id,
+                )
+                .await
+                {
+                    Ok(Some(id)) => id,
+                    Ok(None) => return,
+                    Err(error) => {
+                        tracing::warn!(doc_id, error = %error, "SE retry: failed to resolve collection");
+                        return;
+                    }
+                };
+            resolved_collection_id.as_str()
+        } else {
+            collection_id
+        };
         let collection = match self.db.find_collection_by_id(collection_id) {
             Ok(Some(collection)) => collection,
             Ok(None) => return,

--- a/tools/integration-test/tests/encryption/se_cross_runtime.rs
+++ b/tools/integration-test/tests/encryption/se_cross_runtime.rs
@@ -33,7 +33,7 @@
 
 use std::time::{Duration, Instant};
 
-use integration_test::TestCluster;
+use integration_test::{poll_until, TestCluster};
 
 /// A fixed 32-byte AES-256 searchable-encryption key shared across nodes.
 /// Distinct value per byte so a wrong key (e.g. a freshly generated one)
@@ -255,4 +255,132 @@ async fn go_to_rust_se_cross_node() {
     // (node 0) -- this exercises the Rust SE serve loop.
     let deadline = Instant::now() + Duration::from_secs(45);
     wait_for_se_query(&go, "User", r#"{name: {_eq: "John"}}"#, &doc_id, deadline).await;
+}
+
+fn peer_id_from_addr(addr: &str) -> String {
+    addr.rsplit_once("/p2p/")
+        .map_or(addr, |(_, peer_id)| peer_id)
+        .to_string()
+}
+
+/// Issue #1601: the replicator is killed, the OWNER writes while it is down
+/// (live push fails, leaving durable retry markers), the replicator restarts
+/// on the same rootdir + ports, and the owner reconnects. The retry pass must
+/// re-push the documents AND their SE artifacts: the documents arriving on the
+/// replicator (step 1) separates "retry never ran" from the SE symptom, then
+/// `encrypted_User` on the owner must resolve John via the replicator.
+/// Mirrors Go's `TestSEReplicator_IfDocAddedWhileReplicatorIsOffline_ShouldRetry`.
+#[tokio::test]
+async fn rust_rust_se_replicator_restart_retries_artifacts() {
+    let mut cluster = TestCluster::builder()
+        .rust_nodes(2)
+        .with_p2p()
+        .with_encryption()
+        .with_shared_searchable_encryption_key(SHARED_SE_KEY)
+        .with_store("regolith")
+        .health_timeout(Duration::from_secs(60))
+        .build()
+        .await
+        .expect("build rust 2-node regolith cluster with shared SE key");
+
+    let owner = cluster.client(0);
+    let replicator = cluster.client(1);
+
+    owner.schema_add(USER_SCHEMA).expect("add schema owner");
+    replicator
+        .schema_add(USER_SCHEMA)
+        .expect("add schema replicator");
+    owner
+        .encrypted_index_add("User", "name")
+        .expect("encrypted index owner");
+    replicator
+        .encrypted_index_add("User", "name")
+        .expect("encrypted index replicator");
+
+    connect_and_replicate(&cluster, 0, 1, "User").await;
+
+    let replicator_addr_before = replicator.p2p_info().expect("replicator p2p info")[0]
+        .as_str()
+        .expect("replicator has no P2P address")
+        .to_string();
+    let replicator_peer_id = peer_id_from_addr(&replicator_addr_before);
+
+    cluster.nodes[1].process.kill();
+    let owner_ref = &owner;
+    poll_until(
+        || {
+            owner_ref
+                .p2p_active_peers()
+                .unwrap_or_default()
+                .as_array()
+                .is_some_and(Vec::is_empty)
+        },
+        Duration::from_secs(15),
+        Duration::from_millis(250),
+        "owner still lists the killed replicator as an active peer",
+    )
+    .await;
+
+    let created = owner
+        .query(r#"mutation { add_User(input: {name: "John", age: 21, city: "NYC"}) { _docID } }"#)
+        .expect("create John on owner");
+    let john_doc_id = created["add_User"][0]["_docID"]
+        .as_str()
+        .or_else(|| created["add_User"]["_docID"].as_str())
+        .expect("missing _docID")
+        .to_string();
+    owner
+        .query(r#"mutation { add_User(input: {name: "Fred", age: 22, city: "LA"}) { _docID } }"#)
+        .expect("create Fred on owner");
+
+    cluster
+        .restart_node(1, Duration::from_secs(60))
+        .await
+        .expect("restart replicator after kill");
+    cluster
+        .wait_for_log(1, "p2p_listening", Duration::from_secs(30))
+        .await
+        .expect("restarted replicator P2P listener did not start");
+
+    let owner = cluster.client(0);
+    let replicator = cluster.client(1);
+    let replicator_addr_after = replicator.p2p_info().expect("replicator p2p info")[0]
+        .as_str()
+        .expect("restarted replicator has no P2P address")
+        .to_string();
+    assert_eq!(
+        peer_id_from_addr(&replicator_addr_after),
+        replicator_peer_id,
+        "replicator peer id changed across restart; the owner's replicator entry is keyed by it"
+    );
+    owner
+        .p2p_connect(&[&replicator_addr_after])
+        .expect("reconnect owner -> restarted replicator");
+
+    let deadline = Instant::now() + Duration::from_secs(60);
+    loop {
+        let result = replicator
+            .query("query { User { _docID } }")
+            .expect("query User on replicator");
+        if result["User"]
+            .as_array()
+            .is_some_and(|docs| docs.len() == 2)
+        {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "retry did not deliver both documents to the replicator; last result: {result}"
+        );
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+
+    wait_for_se_query(
+        &owner,
+        "User",
+        r#"{name: {_eq: "John"}}"#,
+        &john_doc_id,
+        Instant::now() + Duration::from_secs(30),
+    )
+    .await;
 }


### PR DESCRIPTION
Closes #1601

## What

When a replicator target is offline while the owner writes, the durable retry later re-delivers the documents but never their searchable-encryption artifacts, so the owner's `encrypted_<Collection>` query returns an empty `docIDs` list instead of the matching documents. The standalone CLI never wired an `SeArtifactRepusher` into its retry loop, and the shared re-push silently bailed on the empty `collection_id` that document-scope retry markers carry by design.

## What Changed

- `crates/cli/.../server_p2p/libp2p.rs`, `iroh.rs`: pass the broadcast mutator as the SE repusher to `spawn_retry_loop`, matching the embedded node.
- `crates/db/src/merge/broadcast_mutator/mod.rs`: `regenerate_and_push_se_artifacts` resolves the collection from the document when the marker's `collection_id` is empty, as `retry_doc` already does.
- `tools/integration-test/tests/encryption/se_cross_runtime.rs`: new `rust_rust_se_replicator_restart_retries_artifacts` (SIGKILL replicator, write, restart, reconnect, owner SE query), red before the fix.

## Verification

- [x] New integration test fails on the base commit with `{"encrypted_User":[{"docIDs":[]}]}` after both documents reached the replicator, and passes with the fix
- [x] `cargo test -p integration-test --test encryption -- se_cross_runtime::` (the two `rust_rust_*` tests pass; the `go_*` tests need a Go binary)
- [x] `cargo test -p cli` and `cargo test -p db` pass
- [x] `cargo clippy -p cli --all-targets -- -D warnings`, `cargo clippy -p db -- -D warnings`, `cargo clippy -p integration-test --test encryption -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] FFI oracle: `searchable_encryption` `TestSEReplicator_IfDocAddedWhileReplicatorIsOffline_ShouldRetry` passes (failed on main in the 2026-09-02 remeasure)
- [ ] CI green
