### PR TITLE
fix(ffi-test): pin a reachable Go client

### DIFF
--- a/crates/defra-version/src/lib.rs
+++ b/crates/defra-version/src/lib.rs
@@ -15,7 +15,7 @@ pub const GO_COMPAT_TAG: &str = "";
 /// comparable across baseline bumps. It lives on a dedicated compatibility
 /// branch upstream does not merge, and moves only when we retarget the parity
 /// claim or fix the client.
-pub const GO_FFI_CLIENT_COMMIT: &str = "e7cd3a8de";
+pub const GO_FFI_CLIENT_COMMIT: &str = "2c3f7ded0cedbd7a0e70b92e5a382e1db67b6162";
 
 /// Go compatibility metadata.
 #[derive(Debug, Clone, Serialize)]


### PR DESCRIPTION
## Context

The FFI test client pin references a commit that is not available from the remote Go repository, preventing fresh checkouts from preparing the compatibility worktree.

## Changes

- pin the Go FFI client to the verified remote `jack/ffi-rust-compat` head
- use the full commit SHA so the checkout remains unambiguous

## Testing

- [x] `cargo test -p defra-version`
- [x] `cargo test -p ffi-test`
- [x] `cargo clippy -p defra-version -p ffi-test --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check origin/main...HEAD`