### PR TITLE
fix(db): interactive txns detect write-write conflicts on shared blocks

### DIFF
--- a/crates/datastore/src/multistore.rs
+++ b/crates/datastore/src/multistore.rs
@@ -42,6 +42,14 @@ impl SharedTxn {
         txn.has(&prefixed).await
     }
 
+    /// Existence check that enters the key into the transaction's read set.
+    /// See [`storage::corekv::Reader::has_for_update`].
+    pub async fn has_for_update(&self, namespace: Namespace, key: &[u8]) -> Result<bool> {
+        let prefixed = prefix_key(namespace, key);
+        let txn = self.txn.read().await;
+        txn.has_for_update(&prefixed).await
+    }
+
     /// Get value size with namespace prefix.
     pub async fn get_size(&self, namespace: Namespace, key: &[u8]) -> Result<Option<usize>> {
         let prefixed = prefix_key(namespace, key);
@@ -140,6 +148,12 @@ impl NamespaceView {
         self.txn.has(self.namespace, key).await
     }
 
+    /// Existence check that enters the key into the transaction's read set.
+    /// See [`storage::corekv::Reader::has_for_update`].
+    pub async fn has_for_update(&self, key: &[u8]) -> Result<bool> {
+        self.txn.has_for_update(self.namespace, key).await
+    }
+
     /// Get value size.
     pub async fn get_size(&self, key: &[u8]) -> Result<Option<usize>> {
         self.txn.get_size(self.namespace, key).await
@@ -182,6 +196,10 @@ impl Reader for NamespaceView {
 
     async fn has(&self, key: &[u8]) -> Result<bool> {
         self.txn.has(self.namespace, key).await
+    }
+
+    async fn has_for_update(&self, key: &[u8]) -> Result<bool> {
+        self.txn.has_for_update(self.namespace, key).await
     }
 
     async fn get_size(&self, key: &[u8]) -> Result<Option<usize>> {

--- a/crates/db/src/write/doc.rs
+++ b/crates/db/src/write/doc.rs
@@ -249,6 +249,30 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
                 ))
             })?;
 
+            // Two creates with the same field value encode to the same
+            // byte-identical delta and so to the same content-addressed key,
+            // which the engine may treat as a non-conflicting blind write.
+            // `has_for_update` records the read even though this txn just
+            // wrote the block, so the second commit is validated against it
+            // and aborts (#1599).
+            //
+            // Interactive creates only: autocommit, batch and merge keep the
+            // blind write, and interactive updates rely on that to let
+            // distinct documents share a delta block (#1194). Encryption
+            // blocks stay out: the KMS commits the DEK in its own txn, so
+            // reading it back aborts every encrypted create.
+            for cid in block_result.field_cids.iter().chain([&block_result.cid]) {
+                blockstore
+                    .has_for_update(&cid.to_bytes())
+                    .await
+                    .map_err(|e| {
+                        query::error::QueryError::execution(format!(
+                            "failed to record block read for {}: {}",
+                            cid, e
+                        ))
+                    })?;
+            }
+
             let doc_id = crate::write::autocommit::helpers::register_created_doc(
                 &systemstore,
                 &datastore,

--- a/crates/storage/src/backends/regolith/transaction.rs
+++ b/crates/storage/src/backends/regolith/transaction.rs
@@ -141,6 +141,23 @@ impl Reader for RegolithTxn {
         }
     }
 
+    async fn has_for_update(&self, key: &[u8]) -> Result<bool> {
+        if key.is_empty() {
+            return Err(Error::EmptyKey);
+        }
+        match self.handle()?.as_ref() {
+            // A snapshot is never validated at commit, so there is no read
+            // set to enter and this is a plain existence check.
+            Handle::ReadOnly(snapshot) => snapshot
+                .has(key)
+                .map_err(|error| Error::Backend(error.to_string())),
+            // `get_for_update` records the read *before* consulting the write
+            // buffer, which `get_slice` does not, so a key this transaction
+            // already wrote still lands in the read set.
+            Handle::Writable(txn) => Ok(txn.get_for_update(key).map_err(map_txn_error)?.is_some()),
+        }
+    }
+
     async fn get_size(&self, key: &[u8]) -> Result<Option<usize>> {
         if key.is_empty() {
             return Err(Error::EmptyKey);

--- a/crates/storage/src/corekv/traits.rs
+++ b/crates/storage/src/corekv/traits.rs
@@ -100,6 +100,17 @@ pub trait Reader: MaybeSendSync + private::Sealed {
     /// to check existence.
     async fn has(&self, key: &[u8]) -> Result<bool>;
 
+    /// [`Reader::has`] that also enters `key` into the transaction's
+    /// conflict-detection read set, even when this transaction already wrote
+    /// it — a read served from its own write buffer never reaches the engine,
+    /// so plain `has` records nothing (#1599).
+    ///
+    /// Defaults to [`Reader::has`]: correct for any backend that does not
+    /// validate reads at commit.
+    async fn has_for_update(&self, key: &[u8]) -> Result<bool> {
+        self.has(key).await
+    }
+
     /// Get the size of a value without reading the entire value.
     ///
     /// This is useful for checking the size of large values without incurring
@@ -413,6 +424,10 @@ impl Reader for Box<dyn Txn> {
 
     async fn has(&self, key: &[u8]) -> Result<bool> {
         (**self).has(key).await
+    }
+
+    async fn has_for_update(&self, key: &[u8]) -> Result<bool> {
+        (**self).has_for_update(key).await
     }
 
     async fn get_size(&self, key: &[u8]) -> Result<Option<usize>> {

--- a/crates/storage/src/encrypted_store.rs
+++ b/crates/storage/src/encrypted_store.rs
@@ -129,6 +129,10 @@ impl Reader for EncryptedTxn {
         self.inner.has(key).await
     }
 
+    async fn has_for_update(&self, key: &[u8]) -> Result<bool> {
+        self.inner.has_for_update(key).await
+    }
+
     async fn get_size(&self, key: &[u8]) -> Result<Option<usize>> {
         match self.inner.get(key).await? {
             Some(ct) => Ok(Some(decrypt_value(&self.key, key, &ct)?.len())),

--- a/tools/integration-test/tests/basic/transactions.rs
+++ b/tools/integration-test/tests/basic/transactions.rs
@@ -579,3 +579,87 @@ async fn rust_txn_discard_publishes_no_events() {
     let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
     txn_discard_publishes_no_events(cluster).await;
 }
+
+/// Two overlapping interactive txns creating different documents that share a
+/// field value must not both commit. See crates/db/src/write/doc.rs (#1599).
+async fn txn_create_conflicting_block_aborts_second_commit(cluster: TestCluster) {
+    let client = cluster.client(0);
+
+    client
+        .schema_add("type Book { name: String  rating: Float }")
+        .expect("add schema");
+
+    let tx0 = client.tx_create().expect("tx0 create");
+    let tx1 = client.tx_create().expect("tx1 create");
+
+    client
+        .query_with_tx(
+            r#"mutation { add_Book(input: {name: "Book By Website", rating: 4.0}) { _docID } }"#,
+            &tx0,
+        )
+        .expect("tx0 create Book By Website");
+    client
+        .query_with_tx(
+            r#"mutation { add_Book(input: {name: "Book By Online", rating: 4.0}) { _docID } }"#,
+            &tx1,
+        )
+        .expect("tx1 create Book By Online");
+
+    client.tx_commit(&tx0).expect("tx0 commit");
+    let err = client
+        .tx_commit(&tx1)
+        .expect_err("tx1 commit must abort: both creates write the same rating block");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("transaction conflict"),
+        "expected a transaction conflict, got: {msg}"
+    );
+
+    let books = client
+        .query("query { Book { name } }")
+        .expect("query Book after commits");
+    let books = books["Book"].as_array().expect("Book result not array");
+    assert_eq!(books.len(), 1, "only tx0's Book should survive: {books:?}");
+    assert_eq!(books[0]["name"], "Book By Website");
+}
+
+#[tokio::test]
+async fn rust_txn_create_conflicting_block_aborts_second_commit() {
+    let _root = integration_test::workspace_root();
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    txn_create_conflicting_block_aborts_second_commit(cluster).await;
+}
+
+/// An `encrypt: true` create inside an interactive txn must commit: the KMS
+/// writes the DEK block in its own txn, so reading it back would abort every
+/// encrypted create. See crates/db/src/write/doc.rs (#1599).
+async fn txn_encrypted_create_commits(cluster: TestCluster) {
+    let client = cluster.client(0);
+
+    client
+        .schema_add("type TxnVault { name: String }")
+        .expect("add schema");
+
+    let tx_id = client.tx_create().expect("tx_create");
+    client
+        .query_with_tx(
+            r#"mutation { add_TxnVault(input: {name: "Alice"}, encrypt: true) { _docID } }"#,
+            &tx_id,
+        )
+        .expect("encrypted create in tx");
+    client
+        .tx_commit(&tx_id)
+        .expect("an encrypted interactive create must commit");
+
+    let read = client
+        .query("query { TxnVault { name } }")
+        .expect("query after commit");
+    assert_eq!(read["TxnVault"][0]["name"], "Alice");
+}
+
+#[tokio::test]
+async fn rust_txn_encrypted_create_commits() {
+    let _root = integration_test::workspace_root();
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    txn_encrypted_create_commits(cluster).await;
+}


### PR DESCRIPTION
Closes #1599

## What

Two overlapping interactive transactions that each create a different document both commit when their field deltas collide. An LWW delta carries no document identity, so two creates with the same field value encode to the same content-addressed block key, which the storage engine treats as a non-conflicting blind write. Go conflicts here because its blockstore `Put` is HAS-then-PUT and the existence read is recorded; the Rust writer sets blindly, so neither conflict rule fires and the second write is silently lost.

## What Changed

- Add `Reader::has_for_update`, an existence check that enters the key into the transaction's conflict-detection read set
- Implement it on `RegolithTxn` via `get_for_update`, recording the read before the write buffer is consulted
- Forward it through `Box<dyn Txn>`, `EncryptedTxn`, `SharedTxn` and `NamespaceView`
- Call it on the field and composite block CIDs in the interactive create path, so the second commit aborts with `transaction conflict`
- Keep autocommit, batch and merge on the blind write (the #1194 exemption) and exclude encryption blocks (the KMS commits the DEK in its own txn)
- Add `rust_txn_create_conflicting_block_aborts_second_commit` and `rust_txn_encrypted_create_commits`

## Verification

- [x] `cargo test -p integration-test --test basic rust_txn_create_conflicting_block_aborts_second_commit` — red on main, green here
- [x] `cargo test -p integration-test --test basic rust_txn_encrypted_create_commits`
- [x] `cargo test -p integration-test --test basic` (54), `--test issue1194_repro` (4), `--test query` (116), `--test acp` (204), `--test encryption` (19), `--test p2p` (102)
- [x] `cargo test -p db` (758), `-p storage` (454), `-p datastore` (26)
- [x] `cargo clippy --all -- -D warnings` and `cargo fmt --all --check`
- [ ] CI green
