### PR TITLE
fix(cli): hand the node identity to the libp2p host so peers can authenticate it

### DIFF
--- a/crates/cli/src/commands/start/p2p.rs
+++ b/crates/cli/src/commands/start/p2p.rs
@@ -92,6 +92,7 @@ impl Node {
         config: &Config,
         bitswap_store: p2p::BitswapStoreAdapter<blockstore::DefraBlockstore<storage::DynStore>>,
         keypair: Option<p2p::Keypair>,
+        node_identity: Option<std::sync::Arc<identity::RawIdentity>>,
         enable_pubsub: bool,
         classifier: std::sync::Arc<dyn p2p::bitswap::BlockClassifier>,
         serve_acp: std::sync::Arc<p2p::bitswap::LateBoundServeAcp>,
@@ -127,7 +128,7 @@ impl Node {
                 keypair,
                 bitswap_store,
                 p2p_config,
-                None,
+                node_identity,
                 classifier,
                 serve_acp,
             )

--- a/crates/cli/src/commands/start/server_p2p/libp2p.rs
+++ b/crates/cli/src/commands/start/server_p2p/libp2p.rs
@@ -15,6 +15,7 @@ impl Node {
         event_bus: Arc<dyn events::Bus>,
         config: &Config,
         peer_keypair: Option<p2p::Keypair>,
+        node_identity: Option<Arc<identity::RawIdentity>>,
         se_key: Option<[u8; 32]>,
     ) -> Result<P2PSetup> {
         info!("Initializing P2P network (libp2p)");
@@ -27,6 +28,7 @@ impl Node {
             config,
             bitswap_store,
             peer_keypair,
+            node_identity,
             config.net.pubsub_enabled,
             classifier.clone(),
             serve_acp.clone(),

--- a/crates/cli/src/commands/start/server_p2p/mod.rs
+++ b/crates/cli/src/commands/start/server_p2p/mod.rs
@@ -107,7 +107,16 @@ impl Node {
             }
         }
 
-        Self::setup_libp2p_p2p(store, database, event_bus, config, peer_keypair, se_key).await
+        Self::setup_libp2p_p2p(
+            store,
+            database,
+            event_bus,
+            config,
+            peer_keypair,
+            node_identity,
+            se_key,
+        )
+        .await
     }
 
     fn p2p_disabled(database: Arc<db::DB<storage::DynStore>>) -> P2PSetup {

--- a/tools/integration-test/tests/encryption/acp.rs
+++ b/tools/integration-test/tests/encryption/acp.rs
@@ -1,5 +1,9 @@
+use std::time::Duration;
+
+use integration_test::node::{DefraNode, RustNode};
 use integration_test::{
-    for_each_runtime, generate_identity, users_schema_with_policy, TestCluster, USER_ACP_POLICY,
+    for_each_runtime, generate_identity, poll_until, users_schema_with_policy, TestCluster,
+    USER_ACP_POLICY,
 };
 
 async fn encrypted_acp_test(cluster: TestCluster) {
@@ -148,3 +152,123 @@ async fn encrypted_acp_test(cluster: TestCluster) {
 }
 
 for_each_runtime!(encrypted_acp, encrypted_acp_test, .with_acp_local().with_encryption());
+
+/// Go oracle: `TestDocEncryptionACP_BranchableCollection_AuthorizedPeerCanFetch`.
+///
+/// An encrypted document in a `@branchable` collection must merge on a peer
+/// whose node identity holds `reader` on the collection object. No replicator:
+/// the peer pulls through the ACP read gate, exactly as the oracle does.
+#[tokio::test]
+async fn rust_encrypted_branchable_collection_grant_merges_on_peer() {
+    let binary = RustNode::from_workspace().binary_path().to_path_buf();
+    RustNode::build().expect("build rust binary");
+    let jack = generate_identity(&binary).expect("jack identity");
+    let node1_id = generate_identity(&binary).expect("node1 identity");
+
+    let cluster = TestCluster::builder()
+        .rust_nodes(2)
+        .skip_build()
+        .with_p2p()
+        .with_acp_local()
+        .with_encryption()
+        // Only the grantee needs a node identity. A `--identity` on node 0 would
+        // become the default request identity and make the "anonymous" create
+        // an owned document, which is not the oracle's public-doc scenario.
+        .with_node_identity(1, &node1_id.private_key_hex)
+        .build()
+        .await
+        .expect("build cluster");
+
+    let timeout = Duration::from_secs(15);
+    for i in 0..2 {
+        cluster
+            .wait_for_log(i, "p2p_listening", timeout)
+            .await
+            .expect("P2P listener did not start");
+    }
+
+    let node0 = cluster.client(0);
+    let node1 = cluster.client(1);
+
+    let policy = node0
+        .acp_policy_add(USER_ACP_POLICY, &jack.private_key_hex)
+        .expect("add policy on node0");
+    let policy_id = policy["PolicyID"]
+        .as_str()
+        .or_else(|| policy["policyID"].as_str())
+        .expect("missing PolicyID");
+    node1
+        .acp_policy_add(USER_ACP_POLICY, &jack.private_key_hex)
+        .expect("add policy on node1");
+
+    let schema = format!(
+        r#"type Users @branchable @policy(id: "{policy_id}", resource: "users") {{ name: String  age: Int }}"#
+    );
+    for node in [&node0, &node1] {
+        node.schema_add_with_identity(&schema, &jack.private_key_hex)
+            .expect("add schema");
+    }
+
+    let described = node0
+        .collection_describe_version("Users")
+        .expect("describe Users");
+    let described = described
+        .as_array()
+        .and_then(|versions| versions.first())
+        .cloned()
+        .unwrap_or(described);
+    let collection_id = described["CollectionID"]
+        .as_str()
+        .expect("missing CollectionID")
+        .to_string();
+
+    // The collection id stands in for the docID, exactly as the Go client does.
+    for node in [&node0, &node1] {
+        node.acp_relationship_add(
+            "Users",
+            &collection_id,
+            "reader",
+            &node1_id.did,
+            &jack.private_key_hex,
+        )
+        .expect("grant node1 reader on the collection object");
+    }
+
+    let info0 = node0.p2p_info().expect("node0 p2p info");
+    let addr0 = info0
+        .as_array()
+        .and_then(|arr| arr.first())
+        .and_then(|v| v.as_str())
+        .expect("node0 has no P2P address");
+    node1
+        .p2p_connect(&[addr0])
+        .expect("node1 connects to node0");
+    node0
+        .p2p_collection_add(&["Users"])
+        .expect("node0 subscribes");
+    node1
+        .p2p_collection_add(&["Users"])
+        .expect("node1 subscribes");
+
+    node0
+        .query(
+            r#"mutation { add_Users(input: {name: "Fred", age: 33}, encrypt: true) { _docID } }"#,
+        )
+        .expect("create encrypted doc on node0");
+
+    let node1_ref = &node1;
+    let jack_key = jack.private_key_hex.clone();
+    poll_until(
+        || {
+            node1_ref
+                .query_with_identity("query { Users { name } }", &jack_key)
+                .ok()
+                .map(|v| v["Users"] == serde_json::json!([{"name": "Fred"}]))
+                .unwrap_or(false)
+        },
+        Duration::from_secs(30),
+        Duration::from_millis(500),
+        "encrypted branchable doc did not merge on the granted peer",
+    )
+    .await;
+}


### PR DESCRIPTION
Refs #1603 (found while reproducing it; #1603 closes with the client pin bump at the top of this train)

## What

`start_p2p` passed a literal `None` as the libp2p host's node identity, so a `defra start` node answered every peer identity request with `node identity is not configured`. Every per-peer gate on the other side (bitswap read gate, CAR push gate, KMS key release) therefore denied a CLI node even when it held a valid grant. The embedded node never had this gap, which is why the Go oracle did not catch it.

## What Changed

- `crates/cli/src/commands/start/p2p.rs`, `server_p2p/mod.rs`, `server_p2p/libp2p.rs`: hand the configured node identity to the libp2p host
- `tools/integration-test/tests/encryption/acp.rs`: new `rust_encrypted_branchable_collection_grant_merges_on_peer` (two CLI nodes, local DAC, encryption, reader grant to node 1's node identity), red before the fix

## Verification

- [x] `cargo test -p integration-test --test encryption -- acp::rust_` — 2 passed (red on main)
- [x] `cargo test -p integration-test --test acp -- p2p::` — all Rust cases pass
- [x] `cargo test -p cli`, `cargo clippy --all -- -D warnings`, `cargo fmt --all --check`
- [ ] CI green
