### PR TITLE
chore(ffi-test): pin the merged rustffi client and guard the pin in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -455,6 +455,15 @@ jobs:
           while IFS= read -r H; do
             grep -qR --include='*.rs' -F "$H" crates/p2p/
           done <<< "$HEXES"
+      - name: Verify the pinned rustffi client resolves
+        if: matrix.suite == 'go-compat'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pin=$(sed -nE 's/^pub const GO_FFI_CLIENT_COMMIT: &str = "([0-9a-f]+)";/\1/p' crates/defra-version/src/lib.rs)
+          test -n "$pin" || { echo "GO_FFI_CLIENT_COMMIT not found in crates/defra-version/src/lib.rs"; exit 1; }
+          gh api "repos/sourcenetwork/defradb/commits/$pin" --jq .sha > /dev/null \
+            || { echo "GO_FFI_CLIENT_COMMIT=$pin does not resolve on sourcenetwork/defradb"; exit 1; }
       - name: Run rust integration tests (basic)
         if: matrix.suite == 'rust' || matrix.suite == 'signed-docs'
         run: >-

--- a/crates/defra-version/src/lib.rs
+++ b/crates/defra-version/src/lib.rs
@@ -19,10 +19,11 @@ pub const GO_COMPAT_TAG: &str = "";
 /// Deliberately independent of `GO_COMPAT_COMMIT`: that pin selects the Go
 /// binary the parity job measures against and tracks upstream drift, while this
 /// one fixes the Go *test corpus* the FFI oracle runs, so its pass rate stays
-/// comparable across baseline bumps. It lives on a dedicated compatibility
-/// branch upstream does not merge, and moves only when we retarget the parity
-/// claim or fix the client.
-pub const GO_FFI_CLIENT_COMMIT: &str = "2c3f7ded0cedbd7a0e70b92e5a382e1db67b6162";
+/// comparable across baseline bumps. It lives on `jack/ffi-rust-compat` in
+/// sourcenetwork/defradb, a maintained chore branch upstream does not merge,
+/// and moves only when we retarget the parity claim or fix the client. CI
+/// fails when the pinned commit does not resolve on that repository.
+pub const GO_FFI_CLIENT_COMMIT: &str = "0c0ecfd2e78f5e879064b1caec66ba887265f5bc";
 
 /// Go compatibility metadata.
 #[derive(Debug, Clone, Serialize)]


### PR DESCRIPTION
Closes #1600, closes #1603

## What

#1674 re-pinned `GO_FFI_CLIENT_COMMIT` to a reachable commit, `2c3f7ded0`, the `jack/ffi-rust-compat` head at the time. That head predates the seven client commits on `edjroz/ffi-rust-compat` (cgo pooling, header, and the three Go-side test fixes that took the 2026-08-26 oracle baseline from 82 failures to 26), so main's corpus lost them again. `jack/ffi-rust-compat` is now fast-forwarded to `0c0ecfd2e`, the merge of both lineages plus the node-identity forward for #1603; this PR pins that tip, keeps the branch name in the doc comment, and makes CI fail whenever the pinned commit stops resolving.

## What Changed

- `crates/defra-version/src/lib.rs`: `GO_FFI_CLIENT_COMMIT` `2c3f7ded0…` → `0c0ecfd2e78f5e879064b1caec66ba887265f5bc` (sourcenetwork/defradb@0c0ecfd2e, `jack/ffi-rust-compat` head); doc comment names the branch and the CI guard
- `.github/workflows/ci.yml`: go-compat step "Verify the pinned rustffi client resolves"

## Verification

- [x] `cargo test -p defra-version -p ffi-test`
- [x] Full 17-root `ffi-test` run on this head (`729d3290f`) against the pinned client: **3,255 pass / 17 fail / 141 skip, 99.48%** vs 3,248 / 24 / 141 (99.27%) on main 2026-09-02. Fixed: the #1599, #1600, #1601 and #1603 oracle tests, the two ACP P2P shared-field-block tests and one branchable-commits test; no regressions. Still failing, all pre-existing on main: #1584's four relation-patch tests, three composite-index order tests, two branchable sync tests, two groupBy tests, the `txn` package timeout, one encryption flake, and three signature tests that need the Go harness matcher to stop expecting hex now that Rust emits base64 (#1632); that last one is a client-side follow-up.
- [ ] CI step green
