### PR TITLE
fix(sourcehub): Vera proto package, bech32 prefix, and a separate Orbis service key

### DIFF
--- a/crates/cli/src/commands/start/mod.rs
+++ b/crates/cli/src/commands/start/mod.rs
@@ -404,14 +404,9 @@ impl StartArgs {
         Ok(())
     }
 
-    /// Parse the user identity from the --identity flag.
-    ///
-    /// The identity flag should contain a hex-encoded private key.
-    /// Key type is auto-detected from byte length:
-    /// - 64 bytes -> Ed25519
-    /// - 32 bytes -> secp256k1
     /// Parse `--signer-orbis-identity`, the key used only to authenticate to
-    /// the Orbis ring.
+    /// the Orbis ring. It is separate from `--identity` because the ring
+    /// accepts an EdDSA token while the chain needs a secp256k1 signer.
     #[cfg(feature = "orbis")]
     pub fn parse_orbis_service_identity(
         &self,
@@ -424,6 +419,12 @@ impl StartArgs {
         Ok(Some(std::sync::Arc::new(identity)))
     }
 
+    /// Parse the user identity from the --identity flag.
+    ///
+    /// The identity flag should contain a hex-encoded private key.
+    /// Key type is auto-detected from byte length:
+    /// - 64 bytes -> Ed25519
+    /// - 32 bytes -> secp256k1
     pub fn parse_user_identity(&self) -> Result<Option<std::sync::Arc<identity::RawIdentity>>> {
         let hex_key = match &self.identity {
             Some(key) => key,

--- a/crates/cli/src/commands/start/mod.rs
+++ b/crates/cli/src/commands/start/mod.rs
@@ -361,6 +361,8 @@ impl StartArgs {
             })?,
         };
 
+        Self::require_ed25519_service_key(service_identity.key_type())?;
+
         let endpoint = self.signer_orbis_endpoint.as_ref().ok_or_else(|| {
             Error::InvalidConfig("--signer-orbis-endpoint required for orbis signer".into())
         })?;
@@ -437,6 +439,25 @@ impl StartArgs {
         tracing::info!("User identity DID: {}", did);
 
         Ok(Some(std::sync::Arc::new(raw_identity)))
+    }
+
+    /// The Orbis ring authenticates a Sign request with a bearer token and
+    /// accepts EdDSA only. `new_token_with_custom_claims` picks the algorithm
+    /// from the key type, so a secp256k1 service key presents ES256K and the
+    /// ring refuses it. Reject it here, naming the flag, rather than letting it
+    /// surface as `unknown variant ES256K` from the ring at the first write.
+    #[cfg(feature = "orbis")]
+    fn require_ed25519_service_key(key_type: crypto::KeyType) -> Result<()> {
+        if key_type == crypto::KeyType::Ed25519 {
+            return Ok(());
+        }
+        Err(Error::InvalidConfig(format!(
+            "--signer-type=orbis needs an ed25519 service key, got {:?}. Pass \
+             one with --signer-orbis-identity: the ring accepts an EdDSA bearer \
+             token only, while --identity may be secp256k1 because it also \
+             signs chain transactions.",
+            key_type
+        )))
     }
 
     /// Build an identity from a hex private key, choosing the key type by
@@ -689,5 +710,30 @@ mod tests {
             format!("{err}").contains("invalid key length"),
             "unexpected error: {err}"
         );
+    }
+
+    #[cfg(feature = "orbis")]
+    #[test]
+    fn an_ed25519_service_key_is_accepted() {
+        StartArgs::require_ed25519_service_key(crypto::KeyType::Ed25519)
+            .expect("ed25519 is what the ring accepts");
+    }
+
+    #[cfg(feature = "orbis")]
+    #[test]
+    fn a_non_ed25519_service_key_is_refused_before_the_ring_sees_it() {
+        for key_type in [crypto::KeyType::Secp256k1, crypto::KeyType::Secp256r1] {
+            let err = StartArgs::require_ed25519_service_key(key_type)
+                .expect_err("the ring accepts EdDSA only");
+            let message = format!("{err}");
+            assert!(
+                message.contains("--signer-orbis-identity"),
+                "the error must name the flag that fixes it: {message}"
+            );
+            assert!(
+                message.contains(&format!("{key_type:?}")),
+                "the error must name the key type it got: {message}"
+            );
+        }
     }
 }

--- a/crates/cli/src/commands/start/mod.rs
+++ b/crates/cli/src/commands/start/mod.rs
@@ -129,6 +129,22 @@ pub struct StartArgs {
     #[arg(long)]
     pub signer_orbis_derivation: Option<String>,
 
+    /// Hex private key this node authenticates to the Orbis ring with,
+    /// separately from `--identity`.
+    ///
+    /// The ring authenticates a Sign request by a JWT whose algorithm follows
+    /// the key type, and it accepts EdDSA (ed25519) only. `--identity` is also
+    /// the key that signs SourceHub/Vera transactions, which must be
+    /// secp256k1. One key therefore cannot serve both roles: without this
+    /// flag a node with a secp256k1 identity presents an ES256K token and the
+    /// ring rejects it as an unknown algorithm.
+    ///
+    /// Defaults to `--identity` when unset, which keeps the previous behaviour
+    /// for a node whose identity is already ed25519.
+    #[cfg(feature = "orbis")]
+    #[arg(long)]
+    pub signer_orbis_identity: Option<String>,
+
     /// Max request body size in bytes (0 = unlimited, default)
     #[arg(long)]
     pub max_body_size: Option<u64>,
@@ -334,13 +350,16 @@ impl StartArgs {
         &self,
         user_identity: &Option<std::sync::Arc<identity::RawIdentity>>,
     ) -> Result<()> {
-        let service_identity = user_identity.as_ref().ok_or_else(|| {
-            Error::InvalidConfig(
-                "--identity is required when --signer-type=orbis \
-                 (service key signs JWTs for Orbis auth)"
-                    .into(),
-            )
-        })?;
+        let service_identity = match self.parse_orbis_service_identity()? {
+            Some(identity) => identity,
+            None => user_identity.as_ref().cloned().ok_or_else(|| {
+                Error::InvalidConfig(
+                    "--identity or --signer-orbis-identity is required when \
+                     --signer-type=orbis (service key signs JWTs for Orbis auth)"
+                        .into(),
+                )
+            })?,
+        };
 
         let endpoint = self.signer_orbis_endpoint.as_ref().ok_or_else(|| {
             Error::InvalidConfig("--signer-orbis-endpoint required for orbis signer".into())
@@ -391,21 +410,41 @@ impl StartArgs {
     /// Key type is auto-detected from byte length:
     /// - 64 bytes -> Ed25519
     /// - 32 bytes -> secp256k1
-    fn parse_user_identity(&self) -> Result<Option<std::sync::Arc<identity::RawIdentity>>> {
+    /// Parse `--signer-orbis-identity`, the key used only to authenticate to
+    /// the Orbis ring.
+    #[cfg(feature = "orbis")]
+    pub fn parse_orbis_service_identity(
+        &self,
+    ) -> Result<Option<std::sync::Arc<identity::RawIdentity>>> {
+        let Some(hex_key) = self.signer_orbis_identity.as_deref() else {
+            return Ok(None);
+        };
+        let identity = Self::identity_from_hex(hex_key)?;
+        tracing::info!("Orbis service identity DID: {}", identity.did()?);
+        Ok(Some(std::sync::Arc::new(identity)))
+    }
+
+    pub fn parse_user_identity(&self) -> Result<Option<std::sync::Arc<identity::RawIdentity>>> {
         let hex_key = match &self.identity {
             Some(key) => key,
             None => return Ok(None),
         };
 
-        // Remove 0x prefix if present
+        let raw_identity = Self::identity_from_hex(hex_key)?;
+
+        let did = raw_identity.did()?;
+        tracing::info!("User identity DID: {}", did);
+
+        Ok(Some(std::sync::Arc::new(raw_identity)))
+    }
+
+    /// Build an identity from a hex private key, choosing the key type by
+    /// length: 64 bytes is ed25519 (seed + public key), 32 is secp256k1.
+    fn identity_from_hex(hex_key: &str) -> Result<identity::RawIdentity> {
         let hex_str = hex_key.strip_prefix("0x").unwrap_or(hex_key);
+        let key_bytes = hex::decode(hex_str)
+            .map_err(|e| Error::InvalidIdentity(format!("invalid hex in identity key: {}", e)))?;
 
-        // Decode hex to bytes
-        let key_bytes = hex::decode(hex_str).map_err(|e| {
-            Error::InvalidIdentity(format!("invalid hex in --identity flag: {}", e))
-        })?;
-
-        // Auto-detect key type from byte length
         let key_type = match key_bytes.len() {
             64 => identity::IdentityKeyType::Ed25519,
             32 => identity::IdentityKeyType::Secp256k1,
@@ -417,13 +456,9 @@ impl StartArgs {
             }
         };
 
-        // Create identity from bytes
-        let raw_identity = identity::RawIdentity::from_identity_key_type(key_type, &key_bytes)?;
-
-        let did = raw_identity.did()?;
-        tracing::info!("User identity DID: {}", did);
-
-        Ok(Some(std::sync::Arc::new(raw_identity)))
+        Ok(identity::RawIdentity::from_identity_key_type(
+            key_type, &key_bytes,
+        )?)
     }
 
     /// Apply start command flags to config
@@ -604,5 +639,54 @@ impl StartArgs {
         }
         config.api.validate()?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SECP256K1_KEY: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    /// 64 bytes: seed followed by public key, the layout DefraDB stores an
+    /// ed25519 private key in. RFC 8032 test vector 1, so the public half
+    /// really is the seed's public key; the loader checks that.
+    const ED25519_KEY: &str = concat!(
+        "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60",
+        "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"
+    );
+
+    #[test]
+    fn identity_key_type_follows_the_key_length() {
+        let secp = StartArgs::identity_from_hex(SECP256K1_KEY).expect("secp256k1 identity");
+        assert_eq!(secp.key_type(), crypto::KeyType::Secp256k1);
+
+        let ed = StartArgs::identity_from_hex(ED25519_KEY).expect("ed25519 identity");
+        assert_eq!(ed.key_type(), crypto::KeyType::Ed25519);
+    }
+
+    #[test]
+    fn identity_from_hex_accepts_a_0x_prefix() {
+        let prefixed = format!("0x{}", SECP256K1_KEY);
+        assert_eq!(
+            StartArgs::identity_from_hex(&prefixed)
+                .expect("prefixed")
+                .did()
+                .expect("did"),
+            StartArgs::identity_from_hex(SECP256K1_KEY)
+                .expect("bare")
+                .did()
+                .expect("did"),
+            "the 0x prefix must not change the identity"
+        );
+    }
+
+    #[test]
+    fn identity_from_hex_rejects_other_lengths() {
+        let err = StartArgs::identity_from_hex("00112233").expect_err("8 bytes is neither");
+        assert!(
+            format!("{err}").contains("invalid key length"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/crates/cli/src/commands/start/mod.rs
+++ b/crates/cli/src/commands/start/mod.rs
@@ -361,7 +361,10 @@ impl StartArgs {
             })?,
         };
 
-        Self::require_ed25519_service_key(service_identity.key_type())?;
+        Self::require_ed25519_service_key(
+            service_identity.key_type(),
+            self.signer_orbis_identity.is_some(),
+        )?;
 
         let endpoint = self.signer_orbis_endpoint.as_ref().ok_or_else(|| {
             Error::InvalidConfig("--signer-orbis-endpoint required for orbis signer".into())
@@ -444,19 +447,32 @@ impl StartArgs {
     /// The Orbis ring authenticates a Sign request with a bearer token and
     /// accepts EdDSA only. `new_token_with_custom_claims` picks the algorithm
     /// from the key type, so a secp256k1 service key presents ES256K and the
-    /// ring refuses it. Reject it here, naming the flag, rather than letting it
-    /// surface as `unknown variant ES256K` from the ring at the first write.
+    /// ring refuses it. Reject it here rather than letting it surface as
+    /// `unknown variant ES256K` from the ring at the first write, long after
+    /// the node booted clean.
+    ///
+    /// `from_flag` says whether the key came from `--signer-orbis-identity`,
+    /// because the two ways to get here need different advice: the fallback to
+    /// `--identity` needs the flag, while a key already passed to the flag is
+    /// almost always a 32-byte ed25519 seed, which [`Self::identity_from_hex`]
+    /// reads as secp256k1 by length.
     #[cfg(feature = "orbis")]
-    fn require_ed25519_service_key(key_type: crypto::KeyType) -> Result<()> {
+    fn require_ed25519_service_key(key_type: crypto::KeyType, from_flag: bool) -> Result<()> {
         if key_type == crypto::KeyType::Ed25519 {
             return Ok(());
         }
+        let advice = if from_flag {
+            "--signer-orbis-identity must be the 64-byte ed25519 form, seed \
+             followed by public key. A 32-byte value is read as secp256k1 by \
+             length, which is what happened here."
+        } else {
+            "Pass one with --signer-orbis-identity. --identity is not usable \
+             as the service key when it is secp256k1, because it also signs \
+             chain transactions and must stay that type."
+        };
         Err(Error::InvalidConfig(format!(
-            "--signer-type=orbis needs an ed25519 service key, got {:?}. Pass \
-             one with --signer-orbis-identity: the ring accepts an EdDSA bearer \
-             token only, while --identity may be secp256k1 because it also \
-             signs chain transactions.",
-            key_type
+            "--signer-type=orbis needs an ed25519 service key, got {:?}. {}",
+            key_type, advice
         )))
     }
 
@@ -715,25 +731,49 @@ mod tests {
     #[cfg(feature = "orbis")]
     #[test]
     fn an_ed25519_service_key_is_accepted() {
-        StartArgs::require_ed25519_service_key(crypto::KeyType::Ed25519)
-            .expect("ed25519 is what the ring accepts");
+        for from_flag in [true, false] {
+            StartArgs::require_ed25519_service_key(crypto::KeyType::Ed25519, from_flag)
+                .expect("ed25519 is what the ring accepts");
+        }
     }
 
     #[cfg(feature = "orbis")]
     #[test]
     fn a_non_ed25519_service_key_is_refused_before_the_ring_sees_it() {
         for key_type in [crypto::KeyType::Secp256k1, crypto::KeyType::Secp256r1] {
-            let err = StartArgs::require_ed25519_service_key(key_type)
-                .expect_err("the ring accepts EdDSA only");
-            let message = format!("{err}");
-            assert!(
-                message.contains("--signer-orbis-identity"),
-                "the error must name the flag that fixes it: {message}"
-            );
-            assert!(
-                message.contains(&format!("{key_type:?}")),
-                "the error must name the key type it got: {message}"
-            );
+            for from_flag in [true, false] {
+                let err = StartArgs::require_ed25519_service_key(key_type, from_flag)
+                    .expect_err("the ring accepts EdDSA only");
+                let message = format!("{err}");
+                assert!(
+                    message.contains("--signer-orbis-identity"),
+                    "the error must name the flag that fixes it: {message}"
+                );
+                assert!(
+                    message.contains(&format!("{key_type:?}")),
+                    "the error must name the key type it got: {message}"
+                );
+            }
         }
+    }
+
+    /// A raw 32-byte ed25519 seed is read as secp256k1 by length, so the error
+    /// for a key that came from the flag has to say which form to pass.
+    #[cfg(feature = "orbis")]
+    #[test]
+    fn a_seed_passed_to_the_flag_is_told_it_needs_the_64_byte_form() {
+        let seed = StartArgs::identity_from_hex(SECP256K1_KEY).expect("32 bytes parses");
+        assert_eq!(
+            seed.key_type(),
+            crypto::KeyType::Secp256k1,
+            "a 32-byte value is secp256k1 by length, which is the trap"
+        );
+        let err = StartArgs::require_ed25519_service_key(seed.key_type(), true)
+            .expect_err("a seed is not the ed25519 form the ring needs");
+        let message = format!("{err}");
+        assert!(
+            message.contains("64-byte"),
+            "the error must name the form to pass: {message}"
+        );
     }
 }

--- a/crates/cli/tests/start_tests.rs
+++ b/crates/cli/tests/start_tests.rs
@@ -3,6 +3,7 @@
 use cli::commands::StartArgs;
 use cli::config::{Config, DatastoreType};
 use cli::error::Error;
+#[cfg(feature = "orbis")]
 use identity::Identity as _;
 
 fn default_start_args() -> StartArgs {

--- a/crates/cli/tests/start_tests.rs
+++ b/crates/cli/tests/start_tests.rs
@@ -3,6 +3,7 @@
 use cli::commands::StartArgs;
 use cli::config::{Config, DatastoreType};
 use cli::error::Error;
+use identity::Identity as _;
 
 fn default_start_args() -> StartArgs {
     StartArgs {
@@ -32,6 +33,8 @@ fn default_start_args() -> StartArgs {
         signer_orbis_ring_id: None,
         #[cfg(feature = "orbis")]
         signer_orbis_derivation: None,
+        #[cfg(feature = "orbis")]
+        signer_orbis_identity: None,
         max_body_size: None,
         max_schema_size: None,
         max_backup_size: None,
@@ -162,6 +165,8 @@ fn test_apply_to_config_all_flags() {
         signer_orbis_ring_id: None,
         #[cfg(feature = "orbis")]
         signer_orbis_derivation: None,
+        #[cfg(feature = "orbis")]
+        signer_orbis_identity: None,
         max_body_size: Some(1024),
         max_schema_size: Some(2048),
         max_backup_size: Some(4096),
@@ -270,4 +275,50 @@ fn test_rebroadcast_flag_precedence() {
     let args = default_start_args();
     args.apply_to_config(&mut config).unwrap();
     assert!(config.net.p2p_rebroadcast_on_merge);
+}
+
+/// The Orbis ring authenticates a signing request with an EdDSA bearer token,
+/// while a node whose document ACP is SourceHub/Vera must keep a secp256k1
+/// identity to sign chain transactions. `--signer-orbis-identity` is what lets
+/// one node hold both, and it falls back to `--identity` when unset.
+#[cfg(feature = "orbis")]
+#[test]
+fn orbis_service_identity_is_separate_from_the_node_identity() {
+    const SECP256K1_KEY: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    // RFC 8032 test vector 1: seed followed by its public key.
+    const ED25519_KEY: &str = concat!(
+        "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60",
+        "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"
+    );
+
+    let mut args = default_start_args();
+    args.identity = Some(SECP256K1_KEY.to_string());
+    args.signer_orbis_identity = Some(ED25519_KEY.to_string());
+
+    let node = args
+        .parse_user_identity()
+        .expect("node identity parses")
+        .expect("node identity is set");
+    let service = args
+        .parse_orbis_service_identity()
+        .expect("service identity parses")
+        .expect("service identity is set");
+
+    assert_eq!(node.key_type(), crypto::KeyType::Secp256k1);
+    assert_eq!(service.key_type(), crypto::KeyType::Ed25519);
+    assert_ne!(
+        node.did().expect("node did"),
+        service.did().expect("service did"),
+        "the two roles must not collapse onto one DID"
+    );
+}
+
+#[cfg(feature = "orbis")]
+#[test]
+fn orbis_service_identity_is_absent_without_the_flag() {
+    let args = default_start_args();
+    assert!(args
+        .parse_orbis_service_identity()
+        .expect("an absent flag is not an error")
+        .is_none());
 }

--- a/crates/sourcehub/src/cosmos/client.rs
+++ b/crates/sourcehub/src/cosmos/client.rs
@@ -34,7 +34,7 @@ impl SourceHubClient {
         policy_id: &str,
     ) -> Result<Option<PolicyInfo>, ClientError> {
         let url = format!(
-            "{}/sourcenetwork/sourcehub/acp/policy/{}",
+            "{}/sourcenetwork/vera/acp/policy/{}",
             self.rest_base_url(),
             policy_id
         );
@@ -71,7 +71,7 @@ impl SourceHubClient {
         object_id: &str,
     ) -> Result<(bool, String), ClientError> {
         let url = format!(
-            "{}/sourcenetwork/sourcehub/acp/object_owner/{}/{}/{}",
+            "{}/sourcenetwork/vera/acp/object_owner/{}/{}/{}",
             self.rest_base_url(),
             policy_id,
             resource,
@@ -112,7 +112,7 @@ impl SourceHubClient {
         let request_hex = hex::encode(&request_bytes);
 
         let url = format!(
-            "{}/abci_query?path=\"/sourcehub.acp.Query/VerifyAccessRequest\"&data=0x{}",
+            "{}/abci_query?path=\"/vera.acp.Query/VerifyAccessRequest\"&data=0x{}",
             self.comet_rpc_base_url(),
             request_hex
         );

--- a/crates/sourcehub/src/cosmos/event_decoder.rs
+++ b/crates/sourcehub/src/cosmos/event_decoder.rs
@@ -1,12 +1,12 @@
 use base64::Engine as _;
 use prost::Message;
 
-const BEARER_POLICY_COMMAND: &str = "sourcehub.acp.MsgBearerPolicyCmd";
-const CHECK_ACCESS: &str = "sourcehub.acp.MsgCheckAccess";
-const CREATE_POLICY: &str = "sourcehub.acp.MsgCreatePolicy";
-const DIRECT_POLICY_COMMAND: &str = "sourcehub.acp.MsgDirectPolicyCmd";
-const EDIT_POLICY: &str = "sourcehub.acp.MsgEditPolicy";
-const SIGNED_POLICY_COMMAND: &str = "sourcehub.acp.MsgSignedPolicyCmd";
+const BEARER_POLICY_COMMAND: &str = "vera.acp.MsgBearerPolicyCmd";
+const CHECK_ACCESS: &str = "vera.acp.MsgCheckAccess";
+const CREATE_POLICY: &str = "vera.acp.MsgCreatePolicy";
+const DIRECT_POLICY_COMMAND: &str = "vera.acp.MsgDirectPolicyCmd";
+const EDIT_POLICY: &str = "vera.acp.MsgEditPolicy";
+const SIGNED_POLICY_COMMAND: &str = "vera.acp.MsgSignedPolicyCmd";
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(super) enum CacheInvalidation {
@@ -85,46 +85,45 @@ fn decode_transaction(tx_bytes: &[u8]) -> Result<Vec<CacheInvalidation>, EventDe
 
     for message in body.messages {
         let message_type = message.type_url.trim_start_matches('/');
-        let invalidation = match message_type {
-            BEARER_POLICY_COMMAND => {
-                let command =
-                    BearerPolicyCommand::decode(message.value.as_slice()).map_err(|source| {
-                        EventDecodeError::AcpMessage {
+        let invalidation =
+            match message_type {
+                BEARER_POLICY_COMMAND => {
+                    let command = BearerPolicyCommand::decode(message.value.as_slice()).map_err(
+                        |source| EventDecodeError::AcpMessage {
                             message_type: message.type_url.clone(),
                             source,
-                        }
-                    })?;
-                command_invalidation(command.policy_id, command.command)
-            }
-            DIRECT_POLICY_COMMAND => {
-                let command =
-                    DirectPolicyCommand::decode(message.value.as_slice()).map_err(|source| {
-                        EventDecodeError::AcpMessage {
-                            message_type: message.type_url.clone(),
-                            source,
-                        }
-                    })?;
-                command_invalidation(command.policy_id, command.command)
-            }
-            EDIT_POLICY => {
-                let edit =
-                    EditPolicyCommand::decode(message.value.as_slice()).map_err(|source| {
-                        EventDecodeError::AcpMessage {
-                            message_type: message.type_url.clone(),
-                            source,
-                        }
-                    })?;
-                if edit.policy_id.is_empty() {
-                    CacheInvalidation::All
-                } else {
-                    CacheInvalidation::Policy(edit.policy_id)
+                        },
+                    )?;
+                    command_invalidation(command.policy_id, command.command)
                 }
-            }
-            SIGNED_POLICY_COMMAND => CacheInvalidation::All,
-            CREATE_POLICY | CHECK_ACCESS => continue,
-            message_type if message_type.starts_with("sourcehub.acp.") => CacheInvalidation::All,
-            _ => continue,
-        };
+                DIRECT_POLICY_COMMAND => {
+                    let command = DirectPolicyCommand::decode(message.value.as_slice()).map_err(
+                        |source| EventDecodeError::AcpMessage {
+                            message_type: message.type_url.clone(),
+                            source,
+                        },
+                    )?;
+                    command_invalidation(command.policy_id, command.command)
+                }
+                EDIT_POLICY => {
+                    let edit =
+                        EditPolicyCommand::decode(message.value.as_slice()).map_err(|source| {
+                            EventDecodeError::AcpMessage {
+                                message_type: message.type_url.clone(),
+                                source,
+                            }
+                        })?;
+                    if edit.policy_id.is_empty() {
+                        CacheInvalidation::All
+                    } else {
+                        CacheInvalidation::Policy(edit.policy_id)
+                    }
+                }
+                SIGNED_POLICY_COMMAND => CacheInvalidation::All,
+                CREATE_POLICY | CHECK_ACCESS => continue,
+                message_type if message_type.starts_with("vera.acp.") => CacheInvalidation::All,
+                _ => continue,
+            };
 
         if invalidation == CacheInvalidation::All {
             return Ok(vec![CacheInvalidation::All]);
@@ -375,7 +374,7 @@ mod tests {
     fn unknown_acp_message_fails_safe() {
         let event = transaction_event(
             vec![ProtoAny {
-                type_url: "/sourcehub.acp.MsgFuturePolicyMutation".into(),
+                type_url: "/vera.acp.MsgFuturePolicyMutation".into(),
                 value: Vec::new(),
             }],
             0,

--- a/crates/sourcehub/src/cosmos/tx.rs
+++ b/crates/sourcehub/src/cosmos/tx.rs
@@ -39,7 +39,7 @@ impl TxSigner {
 
         let public_key = signing_key.public_key();
         let account_id = public_key
-            .account_id("source")
+            .account_id("vera")
             .map_err(|e| TxSignerError::Key(format!("failed to derive address: {}", e)))?;
 
         let chain_id: cosmrs::tendermint::chain::Id = chain_id
@@ -53,7 +53,7 @@ impl TxSigner {
         })
     }
 
-    /// Get the bech32 account address (e.g., "source1...").
+    /// Get the bech32 account address (e.g., "vera1...").
     pub(crate) fn address(&self) -> String {
         self.account_id.to_string()
     }
@@ -259,7 +259,7 @@ fn build_msg_create_policy(creator: &str, policy: &str) -> Any {
     encode_varint_field(&mut buf, 3, 1);
 
     Any {
-        type_url: "/sourcehub.acp.MsgCreatePolicy".to_string(),
+        type_url: "/vera.acp.MsgCreatePolicy".to_string(),
         value: buf,
     }
 }
@@ -285,7 +285,7 @@ fn build_msg_bearer_policy_cmd(
     encode_bytes_field(&mut buf, 4, &cmd_bytes);
 
     Any {
-        type_url: "/sourcehub.acp.MsgBearerPolicyCmd".to_string(),
+        type_url: "/vera.acp.MsgBearerPolicyCmd".to_string(),
         value: buf,
     }
 }


### PR DESCRIPTION
Vera (github.com/sourcenetwork/vera, formerly SourceHub) renamed its proto package from `sourcehub.*` to `vera.*` and its bech32 account prefix from `source` to `vera`. The SourceHub client on main still speaks the old names, so every ACP transaction and query against a current Vera chain is unroutable and every derived address is wrong.

This branch makes `--document-acp-type source-hub` work against Vera again, and splits the key a node authenticates to an Orbis ring with from the key it signs chain transactions with.

## What changed

**Wire names.** `/vera.acp.*` message type URLs, the `/vera.acp.Query/VerifyAccessRequest` ABCI path, the `/sourcenetwork/vera/acp/...` REST paths, and the `vera` bech32 prefix. The event decoder matches `vera.acp.` message types for cache invalidation.

**A separate Orbis service key: `--signer-orbis-identity`.** The ring authenticates a Sign request with a JWT whose algorithm follows the key type and accepts EdDSA only, while `--identity` is also the key that signs Vera transactions and must be secp256k1. One key cannot serve both roles: a node with a secp256k1 identity presents an ES256K token and the ring refuses it with `unknown variant ES256K`. The new flag carries the ed25519 key for the ring and defaults to `--identity` when unset, so an ed25519-identity node is unaffected.

## Tests

- `crates/cli/src/commands/start/mod.rs`: key type follows key length, the `0x` prefix is transparent, other lengths are refused.
- `crates/cli/tests/start_tests.rs`: the node identity and the Orbis service identity are separately parsed, land on different DIDs and key types, and the service identity is absent when the flag is.
- `cargo test -p cli --features orbis,sourcehub` and `cargo test -p sourcehub` pass (46 sourcehub tests).
- All four `cli` feature sets CI checks are clean: default, `--no-default-features`, `--no-default-features --features release-full`, and `--features otel`.

## Verified end to end

Against a live `verad` devnet (Vera main, ddcb612), a 3-node Orbis ring at threshold 2 and 35 DefraDB cells, in `sourcenetwork/backbone`'s `tests/gents_cloud` suite ([backbone#30](https://github.com/sourcenetwork/backbone/pull/30)): 13 of 13 scenarios passed, 32 tenants provisioned, 223 chain transactions committed with none failed. Policies and relationships apply on Vera, documents register with the creating DID as owner, ring-signed blocks replicate and verify on a peer, revocation propagates in 9 ms on an event-subscribed cell, and all 32 ordered cross-tenant reads are denied. Per-tenant cost measured at 6.06 s to provision and 71 MiB resident.

That run also needs the companion orbis-rs fix ([orbis-rs#264](https://github.com/sourcenetwork/orbis-rs/pull/264)), without which the ring advertises a key its signatures do not verify under.

## Not included

The create path still sends the ring no ACP tuple: `create_access_decision` returns `Ok(None)` for the Cosmos provider, so a create is authorised by DefraDB's own check rather than by the ring. That is unchanged behaviour and is tracked separately.
