### PR TITLE
test(db): cover per-field embedding providers

### DIFF
--- a/crates/db/tests/search/embedding.rs
+++ b/crates/db/tests/search/embedding.rs
@@ -125,17 +125,25 @@ async fn set_embedding_skips_when_effective_config_is_missing() {
 }
 
 #[tokio::test]
-async fn set_embedding_uses_ollama_contract() {
+async fn set_embedding_uses_each_field_provider_and_model() {
     use axum::{routing::post, Json, Router};
     use serde_json::{json, Value};
     use tokio::net::TcpListener;
 
-    async fn embed(Json(request): Json<Value>) -> Json<Value> {
+    async fn openai(Json(request): Json<Value>) -> Json<Value> {
         assert_eq!(
             request,
-            json!({"model": "nomic-embed-text", "prompt": "hello\n"})
+            json!({"model": "text-embedding-3-small", "input": "hello\n"})
         );
-        Json(json!({"embedding": [3.0, 4.0]}))
+        Json(json!({"data": [{"embedding": [1.0, 0.0]}]}))
+    }
+
+    async fn ollama(Json(request): Json<Value>) -> Json<Value> {
+        assert_eq!(
+            request,
+            json!({"model": "nomic-embed-text", "prompt": "world\n"})
+        );
+        Json(json!({"embedding": [0.0, 2.0]}))
     }
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -143,22 +151,33 @@ async fn set_embedding_uses_ollama_contract() {
     let server = tokio::spawn(async move {
         axum::serve(
             listener,
-            Router::new().route("/api/embeddings", post(embed)),
+            Router::new()
+                .route("/openai/embeddings", post(openai))
+                .route("/ollama/embeddings", post(ollama)),
         )
         .await
         .unwrap();
     });
 
-    let embeddings = vec![embedding_with_provider(
+    let openai = embedding_with_provider(
+        "openai",
+        &format!("http://{address}/openai"),
+        "text-embedding-3-small",
+    );
+    let mut ollama = embedding_with_provider(
         "ollama",
-        &format!("http://{address}/api"),
+        &format!("http://{address}/ollama"),
         "nomic-embed-text",
-    )];
+    );
+    ollama.field_name = "summary_v".to_string();
+    ollama.fields = vec!["summary".to_string()];
+
     let mut doc = Document::new();
     doc.set("content", "hello");
+    doc.set("summary", "world");
 
     let generated = set_embedding(
-        &embeddings,
+        &[openai, ollama],
         &mut doc,
         true,
         None,
@@ -168,9 +187,13 @@ async fn set_embedding_uses_ollama_contract() {
     .unwrap();
     server.abort();
 
-    assert_eq!(generated, vec!["content_v"]);
+    assert_eq!(generated, vec!["content_v", "summary_v"]);
     assert_eq!(
         doc.get("content_v"),
-        Some(&document::NormalValue::Float64Array(vec![0.6, 0.8]))
+        Some(&document::NormalValue::Float64Array(vec![1.0, 0.0]))
+    );
+    assert_eq!(
+        doc.get("summary_v"),
+        Some(&document::NormalValue::Float64Array(vec![0.0, 1.0]))
     );
 }

--- a/crates/db/tests/search/embedding.rs
+++ b/crates/db/tests/search/embedding.rs
@@ -126,34 +126,40 @@ async fn set_embedding_skips_when_effective_config_is_missing() {
 
 #[tokio::test]
 async fn set_embedding_uses_each_field_provider_and_model() {
-    use axum::{routing::post, Json, Router};
+    use axum::{extract::State, http::HeaderMap, routing::post, Json, Router};
     use serde_json::{json, Value};
     use tokio::net::TcpListener;
 
-    async fn openai(Json(request): Json<Value>) -> Json<Value> {
-        assert_eq!(
-            request,
-            json!({"model": "text-embedding-3-small", "input": "hello\n"})
-        );
-        Json(json!({"data": [{"embedding": [1.0, 0.0]}]}))
+    type Requests = tokio::sync::mpsc::UnboundedSender<(&'static str, HeaderMap, Value)>;
+
+    async fn openai(
+        State(requests): State<Requests>,
+        headers: HeaderMap,
+        Json(request): Json<Value>,
+    ) -> Json<Value> {
+        requests.send(("openai", headers, request)).unwrap();
+        Json(json!({"data": [{"embedding": [3.0, 4.0]}]}))
     }
 
-    async fn ollama(Json(request): Json<Value>) -> Json<Value> {
-        assert_eq!(
-            request,
-            json!({"model": "nomic-embed-text", "prompt": "world\n"})
-        );
+    async fn ollama(
+        State(requests): State<Requests>,
+        headers: HeaderMap,
+        Json(request): Json<Value>,
+    ) -> Json<Value> {
+        requests.send(("ollama", headers, request)).unwrap();
         Json(json!({"embedding": [0.0, 2.0]}))
     }
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let address = listener.local_addr().unwrap();
+    let (requests, mut received) = tokio::sync::mpsc::unbounded_channel();
     let server = tokio::spawn(async move {
         axum::serve(
             listener,
             Router::new()
                 .route("/openai/embeddings", post(openai))
-                .route("/ollama/embeddings", post(ollama)),
+                .route("/ollama/embeddings", post(ollama))
+                .with_state(requests),
         )
         .await
         .unwrap();
@@ -181,16 +187,35 @@ async fn set_embedding_uses_each_field_provider_and_model() {
         &mut doc,
         true,
         None,
-        &EmbeddingClientConfig::new(),
+        &EmbeddingClientConfig::new()
+            .with_url(format!("http://{address}/unused"))
+            .with_model("unused-model")
+            .with_api_key("test-key"),
     )
     .await
     .unwrap();
     server.abort();
 
+    let mut requests: Vec<_> = std::iter::from_fn(|| received.try_recv().ok()).collect();
+    requests.sort_by_key(|(provider, _, _)| *provider);
+    assert_eq!(requests.len(), 2);
+    assert_eq!(requests[0].0, "ollama");
+    assert!(requests[0].1.get("authorization").is_none());
+    assert_eq!(
+        requests[0].2,
+        json!({"model": "nomic-embed-text", "prompt": "world\n"})
+    );
+    assert_eq!(requests[1].0, "openai");
+    assert_eq!(requests[1].1["authorization"], "Bearer test-key");
+    assert_eq!(
+        requests[1].2,
+        json!({"model": "text-embedding-3-small", "input": "hello\n"})
+    );
+
     assert_eq!(generated, vec!["content_v", "summary_v"]);
     assert_eq!(
         doc.get("content_v"),
-        Some(&document::NormalValue::Float64Array(vec![1.0, 0.0]))
+        Some(&document::NormalValue::Float64Array(vec![3.0, 4.0]))
     );
     assert_eq!(
         doc.get("summary_v"),


### PR DESCRIPTION
## Context

#1631 added provider-specific embedding requests, but its regression exercised Ollama in isolation. #634 also requires multiple embedding configurations to coexist without sharing provider or model state.

## Changes

- exercise OpenAI-compatible and Ollama embeddings on different fields of one document
- verify each request uses its field-specific model and payload contract
- verify each response is decoded into the correct field, including Ollama normalization

## Testing

- `cargo test --profile super-dev -p db --test search embedding -- --nocapture`
- `cargo clippy --profile super-dev -p db --test search -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Refs #634
