### PR TITLE
fix(db): preserve unique winners during reindex

### DIFF
--- a/crates/db/src/definition/migration/reindex.rs
+++ b/crates/db/src/definition/migration/reindex.rs
@@ -243,8 +243,9 @@ impl<S: Store> DB<S> {
                     }
 
                     index_manager
-                        .bulk_index(
+                        .bulk_index_resolving_unique_conflicts(
                             &datastore,
+                            &txn_systemstore,
                             &index_desc.name,
                             &migrated_docs,
                             collection.schema(),

--- a/crates/db/src/definition/migration/reindex.rs
+++ b/crates/db/src/definition/migration/reindex.rs
@@ -141,6 +141,13 @@ impl<S: Store> DB<S> {
                 .await?;
 
             let mut migrated_docs = Vec::with_capacity(raw_docs.len());
+            let index_manager = IndexManager::from_indexes(
+                short_id,
+                collection.schema(),
+                collection.write_indexes(),
+            )
+            .map_err(|e| Error::Other(format!("failed to create index manager: {}", e)))?;
+            let mut original_keys = std::collections::HashMap::new();
             for (doc_short_id, doc, _) in raw_docs {
                 let Some(doc_version) = doc.schema_version_id().map(str::to_string) else {
                     if materialize_identity_paths {
@@ -218,6 +225,10 @@ impl<S: Store> DB<S> {
                     })?
                     .map_err(|e| Error::Lens(e.to_string()))?;
                 let migrated = lens_doc_to_document(migrated_lens_doc, &doc, &collection);
+                original_keys.insert(
+                    doc_short_id,
+                    index_manager.unique_index_keys(&doc, collection.schema())?,
+                );
                 if cache_migrated_document(&datastore, &txn_systemstore, &collection, &migrated)
                     .await?
                 {
@@ -227,13 +238,6 @@ impl<S: Store> DB<S> {
             }
 
             if !collection.write_indexes().is_empty() {
-                let index_manager = IndexManager::from_indexes(
-                    short_id,
-                    collection.schema(),
-                    collection.write_indexes(),
-                )
-                .map_err(|e| Error::Other(format!("failed to create index manager: {}", e)))?;
-
                 for index_desc in collection.write_indexes() {
                     if let Some(index) = index_manager.get_index(&index_desc.name) {
                         index
@@ -249,6 +253,7 @@ impl<S: Store> DB<S> {
                             &index_desc.name,
                             &migrated_docs,
                             collection.schema(),
+                            &original_keys,
                         )
                         .await?;
                 }

--- a/crates/db/src/index/manager/mod.rs
+++ b/crates/db/src/index/manager/mod.rs
@@ -25,7 +25,7 @@ use storage::keys::IndexIDSequenceKey;
 pub mod doc_source;
 pub use doc_source::{DocumentSource, SliceSource};
 
-/// How a live unique conflict was resolved during merge (#1111).
+/// How a live unique conflict was resolved during merge or index rebuild (#1111/#1308).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MergeConflictOutcome {
     /// No conflict, or the stale-entry heal handled it.
@@ -498,6 +498,47 @@ impl IndexManager {
         })
     }
 
+    /// Rebuild an index using the same deterministic unique-conflict rule as replication.
+    pub(crate) async fn bulk_index_resolving_unique_conflicts(
+        &self,
+        datastore: &NamespaceView,
+        systemstore: &NamespaceView,
+        index_name: &str,
+        documents: &[(u64, Document)],
+        schema: &CollectionVersion,
+    ) -> Result<()> {
+        let index = self
+            .indexes
+            .get(index_name)
+            .ok_or_else(|| Error::Other(format!("index '{}' not found", index_name)))?;
+        let mut mutable_datastore = datastore.clone();
+
+        for (doc_short_id, doc) in documents {
+            if *doc_short_id == 0 {
+                continue;
+            }
+            let doc_id = doc
+                .id()
+                .ok_or_else(|| Error::InvalidDocument("document must have an ID".to_string()))?
+                .to_string();
+            let value_sets = self.extract_index_values(doc, index.description(), schema)?;
+            for values in &value_sets {
+                self.save_resolving_unique_conflict(
+                    &mut mutable_datastore,
+                    systemstore,
+                    index,
+                    *doc_short_id,
+                    &doc_id,
+                    values,
+                )
+                .await
+                .map_err(Error::Storage)?;
+            }
+        }
+
+        Ok(())
+    }
+
     /// Save an index entry, healing stale unique conflicts (#1111/#700).
     ///
     /// A unique violation whose existing entry points at a **deleted or
@@ -550,8 +591,7 @@ impl IndexManager {
         }
     }
 
-    /// Save an index entry on the MERGE path, resolving live unique conflicts
-    /// deterministically instead of failing the merge (#1111).
+    /// Save an index entry while resolving live unique conflicts deterministically (#1111/#1308).
     ///
     /// A CRDT merge cannot preserve cross-replica uniqueness: two nodes that
     /// each locally accepted the same unique value must still converge when
@@ -604,7 +644,7 @@ impl IndexManager {
                         index = %index.description().name,
                         winner_doc_id = %doc_id,
                         unindexed_doc_id = %holder_doc_id,
-                        "unique index conflict during merge: incoming document wins the \
+                        "unique index conflict: incoming document wins the \
                          deterministic pick; the previous holder is no longer indexed"
                     );
                     Ok(MergeConflictOutcome::IncomingIndexed)
@@ -614,7 +654,7 @@ impl IndexManager {
                         index = %index.description().name,
                         winner_doc_id = %holder_doc_id,
                         unindexed_doc_id = %doc_id,
-                        "unique index conflict during merge: existing holder wins the \
+                        "unique index conflict: existing holder wins the \
                          deterministic pick; the incoming document is persisted unindexed"
                     );
                     Ok(MergeConflictOutcome::IncomingUnindexed)

--- a/crates/db/src/index/manager/mod.rs
+++ b/crates/db/src/index/manager/mod.rs
@@ -520,6 +520,9 @@ impl IndexManager {
 
         let mut mutable_datastore = datastore.clone();
 
+        // Conflict resolution is a read-modify-write operation on the shared
+        // transaction. Running these writes concurrently can make the winner
+        // depend on scheduling instead of the public DocID ordering.
         for (doc_short_id, doc) in documents {
             if *doc_short_id == 0 {
                 continue;

--- a/crates/db/src/index/manager/mod.rs
+++ b/crates/db/src/index/manager/mod.rs
@@ -511,6 +511,13 @@ impl IndexManager {
             .indexes
             .get(index_name)
             .ok_or_else(|| Error::Other(format!("index '{}' not found", index_name)))?;
+
+        if !matches!(index, IndexType::Unique(_)) {
+            self.bulk_index(datastore, index_name, documents, schema)
+                .await?;
+            return Ok(());
+        }
+
         let mut mutable_datastore = datastore.clone();
 
         for (doc_short_id, doc) in documents {

--- a/crates/db/src/index/manager/mod.rs
+++ b/crates/db/src/index/manager/mod.rs
@@ -498,7 +498,7 @@ impl IndexManager {
         })
     }
 
-    /// Rebuild an index using the same deterministic unique-conflict rule as replication.
+    /// Rebuild an index, preserving existing conflicts but rejecting migration-created ones.
     pub(crate) async fn bulk_index_resolving_unique_conflicts(
         &self,
         datastore: &NamespaceView,
@@ -506,17 +506,18 @@ impl IndexManager {
         index_name: &str,
         documents: &[(u64, Document)],
         schema: &CollectionVersion,
+        original_keys: &HashMap<u64, std::collections::HashSet<Vec<u8>>>,
     ) -> Result<()> {
         let index = self
             .indexes
             .get(index_name)
             .ok_or_else(|| Error::Other(format!("index '{}' not found", index_name)))?;
 
-        if !matches!(index, IndexType::Unique(_)) {
+        let IndexType::Unique(unique) = index else {
             self.bulk_index(datastore, index_name, documents, schema)
                 .await?;
             return Ok(());
-        }
+        };
 
         let mut mutable_datastore = datastore.clone();
 
@@ -533,6 +534,30 @@ impl IndexManager {
                 .to_string();
             let value_sets = self.extract_index_values(doc, index.description(), schema)?;
             for values in &value_sets {
+                let holder = if original_keys.is_empty() {
+                    None
+                } else {
+                    unique
+                        .conflicting_doc_id(&mutable_datastore, values)
+                        .await
+                        .map_err(Error::Storage)?
+                };
+                if let Some(holder) = holder {
+                    let key = self.encode_index_key(index.description(), values)?;
+                    // Both documents must have held this value before the lens ran.
+                    // Missing snapshots denote documents with no transform to apply.
+                    if holder != *doc_short_id
+                        && [holder, *doc_short_id].iter().any(|id| {
+                            original_keys
+                                .get(id)
+                                .is_some_and(|keys| !keys.contains(&key))
+                        })
+                    {
+                        return Err(Error::Storage(
+                            storage::corekv::Error::UniqueConstraintViolation,
+                        ));
+                    }
+                }
                 self.save_resolving_unique_conflict(
                     &mut mutable_datastore,
                     systemstore,

--- a/crates/db/src/index/manager/value_extraction.rs
+++ b/crates/db/src/index/manager/value_extraction.rs
@@ -7,6 +7,42 @@ use schema::{CollectionVersion, IndexDescription};
 use super::IndexManager;
 
 impl IndexManager {
+    pub(crate) fn unique_index_keys(
+        &self,
+        doc: &document::Document,
+        schema: &CollectionVersion,
+    ) -> Result<std::collections::HashSet<Vec<u8>>> {
+        let mut keys = std::collections::HashSet::new();
+        for index in self.indexes.values() {
+            if !matches!(index, super::IndexType::Unique(_)) {
+                continue;
+            }
+            for values in self.extract_index_values(doc, index.description(), schema)? {
+                if !values.iter().any(NormalValue::is_nil) {
+                    keys.insert(self.encode_index_key(index.description(), &values)?);
+                }
+            }
+        }
+        Ok(keys)
+    }
+
+    pub(super) fn encode_index_key(
+        &self,
+        desc: &IndexDescription,
+        values: &[NormalValue],
+    ) -> Result<Vec<u8>> {
+        let fields = values
+            .iter()
+            .zip(&desc.fields)
+            .map(|(value, field)| {
+                storage::keys::datastore::IndexedField::new(value.clone(), field.descending)
+            })
+            .collect();
+        storage::keys::IndexDataStoreKey::new(self.collection_short_id, desc.id, fields)
+            .try_bytes()
+            .map_err(Error::Storage)
+    }
+
     /// Extract field values from a document for indexing.
     ///
     /// # Multi-Value Indexing (Arrays)

--- a/crates/db/tests/definition/migration_suite.rs
+++ b/crates/db/tests/definition/migration_suite.rs
@@ -31,10 +31,13 @@ use storage::index::IndexIterator;
 use storage::RegolithStore;
 use tokio::sync::Notify;
 
+mod unique_conflicts;
+
 #[derive(Default)]
 struct SetVerifiedStore {
     transforms: RwLock<HashSet<TransformId>>,
     transform_calls: AtomicUsize,
+    verified_value: Option<serde_json::Value>,
 }
 
 #[async_trait]
@@ -63,8 +66,12 @@ impl TransformStore for SetVerifiedStore {
             return Err(lens::Error::TransformNotFound(id.to_string()));
         }
         self.transform_calls.fetch_add(1, Ordering::SeqCst);
-        Ok(Box::pin(docs.map(|mut doc| {
-            doc.insert("verified".to_string(), serde_json::Value::Bool(true));
+        let value = self
+            .verified_value
+            .clone()
+            .unwrap_or(serde_json::Value::Bool(true));
+        Ok(Box::pin(docs.map(move |mut doc| {
+            doc.insert("verified".to_string(), value.clone());
             Ok(doc)
         })))
     }

--- a/crates/db/tests/definition/migration_suite/unique_conflicts.rs
+++ b/crates/db/tests/definition/migration_suite/unique_conflicts.rs
@@ -1,0 +1,214 @@
+use super::*;
+
+async fn unique_migration_db() -> (Arc<DB<RegolithStore>>, String) {
+    unique_migration_db_with_value(None).await
+}
+
+async fn unique_migration_db_with_value(
+    verified_value: Option<serde_json::Value>,
+) -> (Arc<DB<RegolithStore>>, String) {
+    let is_array = verified_value
+        .as_ref()
+        .is_some_and(serde_json::Value::is_array);
+    let mut raw_db = DB::from_arc(Arc::new(RegolithStore::in_memory().unwrap())).unwrap();
+    raw_db.set_lens_store(Arc::new(SetVerifiedStore {
+        verified_value,
+        ..Default::default()
+    }));
+    let db = Arc::new(raw_db);
+    let mut schema = indexed_users_schema();
+    schema.indexes[0].unique = true;
+    if is_array {
+        schema.fields[2].kind = FieldKind::bool_array();
+    }
+    db.create_collection(schema).await.unwrap();
+    let v1 = db
+        .get_collection("Users")
+        .unwrap()
+        .unwrap()
+        .version_id()
+        .to_string();
+    let v2 = add_placeholder_version(&db, "placeholder").await;
+    db.set_migration(
+        LensConfig::new(
+            &v1,
+            &v2,
+            LensModule::from_bytes(b"\0asm\x01\0\0\0".to_vec()),
+        ),
+        None,
+    )
+    .await
+    .unwrap();
+    (db, v1)
+}
+
+async fn stored_entries(db: &DB<RegolithStore>) -> Vec<(Vec<u8>, Vec<u8>)> {
+    let txn = db.new_txn(true).await.unwrap();
+    let mut entries = Vec::new();
+    for store in [txn.datastore().unwrap(), txn.systemstore().unwrap()] {
+        let mut iter = store.iterator(IterOptions::new()).await.unwrap();
+        while let Some(entry) = iter.next().await.unwrap() {
+            entries.push((entry.key.to_vec(), entry.value.to_vec()));
+        }
+        iter.close().await.unwrap();
+    }
+    txn.discard().unwrap();
+    entries
+}
+
+#[tokio::test]
+async fn materialize_rejects_new_unique_collision_and_rolls_back() {
+    let (db, v1) = unique_migration_db().await;
+    seed_old_user(&db, &v1, "Alice").await;
+    seed_old_user(&db, &v1, "Bob").await;
+    let before = stored_entries(&db).await;
+
+    let err = db.materialize_collection("Users").await.unwrap_err();
+    assert!(err.is_unique_constraint_violation(), "{err}");
+    assert_eq!(stored_entries(&db).await, before);
+}
+
+async fn set_stored_verified(db: &DB<RegolithStore>, doc_id: &document::DocID, current: bool) {
+    set_stored_value(db, doc_id, current, document::NormalValue::Bool(true)).await;
+}
+
+async fn set_stored_value(
+    db: &DB<RegolithStore>,
+    doc_id: &document::DocID,
+    current: bool,
+    value: document::NormalValue,
+) {
+    let collection = db.get_collection("Users").unwrap().unwrap();
+    let txn = db.new_txn(false).await.unwrap();
+    let datastore = txn.datastore().unwrap();
+    let systemstore = txn.systemstore().unwrap();
+    let short_id = collection
+        .resolve_doc_short_id(&systemstore, doc_id)
+        .await
+        .unwrap()
+        .unwrap();
+    let mut doc = collection
+        .get_by_doc_id(&datastore, &systemstore, doc_id)
+        .await
+        .unwrap()
+        .unwrap();
+    doc.set("verified", value);
+    if current {
+        doc.set_schema_version_id(collection.version_id());
+    }
+    collection
+        .save_with_datastore(&datastore, &doc, short_id)
+        .await
+        .unwrap();
+    drop(datastore);
+    drop(systemstore);
+    txn.commit().await.unwrap();
+}
+
+#[tokio::test]
+async fn materialize_rejects_collision_with_current_document_in_either_order() {
+    for current_first in [false, true] {
+        let (db, v1) = unique_migration_db().await;
+        let first = seed_old_user(&db, &v1, "Alice").await;
+        let second = seed_old_user(&db, &v1, "Bob").await;
+        set_stored_verified(&db, if current_first { &first } else { &second }, true).await;
+        let before = stored_entries(&db).await;
+
+        let err = db
+            .reindex_collection_with_migrations("Users")
+            .await
+            .unwrap_err();
+        assert!(err.is_unique_constraint_violation(), "{err}");
+        assert_eq!(stored_entries(&db).await, before);
+    }
+}
+
+#[tokio::test]
+async fn materialize_preserves_preexisting_unique_collision_across_transform() {
+    let (db, v1) = unique_migration_db().await;
+    let first = seed_old_user(&db, &v1, "Alice").await;
+    let second = seed_old_user(&db, &v1, "Bob").await;
+    // Seed the duplicate persisted values that replication can legitimately retain.
+    set_stored_verified(&db, &first, false).await;
+    set_stored_verified(&db, &second, false).await;
+
+    assert_eq!(db.materialize_collection("Users").await.unwrap(), 2);
+    assert_eq!(verified_index_count(&db).await, 1);
+    let collection = db.get_collection("Users").unwrap().unwrap();
+    for id in [&first, &second] {
+        let doc = load_user(&db, id).await;
+        assert_eq!(doc.schema_version_id(), Some(collection.version_id()));
+        assert_eq!(
+            doc.get("verified"),
+            Some(&document::NormalValue::Bool(true))
+        );
+    }
+    let txn = db.new_txn(true).await.unwrap();
+    let manager = db::index::IndexManager::from_collection(
+        collection.resolved_root_id(),
+        collection.schema(),
+    )
+    .unwrap();
+    let mut iter = manager
+        .get_index("idx_verified")
+        .unwrap()
+        .get(
+            &txn.datastore().unwrap(),
+            &[document::NormalValue::Bool(true)],
+        )
+        .await
+        .unwrap();
+    let entries = iter.collect_all().await.unwrap();
+    let expected = if first.to_string() < second.to_string() {
+        &first
+    } else {
+        &second
+    };
+    let short_id = collection
+        .resolve_doc_short_id(&txn.systemstore().unwrap(), expected)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(entries[0].doc_short_id, short_id);
+    drop(iter);
+    txn.discard().unwrap();
+}
+
+#[tokio::test]
+async fn materialize_checks_array_conflicts_per_value() {
+    for introduces_collision in [false, true] {
+        let output = if introduces_collision {
+            serde_json::json!([true, false])
+        } else {
+            serde_json::json!([true])
+        };
+        let (db, v1) = unique_migration_db_with_value(Some(output)).await;
+        let first = seed_old_user(&db, &v1, "Alice").await;
+        let second = seed_old_user(&db, &v1, "Bob").await;
+        set_stored_value(
+            &db,
+            &first,
+            false,
+            document::NormalValue::BoolArray(vec![true]),
+        )
+        .await;
+        set_stored_value(
+            &db,
+            &second,
+            false,
+            document::NormalValue::BoolArray(vec![true, false]),
+        )
+        .await;
+        let before = stored_entries(&db).await;
+
+        let result = db.materialize_collection("Users").await;
+        if introduces_collision {
+            let err = result.unwrap_err();
+            assert!(err.is_unique_constraint_violation(), "{err}");
+            assert_eq!(stored_entries(&db).await, before);
+        } else {
+            assert_eq!(result.unwrap(), 2);
+            assert_eq!(verified_index_count(&db).await, 1);
+        }
+    }
+}

--- a/crates/db/tests/merge/merge_handler_tests.rs
+++ b/crates/db/tests/merge/merge_handler_tests.rs
@@ -16,6 +16,7 @@ use db::merge::merge_handler::hook::CompositeMergeHook;
 use db::merge::merge_handler::hook::CompositePostCommitAction;
 use db::merge::merge_handler::*;
 use db::DbTransactionRegistry;
+use db::IndexManager;
 use defra_core::block::Block;
 use defra_core::block::CollectionDefinitionDeltaPayload;
 use defra_core::block::CollectionDeltaPayload;
@@ -50,6 +51,7 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use storage::corekv::Key;
+use storage::index::IndexIterator;
 use storage::keys::systemstore::CollectionID;
 use storage::RegolithStore;
 use tokio::time::timeout;
@@ -3050,6 +3052,36 @@ async fn remote_composite_merge_with_unique_index_twin_conflict_merges_via_canon
         "a live twin unique conflict on a replicated merge must converge via \
              #1126's canonical pick, not classify as Rejected: {:?}",
         outcome_b
+    );
+
+    handler
+        .db()
+        .materialize_collection("Sessions")
+        .await
+        .expect("reindexing must preserve the merge-time canonical unique winner");
+
+    let txn = handler.db().new_txn(true).await.unwrap();
+    let datastore = txn.datastore().unwrap();
+    let systemstore = txn.systemstore().unwrap();
+    let index_manager =
+        IndexManager::from_collection(collection.resolved_root_id(), collection.schema()).unwrap();
+    let mut entries = index_manager
+        .get_index("idx_session_id_unique")
+        .unwrap()
+        .get(
+            &datastore,
+            &[NormalValue::String("dup-session".to_string())],
+        )
+        .await
+        .unwrap();
+    let entries = entries.collect_all().await.unwrap();
+    assert_eq!(entries.len(), 1);
+    let indexed_doc_id = db::docid::map::get_doc_id(&systemstore, entries[0].doc_short_id)
+        .await
+        .unwrap();
+    assert_eq!(
+        indexed_doc_id,
+        Some(std::cmp::min(doc_a_id.to_string(), doc_b_id.to_string()))
     );
 
     // Both documents persist — the CRDT merge never drops data, even


### PR DESCRIPTION
## Context

Replication resolves live unique-index conflicts deterministically by keeping the document with the smallest public DocID indexed and persisting the other document without an index entry. Collection materialization rebuilt the same index through the strict bulk path, so a state accepted by replication could make every later materialization fail with a unique-constraint violation.

## Changes

- rebuild unique indexes through the same deterministic conflict resolver used by replication
- retain the existing bulk path for non-unique indexes
- verify materialization succeeds after a replicated unique conflict and preserves the canonical winner

## Testing

- `cargo test --profile super-dev -p db --test merge`
- `cargo clippy --profile super-dev -p db --test merge -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #1308
