### PR TITLE
fix(p2p): stop connection polling when host closes

### DIFF
--- a/crates/p2p/src/host/handle.rs
+++ b/crates/p2p/src/host/handle.rs
@@ -877,10 +877,9 @@ impl P2PHostHandle {
     ) -> Result<()> {
         let deadline = tokio::time::Instant::now() + timeout;
         loop {
-            if let Ok(connected) = self.connected_peers().await {
-                if connected.contains(&peer_id) {
-                    return Ok(());
-                }
+            let connected = self.connected_peers().await?;
+            if connected.contains(&peer_id) {
+                return Ok(());
             }
             if tokio::time::Instant::now() >= deadline {
                 return Err(Error::ConnectionTimeout(peer_id.to_string()));

--- a/crates/p2p/tests/host_tests.rs
+++ b/crates/p2p/tests/host_tests.rs
@@ -169,6 +169,25 @@ async fn test_host_creation() {
 }
 
 #[tokio::test]
+async fn connection_poll_stops_when_host_is_closed() {
+    let store = MockBitswapStore::new();
+    let (host, handle, _events, _replicators) = P2PHost::new(store).await.unwrap();
+    let host_task = tokio::spawn(host.run());
+    handle.shutdown().await.unwrap();
+    host_task.await.unwrap();
+
+    let peer_id = PeerId::from_public_key(&libp2p::identity::Keypair::generate_ed25519().public());
+    let result = timeout(
+        Duration::from_secs(1),
+        handle.poll_until_connected(peer_id, Duration::from_secs(60)),
+    )
+    .await
+    .expect("a closed host must not consume the connection timeout");
+
+    assert!(result.is_err());
+}
+
+#[tokio::test]
 async fn test_host_connects_over_quic() {
     assert_hosts_connect_over("/ip4/127.0.0.1/udp/0/quic-v1").await;
 }


### PR DESCRIPTION
## Context

Connection polling discarded host command-channel errors and could wait until the caller timeout after the host had already closed.

## Changes

- propagate terminal host errors immediately
- cover polling against a closed host

## Testing

- `cargo test --profile super-dev -p p2p --features test-utils --test host_tests connection_poll_stops_when_host_is_closed`
- `cargo clippy --profile super-dev -p p2p --features test-utils --test host_tests -- -D warnings`

Refs #1356
