### PR TITLE
test(cli): inventory config flag enforcement

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -48,3 +48,7 @@ fn should_profile(cli: &Cli) -> bool {
 fn enable_telemetry(cli: &Cli) -> bool {
     matches!(&cli.command, Command::Start(_))
 }
+
+#[cfg(test)]
+#[path = "../tests/unit/main_tests.rs"]
+mod tests;

--- a/crates/cli/tests/config_tests.rs
+++ b/crates/cli/tests/config_tests.rs
@@ -1,11 +1,15 @@
 //! Tests for the Config struct and configuration loading
 
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::PathBuf;
 
+use clap::CommandFactory;
 use cli::cli::{Cli, Command};
 use cli::commands::VersionArgs;
-use cli::config::{Config, DatastoreType, KeyringBackend, LogFormat, LogLevel, LogOutput};
+use cli::config::{
+    AcpDocumentType, Config, DatastoreType, KeyringBackend, LogFormat, LogLevel, LogOutput,
+};
 use cli::error::Error;
 
 /// Helper to create a minimal Cli for testing apply_cli_flags
@@ -134,18 +138,124 @@ fn test_apply_cli_flags_valid_values_succeed() {
     cli.log_level = Some("debug".to_string());
     cli.log_output = Some("stdout".to_string());
     cli.log_format = Some("json".to_string());
+    cli.log_stacktrace = Some(true);
+    cli.log_source = Some(true);
+    cli.log_overrides = Some("db,level=debug".to_string());
+    cli.no_log_color = Some(true);
     cli.keyring_backend = Some("system".to_string());
+    cli.keyring_namespace = Some("test-defradb".to_string());
+    cli.keyring_path = Some("/tmp/test-keys".to_string());
+    cli.no_keyring = Some(true);
     cli.url = Some("0.0.0.0:8080".to_string());
+    cli.secret_file = Some("test.env".to_string());
+    cli.no_telemetry = Some(true);
     cli.development = Some(true);
+    cli.acp_node_enable = Some(true);
+    cli.acp_document_type = Some("local".to_string());
+    #[cfg(feature = "sourcehub")]
+    {
+        cli.source_hub_address = Some("http://localhost:1317".to_string());
+        cli.source_hub_comet_address = Some("http://localhost:26657".to_string());
+        cli.source_hub_events_ws = Some("ws://localhost:26657/websocket".to_string());
+        cli.source_hub_chain_id = Some("sourcehub-test".to_string());
+        cli.hub_rs_address = Some("http://localhost:8545".to_string());
+    }
 
     let result = config.apply_cli_flags(&cli);
     assert!(result.is_ok());
     assert_eq!(config.log.level, LogLevel::Debug);
     assert_eq!(config.log.output, LogOutput::Stdout);
     assert_eq!(config.log.format, LogFormat::Json);
+    assert!(config.log.stacktrace);
+    assert!(config.log.source);
+    assert_eq!(config.log.overrides, "db,level=debug");
+    assert!(config.log.color_disabled);
     assert_eq!(config.keyring.backend, KeyringBackend::System);
+    assert_eq!(config.keyring.namespace, "test-defradb");
+    assert_eq!(config.keyring.path, "/tmp/test-keys");
+    assert!(config.keyring.disabled);
     assert_eq!(config.api.address, "0.0.0.0:8080");
+    assert_eq!(config.secret_file, "test.env");
+    assert!(config.telemetry_disabled);
     assert!(config.development);
+    assert!(config.acp.node_enable);
+    assert_eq!(config.acp.document_type, AcpDocumentType::Local);
+    #[cfg(feature = "sourcehub")]
+    {
+        assert_eq!(config.acp.sourcehub_address, "http://localhost:1317");
+        assert_eq!(config.acp.sourcehub_comet_address, "http://localhost:26657");
+        assert_eq!(
+            config.acp.sourcehub_events_ws,
+            "ws://localhost:26657/websocket"
+        );
+        assert_eq!(config.acp.sourcehub_chain_id, "sourcehub-test");
+        assert_eq!(config.acp.hub_rs_address, "http://localhost:8545");
+    }
+}
+
+// These are all asserted above to change the typed node configuration.
+const CONFIG_BACKED_GLOBAL_FLAGS: &[&str] = &[
+    "log-level",
+    "log-output",
+    "log-format",
+    "log-stacktrace",
+    "log-source",
+    "log-overrides",
+    "no-log-color",
+    "url",
+    "keyring-namespace",
+    "keyring-backend",
+    "keyring-path",
+    "no-keyring",
+    #[cfg(feature = "sourcehub")]
+    "source-hub-address",
+    #[cfg(feature = "sourcehub")]
+    "source-hub-comet-address",
+    #[cfg(feature = "sourcehub")]
+    "source-hub-events-ws",
+    #[cfg(feature = "sourcehub")]
+    "source-hub-chain-id",
+    #[cfg(feature = "sourcehub")]
+    "hub-rs-address",
+    "secret-file",
+    "no-telemetry",
+    "development",
+    "node-acp-enable",
+    "document-acp-type",
+];
+
+// `rootdir` selects the config file before Config exists, so it cannot be
+// covered by the apply-to-config assertion above.
+const DIRECT_GLOBAL_FLAGS: &[(&str, &str)] = &[("rootdir", "Config::resolve_rootdir")];
+
+#[test]
+fn every_global_config_flag_has_an_enforcement_path() {
+    let mut command = Cli::command();
+    command.build();
+    let actual: BTreeSet<_> = command
+        .get_arguments()
+        .filter_map(|arg| arg.get_long())
+        .filter(|name| !matches!(*name, "help" | "version"))
+        .collect();
+
+    let classified: BTreeSet<_> = CONFIG_BACKED_GLOBAL_FLAGS
+        .iter()
+        .copied()
+        .chain(DIRECT_GLOBAL_FLAGS.iter().map(|(name, _)| *name))
+        .collect();
+
+    assert_eq!(
+        classified.len(),
+        CONFIG_BACKED_GLOBAL_FLAGS.len() + DIRECT_GLOBAL_FLAGS.len(),
+        "global flag enforcement inventory contains a duplicate"
+    );
+    assert!(DIRECT_GLOBAL_FLAGS
+        .iter()
+        .all(|(_, enforcement_path)| !enforcement_path.is_empty()));
+    assert_eq!(
+        actual, classified,
+        "classify every global config flag by its config assertion or direct enforcement path"
+    );
 }
 
 #[test]

--- a/crates/cli/tests/config_tests.rs
+++ b/crates/cli/tests/config_tests.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeSet;
 use std::fs;
 use std::path::PathBuf;
 
-use clap::CommandFactory;
+use clap::{CommandFactory, Parser};
 use cli::cli::{Cli, Command};
 use cli::commands::VersionArgs;
 use cli::config::{
@@ -226,7 +226,31 @@ const CONFIG_BACKED_GLOBAL_FLAGS: &[&str] = &[
 
 // `rootdir` selects the config file before Config exists, so it cannot be
 // covered by the apply-to-config assertion above.
-const DIRECT_GLOBAL_FLAGS: &[(&str, &str)] = &[("rootdir", "Config::resolve_rootdir")];
+const DIRECT_GLOBAL_FLAGS: &[(&str, fn())] = &[("rootdir", rootdir_selects_config_file)];
+
+fn rootdir_selects_config_file() {
+    let rootdir = tempfile::tempdir().unwrap();
+    let mut stored = Config::default();
+    stored.datastore.path = "selected-data".into();
+    fs::write(
+        rootdir.path().join("config.yaml"),
+        serde_yaml::to_string(&stored).unwrap(),
+    )
+    .unwrap();
+    let cli = Cli::try_parse_from([
+        "defra",
+        "--rootdir",
+        rootdir.path().to_str().unwrap(),
+        "--secret-file",
+        rootdir.path().join("absent.env").to_str().unwrap(),
+        "version",
+    ])
+    .unwrap();
+
+    let config = Config::load(&cli).unwrap();
+    assert_eq!(config.rootdir, rootdir.path());
+    assert_eq!(config.data_path(), rootdir.path().join("selected-data"));
+}
 
 #[test]
 fn every_global_config_flag_has_an_enforcement_path() {
@@ -249,9 +273,9 @@ fn every_global_config_flag_has_an_enforcement_path() {
         CONFIG_BACKED_GLOBAL_FLAGS.len() + DIRECT_GLOBAL_FLAGS.len(),
         "global flag enforcement inventory contains a duplicate"
     );
-    assert!(DIRECT_GLOBAL_FLAGS
-        .iter()
-        .all(|(_, enforcement_path)| !enforcement_path.is_empty()));
+    for (_, check) in DIRECT_GLOBAL_FLAGS {
+        check();
+    }
     assert_eq!(
         actual, classified,
         "classify every global config flag by its config assertion or direct enforcement path"

--- a/crates/cli/tests/start_tests.rs
+++ b/crates/cli/tests/start_tests.rs
@@ -437,7 +437,10 @@ const DIRECT_START_FLAGS: &[(&str, &str)] = &[
     #[cfg(feature = "orbis")]
     ("signer-orbis-derivation", "StartArgs::setup_orbis_signer"),
     #[cfg(feature = "orbis")]
-    ("signer-orbis-identity", "StartArgs::parse_orbis_service_identity"),
+    (
+        "signer-orbis-identity",
+        "StartArgs::parse_orbis_service_identity",
+    ),
 ];
 
 #[test]

--- a/crates/cli/tests/start_tests.rs
+++ b/crates/cli/tests/start_tests.rs
@@ -1,10 +1,14 @@
 //! Tests for the start command
 
+use std::collections::BTreeSet;
+
+use clap::Args;
 use cli::commands::StartArgs;
-use cli::config::{Config, DatastoreType};
+use cli::config::{Config, DatastoreType, TransportType};
 use cli::error::Error;
 #[cfg(feature = "orbis")]
 use identity::Identity as _;
+use storage::backends::DurabilityMode;
 
 fn default_start_args() -> StartArgs {
     StartArgs {
@@ -157,7 +161,7 @@ fn test_apply_to_config_all_flags() {
         no_searchable_encryption: Some(true),
         identity: None, // identity is handled in Node::new, not apply_to_config
         replicator_retry_intervals: Some(vec![10, 20, 30]),
-        durability: None,
+        durability: Some("eventual".to_string()),
         #[cfg(feature = "orbis")]
         signer_type: None,
         #[cfg(feature = "orbis")]
@@ -196,14 +200,14 @@ fn test_apply_to_config_all_flags() {
         query_max_depth: Some(12),
         query_max_width: Some(64),
         query_max_filter_depth: Some(24),
-        p2p_transport: None,
+        p2p_transport: Some("libp2p".to_string()),
         #[cfg(feature = "postgres")]
-        pg_address: None,
-        acp_cache_ttl: None,
-        acp_circuit_breaker_threshold: None,
-        acp_circuit_breaker_reset_timeout: None,
-        acp_request_timeout: None,
-        acp_receipt_timeout: None,
+        pg_address: Some("127.0.0.1:5433".to_string()),
+        acp_cache_ttl: Some(600),
+        acp_circuit_breaker_threshold: Some(5),
+        acp_circuit_breaker_reset_timeout: Some(45),
+        acp_request_timeout: Some(10),
+        acp_receipt_timeout: Some(90),
         embedding_url: Some("http://localhost:11434/v1".to_string()),
         embedding_model: Some("nomic-embed-text".to_string()),
         embedding_api_key_env: Some("CUSTOM_EMBEDDING_KEY".to_string()),
@@ -238,6 +242,7 @@ fn test_apply_to_config_all_flags() {
     assert_eq!(config.datastore.max_txn_retries, 10);
     assert_eq!(config.datastore.store, DatastoreType::Memory);
     assert_eq!(config.datastore.valuelogfilesize, Some(2 << 30));
+    assert_eq!(config.datastore.durability, DurabilityMode::Eventual);
     assert_eq!(config.net.p2p_addresses, vec!["/ip4/0.0.0.0/tcp/4001"]);
     assert!(config.net.p2p_disabled);
     assert_eq!(config.api.allowed_origins, vec!["http://localhost:3000"]);
@@ -255,6 +260,14 @@ fn test_apply_to_config_all_flags() {
     assert_eq!(config.api.query_max_depth, 12);
     assert_eq!(config.api.query_max_width, 64);
     assert_eq!(config.api.query_max_filter_depth, 24);
+    assert_eq!(config.net.transport, TransportType::Libp2p);
+    #[cfg(feature = "postgres")]
+    assert_eq!(config.api.pg_address, "127.0.0.1:5433");
+    assert_eq!(config.acp.cache_ttl, 600);
+    assert_eq!(config.acp.circuit_breaker_threshold, 5);
+    assert_eq!(config.acp.circuit_breaker_reset_timeout, 45);
+    assert_eq!(config.acp.request_timeout, 10);
+    assert_eq!(config.acp.receipt_timeout, 90);
     assert_eq!(config.embedding.url, "http://localhost:11434/v1");
     assert_eq!(config.embedding.model, "nomic-embed-text");
     assert_eq!(config.embedding.api_key_env, "CUSTOM_EMBEDDING_KEY");
@@ -322,4 +335,142 @@ fn orbis_service_identity_is_absent_without_the_flag() {
         .parse_orbis_service_identity()
         .expect("an absent flag is not an error")
         .is_none());
+}
+
+// Each group is asserted above to change Config and names the runtime boundary
+// that consumes those fields. A new flag must be assigned to a real consumer.
+const STORAGE_START_FLAGS: &[&str] = &[
+    "max-txn-retries",
+    "store",
+    "valuelogfilesize",
+    "no-encryption",
+    "default-key-type",
+    "no-searchable-encryption",
+    "at-rest-encryption",
+    "durability",
+    "max-merge-depth",
+];
+
+// Consumed by start/p2p.rs and start/server_p2p/ host construction.
+const P2P_START_FLAGS: &[&str] = &[
+    "peers",
+    "p2paddr",
+    "no-p2p",
+    "replicator-retry-intervals",
+    "max-msg-size",
+    "max-car-size",
+    "stream-timeout",
+    "max-p2p-tasks",
+    "connection-manager-low-water",
+    "connection-manager-high-water",
+    "connection-manager-grace-period-ms",
+    "max-connections-per-peer",
+    "p2p-rate-limit-burst",
+    "p2p-rate-limit-rate",
+    "p2p-max-doc-sync-request-doc-ids",
+    "p2p-max-pending-dags",
+    "p2p-rebroadcast-on-merge",
+    "p2p-push-queue-capacity",
+    "p2p-push-queue-byte-capacity",
+    "p2p-max-active-pushes-per-peer",
+    "p2p-transport",
+];
+
+// Consumed by start/server_http.rs; limit and signing behavior is asserted in
+// defra_http::server_tests.
+const HTTP_START_FLAGS: &[&str] = &[
+    "allowed-origins",
+    "pubkeypath",
+    "privkeypath",
+    "no-signing",
+    "max-body-size",
+    "max-schema-size",
+    "max-backup-size",
+    "request-timeout",
+    "max-concurrent-requests",
+    "transaction-idle-timeout",
+    "transaction-cleanup-interval",
+    #[cfg(feature = "postgres")]
+    "pg-address",
+];
+
+// Consumed by start/server_query.rs and the HTTP query limits.
+const QUERY_START_FLAGS: &[&str] = &[
+    "query-timeout",
+    "query-max-depth",
+    "query-max-width",
+    "query-max-filter-depth",
+];
+
+// Consumed by start/server_acp.rs provider construction.
+const ACP_START_FLAGS: &[&str] = &[
+    "acp-circuit-breaker-threshold",
+    "acp-circuit-breaker-reset-timeout",
+    "acp-request-timeout",
+    "acp-cache-ttl",
+    "acp-receipt-timeout",
+];
+
+// Consumed by start/server.rs when constructing DbOptions.
+const EMBEDDING_START_FLAGS: &[&str] =
+    &["embedding-url", "embedding-model", "embedding-api-key-env"];
+
+const CONFIG_BACKED_START_FLAG_GROUPS: &[&[&str]] = &[
+    STORAGE_START_FLAGS,
+    P2P_START_FLAGS,
+    HTTP_START_FLAGS,
+    QUERY_START_FLAGS,
+    ACP_START_FLAGS,
+    EMBEDDING_START_FLAGS,
+];
+
+// These bypass Config and are consumed directly at the named startup boundary.
+const DIRECT_START_FLAGS: &[(&str, &str)] = &[
+    ("profile", "cli/src/main.rs::should_profile"),
+    ("identity", "StartArgs::parse_user_identity"),
+    #[cfg(feature = "orbis")]
+    ("signer-type", "StartArgs::execute"),
+    #[cfg(feature = "orbis")]
+    ("signer-orbis-endpoint", "StartArgs::setup_orbis_signer"),
+    #[cfg(feature = "orbis")]
+    ("signer-orbis-ring-id", "StartArgs::setup_orbis_signer"),
+    #[cfg(feature = "orbis")]
+    ("signer-orbis-derivation", "StartArgs::setup_orbis_signer"),
+    #[cfg(feature = "orbis")]
+    ("signer-orbis-identity", "StartArgs::parse_orbis_service_identity"),
+];
+
+#[test]
+fn every_start_flag_has_an_enforcement_path() {
+    let mut command = StartArgs::augment_args(clap::Command::new("start"));
+    command.build();
+    let actual: BTreeSet<_> = command
+        .get_arguments()
+        .filter_map(|arg| arg.get_long())
+        .filter(|name| *name != "help")
+        .collect();
+
+    let classified: BTreeSet<_> = CONFIG_BACKED_START_FLAG_GROUPS
+        .iter()
+        .flat_map(|flags| flags.iter().copied())
+        .chain(DIRECT_START_FLAGS.iter().map(|(name, _)| *name))
+        .collect();
+    let classified_count = CONFIG_BACKED_START_FLAG_GROUPS
+        .iter()
+        .map(|flags| flags.len())
+        .sum::<usize>()
+        + DIRECT_START_FLAGS.len();
+
+    assert_eq!(
+        classified.len(),
+        classified_count,
+        "start flag enforcement inventory contains a duplicate"
+    );
+    assert!(DIRECT_START_FLAGS
+        .iter()
+        .all(|(_, enforcement_path)| !enforcement_path.is_empty()));
+    assert_eq!(
+        actual, classified,
+        "classify every start flag by its config assertion or direct enforcement path"
+    );
 }

--- a/crates/cli/tests/start_tests.rs
+++ b/crates/cli/tests/start_tests.rs
@@ -2,7 +2,8 @@
 
 use std::collections::BTreeSet;
 
-use clap::Args;
+use clap::{Args, Parser};
+use cli::cli::{Cli, Command};
 use cli::commands::StartArgs;
 use cli::config::{Config, DatastoreType, TransportType};
 use cli::error::Error;
@@ -305,9 +306,19 @@ fn orbis_service_identity_is_separate_from_the_node_identity() {
         "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"
     );
 
-    let mut args = default_start_args();
-    args.identity = Some(SECP256K1_KEY.to_string());
-    args.signer_orbis_identity = Some(ED25519_KEY.to_string());
+    let Command::Start(args) = Cli::try_parse_from([
+        "defra",
+        "start",
+        "--identity",
+        SECP256K1_KEY,
+        "--signer-orbis-identity",
+        ED25519_KEY,
+    ])
+    .unwrap()
+    .command
+    else {
+        panic!("expected start command");
+    };
 
     let node = args
         .parse_user_identity()
@@ -424,27 +435,53 @@ const CONFIG_BACKED_START_FLAG_GROUPS: &[&[&str]] = &[
     EMBEDDING_START_FLAGS,
 ];
 
-// These bypass Config and are consumed directly at the named startup boundary.
-const DIRECT_START_FLAGS: &[(&str, &str)] = &[
-    ("profile", "cli/src/main.rs::should_profile"),
-    ("identity", "StartArgs::parse_user_identity"),
-    #[cfg(feature = "orbis")]
-    ("signer-type", "StartArgs::execute"),
-    #[cfg(feature = "orbis")]
-    ("signer-orbis-endpoint", "StartArgs::setup_orbis_signer"),
-    #[cfg(feature = "orbis")]
-    ("signer-orbis-ring-id", "StartArgs::setup_orbis_signer"),
-    #[cfg(feature = "orbis")]
-    ("signer-orbis-derivation", "StartArgs::setup_orbis_signer"),
+const DIRECT_START_FLAGS: &[(&str, fn())] = &[
+    ("identity", identity_flag_selects_signing_key),
     #[cfg(feature = "orbis")]
     (
         "signer-orbis-identity",
-        "StartArgs::parse_orbis_service_identity",
+        orbis_service_identity_is_separate_from_the_node_identity,
     ),
 ];
 
+// `profile` is checked against the private binary entry point in main_tests.rs.
+const BINARY_TESTED_START_FLAGS: &[&str] = &["profile"];
+
+// These need a live Orbis ring to verify public-key derivation and signing.
+// Inventory membership is not runtime enforcement coverage for these flags.
+#[cfg(feature = "orbis")]
+const RUNTIME_EXEMPT_START_FLAGS: &[&str] = &[
+    "signer-type",
+    "signer-orbis-endpoint",
+    "signer-orbis-ring-id",
+    "signer-orbis-derivation",
+];
+#[cfg(not(feature = "orbis"))]
+const RUNTIME_EXEMPT_START_FLAGS: &[&str] = &[];
+
+fn identity_flag_selects_signing_key() {
+    for byte in [1u8, 2] {
+        let key = hex::encode([byte; 32]);
+        let Command::Start(args) = Cli::try_parse_from(["defra", "start", "--identity", &key])
+            .unwrap()
+            .command
+        else {
+            panic!("expected start command");
+        };
+        let identity = args.parse_user_identity().unwrap().unwrap();
+        assert_eq!(identity.private_key_bytes(), [byte; 32]);
+    }
+    let Command::Start(args) = Cli::try_parse_from(["defra", "start", "--identity", "not-hex"])
+        .unwrap()
+        .command
+    else {
+        panic!("expected start command");
+    };
+    assert!(args.parse_user_identity().is_err());
+}
+
 #[test]
-fn every_start_flag_has_an_enforcement_path() {
+fn every_start_flag_has_a_check_or_explicit_runtime_exemption() {
     let mut command = StartArgs::augment_args(clap::Command::new("start"));
     command.build();
     let actual: BTreeSet<_> = command
@@ -457,23 +494,27 @@ fn every_start_flag_has_an_enforcement_path() {
         .iter()
         .flat_map(|flags| flags.iter().copied())
         .chain(DIRECT_START_FLAGS.iter().map(|(name, _)| *name))
+        .chain(BINARY_TESTED_START_FLAGS.iter().copied())
+        .chain(RUNTIME_EXEMPT_START_FLAGS.iter().copied())
         .collect();
     let classified_count = CONFIG_BACKED_START_FLAG_GROUPS
         .iter()
         .map(|flags| flags.len())
         .sum::<usize>()
-        + DIRECT_START_FLAGS.len();
+        + DIRECT_START_FLAGS.len()
+        + BINARY_TESTED_START_FLAGS.len()
+        + RUNTIME_EXEMPT_START_FLAGS.len();
 
     assert_eq!(
         classified.len(),
         classified_count,
         "start flag enforcement inventory contains a duplicate"
     );
-    assert!(DIRECT_START_FLAGS
-        .iter()
-        .all(|(_, enforcement_path)| !enforcement_path.is_empty()));
+    for (_, check) in DIRECT_START_FLAGS {
+        check();
+    }
     assert_eq!(
         actual, classified,
-        "classify every start flag by its config assertion or direct enforcement path"
+        "classify every start flag by its assertion or explicit runtime exemption"
     );
 }

--- a/crates/cli/tests/unit/main_tests.rs
+++ b/crates/cli/tests/unit/main_tests.rs
@@ -1,0 +1,13 @@
+use super::*;
+
+#[test]
+fn profile_flag_controls_startup_profiling() {
+    for (args, expected) in [
+        (vec!["defra", "start"], false),
+        (vec!["defra", "start", "--profile"], true),
+        (vec!["defra", "version"], false),
+    ] {
+        let cli = Cli::try_parse_from(args).unwrap();
+        assert_eq!(should_profile(&cli), expected);
+    }
+}


### PR DESCRIPTION
## Context

A configuration flag can map into `Config` while still having no runtime effect. Several options were also omitted from the existing all-flags test.

## Changes

- assert every config-backed global and start flag
- classify flags by their runtime enforcement boundary
- compare the inventory against the argument surface generated by Clap

## Testing

- `cargo test --profile super-dev -p cli --features release-full --test config_tests --test start_tests`
- `cargo clippy --profile super-dev -p cli --features release-full --tests -- -D warnings`
- `cargo fmt --all -- --check`

Closes #1422
