### PR TITLE
perf: benchmark suite, run-document history and a published dashboard

### DIFF
--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -1,0 +1,237 @@
+name: Performance (pull request)
+
+# Its own workflow, and that is the whole reason it exists separately.
+#
+# The full matrix is forty jobs across three platforms. Keeping it in the
+# workflow a pull request triggers meant every PR carried forty skipped checks,
+# and GitHub renders a skipped matrix job without expanding its matrix: the
+# check list filled up with literal `${{ matrix.family }}` rows. A pull request
+# triggers this file, which has no matrix, so those checks are never created.
+#
+# The full sweep lives in `perf.yml` and runs on a push to `main` or on a
+# `workflow_dispatch`, which can be pointed at any branch.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: perf-pr-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: '0'
+
+jobs:
+  # Every pull request, no ceremony. Four families on Linux,
+  # measured against this PR's own merge base on this same runner with this
+  # same profile, and posted back as a comment.
+  #
+  # Two decisions keep it quick without making it dishonest.
+  #
+  # `release-fast` rather than the `bench` profile: thin LTO and sixteen
+  # codegen units build in a fraction of the time fat LTO takes. It produces
+  # different absolute numbers, which is exactly why this path never publishes
+  # to the dashboard and never compares against it. Both sides of this
+  # comparison are built the same way, so the delta between them is real even
+  # though neither figure is the one a release would post.
+  #
+  # And the base measurement is cached by its commit. A base is measured once
+  # and then reused by every later pull request that shares it, so only the
+  # first one after a merge to `main` pays for the second build.
+  quick:
+    name: Quick benchmark
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      DEFRA_BENCH_CRITERION_ARGS: --warm-up-time 0.5 --measurement-time 1.5 --sample-size 10
+      PERF_PROFILE: release-fast
+      # The write path, the allocation counts that catch a stray clone before
+      # the clock does, cold start, and the storage transaction seam.
+      QUICK_FAMILIES: document_write allocs startup transaction
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: head
+      - uses: extractions/setup-just@v2
+      # Its own interpreter rather than the system one: a PEP 668 image refuses
+      # to let pip touch the system environment, and this gate must not be the
+      # thing that fails before it has checked anything.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      # A bench target the matrix does not name measures nothing, and nothing
+      # else in CI would notice.
+      - name: Check every bench target is measured
+        working-directory: head
+        run: |
+          python3 -m pip install --quiet pyyaml
+          just perf-matrix
+      - uses: dtolnay/rust-toolchain@stable
+      - run: head/.github/scripts/install-linux-ci-deps.sh
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: perf-quick
+          workspaces: head
+
+      - name: Record how quiet the host is
+        run: python3 head/tools/perf-site/loadguard.py --out loadguard.json
+
+      - name: Measure this pull request
+        working-directory: head
+        env:
+          DEFRA_BENCH_OUT: ${{ github.workspace }}/head.jsonl
+        run: |
+          set -euo pipefail
+          for family in $QUICK_FAMILIES; do
+            echo "::group::$family"
+            rm -rf target/criterion
+            cargo bench --profile "$PERF_PROFILE" -p benches --bench "$family" \
+              -- $DEFRA_BENCH_CRITERION_ARGS
+            mkdir -p "$GITHUB_WORKSPACE/criterion-head/$family"
+            [ -d target/criterion ] && cp -R target/criterion/. "$GITHUB_WORKSPACE/criterion-head/$family/"
+            echo "::endgroup::"
+          done
+          touch "$DEFRA_BENCH_OUT"
+
+      - name: Assemble this pull request's document
+        working-directory: head
+        env:
+          DEFRA_BENCH_OUT: ${{ github.workspace }}/head.jsonl
+          PERF_COMMIT: ${{ github.event.pull_request.head.sha }}
+          PERF_LABEL: pr-${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          cargo run --profile "$PERF_PROFILE" -p defra-perf --bin collect -- \
+            --criterion-root "$GITHUB_WORKSPACE/criterion-head" \
+            --out "$GITHUB_WORKSPACE/platform-head.json" \
+            --commit "$PERF_COMMIT" \
+            --label "$PERF_LABEL" \
+            --target x86_64-unknown-linux-gnu \
+            --loadguard "$GITHUB_WORKSPACE/loadguard.json"
+
+      # A base is the same commit for every PR branched off it, so measuring it
+      # once and reusing the document is the difference between paying for two
+      # builds on every pull request and paying for them once per merge.
+      - name: Restore the baseline measured for this base commit
+        id: basecache
+        uses: actions/cache@v4
+        with:
+          path: platform-base.json
+          key: perf-quick-base-${{ github.event.pull_request.base.sha }}-v1
+
+      - uses: actions/checkout@v4
+        if: steps.basecache.outputs.cache-hit != 'true'
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+
+      - name: Measure the merge base
+        if: steps.basecache.outputs.cache-hit != 'true'
+        working-directory: base
+        env:
+          DEFRA_BENCH_OUT: ${{ github.workspace }}/base.jsonl
+          # The same target directory as the head build, so the second build
+          # reuses every dependency artifact the first one produced.
+          CARGO_TARGET_DIR: ${{ github.workspace }}/head/target
+        run: |
+          set -euo pipefail
+          for family in $QUICK_FAMILIES; do
+            # A family this pull request introduces does not exist on the base,
+            # and that is a new measurement rather than a failure. The
+            # comparison reports it as measured on one side only.
+            echo "::group::$family"
+            rm -rf "$CARGO_TARGET_DIR/criterion"
+            cargo bench --profile "$PERF_PROFILE" -p benches --bench "$family" \
+              -- $DEFRA_BENCH_CRITERION_ARGS \
+              || echo "::notice::$family did not run on the base commit; it will show as new"
+            mkdir -p "$GITHUB_WORKSPACE/criterion-base/$family"
+            [ -d "$CARGO_TARGET_DIR/criterion" ] && \
+              cp -R "$CARGO_TARGET_DIR/criterion/." "$GITHUB_WORKSPACE/criterion-base/$family/"
+            echo "::endgroup::"
+          done
+          touch "$DEFRA_BENCH_OUT"
+
+      - name: Assemble the merge base's document
+        if: steps.basecache.outputs.cache-hit != 'true'
+        working-directory: base
+        env:
+          DEFRA_BENCH_OUT: ${{ github.workspace }}/base.jsonl
+          CARGO_TARGET_DIR: ${{ github.workspace }}/head/target
+          PERF_BASE_COMMIT: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          # Built from the base checkout when it has the collector, and from
+          # this PR's when the PR is what introduces it.
+          manifest=Cargo.toml
+          if ! grep -q '"tools/perf"' Cargo.toml; then
+            manifest="$GITHUB_WORKSPACE/head/Cargo.toml"
+          fi
+          cargo run --manifest-path "$manifest" --profile "$PERF_PROFILE" \
+            -p defra-perf --bin collect -- \
+            --criterion-root "$GITHUB_WORKSPACE/criterion-base" \
+            --out "$GITHUB_WORKSPACE/platform-base.json" \
+            --commit "$PERF_BASE_COMMIT" \
+            --label "base" \
+            --target x86_64-unknown-linux-gnu \
+            --loadguard "$GITHUB_WORKSPACE/loadguard.json"
+
+      - name: Compare
+        id: compare
+        env:
+          PERF_THRESHOLD: '5'
+        run: |
+          set -euo pipefail
+          mkdir -p head-site base-site
+          python3 head/tools/perf-site/publish.py --site head-site platform-head.json
+          if [ ! -f platform-base.json ]; then
+            {
+              echo "## Performance"
+              echo ""
+              echo "The merge base could not be measured, so there is nothing to compare"
+              echo "against. This pull request's own numbers are attached to the workflow run."
+            } > report.md
+          else
+            python3 head/tools/perf-site/publish.py --site base-site platform-base.json
+            python3 head/tools/perf-site/compare.py \
+              --baseline "$(ls base-site/runs/*.json | grep -v index.json | head -1)" \
+              --current  "$(ls head-site/runs/*.json | grep -v index.json | head -1)" \
+              --threshold "$PERF_THRESHOLD" \
+              --markdown report.md \
+              --note "Quick check: \`$QUICK_FAMILIES\` on \`x86_64-unknown-linux-gnu\`, built with the \`$PERF_PROFILE\` profile against this PR's own merge base on this runner. Both sides were built and measured identically, so the deltas are real; the absolute figures are not the release-profile ones the dashboard publishes. The full matrix across Linux, macOS and the browser runs on a push to \`main\`, or on demand from the Performance workflow."
+          fi
+          cat report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment on the pull request
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = require('fs').readFileSync('report.md', 'utf8');
+            const marker = '<!-- defradb-perf-quick -->';
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const existing = (await github.rest.issues.listComments({ owner, repo, issue_number }))
+              .data.find(c => c.body && c.body.includes(marker));
+            const payload = `${marker}\n${body}`;
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: payload });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body: payload });
+            }
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: perf-quick
+          path: |
+            report.md
+            platform-head.json
+            platform-base.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -5,21 +5,16 @@ name: Performance
 # the code is wrong, a regression here means the code is slow. Mixing them makes
 # every PR wait for the slower answer to a question it did not ask.
 #
-# Two paths, because a pull request and a release history want different
-# things from a benchmark:
+# The full sweep: every family across Linux, macOS and a browser.
 #
-#   * every pull request runs the QUICK path: a handful of families on Linux,
-#     measured against this PR's own merge base on the same runner, commented
-#     back onto the PR. Minutes, not tens of minutes.
-#   * a push to `main`, a `workflow_dispatch`, or the `perf-full` PR label runs
-#     the FULL matrix across Linux, macOS and the browser. Only the push to
-#     `main` publishes to the dashboard.
+# A push to `main` measures and publishes to the dashboard. A
+# `workflow_dispatch` measures whichever branch it is pointed at and compares it
+# with the newest published run without publishing.
 #
-# The quick path measures its own baseline rather than reading one off the
-# dashboard, and that is the point. A PR built one way compared against
-# published numbers built another way, on another runner, produces deltas that
-# are real arithmetic over incomparable measurements. Measuring both sides here
-# costs a second build and is the only version of this number worth posting.
+# Deliberately not triggered by a pull request. GitHub renders a skipped matrix
+# job without expanding its matrix, so gating forty jobs behind an `if` filled
+# every PR's check list with literal `${{ matrix.family }}` rows. The pull
+# request path is `perf-pr.yml`, which has no matrix and creates one check.
 on:
   push:
     branches: [main]
@@ -33,9 +28,6 @@ on:
         description: 'Fail the run when a metric regresses'
         type: boolean
         default: false
-  pull_request:
-    types: [opened, synchronize, reopened, labeled]
-
 permissions:
   contents: read
 
@@ -59,7 +51,6 @@ jobs:
       label: ${{ steps.decide.outputs.label }}
       publish: ${{ steps.decide.outputs.publish }}
       threshold: ${{ steps.decide.outputs.threshold }}
-      full: ${{ steps.decide.outputs.full }}
     steps:
       - uses: actions/checkout@v4
       - uses: extractions/setup-just@v2
@@ -78,225 +69,20 @@ jobs:
       - id: decide
         env:
           THRESHOLD_INPUT: ${{ github.event.inputs.threshold }}
+          GITHUB_EVENT: ${{ github.event_name }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "push" ]; then
-            echo "label=main"     >> "$GITHUB_OUTPUT"
-            echo "publish=true"   >> "$GITHUB_OUTPUT"
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "label=pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
-            echo "publish=false" >> "$GITHUB_OUTPUT"
+          # Only a push to `main` writes history. A dispatch measures whichever
+          # branch it was pointed at and reports, so a branch can never file a
+          # run document under a `main` label.
+          if [ "$GITHUB_EVENT" = "push" ]; then
+            echo "label=main"   >> "$GITHUB_OUTPUT"
+            echo "publish=true" >> "$GITHUB_OUTPUT"
           else
             echo "label=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
             echo "publish=false" >> "$GITHUB_OUTPUT"
           fi
           echo "threshold=${THRESHOLD_INPUT:-5}" >> "$GITHUB_OUTPUT"
-          # The full matrix costs macOS and browser runners, so a pull request
-          # opts into it rather than paying for it by default.
-          if [ "${{ github.event_name }}" = "pull_request" ] \
-             && [ "${{ contains(github.event.pull_request.labels.*.name, 'perf-full') }}" != "true" ]; then
-            echo "full=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "full=true" >> "$GITHUB_OUTPUT"
-          fi
-
-  # Every pull request, no label and no ceremony. Four families on Linux,
-  # measured against this PR's own merge base on this same runner with this
-  # same profile, and posted back as a comment.
-  #
-  # Two decisions keep it quick without making it dishonest.
-  #
-  # `release-fast` rather than the `bench` profile: thin LTO and sixteen
-  # codegen units build in a fraction of the time fat LTO takes. It produces
-  # different absolute numbers, which is exactly why this path never publishes
-  # to the dashboard and never compares against it. Both sides of this
-  # comparison are built the same way, so the delta between them is real even
-  # though neither figure is the one a release would post.
-  #
-  # And the base measurement is cached by its commit. A base is measured once
-  # and then reused by every later pull request that shares it, so only the
-  # first one after a merge to `main` pays for the second build.
-  quick:
-    name: Quick benchmark
-    if: github.event_name == 'pull_request'
-    needs: scope
-    runs-on: ubuntu-latest
-    timeout-minutes: 40
-    permissions:
-      contents: read
-      pull-requests: write
-    env:
-      DEFRA_BENCH_CRITERION_ARGS: --warm-up-time 0.5 --measurement-time 1.5 --sample-size 10
-      PERF_PROFILE: release-fast
-      # The write path, the allocation counts that catch a stray clone before
-      # the clock does, cold start, and the storage transaction seam.
-      QUICK_FAMILIES: document_write allocs startup transaction
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          path: head
-      - uses: dtolnay/rust-toolchain@stable
-      - run: head/.github/scripts/install-linux-ci-deps.sh
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: perf-quick
-          workspaces: head
-
-      - name: Record how quiet the host is
-        run: python3 head/tools/perf-site/loadguard.py --out loadguard.json
-
-      - name: Measure this pull request
-        working-directory: head
-        env:
-          DEFRA_BENCH_OUT: ${{ github.workspace }}/head.jsonl
-        run: |
-          set -euo pipefail
-          for family in $QUICK_FAMILIES; do
-            echo "::group::$family"
-            rm -rf target/criterion
-            cargo bench --profile "$PERF_PROFILE" -p benches --bench "$family" \
-              -- $DEFRA_BENCH_CRITERION_ARGS
-            mkdir -p "$GITHUB_WORKSPACE/criterion-head/$family"
-            [ -d target/criterion ] && cp -R target/criterion/. "$GITHUB_WORKSPACE/criterion-head/$family/"
-            echo "::endgroup::"
-          done
-          touch "$DEFRA_BENCH_OUT"
-
-      - name: Assemble this pull request's document
-        working-directory: head
-        env:
-          DEFRA_BENCH_OUT: ${{ github.workspace }}/head.jsonl
-          PERF_COMMIT: ${{ github.event.pull_request.head.sha }}
-          PERF_LABEL: pr-${{ github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
-          cargo run --profile "$PERF_PROFILE" -p defra-perf --bin collect -- \
-            --criterion-root "$GITHUB_WORKSPACE/criterion-head" \
-            --out "$GITHUB_WORKSPACE/platform-head.json" \
-            --commit "$PERF_COMMIT" \
-            --label "$PERF_LABEL" \
-            --target x86_64-unknown-linux-gnu \
-            --loadguard "$GITHUB_WORKSPACE/loadguard.json"
-
-      # A base is the same commit for every PR branched off it, so measuring it
-      # once and reusing the document is the difference between paying for two
-      # builds on every pull request and paying for them once per merge.
-      - name: Restore the baseline measured for this base commit
-        id: basecache
-        uses: actions/cache@v4
-        with:
-          path: platform-base.json
-          key: perf-quick-base-${{ github.event.pull_request.base.sha }}-v1
-
-      - uses: actions/checkout@v4
-        if: steps.basecache.outputs.cache-hit != 'true'
-        with:
-          ref: ${{ github.event.pull_request.base.sha }}
-          path: base
-
-      - name: Measure the merge base
-        if: steps.basecache.outputs.cache-hit != 'true'
-        working-directory: base
-        env:
-          DEFRA_BENCH_OUT: ${{ github.workspace }}/base.jsonl
-          # The same target directory as the head build, so the second build
-          # reuses every dependency artifact the first one produced.
-          CARGO_TARGET_DIR: ${{ github.workspace }}/head/target
-        run: |
-          set -euo pipefail
-          for family in $QUICK_FAMILIES; do
-            # A family this pull request introduces does not exist on the base,
-            # and that is a new measurement rather than a failure. The
-            # comparison reports it as measured on one side only.
-            echo "::group::$family"
-            rm -rf "$CARGO_TARGET_DIR/criterion"
-            cargo bench --profile "$PERF_PROFILE" -p benches --bench "$family" \
-              -- $DEFRA_BENCH_CRITERION_ARGS \
-              || echo "::notice::$family did not run on the base commit; it will show as new"
-            mkdir -p "$GITHUB_WORKSPACE/criterion-base/$family"
-            [ -d "$CARGO_TARGET_DIR/criterion" ] && \
-              cp -R "$CARGO_TARGET_DIR/criterion/." "$GITHUB_WORKSPACE/criterion-base/$family/"
-            echo "::endgroup::"
-          done
-          touch "$DEFRA_BENCH_OUT"
-
-      - name: Assemble the merge base's document
-        if: steps.basecache.outputs.cache-hit != 'true'
-        working-directory: base
-        env:
-          DEFRA_BENCH_OUT: ${{ github.workspace }}/base.jsonl
-          CARGO_TARGET_DIR: ${{ github.workspace }}/head/target
-          PERF_BASE_COMMIT: ${{ github.event.pull_request.base.sha }}
-        run: |
-          set -euo pipefail
-          # Built from the base checkout when it has the collector, and from
-          # this PR's when the PR is what introduces it.
-          manifest=Cargo.toml
-          if ! grep -q '"tools/perf"' Cargo.toml; then
-            manifest="$GITHUB_WORKSPACE/head/Cargo.toml"
-          fi
-          cargo run --manifest-path "$manifest" --profile "$PERF_PROFILE" \
-            -p defra-perf --bin collect -- \
-            --criterion-root "$GITHUB_WORKSPACE/criterion-base" \
-            --out "$GITHUB_WORKSPACE/platform-base.json" \
-            --commit "$PERF_BASE_COMMIT" \
-            --label "base" \
-            --target x86_64-unknown-linux-gnu \
-            --loadguard "$GITHUB_WORKSPACE/loadguard.json"
-
-      - name: Compare
-        id: compare
-        env:
-          PERF_THRESHOLD: ${{ needs.scope.outputs.threshold }}
-        run: |
-          set -euo pipefail
-          mkdir -p head-site base-site
-          python3 head/tools/perf-site/publish.py --site head-site platform-head.json
-          if [ ! -f platform-base.json ]; then
-            {
-              echo "## Performance"
-              echo ""
-              echo "The merge base could not be measured, so there is nothing to compare"
-              echo "against. This pull request's own numbers are attached to the workflow run."
-            } > report.md
-          else
-            python3 head/tools/perf-site/publish.py --site base-site platform-base.json
-            python3 head/tools/perf-site/compare.py \
-              --baseline "$(ls base-site/runs/*.json | grep -v index.json | head -1)" \
-              --current  "$(ls head-site/runs/*.json | grep -v index.json | head -1)" \
-              --threshold "$PERF_THRESHOLD" \
-              --markdown report.md \
-              --note "Quick check: \`$QUICK_FAMILIES\` on \`x86_64-unknown-linux-gnu\`, built with the \`$PERF_PROFILE\` profile against this PR's own merge base on this runner. Both sides were built and measured identically, so the deltas are real; the absolute figures are not the release-profile ones the dashboard publishes. Add the \`perf-full\` label for the full matrix across Linux, macOS and the browser."
-          fi
-          cat report.md >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Comment on the pull request
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const body = require('fs').readFileSync('report.md', 'utf8');
-            const marker = '<!-- defradb-perf-quick -->';
-            const { owner, repo } = context.repo;
-            const issue_number = context.payload.pull_request.number;
-            const existing = (await github.rest.issues.listComments({ owner, repo, issue_number }))
-              .data.find(c => c.body && c.body.includes(marker));
-            const payload = `${marker}\n${body}`;
-            if (existing) {
-              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: payload });
-            } else {
-              await github.rest.issues.createComment({ owner, repo, issue_number, body: payload });
-            }
-
-      - uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: perf-quick
-          path: |
-            report.md
-            platform-head.json
-            platform-base.json
-          if-no-files-found: warn
-          retention-days: 30
 
   # Each family on its own runner. A sweep that runs every benchmark in one job
   # takes as long as the sum of them and reports nothing until the slowest
@@ -311,7 +97,6 @@ jobs:
   bench:
     name: ${{ matrix.family }} (${{ matrix.target }})
     needs: scope
-    if: needs.scope.outputs.full == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     strategy:
@@ -425,7 +210,6 @@ jobs:
   bench-wasm:
     name: browser (wasm32-unknown-unknown)
     needs: scope
-    if: needs.scope.outputs.full == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -481,8 +265,12 @@ jobs:
   # the database on every platform in the matrix.
   collect:
     name: Collect (${{ matrix.target }})
+    # `always()` and never a condition that can be false: a skipped matrix job
+    # is rendered by GitHub without expanding its matrix, so the job list would
+    # show a literal `${{ matrix.target }}`. Whether scope actually produced
+    # anything is checked below, where it can fail with a reason.
     needs: [scope, bench, bench-wasm]
-    if: always() && needs.scope.result == 'success' && needs.scope.outputs.full == 'true'
+    if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
@@ -502,6 +290,15 @@ jobs:
         with:
           pattern: perf-${{ matrix.target }}-*
           path: artifacts
+      - name: Refuse to assemble without the run's identity
+        env:
+          PERF_LABEL: ${{ needs.scope.outputs.label }}
+        run: |
+          set -euo pipefail
+          if [ -z "$PERF_LABEL" ]; then
+            echo "::error::the scope job produced no label, so this run has no identity to file it under" >&2
+            exit 1
+          fi
       - name: Assemble the platform document
         env:
           PERF_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -601,7 +398,7 @@ jobs:
   compare:
     name: Compare with main
     needs: [scope, collect]
-    if: needs.scope.outputs.full == 'true' && needs.scope.outputs.publish != 'true'
+    if: needs.scope.outputs.publish != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -63,6 +63,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: extractions/setup-just@v2
+      # Its own interpreter rather than the system one: a PEP 668 image refuses
+      # to let pip touch the system environment, and this gate must not be the
+      # thing that fails before it has checked anything.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
       # A bench target the matrix does not name measures nothing, and nothing
       # else in CI would notice.
       - name: Check every bench target is measured
@@ -70,6 +76,8 @@ jobs:
           python3 -m pip install --quiet pyyaml
           just perf-matrix
       - id: decide
+        env:
+          THRESHOLD_INPUT: ${{ github.event.inputs.threshold }}
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "push" ]; then
@@ -82,7 +90,7 @@ jobs:
             echo "label=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
             echo "publish=false" >> "$GITHUB_OUTPUT"
           fi
-          echo "threshold=${{ github.event.inputs.threshold || '5' }}" >> "$GITHUB_OUTPUT"
+          echo "threshold=${THRESHOLD_INPUT:-5}" >> "$GITHUB_OUTPUT"
           # The full matrix costs macOS and browser runners, so a pull request
           # opts into it rather than paying for it by default.
           if [ "${{ github.event_name }}" = "pull_request" ] \
@@ -158,13 +166,15 @@ jobs:
         working-directory: head
         env:
           DEFRA_BENCH_OUT: ${{ github.workspace }}/head.jsonl
+          PERF_COMMIT: ${{ github.event.pull_request.head.sha }}
+          PERF_LABEL: pr-${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
           cargo run --profile "$PERF_PROFILE" -p defra-perf --bin collect -- \
             --criterion-root "$GITHUB_WORKSPACE/criterion-head" \
             --out "$GITHUB_WORKSPACE/platform-head.json" \
-            --commit "${{ github.event.pull_request.head.sha }}" \
-            --label "pr-${{ github.event.pull_request.number }}" \
+            --commit "$PERF_COMMIT" \
+            --label "$PERF_LABEL" \
             --target x86_64-unknown-linux-gnu \
             --loadguard "$GITHUB_WORKSPACE/loadguard.json"
 
@@ -216,6 +226,7 @@ jobs:
         env:
           DEFRA_BENCH_OUT: ${{ github.workspace }}/base.jsonl
           CARGO_TARGET_DIR: ${{ github.workspace }}/head/target
+          PERF_BASE_COMMIT: ${{ github.event.pull_request.base.sha }}
         run: |
           set -euo pipefail
           # Built from the base checkout when it has the collector, and from
@@ -228,13 +239,15 @@ jobs:
             -p defra-perf --bin collect -- \
             --criterion-root "$GITHUB_WORKSPACE/criterion-base" \
             --out "$GITHUB_WORKSPACE/platform-base.json" \
-            --commit "${{ github.event.pull_request.base.sha }}" \
+            --commit "$PERF_BASE_COMMIT" \
             --label "base" \
             --target x86_64-unknown-linux-gnu \
             --loadguard "$GITHUB_WORKSPACE/loadguard.json"
 
       - name: Compare
         id: compare
+        env:
+          PERF_THRESHOLD: ${{ needs.scope.outputs.threshold }}
         run: |
           set -euo pipefail
           mkdir -p head-site base-site
@@ -251,7 +264,7 @@ jobs:
             python3 head/tools/perf-site/compare.py \
               --baseline "$(ls base-site/runs/*.json | grep -v index.json | head -1)" \
               --current  "$(ls head-site/runs/*.json | grep -v index.json | head -1)" \
-              --threshold "${{ needs.scope.outputs.threshold }}" \
+              --threshold "$PERF_THRESHOLD" \
               --markdown report.md \
               --note "Quick check: \`$QUICK_FAMILIES\` on \`x86_64-unknown-linux-gnu\`, built with the \`$PERF_PROFILE\` profile against this PR's own merge base on this runner. Both sides were built and measured identically, so the deltas are real; the absolute figures are not the release-profile ones the dashboard publishes. Add the \`perf-full\` label for the full matrix across Linux, macOS and the browser."
           fi
@@ -490,6 +503,9 @@ jobs:
           pattern: perf-${{ matrix.target }}-*
           path: artifacts
       - name: Assemble the platform document
+        env:
+          PERF_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+          PERF_LABEL: ${{ needs.scope.outputs.label }}
         run: |
           set -euo pipefail
           if [ ! -d artifacts ] || [ -z "$(ls -A artifacts 2>/dev/null)" ]; then
@@ -516,8 +532,8 @@ jobs:
           cargo run -p defra-perf --bin collect -- \
               --criterion-root "$PWD/criterion-merged" \
               --out "platform-${{ matrix.target }}.json" \
-              --commit "${{ github.event.pull_request.head.sha || github.sha }}" \
-              --label "${{ needs.scope.outputs.label }}" \
+              --commit "$PERF_COMMIT" \
+              --label "$PERF_LABEL" \
               --target "${{ matrix.target }}" \
               ${guard:+--loadguard "$guard"}
       - uses: actions/upload-artifact@v4
@@ -629,6 +645,8 @@ jobs:
           echo "file=base/runs/$newest" >> "$GITHUB_OUTPUT"
       - name: Compare
         id: compare
+        env:
+          PERF_THRESHOLD: ${{ needs.scope.outputs.threshold }}
         run: |
           set -euo pipefail
           if [ "${{ steps.baseline.outputs.found }}" != "true" ]; then
@@ -645,7 +663,7 @@ jobs:
           python3 tools/perf-site/compare.py \
             --baseline "${{ steps.baseline.outputs.file }}" \
             --current "$cur" \
-            --threshold "${{ needs.scope.outputs.threshold }}" \
+            --threshold "$PERF_THRESHOLD" \
             --markdown report.md \
             ${{ github.event.inputs.fail_on_regression == 'true' && '--fail-on-regression' || '' }}
           cat report.md >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,0 +1,676 @@
+name: Performance
+
+# Separate from CI on purpose. The bench matrix is far slower than the checks a
+# pull request waits on, and it fails for a different reason: a red CI job means
+# the code is wrong, a regression here means the code is slow. Mixing them makes
+# every PR wait for the slower answer to a question it did not ask.
+#
+# Two paths, because a pull request and a release history want different
+# things from a benchmark:
+#
+#   * every pull request runs the QUICK path: a handful of families on Linux,
+#     measured against this PR's own merge base on the same runner, commented
+#     back onto the PR. Minutes, not tens of minutes.
+#   * a push to `main`, a `workflow_dispatch`, or the `perf-full` PR label runs
+#     the FULL matrix across Linux, macOS and the browser. Only the push to
+#     `main` publishes to the dashboard.
+#
+# The quick path measures its own baseline rather than reading one off the
+# dashboard, and that is the point. A PR built one way compared against
+# published numbers built another way, on another runner, produces deltas that
+# are real arithmetic over incomparable measurements. Measuring both sides here
+# costs a second build and is the only version of this number worth posting.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      threshold:
+        description: 'Percent change below which a delta is noise'
+        default: '5'
+        required: false
+      fail_on_regression:
+        description: 'Fail the run when a metric regresses'
+        type: boolean
+        default: false
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: perf-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: '0'
+  # Bounded sampling so a full matrix finishes inside a CI budget. Recorded in
+  # the run document with the numbers it produced, because a reduced sample is
+  # comparable with another reduced sample and not with a full one.
+  DEFRA_BENCH_CRITERION_ARGS: --warm-up-time 1 --measurement-time 3 --sample-size 30
+
+jobs:
+  scope:
+    name: Scope
+    runs-on: ubuntu-latest
+    outputs:
+      label: ${{ steps.decide.outputs.label }}
+      publish: ${{ steps.decide.outputs.publish }}
+      threshold: ${{ steps.decide.outputs.threshold }}
+      full: ${{ steps.decide.outputs.full }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: extractions/setup-just@v2
+      # A bench target the matrix does not name measures nothing, and nothing
+      # else in CI would notice.
+      - name: Check every bench target is measured
+        run: |
+          python3 -m pip install --quiet pyyaml
+          just perf-matrix
+      - id: decide
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "label=main"     >> "$GITHUB_OUTPUT"
+            echo "publish=true"   >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "label=pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "label=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "threshold=${{ github.event.inputs.threshold || '5' }}" >> "$GITHUB_OUTPUT"
+          # The full matrix costs macOS and browser runners, so a pull request
+          # opts into it rather than paying for it by default.
+          if [ "${{ github.event_name }}" = "pull_request" ] \
+             && [ "${{ contains(github.event.pull_request.labels.*.name, 'perf-full') }}" != "true" ]; then
+            echo "full=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "full=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  # Every pull request, no label and no ceremony. Four families on Linux,
+  # measured against this PR's own merge base on this same runner with this
+  # same profile, and posted back as a comment.
+  #
+  # Two decisions keep it quick without making it dishonest.
+  #
+  # `release-fast` rather than the `bench` profile: thin LTO and sixteen
+  # codegen units build in a fraction of the time fat LTO takes. It produces
+  # different absolute numbers, which is exactly why this path never publishes
+  # to the dashboard and never compares against it. Both sides of this
+  # comparison are built the same way, so the delta between them is real even
+  # though neither figure is the one a release would post.
+  #
+  # And the base measurement is cached by its commit. A base is measured once
+  # and then reused by every later pull request that shares it, so only the
+  # first one after a merge to `main` pays for the second build.
+  quick:
+    name: Quick benchmark
+    if: github.event_name == 'pull_request'
+    needs: scope
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      DEFRA_BENCH_CRITERION_ARGS: --warm-up-time 0.5 --measurement-time 1.5 --sample-size 10
+      PERF_PROFILE: release-fast
+      # The write path, the allocation counts that catch a stray clone before
+      # the clock does, cold start, and the storage transaction seam.
+      QUICK_FAMILIES: document_write allocs startup transaction
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: head
+      - uses: dtolnay/rust-toolchain@stable
+      - run: head/.github/scripts/install-linux-ci-deps.sh
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: perf-quick
+          workspaces: head
+
+      - name: Record how quiet the host is
+        run: python3 head/tools/perf-site/loadguard.py --out loadguard.json
+
+      - name: Measure this pull request
+        working-directory: head
+        env:
+          DEFRA_BENCH_OUT: ${{ github.workspace }}/head.jsonl
+        run: |
+          set -euo pipefail
+          for family in $QUICK_FAMILIES; do
+            echo "::group::$family"
+            rm -rf target/criterion
+            cargo bench --profile "$PERF_PROFILE" -p benches --bench "$family" \
+              -- $DEFRA_BENCH_CRITERION_ARGS
+            mkdir -p "$GITHUB_WORKSPACE/criterion-head/$family"
+            [ -d target/criterion ] && cp -R target/criterion/. "$GITHUB_WORKSPACE/criterion-head/$family/"
+            echo "::endgroup::"
+          done
+          touch "$DEFRA_BENCH_OUT"
+
+      - name: Assemble this pull request's document
+        working-directory: head
+        env:
+          DEFRA_BENCH_OUT: ${{ github.workspace }}/head.jsonl
+        run: |
+          set -euo pipefail
+          cargo run --profile "$PERF_PROFILE" -p defra-perf --bin collect -- \
+            --criterion-root "$GITHUB_WORKSPACE/criterion-head" \
+            --out "$GITHUB_WORKSPACE/platform-head.json" \
+            --commit "${{ github.event.pull_request.head.sha }}" \
+            --label "pr-${{ github.event.pull_request.number }}" \
+            --target x86_64-unknown-linux-gnu \
+            --loadguard "$GITHUB_WORKSPACE/loadguard.json"
+
+      # A base is the same commit for every PR branched off it, so measuring it
+      # once and reusing the document is the difference between paying for two
+      # builds on every pull request and paying for them once per merge.
+      - name: Restore the baseline measured for this base commit
+        id: basecache
+        uses: actions/cache@v4
+        with:
+          path: platform-base.json
+          key: perf-quick-base-${{ github.event.pull_request.base.sha }}-v1
+
+      - uses: actions/checkout@v4
+        if: steps.basecache.outputs.cache-hit != 'true'
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+
+      - name: Measure the merge base
+        if: steps.basecache.outputs.cache-hit != 'true'
+        working-directory: base
+        env:
+          DEFRA_BENCH_OUT: ${{ github.workspace }}/base.jsonl
+          # The same target directory as the head build, so the second build
+          # reuses every dependency artifact the first one produced.
+          CARGO_TARGET_DIR: ${{ github.workspace }}/head/target
+        run: |
+          set -euo pipefail
+          for family in $QUICK_FAMILIES; do
+            # A family this pull request introduces does not exist on the base,
+            # and that is a new measurement rather than a failure. The
+            # comparison reports it as measured on one side only.
+            echo "::group::$family"
+            rm -rf "$CARGO_TARGET_DIR/criterion"
+            cargo bench --profile "$PERF_PROFILE" -p benches --bench "$family" \
+              -- $DEFRA_BENCH_CRITERION_ARGS \
+              || echo "::notice::$family did not run on the base commit; it will show as new"
+            mkdir -p "$GITHUB_WORKSPACE/criterion-base/$family"
+            [ -d "$CARGO_TARGET_DIR/criterion" ] && \
+              cp -R "$CARGO_TARGET_DIR/criterion/." "$GITHUB_WORKSPACE/criterion-base/$family/"
+            echo "::endgroup::"
+          done
+          touch "$DEFRA_BENCH_OUT"
+
+      - name: Assemble the merge base's document
+        if: steps.basecache.outputs.cache-hit != 'true'
+        working-directory: base
+        env:
+          DEFRA_BENCH_OUT: ${{ github.workspace }}/base.jsonl
+          CARGO_TARGET_DIR: ${{ github.workspace }}/head/target
+        run: |
+          set -euo pipefail
+          # Built from the base checkout when it has the collector, and from
+          # this PR's when the PR is what introduces it.
+          manifest=Cargo.toml
+          if ! grep -q '"tools/perf"' Cargo.toml; then
+            manifest="$GITHUB_WORKSPACE/head/Cargo.toml"
+          fi
+          cargo run --manifest-path "$manifest" --profile "$PERF_PROFILE" \
+            -p defra-perf --bin collect -- \
+            --criterion-root "$GITHUB_WORKSPACE/criterion-base" \
+            --out "$GITHUB_WORKSPACE/platform-base.json" \
+            --commit "${{ github.event.pull_request.base.sha }}" \
+            --label "base" \
+            --target x86_64-unknown-linux-gnu \
+            --loadguard "$GITHUB_WORKSPACE/loadguard.json"
+
+      - name: Compare
+        id: compare
+        run: |
+          set -euo pipefail
+          mkdir -p head-site base-site
+          python3 head/tools/perf-site/publish.py --site head-site platform-head.json
+          if [ ! -f platform-base.json ]; then
+            {
+              echo "## Performance"
+              echo ""
+              echo "The merge base could not be measured, so there is nothing to compare"
+              echo "against. This pull request's own numbers are attached to the workflow run."
+            } > report.md
+          else
+            python3 head/tools/perf-site/publish.py --site base-site platform-base.json
+            python3 head/tools/perf-site/compare.py \
+              --baseline "$(ls base-site/runs/*.json | grep -v index.json | head -1)" \
+              --current  "$(ls head-site/runs/*.json | grep -v index.json | head -1)" \
+              --threshold "${{ needs.scope.outputs.threshold }}" \
+              --markdown report.md \
+              --note "Quick check: \`$QUICK_FAMILIES\` on \`x86_64-unknown-linux-gnu\`, built with the \`$PERF_PROFILE\` profile against this PR's own merge base on this runner. Both sides were built and measured identically, so the deltas are real; the absolute figures are not the release-profile ones the dashboard publishes. Add the \`perf-full\` label for the full matrix across Linux, macOS and the browser."
+          fi
+          cat report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment on the pull request
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = require('fs').readFileSync('report.md', 'utf8');
+            const marker = '<!-- defradb-perf-quick -->';
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const existing = (await github.rest.issues.listComments({ owner, repo, issue_number }))
+              .data.find(c => c.body && c.body.includes(marker));
+            const payload = `${marker}\n${body}`;
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: payload });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body: payload });
+            }
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: perf-quick
+          path: |
+            report.md
+            platform-head.json
+            platform-base.json
+          if-no-files-found: warn
+          retention-days: 30
+
+  # Each family on its own runner. A sweep that runs every benchmark in one job
+  # takes as long as the sum of them and reports nothing until the slowest
+  # finishes; split, the wall clock is the slowest single family and a failure
+  # names which one.
+  #
+  # Linux runs the whole suite. macOS runs the families a user actually feels,
+  # because a macOS minute bills at ten times a Linux one and a full second
+  # matrix buys duplicate answers to questions Linux already answered. A family
+  # macOS does not run is drawn as an explicit gap on that platform, never as a
+  # zero.
+  bench:
+    name: ${{ matrix.family }} (${{ matrix.target }})
+    needs: scope
+    if: needs.scope.outputs.full == 'true'
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { family: acp, os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
+          - { family: allocs, os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
+          - { family: backup, os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
+          - { family: block, os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
+          - { family: block_write, os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
+          - { family: blockstore, os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
+          - { family: crypto, os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
+          - { family: cursor_codec, os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
+          - { family: document_codec, os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
+          - { family: document_read, os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
+          - { family: document_write, os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
+          - { family: events, os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
+          - { family: filter, os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
+          - { family: groupby, os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
+          - { family: identity, os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
+          - { family: memory, os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
+          - { family: merge, os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
+          - { family: merge_dag, os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
+          - { family: p2p_codec, os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
+          - { family: parsing, os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
+          - { family: planner, os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
+          - { family: query_e2e, os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
+          - { family: replication_filter, os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
+          - { family: retry_markers, os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
+          - { family: schema_validate, os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
+          - { family: sift, os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
+          - { family: startup, os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
+          - { family: transaction, os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
+          - { family: transport, os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
+          - { family: vector_mutations, os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
+          - { family: vector_search, os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
+          - { family: backup, os: macos-latest, target: aarch64-apple-darwin }
+          - { family: crypto, os: macos-latest, target: aarch64-apple-darwin }
+          - { family: document_read, os: macos-latest, target: aarch64-apple-darwin }
+          - { family: document_write, os: macos-latest, target: aarch64-apple-darwin }
+          - { family: memory, os: macos-latest, target: aarch64-apple-darwin }
+          - { family: query_e2e, os: macos-latest, target: aarch64-apple-darwin }
+          - { family: startup, os: macos-latest, target: aarch64-apple-darwin }
+          - { family: transaction, os: macos-latest, target: aarch64-apple-darwin }
+          - { family: transport, os: macos-latest, target: aarch64-apple-darwin }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: .github/scripts/install-linux-ci-deps.sh
+      - name: Install macOS dependencies
+        if: runner.os == 'macOS'
+        run: brew install protobuf
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: perf-${{ matrix.target }}
+      # Before the benchmarks, never after: a guard that samples load once the
+      # suite has finished is measuring the suite.
+      # The corpus is a third-party FTP fetch. When it fails the bench skips
+      # cleanly and the family is drawn as a gap, which is the honest outcome:
+      # better an empty recall row than a recall number measured on synthetic
+      # vectors and labelled as SIFT.
+      - name: Fetch the SIFT corpus
+        if: matrix.family == 'sift'
+        continue-on-error: true
+        uses: extractions/setup-just@v2
+      - name: Fetch the SIFT corpus (run)
+        if: matrix.family == 'sift'
+        continue-on-error: true
+        run: just setup-sift
+      - name: Record how quiet the host is
+        run: python3 tools/perf-site/loadguard.py --out loadguard.json
+      - name: Run ${{ matrix.family }}
+        env:
+          DEFRA_BENCH_OUT: ${{ github.workspace }}/bench-${{ matrix.family }}.jsonl
+        run: cargo bench -p benches --bench ${{ matrix.family }} -- $DEFRA_BENCH_CRITERION_ARGS
+      - name: Collect what criterion recorded
+        run: |
+          set -euo pipefail
+          mkdir -p "criterion-out/${{ matrix.family }}"
+          # Only the estimate files, which are small; the rest of criterion's
+          # output is plots and raw samples this pipeline never reads. Filed
+          # under the bench target that produced them, because criterion records
+          # only the group name and the target is what gives each set its own
+          # section on the dashboard.
+          if [ -d target/criterion ]; then
+            find target/criterion -name estimates.json -path '*/new/*' -print0 \
+              | while IFS= read -r -d '' f; do
+                  dest="criterion-out/${{ matrix.family }}/${f#target/criterion/}"
+                  mkdir -p "$(dirname "$dest")"
+                  cp "$f" "$dest"
+                done
+          fi
+          touch "bench-${{ matrix.family }}.jsonl"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: perf-${{ matrix.target }}-${{ matrix.family }}
+          path: |
+            bench-${{ matrix.family }}.jsonl
+            loadguard.json
+            criterion-out
+          if-no-files-found: error
+          retention-days: 7
+
+  # The browser is a first-class target for this database, so it is measured in
+  # one rather than inferred from a native number. The suite runs under
+  # wasm-bindgen-test in headless Firefox, exactly the harness the WASM tests
+  # already use, and reports through the same family contract.
+  bench-wasm:
+    name: browser (wasm32-unknown-unknown)
+    needs: scope
+    if: needs.scope.outputs.full == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - run: .github/scripts/install-linux-ci-deps.sh
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: perf-wasm
+      - name: Isolate the WASM dependency graph
+        run: sed -i '/"tools\/integration-test"/d; /"tools\/ffi-test"/d; /"proofs"/d' Cargo.toml
+      - uses: browser-actions/setup-firefox@0bc507ddf224827e3b1af68e014d5e42ab93e795 # v1
+      - uses: browser-actions/setup-geckodriver@eb8b0670366f719ca31703766a8cb7e3ea2c56ed # v0.0.0
+        with:
+          geckodriver-version: '0.37.1'
+      - name: Install lockfile-matched wasm-bindgen-cli
+        run: |
+          set -euo pipefail
+          VER="$(awk '/^name = "wasm-bindgen"$/{getline; gsub(/[",]/,""); print $3; exit}' Cargo.lock)"
+          test -n "$VER"
+          cargo install wasm-bindgen-cli --version "$VER" --locked
+      - name: Record how quiet the host is
+        run: python3 tools/perf-site/loadguard.py --out loadguard.json
+      - name: Run the browser benchmarks
+        env:
+          CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER: wasm-bindgen-test-runner
+          RUSTFLAGS: -C target-feature=+simd128
+        run: |
+          set -euo pipefail
+          cargo test -p defra-wasm --target wasm32-unknown-unknown --release \
+            --test perf -- --nocapture 2>&1 | tee wasm-perf.log
+          # The browser cannot write a file, so the harness prints each family
+          # on its own line behind a marker and the marker is stripped here.
+          # An empty result is a failure: a silent zero-family run would
+          # publish a browser platform with nothing on it.
+          grep -o 'DEFRA_BENCH_FAMILY .*' wasm-perf.log | sed 's/^DEFRA_BENCH_FAMILY //' \
+            > bench-wasm.jsonl
+          test -s bench-wasm.jsonl
+      - uses: actions/upload-artifact@v4
+        with:
+          name: perf-wasm32-unknown-unknown-browser
+          path: |
+            bench-wasm.jsonl
+            loadguard.json
+            wasm-perf.log
+          if-no-files-found: error
+          retention-days: 7
+
+  # Fold one platform's families into one platform document. Cheap: `collect`
+  # depends on the reporting contract and nothing else, so this does not build
+  # the database on every platform in the matrix.
+  collect:
+    name: Collect (${{ matrix.target }})
+    needs: [scope, bench, bench-wasm]
+    if: always() && needs.scope.result == 'success' && needs.scope.outputs.full == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - aarch64-apple-darwin
+          - wasm32-unknown-unknown
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: perf-collect
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: perf-${{ matrix.target }}-*
+          path: artifacts
+      - name: Assemble the platform document
+        run: |
+          set -euo pipefail
+          if [ ! -d artifacts ] || [ -z "$(ls -A artifacts 2>/dev/null)" ]; then
+            echo "::warning::no results for ${{ matrix.target }}; every family will be absent"
+            mkdir -p artifacts
+          fi
+          # One JSON Lines stream out of every family this platform recorded,
+          # and one criterion tree out of every runner's estimates.
+          : > families.jsonl
+          find artifacts -name '*.jsonl' -exec cat {} + >> families.jsonl || true
+          mkdir -p criterion-merged
+          for d in artifacts/*/criterion-out; do
+            [ -d "$d" ] && cp -R "$d/." criterion-merged/ || true
+          done
+          # Any runner's guard verdict speaks for the platform: the matrix runs
+          # the same image, and a single busy runner is enough to stop the
+          # timings being called clean.
+          guard=""
+          for g in artifacts/*/loadguard.json; do
+            [ -f "$g" ] || continue
+            guard="$g"
+            python3 -c "import json,sys; sys.exit(0 if json.load(open('$g')).get('passed') else 1)" || break
+          done
+          cargo run -p defra-perf --bin collect -- \
+              --criterion-root "$PWD/criterion-merged" \
+              --out "platform-${{ matrix.target }}.json" \
+              --commit "${{ github.event.pull_request.head.sha || github.sha }}" \
+              --label "${{ needs.scope.outputs.label }}" \
+              --target "${{ matrix.target }}" \
+              ${guard:+--loadguard "$guard"}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: perf-platform-${{ matrix.target }}
+          path: platform-${{ matrix.target }}.json
+          if-no-files-found: error
+          retention-days: 30
+
+  # A push to main is the only thing that writes history. The run documents are
+  # the artifact, not a rendered page: a page regenerated per run shows one run
+  # and loses the comparison the moment it is replaced, and keeping the
+  # documents is what lets the dashboard plot a metric across every run ever
+  # recorded.
+  publish:
+    name: Publish
+    needs: [scope, collect]
+    if: needs.scope.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: perf-platform-*
+          path: platforms
+          merge-multiple: true
+      - name: Fetch the history already published
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          mkdir -p site
+          git fetch origin gh-pages --depth=1
+          git --work-tree=site checkout origin/gh-pages -- runs 2>/dev/null || true
+      - name: File this run
+        run: |
+          set -euo pipefail
+          mkdir -p site
+          cp tools/perf-site/index.html site/index.html
+          python3 tools/perf-site/publish.py --site site platforms/*.json
+      # Refuse to publish a dashboard that would drop a family it collected. A
+      # blank section is not an error to a browser, so without this the job
+      # stays green and the site goes quiet.
+      - name: Check the page renders every collected family
+        run: node tools/perf-site/render_check.mjs site
+      - uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          publish_branch: gh-pages
+          keep_files: true
+          commit_message: 'perf: record run ${{ github.sha }}'
+      - name: Link
+        run: |
+          {
+            echo "## Performance dashboard"
+            echo ""
+            echo "https://${GITHUB_REPOSITORY%%/*}.github.io/${GITHUB_REPOSITORY##*/}/"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # A branch reports rather than publishes. The baseline is the newest run on
+  # the dashboard, which is by construction the newest `main` commit measured.
+  compare:
+    name: Compare with main
+    needs: [scope, collect]
+    if: needs.scope.outputs.full == 'true' && needs.scope.outputs.publish != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: perf-platform-*
+          path: platforms
+          merge-multiple: true
+      - name: Assemble this branch's run document
+        run: |
+          set -euo pipefail
+          mkdir -p branch
+          python3 tools/perf-site/publish.py --site branch platforms/*.json
+      - name: Fetch the newest published run
+        id: baseline
+        run: |
+          set -euo pipefail
+          mkdir -p base
+          if ! git fetch origin gh-pages --depth=1 2>/dev/null; then
+            echo "found=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          git --work-tree=base checkout origin/gh-pages -- runs 2>/dev/null || {
+            echo "found=false" >> "$GITHUB_OUTPUT"; exit 0
+          }
+          newest="$(python3 -c "
+          import json, pathlib, sys
+          index = pathlib.Path('base/runs/index.json')
+          if not index.is_file():
+              sys.exit(0)
+          runs = json.loads(index.read_text()).get('runs') or []
+          print(runs[0]['file'] if runs else '')
+          ")"
+          if [ -z "$newest" ]; then
+            echo "found=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          echo "found=true" >> "$GITHUB_OUTPUT"
+          echo "file=base/runs/$newest" >> "$GITHUB_OUTPUT"
+      - name: Compare
+        id: compare
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.baseline.outputs.found }}" != "true" ]; then
+            {
+              echo "## Performance"
+              echo ""
+              echo "No run has been published yet, so there is no baseline to compare with."
+              echo "This branch's numbers were collected and are attached to this workflow run."
+            } > report.md
+            cat report.md >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          cur="$(ls branch/runs/*.json | grep -v index.json | head -1)"
+          python3 tools/perf-site/compare.py \
+            --baseline "${{ steps.baseline.outputs.file }}" \
+            --current "$cur" \
+            --threshold "${{ needs.scope.outputs.threshold }}" \
+            --markdown report.md \
+            ${{ github.event.inputs.fail_on_regression == 'true' && '--fail-on-regression' || '' }}
+          cat report.md >> "$GITHUB_STEP_SUMMARY"
+      - name: Comment on the pull request
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = require('fs').readFileSync('report.md', 'utf8');
+            const marker = '<!-- defradb-perf -->';
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const existing = (await github.rest.issues.listComments({ owner, repo, issue_number }))
+              .data.find(c => c.body && c.body.includes(marker));
+            const payload = `${marker}\n${body}`;
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: payload });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body: payload });
+            }
+      - uses: actions/upload-artifact@v4
+        with:
+          name: perf-comparison
+          path: |
+            report.md
+            branch/runs
+          if-no-files-found: warn
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,13 @@ docs/
 
 # Local dev tooling installed by `just setup`
 .tooling/
+
+# Benchmark output. `bench-out/` is where a bench writes its family when it is
+# run standalone, without DEFRA_BENCH_OUT pointing somewhere; the rest is what
+# `just perf` leaves behind building the dashboard locally.
+bench-out/
+/perf-out.jsonl
+/perf-platform.json
+/perf-loadguard.json
+/perf-criterion/
+/perf-site/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1448,6 +1448,7 @@ dependencies = [
 name = "benches"
 version = "0.5.0"
 dependencies = [
+ "acp",
  "async-trait",
  "axum",
  "blockstore",
@@ -1456,14 +1457,21 @@ dependencies = [
  "crdt",
  "criterion 0.6.0",
  "crypto",
+ "cursor",
  "datastore",
  "db",
  "defra-core",
  "defra-http",
+ "defra-perf",
  "document",
+ "events",
+ "identity",
+ "libp2p-identity",
  "lru 0.16.4",
  "multihash",
+ "p2p",
  "query",
+ "replication-filter",
  "schema",
  "serde_json",
  "sha2 0.10.9",
@@ -1471,6 +1479,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tower",
+ "x25519-dalek",
 ]
 
 [[package]]
@@ -3560,6 +3569,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "defra-perf"
+version = "0.5.0"
+dependencies = [
+ "chrono",
+ "libc",
+ "serde",
+ "serde_json",
+ "sysinfo 0.33.1",
+]
+
+[[package]]
 name = "defra-version"
 version = "0.5.0"
 dependencies = [
@@ -3578,6 +3598,7 @@ dependencies = [
  "crypto",
  "db",
  "defra-core",
+ "defra-perf",
  "document",
  "events",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ members = [
     "crates/replication-filter",
     "crates/telemetry",
     "tools/lens-host",
+    "tools/perf",
     "tools/ffi-test",
     "tools/integration-test",
     "proofs",

--- a/README.md
+++ b/README.md
@@ -206,7 +206,8 @@ presumed comparable.
 
 Every pull request gets a quick check commented back onto it: a few families on
 Linux, measured against that PR's own merge base on the same runner with the
-same build profile. Add the `perf-full` label for the whole matrix.
+same build profile. Run the whole matrix on a branch with the **Performance**
+workflow's `Run workflow` button.
 
 ```bash
 just perf                     # measure this machine, build the dashboard locally

--- a/README.md
+++ b/README.md
@@ -191,6 +191,30 @@ ffi-test status                        # Show pass rates
 
 See `tools/ffi-test/README.md` for full usage.
 
+## Performance
+
+Every push to `main` measures the suite across Linux, macOS and a browser, and
+publishes the run to the dashboard:
+
+**https://sourcenetwork.github.io/defradb.rs/**
+
+The run documents under `runs/` are the artifact; the page is a reader over
+them, so any metric can be plotted across every run ever recorded. A family the
+collector did not receive is drawn as an explicit gap and never as a zero, and a
+timing taken on a runner that was not quiet is marked contaminated rather than
+presumed comparable.
+
+Every pull request gets a quick check commented back onto it: a few families on
+Linux, measured against that PR's own merge base on the same runner with the
+same build profile. Add the `perf-full` label for the whole matrix.
+
+```bash
+just perf                     # measure this machine, build the dashboard locally
+just perf-serve               # then read it at http://127.0.0.1:8099/
+just perf-compare a.json b.json
+cargo bench -p benches --bench document_write
+```
+
 ## P2P Replication
 
 ### Filtered replication

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -46,6 +46,31 @@ query = { path = "../crates/query" }
 schema = { path = "../crates/schema" }
 storage = { path = "../crates/storage" }
 
+# How a bench reports what it measured to the performance site.
+defra-perf = { path = "../tools/perf" }
+
+# Crates the coverage sweep reaches that the older benches never linked.
+acp = { path = "../crates/acp" }
+cursor = { path = "../crates/cursor" }
+libp2p-identity = { version = "0.2", features = ["ed25519", "peerid"] }
+p2p = { path = "../crates/p2p" }
+replication-filter = { path = "../crates/replication-filter" }
+events = { path = "../crates/events", features = ["channel"] }
+identity = { path = "../crates/identity" }
+x25519-dalek = "2"
+
+[[bench]]
+name = "acp"
+harness = false
+
+[[bench]]
+name = "allocs"
+harness = false
+
+[[bench]]
+name = "backup"
+harness = false
+
 [[bench]]
 name = "block"
 harness = false
@@ -59,11 +84,43 @@ name = "blockstore"
 harness = false
 
 [[bench]]
+name = "crypto"
+harness = false
+
+[[bench]]
+name = "cursor_codec"
+harness = false
+
+[[bench]]
+name = "document_read"
+harness = false
+
+[[bench]]
+name = "document_write"
+harness = false
+
+[[bench]]
+name = "document_codec"
+harness = false
+
+[[bench]]
+name = "events"
+harness = false
+
+[[bench]]
+name = "identity"
+harness = false
+
+[[bench]]
 name = "filter"
 harness = false
 
 [[bench]]
 name = "groupby"
+harness = false
+
+[[bench]]
+name = "memory"
 harness = false
 
 [[bench]]
@@ -75,6 +132,10 @@ name = "merge_dag"
 harness = false
 
 [[bench]]
+name = "p2p_codec"
+harness = false
+
+[[bench]]
 name = "parsing"
 harness = false
 
@@ -83,11 +144,27 @@ name = "planner"
 harness = false
 
 [[bench]]
+name = "query_e2e"
+harness = false
+
+[[bench]]
+name = "replication_filter"
+harness = false
+
+[[bench]]
 name = "retry_markers"
 harness = false
 
 [[bench]]
+name = "schema_validate"
+harness = false
+
+[[bench]]
 name = "sift"
+harness = false
+
+[[bench]]
+name = "startup"
 harness = false
 
 [[bench]]

--- a/benches/benches/acp.rs
+++ b/benches/benches/acp.rs
@@ -1,0 +1,160 @@
+//! Access-control checks, and how they multiply across a result set.
+//!
+//! ```text
+//! cargo bench -p benches --bench acp
+//! ```
+//!
+//! `check_doc_access` runs once per document, not once per query, so a read
+//! returning a thousand documents pays for a thousand checks. That multiplier
+//! is the number nobody had: a per-check figure in microseconds is fine on its
+//! own and is the whole query budget at scale.
+//!
+//! Both answers are measured. A denial walks the relationship set without
+//! finding a match, so it is not automatically the same cost as an approval,
+//! and a query that filters most of a collection away pays the denial cost far
+//! more often than the approval one.
+
+use std::hint::black_box;
+use std::sync::Arc;
+
+use acp::{DocumentACP, DocumentPermission, Identity, LocalDocumentACP, MemoryAcpStore};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use identity::Did;
+
+mod common;
+
+const POLICY: &str = "policy1";
+const RESOURCE: &str = "file";
+const REGISTERED: [usize; 4] = [1, 100, 1_000, 10_000];
+const FANOUT: [usize; 4] = [1, 10, 100, 1_000];
+
+fn owner() -> Did {
+    Did::new("did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK")
+        .expect("a well-formed owner did")
+}
+
+fn stranger() -> Did {
+    Did::new("did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH")
+        .expect("a well-formed stranger did")
+}
+
+fn doc_id(index: usize) -> String {
+    format!("bae-doc-{index:08}")
+}
+
+/// An ACP holding `count` registered documents, all owned by [`owner`].
+async fn fixture(count: usize) -> LocalDocumentACP {
+    let acp = LocalDocumentACP::new(Arc::new(MemoryAcpStore::new()));
+    let owner = owner();
+    for index in 0..count {
+        acp.register_doc_object(&owner, POLICY, RESOURCE, &doc_id(index))
+            .await
+            .expect("the document to register");
+    }
+    acp
+}
+
+/// One check, against how many documents the store already holds. A per-check
+/// cost that grows with the store is the difference between a node that scales
+/// and one that does not.
+fn single_check(c: &mut Criterion) {
+    let rt = common::owned_runtime();
+    let allowed = Identity::authenticated(owner());
+    let denied = Identity::authenticated(stranger());
+
+    let mut group = c.benchmark_group("acp_check");
+    for count in REGISTERED {
+        let acp = rt.block_on(fixture(count));
+        // A document from the middle of the set, so neither the first nor the
+        // last insertion order is what gets measured.
+        let target = doc_id(count / 2);
+        group.bench_with_input(BenchmarkId::new("allow", count), &target, |b, target| {
+            b.iter(|| {
+                let ok = rt
+                    .block_on(acp.check_doc_access(
+                        &allowed,
+                        DocumentPermission::Read,
+                        POLICY,
+                        RESOURCE,
+                        black_box(target),
+                    ))
+                    .expect("the check to answer");
+                assert!(ok, "the owner must be allowed to read their own document");
+                black_box(ok)
+            })
+        });
+        group.bench_with_input(BenchmarkId::new("deny", count), &target, |b, target| {
+            b.iter(|| {
+                let ok = rt
+                    .block_on(acp.check_doc_access(
+                        &denied,
+                        DocumentPermission::Read,
+                        POLICY,
+                        RESOURCE,
+                        black_box(target),
+                    ))
+                    .expect("the check to answer");
+                assert!(!ok, "a stranger must not be allowed to read the document");
+                black_box(ok)
+            })
+        });
+    }
+    group.finish();
+}
+
+/// What a result set costs. This is the row that matters: it is the same check
+/// as above, multiplied by how many documents a query returned.
+fn result_set(c: &mut Criterion) {
+    let rt = common::owned_runtime();
+    let allowed = Identity::authenticated(owner());
+    let acp = rt.block_on(fixture(*FANOUT.last().expect("a fan-out size")));
+
+    let mut group = c.benchmark_group("acp_result_set");
+    group.sample_size(20);
+    for count in FANOUT {
+        group.throughput(Throughput::Elements(count as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(count), &count, |b, &count| {
+            b.iter(|| {
+                rt.block_on(async {
+                    for index in 0..count {
+                        black_box(
+                            acp.check_doc_access(
+                                &allowed,
+                                DocumentPermission::Read,
+                                POLICY,
+                                RESOURCE,
+                                &doc_id(index),
+                            )
+                            .await
+                            .expect("the check to answer"),
+                        );
+                    }
+                })
+            })
+        });
+    }
+    group.finish();
+}
+
+/// Registration, which every document create pays once when ACP is on.
+fn registration(c: &mut Criterion) {
+    let rt = common::owned_runtime();
+    let owner = owner();
+    let mut group = c.benchmark_group("acp_register");
+    let mut seq = 0usize;
+    group.bench_function("register_doc_object", |b| {
+        b.iter_batched_ref(
+            || rt.block_on(fixture(0)),
+            |acp| {
+                seq += 1;
+                rt.block_on(acp.register_doc_object(&owner, POLICY, RESOURCE, &doc_id(seq)))
+                    .expect("the document to register")
+            },
+            criterion::BatchSize::SmallInput,
+        )
+    });
+    group.finish();
+}
+
+criterion_group!(benches, single_check, result_set, registration);
+criterion_main!(benches);

--- a/benches/benches/allocs.rs
+++ b/benches/benches/allocs.rs
@@ -1,0 +1,154 @@
+//! Allocations per operation on the paths a request actually walks.
+//!
+//! ```text
+//! cargo bench -p benches --bench allocs
+//! ```
+//!
+//! A count, not a rate: a busy host cannot move it, so this stays comparable
+//! on a runner the load guard failed and a change in it is always a change in
+//! the code. That makes it the cheapest early warning the suite has for a
+//! clone that crept into a hot path, long before the wall clock notices.
+//!
+//! What is counted is every allocation the process made while performing the
+//! operations, divided by how many there were. That includes whatever the
+//! runtime allocated on the way, which is why the runtime here is
+//! single-threaded and why the number is reported as "observed per operation"
+//! rather than as the operation's own footprint. The comparison between runs
+//! is the point; the absolute figure is a ceiling, not an attribution.
+//!
+//! Not a criterion target: an allocation count is exact on one execution, and
+//! sampling it a thousand times would only measure the sampler.
+
+use std::sync::Arc;
+
+use db::DB;
+use defra_perf::emit::{Family, Group, Row};
+use defra_perf::measure::{per_op, CountingAllocator};
+use document::{Document, NormalValue};
+use query::mutator::DocMutator;
+use query::DocFetcher;
+use schema::{CollectionVersion, FieldDescription, FieldKind};
+use storage::RegolithStore;
+
+#[global_allocator]
+static ALLOC: CountingAllocator = CountingAllocator;
+
+const COLLECTION: &str = "Users";
+const FIELDS: usize = 16;
+const OPS: u64 = 200;
+
+fn field_names() -> Vec<String> {
+    (0..FIELDS).map(|i| format!("field_{i}")).collect()
+}
+
+fn collection_version() -> CollectionVersion {
+    let mut fields = vec![FieldDescription::new("1", "_docID", FieldKind::doc_id())];
+    for (index, name) in field_names().iter().enumerate() {
+        fields.push(FieldDescription::new(
+            (index + 2).to_string(),
+            name,
+            FieldKind::string(),
+        ));
+    }
+    CollectionVersion::new(COLLECTION, "bafkallocs", "allocs", fields)
+}
+
+fn document(seq: usize) -> Document {
+    let mut doc = Document::new();
+    for name in field_names() {
+        doc.set(&name, NormalValue::String(format!("{name}-{seq}")));
+    }
+    doc
+}
+
+fn main() {
+    // Single-threaded on purpose: a worker pool allocates on threads this has
+    // no way to attribute, and the resulting count would drift with the
+    // scheduler rather than with the code.
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("a runtime");
+
+    let mut group = Group::lower_better("per operation", "allocations/op").note(
+        "Allocations observed across the whole process while performing the operation, divided \
+         by how many were performed. A ceiling on the operation's own cost, not an attribution \
+         of it.",
+    );
+
+    let store = Arc::new(RegolithStore::in_memory().expect("an in-memory store"));
+    let db = Arc::new(rt.block_on(DB::open_from_arc(store)).expect("a database"));
+    rt.block_on(db.create_collection(collection_version()))
+        .expect("the collection");
+    let mutator = db::write::autocommit::AutoCommitMutator::new(db.clone());
+    let fetcher = db::AutoCommitFetcher::new(db.clone());
+
+    // The document set both the write and the read rows work over. Seeded
+    // before any counting starts so its cost lands in neither.
+    let mut seeded = Vec::new();
+    for seq in 0..OPS as usize {
+        let created = rt
+            .block_on(mutator.create(COLLECTION, document(seq)))
+            .expect("the seed create to succeed");
+        seeded.push(created.doc_id.to_string());
+    }
+
+    group = group.row(Row::new(
+        "document create",
+        per_op(OPS, || {
+            for seq in 0..OPS as usize {
+                rt.block_on(mutator.create(COLLECTION, document(OPS as usize + seq)))
+                    .expect("the create to succeed");
+            }
+        }),
+    ));
+
+    group = group.row(Row::new(
+        "document get by id",
+        per_op(OPS, || {
+            for doc_id in &seeded {
+                rt.block_on(fetcher.get_by_ids(COLLECTION, std::slice::from_ref(doc_id)))
+                    .expect("the read to succeed");
+            }
+        }),
+    ));
+
+    // Pure codec paths, with no store under them: these are the ones a change
+    // in a serializer moves first.
+    let doc = document(0);
+    group = group.row(Row::new(
+        "document to map",
+        per_op(OPS, || {
+            for _ in 0..OPS {
+                std::hint::black_box(doc.to_map().expect("the document to serialize"));
+            }
+        }),
+    ));
+
+    let json = serde_json::to_vec(&doc.to_map().expect("the document to serialize"))
+        .expect("a JSON encoding of it");
+    group = group.row(Row::new(
+        "document from json",
+        per_op(OPS, || {
+            for _ in 0..OPS {
+                std::hint::black_box(Document::from_json(&json).expect("the document to parse"));
+            }
+        }),
+    ));
+
+    let family = Family::new(
+        "Allocations per operation",
+        format!(
+            "How many allocations each path makes, averaged over {OPS} operations. Deterministic: \
+             a count does not move because the runner was busy, so this is comparable across \
+             every run whatever the load guard said."
+        ),
+    )
+    .deterministic()
+    .group(group);
+
+    for row in family.groups.iter().flat_map(|g| &g.rows) {
+        println!("  {:<24} {:>10.1} allocations/op", row.name, row.value);
+    }
+    family.emit("allocs");
+}

--- a/benches/benches/backup.rs
+++ b/benches/benches/backup.rs
@@ -1,0 +1,147 @@
+//! Database export and import.
+//!
+//! ```text
+//! cargo bench -p benches --bench backup
+//! ```
+//!
+//! Backup is the one operation whose cost scales with the whole database
+//! rather than with a request, so it is the operation most likely to be
+//! discovered to be slow at exactly the wrong moment. Export renders every
+//! document to JSON through the query engine; import writes every one of them
+//! back through the mutator. Neither had a number.
+//!
+//! Swept by document count, because the question is whether either side grows
+//! worse than linearly.
+
+use std::hint::black_box;
+use std::sync::Arc;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use db::DB;
+use document::{Document, NormalValue};
+use query::mutator::DocMutator;
+use query::{QueryExecutor, QueryRunner};
+use schema::{CollectionVersion, FieldDescription, FieldKind};
+use storage::RegolithStore;
+
+mod common;
+
+const COLLECTION: &str = "User";
+const CORPUS: [usize; 3] = [100, 1_000, 5_000];
+
+fn collection_version() -> CollectionVersion {
+    CollectionVersion::new(
+        COLLECTION,
+        "bafkbackup",
+        "backup",
+        vec![
+            FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+            FieldDescription::new("2", "name", FieldKind::string()),
+            FieldDescription::new("3", "city", FieldKind::string()),
+            FieldDescription::new("4", "age", FieldKind::int()),
+        ],
+    )
+}
+
+struct Fixture {
+    db: Arc<DB<RegolithStore>>,
+    runner: Arc<dyn QueryExecutor>,
+}
+
+async fn fixture(count: usize) -> Fixture {
+    let store = Arc::new(RegolithStore::in_memory().expect("an in-memory store"));
+    let db = Arc::new(DB::open_from_arc(store).await.expect("a database"));
+    db.create_collection(collection_version())
+        .await
+        .expect("the collection to register");
+
+    let mutator = Arc::new(db::write::autocommit::AutoCommitMutator::new(db.clone()));
+    for seq in 0..count {
+        let mut doc = Document::new();
+        doc.set("name", NormalValue::String(format!("person-{seq}")));
+        doc.set("city", NormalValue::String(format!("city-{}", seq % 10)));
+        doc.set("age", NormalValue::Int((seq % 80) as i64 + 18));
+        mutator
+            .create(COLLECTION, doc)
+            .await
+            .expect("the seed create to succeed");
+    }
+
+    let fetcher = db::AutoCommitFetcher::new(db.clone());
+    let runner: Arc<dyn QueryExecutor> = Arc::new(
+        QueryRunner::new(fetcher, vec![collection_version()])
+            .with_mutator(mutator as Arc<dyn DocMutator>),
+    );
+    Fixture { db, runner }
+}
+
+fn export(c: &mut Criterion) {
+    let rt = common::owned_runtime();
+    let mut group = c.benchmark_group("backup_export");
+    group.sample_size(10);
+    for count in CORPUS {
+        let fixture = rt.block_on(fixture(count));
+        let names = vec![COLLECTION.to_string()];
+        group.throughput(Throughput::Elements(count as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(count), &count, |b, _| {
+            b.iter(|| {
+                black_box(
+                    rt.block_on(db::backup::export_database(
+                        &fixture.db,
+                        &fixture.runner,
+                        &names,
+                        false,
+                    ))
+                    .expect("the export to succeed"),
+                )
+            })
+        });
+    }
+    group.finish();
+}
+
+/// Restore, into an empty database.
+///
+/// Not into a populated one: `import_database` refuses a document whose id is
+/// already present ("a document with the given ID already exists"), so restore
+/// is a fresh-database operation and timing it against a populated one would
+/// measure the rejection path. A fresh database per batch, built outside the
+/// measured region, is what keeps the row honest.
+fn import(c: &mut Criterion) {
+    let rt = common::owned_runtime();
+    let mut group = c.benchmark_group("backup_import");
+    group.sample_size(10);
+    let names = vec![COLLECTION.to_string()];
+    for count in CORPUS {
+        let source = rt.block_on(fixture(count));
+        let dump = rt
+            .block_on(db::backup::export_database(
+                &source.db,
+                &source.runner,
+                &names,
+                false,
+            ))
+            .expect("the export to succeed");
+        group.throughput(Throughput::Elements(count as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(count), &dump, |b, dump| {
+            b.iter_batched_ref(
+                || rt.block_on(fixture(0)),
+                |target| {
+                    black_box(
+                        rt.block_on(db::backup::import_database(
+                            &target.db,
+                            &target.runner,
+                            black_box(dump),
+                        ))
+                        .expect("the import to succeed"),
+                    )
+                },
+                criterion::BatchSize::LargeInput,
+            )
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, export, import);
+criterion_main!(benches);

--- a/benches/benches/crypto.rs
+++ b/benches/benches/crypto.rs
@@ -1,0 +1,144 @@
+//! The cryptographic primitives on the request and replication paths.
+//!
+//! ```text
+//! cargo bench -p benches --bench crypto
+//! ```
+//!
+//! Nothing here was measured before, and the curve a deployment picks decides
+//! several of these numbers by an order of magnitude. Signing runs on every
+//! authored commit, verification on every inbound block, AES on every
+//! encrypted field, and ECIES on every key handed to a peer.
+//!
+//! Sizes are swept because these are byte-rate operations: a figure quoted for
+//! one payload size says nothing about another.
+
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use crypto::{
+    decrypt_aes, decrypt_ecies, encrypt_aes, encrypt_ecies, EciesOptionsBuilder, PrivateKey,
+};
+
+const SIZES: [usize; 4] = [64, 1024, 16 * 1024, 256 * 1024];
+const KEY: [u8; 32] = [0x5a; 32];
+
+fn payload(len: usize) -> Vec<u8> {
+    (0..len).map(|i| (i % 251) as u8).collect()
+}
+
+fn aes(c: &mut Criterion) {
+    let mut group = c.benchmark_group("crypto_aes");
+    for size in SIZES {
+        let plaintext = payload(size);
+        let (ciphertext, nonce) =
+            encrypt_aes(&plaintext, &KEY, b"", false).expect("the payload to encrypt");
+        group.throughput(Throughput::Bytes(size as u64));
+        group.bench_with_input(BenchmarkId::new("encrypt", size), &plaintext, |b, data| {
+            b.iter(|| black_box(encrypt_aes(black_box(data), &KEY, b"", false).expect("encrypt")))
+        });
+        group.bench_with_input(
+            BenchmarkId::new("decrypt", size),
+            &(ciphertext, nonce),
+            |b, (ciphertext, nonce)| {
+                b.iter(|| {
+                    black_box(
+                        decrypt_aes(Some(nonce), black_box(ciphertext), &KEY, b"")
+                            .expect("decrypt"),
+                    )
+                })
+            },
+        );
+    }
+    group.finish();
+}
+
+/// What it costs to seal a key for one recipient. Every document encryption
+/// key handed to a peer goes through this.
+fn ecies(c: &mut Criterion) {
+    let secret = crypto::generate_x25519().expect("an x25519 secret");
+    let public = x25519_dalek::PublicKey::from(&secret);
+    // The ephemeral public key travels with the ciphertext, which is how a
+    // sealed key actually reaches a peer: without it the recipient has nothing
+    // to derive the shared secret from.
+    let options = || {
+        EciesOptionsBuilder::default()
+            .prepend_public_key(true)
+            .build()
+    };
+    let mut group = c.benchmark_group("crypto_ecies");
+    for size in [32usize, 1024] {
+        let plaintext = payload(size);
+        let sealed = encrypt_ecies(&plaintext, &public, options()).expect("the payload to seal");
+        group.throughput(Throughput::Bytes(size as u64));
+        group.bench_with_input(BenchmarkId::new("seal", size), &plaintext, |b, data| {
+            b.iter(|| black_box(encrypt_ecies(black_box(data), &public, options()).expect("seal")))
+        });
+        group.bench_with_input(BenchmarkId::new("open", size), &sealed, |b, sealed| {
+            b.iter(|| {
+                black_box(decrypt_ecies(black_box(sealed), &secret, options()).expect("open"))
+            })
+        });
+    }
+    group.finish();
+}
+
+/// Signing and verification across every curve the node supports. BLS signs
+/// but is verified through the threshold path, so only its signing side is
+/// comparable here.
+fn signatures(c: &mut Criterion) {
+    let keys: Vec<(&str, Box<dyn PrivateKey>)> = vec![
+        (
+            "ed25519",
+            Box::new(crypto::generate_ed25519().expect("a key")),
+        ),
+        (
+            "secp256k1",
+            Box::new(crypto::generate_secp256k1().expect("a key")),
+        ),
+        (
+            "secp256r1",
+            Box::new(crypto::generate_secp256r1().expect("a key")),
+        ),
+    ];
+    let message = payload(256);
+
+    let mut signing = c.benchmark_group("crypto_sign");
+    for (curve, key) in &keys {
+        signing.bench_with_input(BenchmarkId::from_parameter(curve), key, |b, key| {
+            b.iter(|| black_box(key.sign(black_box(&message)).expect("the signature")))
+        });
+    }
+    signing.finish();
+
+    let mut verifying = c.benchmark_group("crypto_verify");
+    for (curve, key) in &keys {
+        let signature = key.sign(&message).expect("the signature");
+        verifying.bench_with_input(BenchmarkId::from_parameter(curve), key, |b, key| {
+            b.iter(|| {
+                black_box(
+                    key.public_key()
+                        .verify(black_box(&message), &signature)
+                        .expect("the signature to verify"),
+                )
+            })
+        });
+    }
+    verifying.finish();
+}
+
+/// Content addressing. Every block and every document id is hashed, so this is
+/// the most-called function in the suite.
+fn hashing(c: &mut Criterion) {
+    let mut group = c.benchmark_group("crypto_sha256");
+    for size in SIZES {
+        let data = payload(size);
+        group.throughput(Throughput::Bytes(size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), &data, |b, data| {
+            b.iter(|| black_box(crypto::sha256(black_box(data))))
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, aes, ecies, signatures, hashing);
+criterion_main!(benches);

--- a/benches/benches/cursor_codec.rs
+++ b/benches/benches/cursor_codec.rs
@@ -1,0 +1,63 @@
+//! Pagination token encode and decode.
+//!
+//! ```text
+//! cargo bench -p benches --bench cursor_codec
+//! ```
+//!
+//! Two documents' worth of work on every paged query: one token decoded on the
+//! way in and one encoded on the way out. Small, but on the path of every
+//! paginated read, and swept by key count because a composite index cursor
+//! carries one key per indexed field.
+
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use cursor::Cursor;
+
+const KEY_COUNTS: [usize; 4] = [0, 1, 4, 16];
+
+fn sample(keys: usize) -> Cursor {
+    let mut cursor = Cursor::from_doc_id("bae-8a1f9c2d-4e5b-4c3a-9d7e-1f2a3b4c5d6e");
+    for i in 0..keys {
+        cursor.keys.insert(
+            format!("field_{i}"),
+            serde_json::json!(format!("value-{i}")),
+        );
+    }
+    cursor.direction = "ASC".into();
+    cursor
+}
+
+fn round_trip(c: &mut Criterion) {
+    let mut group = c.benchmark_group("cursor_codec");
+    for keys in KEY_COUNTS {
+        let cursor = sample(keys);
+        let token = cursor.encode();
+        group.bench_with_input(BenchmarkId::new("encode", keys), &cursor, |b, cursor| {
+            b.iter(|| black_box(black_box(cursor).encode()))
+        });
+        group.bench_with_input(BenchmarkId::new("decode", keys), &token, |b, token| {
+            b.iter(|| black_box(Cursor::decode(black_box(token)).expect("a valid token")))
+        });
+    }
+    group.finish();
+}
+
+/// A malformed token is the untrusted-input path: it arrives from a client and
+/// has to be rejected rather than trusted, so its cost is a real one.
+fn rejection(c: &mut Criterion) {
+    let mut group = c.benchmark_group("cursor_reject");
+    for (name, token) in [
+        ("not_base64", "!!!not-base64!!!"),
+        ("not_json", "aGVsbG8gd29ybGQ"),
+        ("empty_doc_id", &Cursor::from_doc_id("").encode() as &str),
+    ] {
+        group.bench_with_input(BenchmarkId::from_parameter(name), &token, |b, token| {
+            b.iter(|| black_box(Cursor::decode(black_box(token)).is_err()))
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, round_trip, rejection);
+criterion_main!(benches);

--- a/benches/benches/document_codec.rs
+++ b/benches/benches/document_codec.rs
@@ -1,0 +1,103 @@
+//! Document field-value conversion, content addressing and timestamps.
+//!
+//! ```text
+//! cargo bench -p benches --bench document_codec
+//! ```
+//!
+//! [`block`](../block.rs) covers the block envelope, and the CBOR value codec
+//! underneath it along with it. This covers the rest of what every document
+//! read and write pays for and nothing measured: JSON in and out, deriving a
+//! content-addressed id, and parsing a timestamp.
+//!
+//! Parameterized by document width and by value kind, because the cost is per
+//! value and the kinds do not cost the same.
+
+use std::hint::black_box;
+
+use cid::Cid;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use document::{DocID, Document, NormalValue};
+use multihash::Multihash;
+use sha2::{Digest, Sha256};
+
+const WIDTHS: [usize; 3] = [4, 16, 64];
+const SHA2_256: u64 = 0x12;
+const DAG_CBOR: u64 = 0x71;
+
+fn value_kinds() -> Vec<(&'static str, NormalValue)> {
+    vec![
+        (
+            "string",
+            NormalValue::String("a moderately sized value".into()),
+        ),
+        ("int", NormalValue::Int(-4_611_686_018_427_387_904)),
+        ("float", NormalValue::Float64(1.234_567_890_123_456_7)),
+        ("bool", NormalValue::Bool(true)),
+        ("bytes", NormalValue::Bytes(vec![0xa5; 256])),
+    ]
+}
+
+fn wide_document(width: usize) -> Document {
+    let mut doc = Document::new();
+    let kinds = value_kinds();
+    for index in 0..width {
+        let (_, value) = &kinds[index % kinds.len()];
+        doc.set(format!("field_{index}"), value.clone());
+    }
+    doc
+}
+
+fn json_round_trip(c: &mut Criterion) {
+    let mut group = c.benchmark_group("codec_json");
+    for width in WIDTHS {
+        let doc = wide_document(width);
+        let json = serde_json::to_vec(&doc.to_map().expect("the document to serialize"))
+            .expect("a JSON encoding of it");
+        group.throughput(Throughput::Elements(width as u64));
+        group.bench_with_input(BenchmarkId::new("to_map", width), &doc, |b, doc| {
+            b.iter(|| black_box(doc.to_map().expect("the document to serialize")))
+        });
+        group.bench_with_input(BenchmarkId::new("from_json", width), &json, |b, json| {
+            b.iter(|| {
+                black_box(Document::from_json(black_box(json)).expect("the document to parse"))
+            })
+        });
+    }
+    group.finish();
+}
+
+/// A document id is derived from a CID, and every create pays for it.
+fn doc_id(c: &mut Criterion) {
+    let digest = Sha256::digest(b"a document's canonical bytes");
+    let cid = Cid::new_v1(
+        DAG_CBOR,
+        Multihash::wrap(SHA2_256, &digest).expect("a well-formed multihash"),
+    );
+    let mut group = c.benchmark_group("codec_doc_id");
+    group.bench_function("new_v0", |b| {
+        b.iter(|| black_box(DocID::new_v0(black_box(cid))))
+    });
+    group.bench_function("to_string", |b| {
+        let id = DocID::new_v0(cid);
+        b.iter(|| black_box(black_box(&id).to_string()))
+    });
+    group.finish();
+}
+
+/// Every datetime field on every document goes through this.
+fn timestamps(c: &mut Criterion) {
+    let mut group = c.benchmark_group("codec_rfc3339");
+    for (name, text) in [
+        ("utc", "2026-09-04T12:34:56Z"),
+        ("offset", "2026-09-04T12:34:56+02:00"),
+        ("fractional", "2026-09-04T12:34:56.123456789Z"),
+    ] {
+        group.bench_with_input(BenchmarkId::from_parameter(name), &text, |b, text| {
+            b.iter(|| black_box(document::parse_rfc3339(black_box(text))))
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, json_round_trip, doc_id, timestamps);
+criterion_main!(benches);

--- a/benches/benches/document_read.rs
+++ b/benches/benches/document_read.rs
@@ -1,0 +1,166 @@
+//! Document reads through the real fetcher.
+//!
+//! ```text
+//! cargo bench -p benches --bench document_read
+//! ```
+//!
+//! [`document_write`](../document_write.rs) covers the other direction. This
+//! covers the four shapes every read in the system resolves to: fetch by id,
+//! fetch the whole collection, stream it rather than materialize it, and
+//! resolve a foreign key by field value. None of them was measured, and the
+//! difference between the second and the third is the difference between
+//! holding one document and holding all of them.
+//!
+//! Swept by corpus size, because the point of the streaming row is that it
+//! should not grow the way the materializing one does.
+
+use std::hint::black_box;
+use std::sync::Arc;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use db::DB;
+use document::{Document, NormalValue};
+use query::mutator::DocMutator;
+use query::DocFetcher;
+use schema::{CollectionVersion, FieldDescription, FieldKind};
+use storage::RegolithStore;
+
+mod common;
+
+const COLLECTION: &str = "User";
+const CORPUS: [usize; 3] = [100, 1_000, 5_000];
+
+fn collection_version() -> CollectionVersion {
+    CollectionVersion::new(
+        COLLECTION,
+        "bafkdocread",
+        "docread",
+        vec![
+            FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+            FieldDescription::new("2", "name", FieldKind::string()),
+            FieldDescription::new("3", "city", FieldKind::string()),
+        ],
+    )
+}
+
+type Fetcher = db::AutoCommitFetcher<RegolithStore>;
+
+/// A database holding `count` documents, the fetcher over it, and the ids it
+/// wrote, so the by-id rows read documents that are actually there.
+async fn fixture(count: usize) -> (Fetcher, Vec<String>) {
+    let store = Arc::new(RegolithStore::in_memory().expect("an in-memory store"));
+    let db = Arc::new(DB::open_from_arc(store).await.expect("a database"));
+    db.create_collection(collection_version())
+        .await
+        .expect("the collection to register");
+
+    let mutator = db::write::autocommit::AutoCommitMutator::new(db.clone());
+    let mut ids = Vec::with_capacity(count);
+    for seq in 0..count {
+        let mut doc = Document::new();
+        doc.set("name", NormalValue::String(format!("person-{seq}")));
+        doc.set("city", NormalValue::String(format!("city-{}", seq % 10)));
+        let created = mutator
+            .create(COLLECTION, doc)
+            .await
+            .expect("the seed create to succeed");
+        ids.push(created.doc_id.to_string());
+    }
+    (db::AutoCommitFetcher::new(db), ids)
+}
+
+fn by_id(c: &mut Criterion) {
+    let rt = common::owned_runtime();
+    let mut group = c.benchmark_group("document_read_by_id");
+    for count in CORPUS {
+        let (fetcher, ids) = rt.block_on(fixture(count));
+        // One id from the middle: the first and the last can both be
+        // accidentally cheap depending on how the store lays keys out.
+        let one = vec![ids[ids.len() / 2].clone()];
+        group.bench_with_input(BenchmarkId::new("single", count), &one, |b, ids| {
+            b.iter(|| {
+                black_box(
+                    rt.block_on(fetcher.get_by_ids(COLLECTION, black_box(ids)))
+                        .expect("the read to succeed"),
+                )
+            })
+        });
+        // A batched read is what a relation resolves to, so its per-document
+        // cost against the single-id row is the number that decides whether
+        // batching a join is worth it.
+        let many: Vec<String> = ids.iter().take(50).cloned().collect();
+        group.throughput(Throughput::Elements(many.len() as u64));
+        group.bench_with_input(BenchmarkId::new("batch_50", count), &many, |b, ids| {
+            b.iter(|| {
+                black_box(
+                    rt.block_on(fetcher.get_by_ids(COLLECTION, black_box(ids)))
+                        .expect("the read to succeed"),
+                )
+            })
+        });
+    }
+    group.finish();
+}
+
+/// Materializing the collection against streaming it. Both walk the same
+/// bytes; what differs is how much a caller has to hold to do it.
+fn collection_scan(c: &mut Criterion) {
+    let rt = common::owned_runtime();
+    let mut group = c.benchmark_group("document_read_scan");
+    group.sample_size(20);
+    for count in CORPUS {
+        let (fetcher, _) = rt.block_on(fixture(count));
+        group.throughput(Throughput::Elements(count as u64));
+        group.bench_with_input(BenchmarkId::new("get_all", count), &count, |b, _| {
+            b.iter(|| {
+                let docs = rt
+                    .block_on(fetcher.get_all(COLLECTION))
+                    .expect("the scan to succeed");
+                assert_eq!(docs.len(), count, "the scan must see every document");
+                black_box(docs)
+            })
+        });
+        group.bench_with_input(BenchmarkId::new("stream", count), &count, |b, _| {
+            b.iter(|| {
+                rt.block_on(async {
+                    let mut stream = fetcher
+                        .stream_all_with_deleted(COLLECTION, false)
+                        .await
+                        .expect("the stream to open");
+                    let mut seen = 0usize;
+                    while let Some(doc) = stream.next().await.expect("the stream to advance") {
+                        black_box(&doc);
+                        seen += 1;
+                    }
+                    assert_eq!(seen, count, "the stream must see every document");
+                })
+            })
+        });
+    }
+    group.finish();
+}
+
+/// The foreign-key path: every relation traversal resolves through this.
+fn by_field_value(c: &mut Criterion) {
+    let rt = common::owned_runtime();
+    let mut group = c.benchmark_group("document_read_by_field");
+    group.sample_size(20);
+    for count in CORPUS {
+        let (fetcher, _) = rt.block_on(fixture(count));
+        // A tenth of the corpus matches, so the row measures selecting rather
+        // than either scanning everything or finding nothing.
+        group.throughput(Throughput::Elements(count as u64 / 10));
+        group.bench_with_input(BenchmarkId::from_parameter(count), &count, |b, _| {
+            b.iter(|| {
+                black_box(
+                    rt.block_on(fetcher.get_by_field_value(COLLECTION, "city", "city-3"))
+                        .expect("the lookup to succeed"),
+                )
+            })
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, by_id, collection_scan, by_field_value);
+criterion_main!(benches);

--- a/benches/benches/document_read.rs
+++ b/benches/benches/document_read.rs
@@ -77,6 +77,10 @@ fn by_id(c: &mut Criterion) {
         // One id from the middle: the first and the last can both be
         // accidentally cheap depending on how the store lays keys out.
         let one = vec![ids[ids.len() / 2].clone()];
+        // Set for every benchmark, not just the batched one: criterion keeps a
+        // group's throughput until it is replaced, so leaving it unset here
+        // would report the single read at the previous iteration's batch size.
+        group.throughput(Throughput::Elements(1));
         group.bench_with_input(BenchmarkId::new("single", count), &one, |b, ids| {
             b.iter(|| {
                 black_box(

--- a/benches/benches/document_write.rs
+++ b/benches/benches/document_write.rs
@@ -1,0 +1,310 @@
+//! Document writes through the real mutator.
+//!
+//! ```text
+//! cargo bench -p benches --bench document_write
+//! ```
+//!
+//! [`block_write`](../block_write.rs) times the block-building slice of a
+//! write against raw namespace views. This times the operation a user actually
+//! performs: `AutoCommitMutator::create` and its siblings, which allocate the
+//! document's short id, build and link the blocks, maintain every secondary
+//! index, and commit. The gap between the two is the cost of everything
+//! wrapped around block building, and until this existed nothing measured it.
+//!
+//! Parameterized by field count, by batch size, and by whether a secondary
+//! index is present, because index maintenance is paid per write and per
+//! indexed field and is invisible in a bench that has no index.
+
+use std::collections::HashSet;
+use std::hint::black_box;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
+use db::DB;
+use defra_perf::emit::{Family, Group};
+use defra_perf::measure::repeat;
+use document::{DocID, Document, NormalValue};
+use query::mutator::DocMutator;
+use query::DocFetcher;
+use schema::{CollectionVersion, FieldDescription, FieldKind};
+use storage::RegolithStore;
+
+mod common;
+
+const COLLECTION: &str = "Users";
+const SCHEMA_VERSION_ID: &str = "bafkdocwrite";
+const COLLECTION_ID: &str = "docwrite";
+const FIELD_COUNTS: [usize; 3] = [4, 16, 64];
+
+fn field_names(count: usize) -> Vec<String> {
+    (0..count).map(|i| format!("field_{i}")).collect()
+}
+
+fn collection_version(field_count: usize) -> CollectionVersion {
+    let mut fields = vec![FieldDescription::new("1", "_docID", FieldKind::doc_id())];
+    for (index, name) in field_names(field_count).iter().enumerate() {
+        fields.push(FieldDescription::new(
+            (index + 2).to_string(),
+            name,
+            FieldKind::string(),
+        ));
+    }
+    CollectionVersion::new(COLLECTION, SCHEMA_VERSION_ID, COLLECTION_ID, fields)
+}
+
+/// A document whose every field is distinct per `seq`, so two documents in one
+/// run never collide on a content-addressed id.
+fn document(field_count: usize, seq: usize) -> Document {
+    let mut doc = Document::new();
+    for name in field_names(field_count) {
+        doc.set(&name, NormalValue::String(format!("{name}-{seq}")));
+    }
+    doc
+}
+
+type Mutator = db::write::autocommit::AutoCommitMutator<RegolithStore>;
+
+/// A fresh in-memory database with the collection already registered. In
+/// memory on purpose: this measures the write path, and putting a real disk
+/// under it would measure the disk.
+async fn fixture(field_count: usize) -> Mutator {
+    let store = Arc::new(RegolithStore::in_memory().expect("an in-memory store"));
+    let db = Arc::new(DB::from_arc(store).expect("a database over it"));
+    db.create_collection(collection_version(field_count))
+        .await
+        .expect("the collection to register");
+    Mutator::new(db)
+}
+
+/// A fixture with one document already in it, and that document's id.
+async fn seeded(field_count: usize) -> (Mutator, DocID) {
+    let mutator = fixture(field_count).await;
+    let created = mutator
+        .create(COLLECTION, document(field_count, next_seq()))
+        .await
+        .expect("the seed create to succeed");
+    (mutator, created.doc_id)
+}
+
+/// A document id is content-addressed, so two identical documents are one
+/// document and the second create is a conflict rather than a write. Every
+/// document this bench builds gets a sequence nobody else in the process used.
+fn next_seq() -> usize {
+    static SEQ: AtomicUsize = AtomicUsize::new(0);
+    SEQ.fetch_add(1, Ordering::Relaxed)
+}
+
+/// The same operations, reported as a throughput family rather than as
+/// criterion timings.
+///
+/// Criterion cannot run in a browser, so a criterion row exists on the native
+/// platforms and nowhere else. This family carries group and row names the
+/// browser harness in `crates/wasm/tests/perf.rs` reproduces exactly, which is
+/// what puts a browser column beside the Linux and macOS ones on the dashboard
+/// instead of three tables that do not line up.
+fn report(rt: &tokio::runtime::Runtime) {
+    const OPS: usize = 200;
+    const REPS: usize = 5;
+
+    let mut create = Group::higher_better("create", "ops/s").over("fields");
+    let mut read = Group::higher_better("read", "ops/s").over("fields");
+
+    for fields in FIELD_COUNTS {
+        create = create.row(
+            repeat(format!("{fields} fields"), REPS, || {
+                rt.block_on(async {
+                    let mutator = fixture(fields).await;
+                    let base = next_seq() * OPS;
+                    let start = std::time::Instant::now();
+                    for seq in 0..OPS {
+                        mutator
+                            .create(COLLECTION, document(fields, base + seq))
+                            .await
+                            .expect("the create to succeed");
+                    }
+                    OPS as f64 / start.elapsed().as_secs_f64()
+                })
+            })
+            .at(fields as f64),
+        );
+
+        read = read.row(
+            repeat(format!("{fields} fields"), REPS, || {
+                rt.block_on(async {
+                    let store = Arc::new(storage::RegolithStore::in_memory().expect("a store"));
+                    let db = Arc::new(DB::open_from_arc(store).await.expect("a database"));
+                    db.create_collection(collection_version(fields))
+                        .await
+                        .expect("the collection to register");
+                    let mutator = Mutator::new(db.clone());
+                    let base = next_seq() * OPS;
+                    let mut ids = Vec::with_capacity(OPS);
+                    for seq in 0..OPS {
+                        ids.push(
+                            mutator
+                                .create(COLLECTION, document(fields, base + seq))
+                                .await
+                                .expect("the create to succeed")
+                                .doc_id
+                                .to_string(),
+                        );
+                    }
+                    let fetcher = db::AutoCommitFetcher::new(db);
+                    let start = std::time::Instant::now();
+                    for id in &ids {
+                        fetcher
+                            .get_by_ids(COLLECTION, std::slice::from_ref(id))
+                            .await
+                            .expect("the read to succeed");
+                    }
+                    ids.len() as f64 / start.elapsed().as_secs_f64()
+                })
+            })
+            .at(fields as f64),
+        );
+    }
+
+    Family::new(
+        "Document operations",
+        format!(
+            "Documents created and read back one at a time, {OPS} of each, through the same \
+             mutator and fetcher every platform uses. Measured with a wall clock natively and \
+             with `performance.now()` in the browser, so the two are the same operation counted \
+             the same way."
+        ),
+    )
+    .group(create)
+    .group(read)
+    .emit("document_ops");
+}
+
+fn create(c: &mut Criterion) {
+    let rt = common::owned_runtime();
+    report(&rt);
+    let mut group = c.benchmark_group("document_create");
+    for fields in FIELD_COUNTS {
+        group.throughput(Throughput::Elements(1));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(fields),
+            &fields,
+            |b, &fields| {
+                // A fresh database per batch: a create into a store holding a
+                // million documents is a different measurement from a create into
+                // an empty one, and mixing the two would report their average.
+                b.iter_batched_ref(
+                    || rt.block_on(fixture(fields)),
+                    |mutator| {
+                        rt.block_on(async {
+                            black_box(
+                                mutator
+                                    .create(COLLECTION, document(fields, next_seq()))
+                                    .await
+                                    .expect("the create to succeed"),
+                            );
+                        })
+                    },
+                    BatchSize::LargeInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+/// One commit for many documents against one commit each. The difference is
+/// the whole reason `create_many` exists, and it has never been measured.
+fn create_many(c: &mut Criterion) {
+    let rt = common::owned_runtime();
+    let mut group = c.benchmark_group("document_create_many");
+    let fields = 16;
+    for batch in [1usize, 8, 64, 256] {
+        group.throughput(Throughput::Elements(batch as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(batch), &batch, |b, &batch| {
+            b.iter_batched_ref(
+                || rt.block_on(fixture(fields)),
+                |mutator| {
+                    rt.block_on(async {
+                        let base = next_seq();
+                        let docs: Vec<Document> =
+                            (0..batch).map(|s| document(fields, base + s)).collect();
+                        black_box(
+                            mutator
+                                .create_many(COLLECTION, docs)
+                                .await
+                                .expect("the batch create to succeed"),
+                        );
+                    })
+                },
+                BatchSize::LargeInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+fn update(c: &mut Criterion) {
+    let rt = common::owned_runtime();
+    let mut group = c.benchmark_group("document_update");
+    for fields in FIELD_COUNTS {
+        group.throughput(Throughput::Elements(1));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(fields),
+            &fields,
+            |b, &fields| {
+                b.iter_batched_ref(
+                    || rt.block_on(seeded(fields)),
+                    |(mutator, doc_id)| {
+                        rt.block_on(async {
+                            // One field touched, which is the common shape: a
+                            // write that rewrote every field would measure a
+                            // create.
+                            let mut doc = Document::with_id(doc_id.clone());
+                            doc.set(
+                                "field_0",
+                                NormalValue::String(format!("updated-{}", next_seq())),
+                            );
+                            let modified: HashSet<String> =
+                                ["field_0".to_string()].into_iter().collect();
+                            black_box(
+                                mutator
+                                    .update(COLLECTION, doc, modified)
+                                    .await
+                                    .expect("the update to succeed"),
+                            );
+                        })
+                    },
+                    BatchSize::LargeInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+fn delete(c: &mut Criterion) {
+    let rt = common::owned_runtime();
+    let mut group = c.benchmark_group("document_delete");
+    let fields = 16;
+    group.throughput(Throughput::Elements(1));
+    group.bench_function("16", |b| {
+        b.iter_batched_ref(
+            || rt.block_on(seeded(fields)),
+            |(mutator, doc_id)| {
+                rt.block_on(async {
+                    black_box(
+                        mutator
+                            .delete(COLLECTION, doc_id)
+                            .await
+                            .expect("the delete to succeed"),
+                    );
+                })
+            },
+            BatchSize::LargeInput,
+        );
+    });
+    group.finish();
+}
+
+criterion_group!(benches, create, create_many, update, delete);
+criterion_main!(benches);

--- a/benches/benches/events.rs
+++ b/benches/benches/events.rs
@@ -1,0 +1,64 @@
+//! Event-bus publish fan-out.
+//!
+//! ```text
+//! cargo bench -p benches --bench events
+//! ```
+//!
+//! Every write publishes an update, and the publish walks every subscriber. So
+//! the cost that matters is not one publish but one publish against a
+//! subscriber count, and that curve is what decides whether a node with many
+//! open subscriptions pays for them on the write path. Nothing measured it.
+//!
+//! Also measured: a publish nobody is listening to, which is the common case
+//! on a server with no open subscriptions and should be close to free.
+
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use events::{Bus, ChannelBus, EventName, Message};
+
+const SUBSCRIBERS: [usize; 5] = [0, 1, 8, 64, 512];
+
+fn publish_fanout(c: &mut Criterion) {
+    let mut group = c.benchmark_group("events_publish");
+    for count in SUBSCRIBERS {
+        let bus = ChannelBus::new();
+        // Held for the whole measurement: a dropped subscription is a dead
+        // subscriber the bus sweeps, which would measure the sweep instead of
+        // the fan-out.
+        let subscriptions: Vec<_> = (0..count)
+            .map(|_| bus.subscribe(&[EventName::Merge]))
+            .collect();
+        assert_eq!(
+            bus.subscriber_count(),
+            count,
+            "every subscriber must be live"
+        );
+
+        group.throughput(Throughput::Elements(count.max(1) as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(count), &bus, |b, bus| {
+            b.iter(|| bus.publish(black_box(Message::merge())))
+        });
+        drop(subscriptions);
+    }
+    group.finish();
+}
+
+/// A subscriber that never drains fills its channel. What a publish costs once
+/// that has happened is the difference between a slow consumer degrading
+/// gracefully and one stalling every writer behind it.
+fn publish_to_a_full_subscriber(c: &mut Criterion) {
+    let bus = ChannelBus::new();
+    let _subscription = bus.subscribe(&[EventName::Merge]);
+    for _ in 0..100_000 {
+        bus.publish(Message::merge());
+    }
+    let mut group = c.benchmark_group("events_publish_backlogged");
+    group.bench_function("1_subscriber_not_draining", |b| {
+        b.iter(|| bus.publish(black_box(Message::merge())))
+    });
+    group.finish();
+}
+
+criterion_group!(benches, publish_fanout, publish_to_a_full_subscriber);
+criterion_main!(benches);

--- a/benches/benches/identity.rs
+++ b/benches/benches/identity.rs
@@ -1,0 +1,90 @@
+//! Minting and verifying the token on an authenticated request.
+//!
+//! ```text
+//! cargo bench -p benches --bench identity
+//! ```
+//!
+//! `from_token` runs on every authenticated HTTP request, so its cost is paid
+//! per request before any database work starts. It is signature verification,
+//! which means the curve the deployment picked decides the number, and nothing
+//! here compared them.
+
+use std::hint::black_box;
+use std::time::Duration;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use identity::RawIdentity;
+
+const AUDIENCE: &str = "defradb-bench";
+const TTL: Duration = Duration::from_secs(3600);
+
+/// One identity per curve the token path supports. BLS is deliberately absent:
+/// `new_token` rejects it, so there is no token to measure.
+fn identities() -> Vec<(&'static str, RawIdentity)> {
+    vec![
+        (
+            "ed25519",
+            RawIdentity::from_private_key(crypto::generate_ed25519().expect("a key"))
+                .expect("an identity"),
+        ),
+        (
+            "secp256k1",
+            RawIdentity::from_private_key(crypto::generate_secp256k1().expect("a key"))
+                .expect("an identity"),
+        ),
+        (
+            "secp256r1",
+            RawIdentity::from_private_key(crypto::generate_secp256r1().expect("a key"))
+                .expect("an identity"),
+        ),
+    ]
+}
+
+fn mint(c: &mut Criterion) {
+    let mut group = c.benchmark_group("identity_new_token");
+    for (curve, id) in identities() {
+        group.bench_with_input(BenchmarkId::from_parameter(curve), &id, |b, id| {
+            b.iter(|| {
+                black_box(
+                    identity::new_token(black_box(id), TTL, Some(AUDIENCE.to_string()), None)
+                        .expect("the token to mint"),
+                )
+            })
+        });
+    }
+    group.finish();
+}
+
+fn verify(c: &mut Criterion) {
+    let mut group = c.benchmark_group("identity_from_token");
+    for (curve, id) in identities() {
+        let token = identity::new_token(&id, TTL, Some(AUDIENCE.to_string()), None)
+            .expect("the token to mint");
+        group.bench_with_input(BenchmarkId::from_parameter(curve), &token, |b, token| {
+            b.iter(|| {
+                black_box(identity::from_token(black_box(token)).expect("the token to verify"))
+            })
+        });
+    }
+    group.finish();
+}
+
+/// The audience and expiry check that follows signature verification on every
+/// request, measured on its own so a regression in either is attributable.
+fn audience(c: &mut Criterion) {
+    let (_, id) = identities().remove(0);
+    let token =
+        identity::new_token(&id, TTL, Some(AUDIENCE.to_string()), None).expect("the token to mint");
+    let verified = identity::from_token(&token).expect("the token to verify");
+    let mut group = c.benchmark_group("identity_verify_auth_token");
+    group.bench_function("ed25519", |b| {
+        b.iter(|| {
+            identity::verify_auth_token(black_box(&verified), AUDIENCE)
+                .expect("the audience to match")
+        })
+    });
+    group.finish();
+}
+
+criterion_group!(benches, mint, verify, audience);
+criterion_main!(benches);

--- a/benches/benches/memory.rs
+++ b/benches/benches/memory.rs
@@ -1,0 +1,186 @@
+//! Peak resident memory, per store profile and per workload.
+//!
+//! ```text
+//! cargo bench -p benches --bench memory
+//! ```
+//!
+//! Every case runs in its own child process, and that is the whole design.
+//! Peak RSS is a process-wide high-water mark: it only ever rises, so a parent
+//! that ran the embedded profile after the server one would report the server
+//! profile's peak twice and call the second number "embedded". Re-executing
+//! this binary once per case is what makes each figure belong to the case it
+//! is labelled with.
+//!
+//! A `baseline` case does nothing but start, so the process floor can be
+//! subtracted from every other row rather than silently inflating it.
+//!
+//! Not a criterion target: peak memory is a high-water mark, not a rate, and
+//! a sampling loop would measure the loop.
+
+use std::process::Command;
+use std::sync::Arc;
+
+use db::DB;
+use defra_perf::emit::{Family, Group, Row};
+use defra_perf::measure::peak_rss_bytes;
+use document::{Document, NormalValue};
+use query::mutator::DocMutator;
+use query::DocFetcher;
+use schema::{CollectionVersion, FieldDescription, FieldKind};
+use storage::{RegolithStore, RegolithStoreOptions};
+use tempfile::TempDir;
+
+const CASE_VAR: &str = "DEFRA_MEMORY_CASE";
+const MARKER: &str = "DEFRA_PEAK_RSS_BYTES ";
+const COLLECTION: &str = "Users";
+const DOCS: usize = 1_000;
+
+const PROFILES: [&str; 3] = ["server", "embedded", "memory"];
+/// What each row's name means is said once in the family note rather than
+/// repeated into every row: a row name is a column heading, not a sentence.
+const WORKLOADS: [&str; 4] = ["baseline", "open", "seed", "scan"];
+
+fn options(profile: &str) -> RegolithStoreOptions {
+    match profile {
+        "embedded" => RegolithStoreOptions::embedded(),
+        _ => RegolithStoreOptions::new(),
+    }
+}
+
+fn collection_version() -> CollectionVersion {
+    CollectionVersion::new(
+        COLLECTION,
+        "bafkmemory",
+        "memory",
+        vec![
+            FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+            FieldDescription::new("2", "name", FieldKind::string()),
+            FieldDescription::new("3", "note", FieldKind::string()),
+        ],
+    )
+}
+
+async fn run_case(profile: &str, workload: &str) {
+    if workload == "baseline" {
+        return;
+    }
+    let dir = TempDir::new().expect("a scratch directory");
+    let store = Arc::new(if profile == "memory" {
+        RegolithStore::in_memory().expect("an in-memory store")
+    } else {
+        RegolithStore::open_with_options(dir.path().join("db"), options(profile))
+            .expect("a store on disk")
+    });
+    let db = Arc::new(DB::open_from_arc(store).await.expect("a database"));
+    if workload == "open" {
+        db.close().await.expect("a clean close");
+        return;
+    }
+
+    db.create_collection(collection_version())
+        .await
+        .expect("the collection to register");
+    let mutator = db::write::autocommit::AutoCommitMutator::new(db.clone());
+    for seq in 0..DOCS {
+        let mut doc = Document::new();
+        doc.set("name", NormalValue::String(format!("name-{seq}")));
+        doc.set("note", NormalValue::String(format!("note-{seq}")));
+        mutator
+            .create(COLLECTION, doc)
+            .await
+            .expect("the create to succeed");
+    }
+
+    if workload == "scan" {
+        let fetcher = db::AutoCommitFetcher::new(db.clone());
+        let docs = fetcher
+            .get_all(COLLECTION)
+            .await
+            .expect("the scan to succeed");
+        assert_eq!(docs.len(), DOCS, "the scan must see every document written");
+    }
+    db.close().await.expect("a clean close");
+}
+
+/// Re-execute this binary for one case and read back the peak it reached.
+///
+/// `None` when the child could not report one, which is drawn as a gap. A
+/// platform without `getrusage` is a platform this cannot measure, and saying
+/// so is the only honest answer.
+fn measure(profile: &str, workload: &str) -> Option<f64> {
+    let exe = std::env::current_exe().expect("this binary's own path");
+    let output = Command::new(exe)
+        .env(CASE_VAR, format!("{profile}/{workload}"))
+        .output()
+        .expect("to re-execute this binary");
+    if !output.status.success() {
+        eprintln!(
+            "memory: the {profile}/{workload} child exited {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+        return None;
+    }
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .find_map(|l| l.strip_prefix(MARKER))
+        .and_then(|v| v.trim().parse::<f64>().ok())
+}
+
+fn main() {
+    if let Ok(case) = std::env::var(CASE_VAR) {
+        let (profile, workload) = case.split_once('/').expect("a profile/workload case");
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("a runtime")
+            .block_on(run_case(profile, workload));
+        match peak_rss_bytes() {
+            Some(bytes) => println!("{MARKER}{bytes}"),
+            None => eprintln!("memory: peak RSS is not available on this platform"),
+        }
+        return;
+    }
+
+    let mut family = Family::new(
+        "Resident memory",
+        format!(
+            "Peak resident set size of a process that ran one workload and nothing else. Each \
+             row is its own child process, because peak RSS only ever rises and cases sharing a \
+             process would all report the largest of them. baseline is the process floor, to be \
+             subtracted from the rest; open is an empty database opened and closed; seed writes \
+             {DOCS} documents; scan writes them and reads every one back."
+        ),
+    )
+    // RSS for a given configuration does not depend on how busy the host was,
+    // so it stays comparable on a runner the load guard failed.
+    .deterministic();
+
+    let mut unmeasured = Vec::new();
+    for profile in PROFILES {
+        let mut group = Group::lower_better(format!("{profile} profile"), "B");
+        for workload in WORKLOADS {
+            match measure(profile, workload) {
+                Some(bytes) => group = group.row(Row::new(workload, bytes)),
+                None => unmeasured.push(format!("{profile}/{workload}")),
+            }
+        }
+        if !group.rows.is_empty() {
+            family = family.group(group);
+        }
+    }
+
+    if !unmeasured.is_empty() {
+        eprintln!(
+            "memory: {} case(s) reported no peak and are absent from the family: {}",
+            unmeasured.len(),
+            unmeasured.join(", ")
+        );
+    }
+    if family.groups.is_empty() {
+        eprintln!("memory: nothing could be measured on this platform");
+        family = family.trust(defra_perf::emit::Trust::Absent);
+    }
+    family.emit("memory");
+    println!("memory: recorded {} profile group(s)", PROFILES.len());
+}

--- a/benches/benches/p2p_codec.rs
+++ b/benches/benches/p2p_codec.rs
@@ -1,0 +1,116 @@
+//! The replication wire: what a pushed block costs to frame, sign and verify.
+//!
+//! ```text
+//! cargo bench -p benches --bench p2p_codec
+//! ```
+//!
+//! Every replicated document crosses this boundary twice, once serialized on
+//! the sender and once verified on the receiver, and none of it was measured.
+//! Signature verification in particular runs on every inbound message before
+//! any merge work begins, so it sets the floor on how fast a node can accept
+//! replication however fast the merge itself is.
+//!
+//! Swept by block size, because these are byte-rate operations and a figure
+//! quoted for a small block says nothing about a large one.
+
+use std::hint::black_box;
+
+use bytes::Bytes;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use p2p::message::{PushLogBroadcast, PushLogRequest};
+use p2p::{codec, sign_message, verify_message};
+
+const BLOCK_SIZES: [usize; 4] = [256, 4 * 1024, 64 * 1024, 512 * 1024];
+const CID_BYTES: [u8; 36] = [0x01; 36];
+
+fn request(block_size: usize) -> PushLogRequest {
+    PushLogRequest::new(
+        "bae-8a1f9c2d-4e5b-4c3a-9d7e-1f2a3b4c5d6e".into(),
+        Bytes::from_static(&CID_BYTES),
+        "collection-1".into(),
+        "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH".into(),
+        Bytes::from(
+            (0..block_size)
+                .map(|i| (i % 251) as u8)
+                .collect::<Vec<u8>>(),
+        ),
+    )
+}
+
+fn cbor(c: &mut Criterion) {
+    let mut group = c.benchmark_group("p2p_cbor");
+    for size in BLOCK_SIZES {
+        let message = request(size);
+        let encoded = codec::encode(&message).expect("the message to encode");
+        group.throughput(Throughput::Bytes(size as u64));
+        group.bench_with_input(BenchmarkId::new("encode", size), &message, |b, message| {
+            b.iter(|| black_box(codec::encode(black_box(message)).expect("encode")))
+        });
+        group.bench_with_input(BenchmarkId::new("decode", size), &encoded, |b, encoded| {
+            b.iter(|| {
+                black_box(codec::decode::<PushLogRequest>(black_box(encoded)).expect("decode"))
+            })
+        });
+    }
+    group.finish();
+}
+
+/// The gossip path frames the same request differently from the request path,
+/// so its cost is measured on its own rather than assumed equal.
+fn gossip(c: &mut Criterion) {
+    let mut group = c.benchmark_group("p2p_gossip");
+    for size in BLOCK_SIZES {
+        let broadcast = PushLogBroadcast::from_request(&request(size));
+        let payload = broadcast
+            .encode_gossip_payload()
+            .expect("the payload to encode");
+        group.throughput(Throughput::Bytes(size as u64));
+        group.bench_with_input(
+            BenchmarkId::new("encode", size),
+            &broadcast,
+            |b, broadcast| {
+                b.iter(|| {
+                    black_box(
+                        black_box(broadcast)
+                            .encode_gossip_payload()
+                            .expect("encode"),
+                    )
+                })
+            },
+        );
+        group.bench_with_input(BenchmarkId::new("decode", size), &payload, |b, payload| {
+            b.iter(|| {
+                black_box(
+                    PushLogBroadcast::decode_gossip_payload(black_box(payload)).expect("decode"),
+                )
+            })
+        });
+    }
+    group.finish();
+}
+
+/// What a node pays before it will look at an inbound block at all.
+fn authentication(c: &mut Criterion) {
+    let keypair = libp2p_identity::Keypair::generate_ed25519();
+    let mut group = c.benchmark_group("p2p_auth");
+    for size in BLOCK_SIZES {
+        let mut signed = request(size);
+        sign_message(&keypair, &mut signed).expect("the message to sign");
+
+        group.throughput(Throughput::Bytes(size as u64));
+        group.bench_with_input(BenchmarkId::new("sign", size), &size, |b, &size| {
+            b.iter_batched_ref(
+                || request(size),
+                |message| sign_message(&keypair, message).expect("sign"),
+                criterion::BatchSize::SmallInput,
+            )
+        });
+        group.bench_with_input(BenchmarkId::new("verify", size), &signed, |b, signed| {
+            b.iter(|| verify_message(black_box(signed)).expect("verify"))
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, cbor, gossip, authentication);
+criterion_main!(benches);

--- a/benches/benches/query_e2e.rs
+++ b/benches/benches/query_e2e.rs
@@ -1,0 +1,165 @@
+//! GraphQL execution end to end, over a real database.
+//!
+//! ```text
+//! cargo bench -p benches --bench query_e2e
+//! ```
+//!
+//! [`parsing`](../parsing.rs) times the parser and [`planner`](../planner.rs)
+//! times plan construction. [`transport`](../transport.rs) times the HTTP layer
+//! against a stub executor that does no database work at all. Between them, the
+//! thing a user actually waits for, a query running against documents on disk,
+//! was never measured.
+//!
+//! This drives `QueryRunner` over the real fetcher and the real store, so a row
+//! here is the whole cost: parse, plan, index selection, scan, filter, sort,
+//! aggregate and render. Parameterized by result-set size, because a query
+//! shape that is fine over ten documents is not automatically fine over ten
+//! thousand.
+//!
+//! Top-level aggregates are absent, and deliberately so rather than by
+//! oversight: `_count(User: {})` does not parse. `AggregateType::parse` in
+//! `crates/query/src/mapper/types.rs` matches `COUNT` and `AVG`, so the
+//! dispatch in `crates/query/src/query_parse/parser.rs` that would route a
+//! top-level aggregate never fires for `_count`, and the field falls through to
+//! the collection path where the collection name is rejected as an argument.
+//! Benchmarking a shape the engine rejects would measure its error path.
+
+use std::hint::black_box;
+use std::sync::Arc;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use db::DB;
+use document::{Document, NormalValue};
+use query::mutator::DocMutator;
+use query::{QueryExecutor, QueryRequest, QueryRunner};
+use schema::{CollectionVersion, FieldDescription, FieldKind};
+use storage::RegolithStore;
+
+mod common;
+
+const COLLECTION: &str = "User";
+const CORPUS: [usize; 3] = [100, 1_000, 5_000];
+
+fn collection_version() -> CollectionVersion {
+    CollectionVersion::new(
+        COLLECTION,
+        "bafkquerye2e",
+        "querye2e",
+        vec![
+            FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+            FieldDescription::new("2", "name", FieldKind::string()),
+            FieldDescription::new("3", "city", FieldKind::string()),
+            FieldDescription::new("4", "age", FieldKind::int()),
+        ],
+    )
+}
+
+/// A database holding `count` documents, and a runner over it.
+async fn fixture(count: usize) -> impl QueryExecutor {
+    let store = Arc::new(RegolithStore::in_memory().expect("an in-memory store"));
+    let db = Arc::new(DB::open_from_arc(store).await.expect("a database"));
+    db.create_collection(collection_version())
+        .await
+        .expect("the collection to register");
+
+    let mutator = Arc::new(db::write::autocommit::AutoCommitMutator::new(db.clone()));
+    // Ten cities and a spread of ages, so a filter selects a tenth of the
+    // corpus rather than all of it or none: a predicate nothing matches
+    // measures the scan and never the rest of the pipeline.
+    for seq in 0..count {
+        let mut doc = Document::new();
+        doc.set("name", NormalValue::String(format!("person-{seq}")));
+        doc.set("city", NormalValue::String(format!("city-{}", seq % 10)));
+        doc.set("age", NormalValue::Int((seq % 80) as i64 + 18));
+        mutator
+            .create(COLLECTION, doc)
+            .await
+            .expect("the seed create to succeed");
+    }
+
+    let fetcher = db::AutoCommitFetcher::new(db.clone());
+    QueryRunner::new(fetcher, vec![collection_version()])
+        .with_mutator(mutator as Arc<dyn DocMutator>)
+}
+
+/// Every shape a read-heavy application actually issues.
+const SHAPES: [(&str, &str); 6] = [
+    ("scan_all", "query { User { name city age } }"),
+    (
+        "filter_eq",
+        r#"query { User(filter: {city: {_eq: "city-3"}}) { name age } }"#,
+    ),
+    (
+        "filter_range",
+        "query { User(filter: {age: {_gt: 40, _lt: 60}}) { name age } }",
+    ),
+    (
+        "order_limit",
+        "query { User(order: {age: DESC}, limit: 20) { name age } }",
+    ),
+    (
+        "filter_order_limit",
+        r#"query { User(filter: {city: {_eq: "city-3"}}, order: {age: ASC}, limit: 10) { name age } }"#,
+    ),
+    (
+        "offset_page",
+        "query { User(limit: 20, offset: 200) { name age } }",
+    ),
+];
+
+fn shapes(c: &mut Criterion) {
+    let rt = common::owned_runtime();
+    let mut group = c.benchmark_group("query_e2e");
+    group.sample_size(20);
+
+    for count in CORPUS {
+        let runner = rt.block_on(fixture(count));
+        for (name, query) in SHAPES {
+            group.throughput(Throughput::Elements(count as u64));
+            group.bench_with_input(BenchmarkId::new(name, count), &query, |b, query| {
+                b.iter(|| {
+                    let response =
+                        rt.block_on(runner.execute(QueryRequest::new(black_box(*query))));
+                    // A query that errored did no work, and timing it would
+                    // report the error path as if it were the query.
+                    assert!(
+                        response.errors.is_empty(),
+                        "{name} failed: {:?}",
+                        response.errors
+                    );
+                    black_box(response)
+                })
+            });
+        }
+    }
+    group.finish();
+}
+
+/// A mutation through the same surface, so the write path is comparable with
+/// the read one at the level a user sees rather than at the mutator's.
+fn mutation(c: &mut Criterion) {
+    let rt = common::owned_runtime();
+    let runner = rt.block_on(fixture(100));
+    let mut group = c.benchmark_group("query_e2e_mutation");
+    group.sample_size(20);
+    let mut seq = 0usize;
+    group.bench_function("create", |b| {
+        b.iter(|| {
+            seq += 1;
+            let query = format!(
+                r#"mutation {{ create_User(input: {{name: "new-{seq}", city: "city-9", age: 33}}) {{ name }} }}"#
+            );
+            let response = rt.block_on(runner.execute(QueryRequest::new(query)));
+            assert!(
+                response.errors.is_empty(),
+                "create failed: {:?}",
+                response.errors
+            );
+            black_box(response)
+        })
+    });
+    group.finish();
+}
+
+criterion_group!(benches, shapes, mutation);
+criterion_main!(benches);

--- a/benches/benches/replication_filter.rs
+++ b/benches/benches/replication_filter.rs
@@ -1,0 +1,83 @@
+//! Validating a replicator's filter predicate.
+//!
+//! ```text
+//! cargo bench -p benches --bench replication_filter
+//! ```
+//!
+//! A filtered replicator checks its predicate against the collection's fields
+//! before it is accepted, and the check walks every condition against every
+//! field. Both grow with the schema, so the cost is swept over predicate width
+//! rather than quoted for one shape.
+
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use p2p::replicator::ReplicationFilter;
+use replication_filter::validate_replication_filter;
+use schema::{FieldDescription, FieldKind};
+
+const WIDTHS: [usize; 4] = [1, 4, 16, 64];
+const COLLECTION_ID: &str = "replfilter";
+
+/// Immutable scalar LWW fields, which are the only kind a replication filter
+/// may reference.
+fn fields(count: usize) -> Vec<FieldDescription> {
+    let mut fields = vec![FieldDescription::new("1", "_docID", FieldKind::doc_id())];
+    for i in 0..count {
+        let mut field = FieldDescription::new(
+            (i + 2).to_string(),
+            format!("field_{i}"),
+            FieldKind::string(),
+        );
+        field.immutable = true;
+        fields.push(field);
+    }
+    fields
+}
+
+fn predicate(width: usize) -> ReplicationFilter {
+    let mut map = serde_json::Map::new();
+    for i in 0..width {
+        map.insert(
+            format!("field_{i}"),
+            serde_json::json!({ "_eq": format!("value-{i}") }),
+        );
+    }
+    ReplicationFilter::Predicate(map)
+}
+
+fn validate(c: &mut Criterion) {
+    let mut group = c.benchmark_group("replication_filter");
+    for width in WIDTHS {
+        // The schema is always wider than the predicate, which is the shape a
+        // real collection has: the check has to find each referenced field.
+        let schema = fields(width.max(16));
+        let filter = predicate(width);
+        group.bench_with_input(BenchmarkId::new("accept", width), &filter, |b, filter| {
+            b.iter(|| {
+                validate_replication_filter(&schema, COLLECTION_ID, black_box(filter))
+                    .expect("the predicate to validate")
+            })
+        });
+    }
+
+    // Rejection is the untrusted-input path: a filter arrives from a peer's
+    // replicator registration and has to be refused, so its cost is real.
+    let schema = fields(16);
+    let unknown = ReplicationFilter::Predicate(
+        [("no_such_field".to_string(), serde_json::json!({"_eq": "x"}))]
+            .into_iter()
+            .collect(),
+    );
+    group.bench_function("reject_unknown_field", |b| {
+        b.iter(|| {
+            black_box(
+                validate_replication_filter(&schema, COLLECTION_ID, black_box(&unknown)).is_err(),
+            )
+        })
+    });
+    group.finish();
+}
+
+criterion_group!(benches, validate);
+criterion_main!(benches);

--- a/benches/benches/replication_filter.rs
+++ b/benches/benches/replication_filter.rs
@@ -71,9 +71,10 @@ fn validate(c: &mut Criterion) {
     );
     group.bench_function("reject_unknown_field", |b| {
         b.iter(|| {
-            black_box(
-                validate_replication_filter(&schema, COLLECTION_ID, black_box(&unknown)).is_err(),
-            )
+            let rejected =
+                validate_replication_filter(&schema, COLLECTION_ID, black_box(&unknown)).is_err();
+            assert!(rejected, "a predicate on an unknown field must be refused");
+            black_box(rejected)
         })
     });
     group.finish();

--- a/benches/benches/schema_validate.rs
+++ b/benches/benches/schema_validate.rs
@@ -1,0 +1,114 @@
+//! Schema and collection validation.
+//!
+//! ```text
+//! cargo bench -p benches --bench schema_validate
+//! ```
+//!
+//! Validation runs when a schema is added or patched, and again on every
+//! collection load at startup, so it sits on the path the cold-open curve in
+//! [`startup`](../startup.rs) measures. Both the whole-schema check and the
+//! per-collection one walk every field, so the cost is swept over width and
+//! over how many collections the schema holds.
+//!
+//! `field_by_name` is measured separately because it is a linear scan called
+//! once per field per document on the read path, where the width of the
+//! collection is the multiplier nobody had a number for.
+
+use std::collections::HashMap;
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use schema::{CollectionVersion, FieldDescription, FieldKind};
+
+const WIDTHS: [usize; 4] = [4, 16, 64, 256];
+const COUNTS: [usize; 4] = [1, 10, 100, 500];
+
+fn collection(index: usize, width: usize) -> CollectionVersion {
+    let mut fields = vec![FieldDescription::new("1", "_docID", FieldKind::doc_id())];
+    for i in 0..width {
+        fields.push(FieldDescription::new(
+            (i + 2).to_string(),
+            format!("field_{i}"),
+            if i % 3 == 0 {
+                FieldKind::int()
+            } else {
+                FieldKind::string()
+            },
+        ));
+    }
+    CollectionVersion::new(
+        format!("Collection{index}"),
+        format!("bafkschema{index:04}"),
+        format!("schema{index:04}"),
+        fields,
+    )
+}
+
+fn one_collection(c: &mut Criterion) {
+    let mut group = c.benchmark_group("schema_collection_validate");
+    for width in WIDTHS {
+        let version = collection(0, width);
+        group.throughput(Throughput::Elements(width as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(width),
+            &version,
+            |b, version| {
+                b.iter(|| {
+                    black_box(version)
+                        .validate()
+                        .expect("the collection to validate")
+                })
+            },
+        );
+    }
+    group.finish();
+}
+
+/// The whole-schema check, which is what a startup with many collections pays.
+fn whole_schema(c: &mut Criterion) {
+    let mut group = c.benchmark_group("schema_validate_all");
+    for count in COUNTS {
+        let collections: HashMap<String, CollectionVersion> = (0..count)
+            .map(|i| {
+                let version = collection(i, 16);
+                (version.name.clone(), version)
+            })
+            .collect();
+        group.throughput(Throughput::Elements(count as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(count),
+            &collections,
+            |b, collections| {
+                b.iter(|| {
+                    schema::validate_schema(black_box(collections)).expect("the schema to validate")
+                })
+            },
+        );
+    }
+    group.finish();
+}
+
+/// A linear scan over the field list, run once per field per document. The
+/// worst case is the field that is not there, because it walks the whole list
+/// before saying so.
+fn field_lookup(c: &mut Criterion) {
+    let mut group = c.benchmark_group("schema_field_by_name");
+    for width in WIDTHS {
+        let version = collection(0, width);
+        let last = format!("field_{}", width - 1);
+        group.bench_with_input(BenchmarkId::new("last", width), &version, |b, version| {
+            b.iter(|| black_box(black_box(version).field_by_name(black_box(&last))))
+        });
+        group.bench_with_input(
+            BenchmarkId::new("missing", width),
+            &version,
+            |b, version| {
+                b.iter(|| black_box(black_box(version).field_by_name(black_box("no_such_field"))))
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, one_collection, whole_schema, field_lookup);
+criterion_main!(benches);

--- a/benches/benches/startup.rs
+++ b/benches/benches/startup.rs
@@ -1,0 +1,186 @@
+//! What it costs to open a database, and what it leaves on disk.
+//!
+//! ```text
+//! cargo bench -p benches --bench startup
+//! ```
+//!
+//! Startup is the first thing a user feels and the last thing anything here
+//! measured. A cold open replays whatever the last process left behind and
+//! then loads every collection, so its cost grows with both, and neither
+//! growth was visible before this existed.
+//!
+//! Reported as two families because they answer to different things. Open
+//! times are wall clock and a busy host moves them; the footprint a database
+//! leaves on disk is a byte count that a busy host does not touch, so it stays
+//! comparable on a runner that was not quiet.
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Instant;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use db::DB;
+use defra_perf::emit::{Family, Group, Row};
+use defra_perf::measure::repeat;
+use document::{Document, NormalValue};
+use query::mutator::DocMutator;
+use schema::{CollectionVersion, FieldDescription, FieldKind};
+use storage::{RegolithStore, RegolithStoreOptions};
+use tempfile::TempDir;
+
+mod common;
+
+const COLLECTION_COUNTS: [usize; 4] = [0, 1, 10, 100];
+const SEEDED_DOCS: usize = 200;
+const REPS: usize = 7;
+
+/// A named store profile and the options it opens with.
+type Profile = (&'static str, fn() -> RegolithStoreOptions);
+
+/// The profiles a deployment actually runs under. There is one engine, so what
+/// varies is the memory budget it was opened with.
+fn profiles() -> Vec<Profile> {
+    vec![
+        ("server", RegolithStoreOptions::new as fn() -> _),
+        ("embedded", RegolithStoreOptions::embedded as fn() -> _),
+    ]
+}
+
+fn collection_version(index: usize) -> CollectionVersion {
+    let fields = vec![
+        FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+        FieldDescription::new("2", "name", FieldKind::string()),
+        FieldDescription::new("3", "note", FieldKind::string()),
+    ];
+    CollectionVersion::new(
+        format!("Collection{index}"),
+        format!("bafkstartup{index:04}"),
+        format!("startup{index:04}"),
+        fields,
+    )
+}
+
+/// Open a store at `path`, build a database over it, and register `count`
+/// collections. Returns how long the open itself took.
+async fn seed(path: &Path, options: RegolithStoreOptions, count: usize, docs: usize) {
+    let store = Arc::new(RegolithStore::open_with_options(path, options).expect("a store"));
+    let db = Arc::new(DB::open_from_arc(store).await.expect("a database"));
+    for index in 0..count {
+        db.create_collection(collection_version(index))
+            .await
+            .expect("the collection to register");
+    }
+    if count > 0 && docs > 0 {
+        let mutator = db::write::autocommit::AutoCommitMutator::new(db.clone());
+        let name = collection_version(0).name.clone();
+        for seq in 0..docs {
+            let mut doc = Document::new();
+            doc.set("name", NormalValue::String(format!("name-{seq}")));
+            doc.set("note", NormalValue::String(format!("note-{seq}")));
+            mutator
+                .create(&name, doc)
+                .await
+                .expect("the seed create to succeed");
+        }
+    }
+    db.close().await.expect("a clean close");
+}
+
+/// Wall time for a cold open of a database already on disk: the store's own
+/// recovery plus loading every collection.
+async fn cold_open_secs(path: &Path, options: RegolithStoreOptions) -> f64 {
+    let start = Instant::now();
+    let store = Arc::new(RegolithStore::open_with_options(path, options).expect("a store"));
+    // `open_from_arc`, not `from_arc`: the latter starts with an empty
+    // collection map and defers the load, so timing it would report a constant
+    // and call it a cold start.
+    let db = Arc::new(DB::open_from_arc(store).await.expect("a database"));
+    let elapsed = start.elapsed().as_secs_f64();
+    db.close().await.expect("a clean close");
+    elapsed
+}
+
+fn dir_bytes(path: &Path) -> u64 {
+    let Ok(entries) = std::fs::read_dir(path) else {
+        return 0;
+    };
+    entries
+        .filter_map(Result::ok)
+        .map(|entry| match entry.file_type() {
+            Ok(t) if t.is_dir() => dir_bytes(&entry.path()),
+            Ok(_) => entry.metadata().map(|m| m.len()).unwrap_or(0),
+            Err(_) => 0,
+        })
+        .sum()
+}
+
+/// The families the dashboard draws. Runs once, outside criterion's sampling,
+/// because an open is a one-shot cost and criterion measures a loop.
+fn report(rt: &tokio::runtime::Runtime) {
+    let mut open = Family::new(
+        "Startup",
+        format!(
+            "Cold open of a database already on disk: the store's recovery plus loading every \
+             collection. The largest collection carries {SEEDED_DOCS} documents, so the open \
+             replays real content rather than an empty log."
+        ),
+    );
+    let mut footprint = Family::new(
+        "Disk footprint",
+        format!(
+            "What a database occupies after {SEEDED_DOCS} documents, per store profile and \
+             collection count. Blocks, heads, indexes and the log, everything the directory \
+             holds."
+        ),
+    )
+    .deterministic();
+
+    for (profile, options) in profiles() {
+        let mut open_group = Group::lower_better(format!("cold open, {profile}"), "s")
+            .over("collections")
+            .note("Lower is better. The x axis is how many collections the open has to load.");
+        let mut size_group =
+            Group::lower_better(format!("on disk, {profile}"), "B").over("collections");
+
+        for count in COLLECTION_COUNTS {
+            let dir = TempDir::new().expect("a scratch directory");
+            let path = dir.path().join("db");
+            rt.block_on(seed(&path, options(), count, SEEDED_DOCS));
+
+            let row = repeat(format!("{count} collections"), REPS, || {
+                rt.block_on(cold_open_secs(&path, options()))
+            })
+            .at(count as f64);
+            open_group = open_group.row(row);
+            size_group = size_group.row(
+                Row::new(format!("{count} collections"), dir_bytes(&path) as f64).at(count as f64),
+            );
+        }
+        open = open.group(open_group);
+        footprint = footprint.group(size_group);
+    }
+
+    open.emit("startup");
+    footprint.emit("disk_footprint");
+}
+
+/// Criterion's own view of the same open, so the trend chart has a sampled
+/// series beside the one-shot numbers above.
+fn cold_open(c: &mut Criterion) {
+    let rt = common::owned_runtime();
+    report(&rt);
+
+    let mut group = c.benchmark_group("startup");
+    for (profile, options) in profiles() {
+        let dir = TempDir::new().expect("a scratch directory");
+        let path = dir.path().join("db");
+        rt.block_on(seed(&path, options(), 10, SEEDED_DOCS));
+        group.bench_function(format!("cold_open/{profile}/10_collections"), |b| {
+            b.iter(|| rt.block_on(cold_open_secs(&path, options())))
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, cold_open);
+criterion_main!(benches);

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -72,6 +72,9 @@ cid.workspace = true
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
+# The browser benchmark reports through the same contract the native suite
+# does, so the two describe a measurement identically.
+defra-perf = { path = "../../tools/perf" }
 
 [features]
 # The shipped browser artifact depends on this default. Building with

--- a/crates/wasm/tests/perf.rs
+++ b/crates/wasm/tests/perf.rs
@@ -1,0 +1,215 @@
+//! What DefraDB costs in a browser.
+//!
+//! ```text
+//! CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=wasm-bindgen-test-runner \
+//!   cargo test -p defra-wasm --target wasm32-unknown-unknown --release \
+//!   --test perf -- --nocapture
+//! ```
+//!
+//! The browser is a first-class target for this database, and every other
+//! number in the suite is a native one. Inferring browser cost from a native
+//! figure would be a guess presented as a measurement, so this measures it
+//! where it actually runs, under the same `wasm-bindgen-test` harness the WASM
+//! tests already use.
+//!
+//! The families here carry the same names, groups and rows as their native
+//! counterparts wherever the operation is genuinely the same one, which is what
+//! lets the dashboard line a browser figure up beside the Linux and macOS ones
+//! rather than showing three unrelated tables.
+//!
+//! A browser cannot write a file, so each family is printed behind a marker the
+//! workflow greps out of the log. `Family::record` builds that line, and the
+//! native emitter builds its own from the same function, so the two transports
+//! cannot drift apart.
+
+#![cfg(target_arch = "wasm32")]
+
+use std::sync::Arc;
+
+use db::DB;
+use defra_perf::emit::{Family, Group, Row, Trust};
+use document::{Document, NormalValue};
+use query::mutator::DocMutator;
+use query::DocFetcher;
+use schema::{CollectionVersion, FieldDescription, FieldKind};
+use storage::corekv::{Reader, Store, Writer};
+use storage::RegolithStore;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen]
+extern "C" {
+    /// `performance.now()`, a monotonic clock in fractional milliseconds.
+    /// `Date.now` is whole milliseconds and would round most of these to zero.
+    #[wasm_bindgen(js_namespace = performance, js_name = now)]
+    fn now() -> f64;
+}
+
+const COLLECTION: &str = "User";
+const FIELD_COUNTS: [usize; 3] = [4, 16, 64];
+const OPS: usize = 200;
+
+/// Print one family where the workflow can find it.
+fn report(family: &Family, name: &str) {
+    web_sys::console::log_1(&JsValue::from_str(&format!(
+        "DEFRA_BENCH_FAMILY {}",
+        family.record(name)
+    )));
+}
+
+/// Operations per second for `ops` operations that took `elapsed_ms`.
+fn ops_per_s(ops: usize, elapsed_ms: f64) -> f64 {
+    if elapsed_ms <= 0.0 {
+        return f64::NAN;
+    }
+    ops as f64 / (elapsed_ms / 1000.0)
+}
+
+fn field_names(count: usize) -> Vec<String> {
+    (0..count).map(|i| format!("field_{i}")).collect()
+}
+
+fn collection_version(field_count: usize) -> CollectionVersion {
+    let mut fields = vec![FieldDescription::new("1", "_docID", FieldKind::doc_id())];
+    for (index, name) in field_names(field_count).iter().enumerate() {
+        fields.push(FieldDescription::new(
+            (index + 2).to_string(),
+            name,
+            FieldKind::string(),
+        ));
+    }
+    CollectionVersion::new(COLLECTION, "bafkwasmperf", "wasmperf", fields)
+}
+
+fn document(field_count: usize, seq: usize) -> Document {
+    let mut doc = Document::new();
+    for name in field_names(field_count) {
+        doc.set(&name, NormalValue::String(format!("{name}-{seq}")));
+    }
+    doc
+}
+
+/// The same document operations the native suite measures, in a browser.
+///
+/// Group and row names match `document_ops` on every other platform on
+/// purpose: that is what puts a browser column beside the native ones instead
+/// of a separate table nothing lines up with.
+#[wasm_bindgen_test]
+async fn document_ops() {
+    let mut create = Group::higher_better("create", "ops/s").over("fields");
+    let mut read = Group::higher_better("read", "ops/s").over("fields");
+
+    for fields in FIELD_COUNTS {
+        let store = Arc::new(RegolithStore::in_memory().expect("an in-memory store"));
+        let db = Arc::new(DB::open_from_arc(store).await.expect("a database"));
+        db.create_collection(collection_version(fields))
+            .await
+            .expect("the collection to register");
+        let mutator = db::write::autocommit::AutoCommitMutator::new(db.clone());
+
+        let started = now();
+        let mut ids = Vec::with_capacity(OPS);
+        for seq in 0..OPS {
+            ids.push(
+                mutator
+                    .create(COLLECTION, document(fields, seq))
+                    .await
+                    .expect("the create to succeed")
+                    .doc_id
+                    .to_string(),
+            );
+        }
+        create = create.row(
+            Row::new(format!("{fields} fields"), ops_per_s(OPS, now() - started)).at(fields as f64),
+        );
+
+        let fetcher = db::AutoCommitFetcher::new(db.clone());
+        let started = now();
+        for id in &ids {
+            fetcher
+                .get_by_ids(COLLECTION, std::slice::from_ref(id))
+                .await
+                .expect("the read to succeed");
+        }
+        read = read.row(
+            Row::new(
+                format!("{fields} fields"),
+                ops_per_s(ids.len(), now() - started),
+            )
+            .at(fields as f64),
+        );
+    }
+
+    let family = Family::new(
+        "Document operations",
+        format!(
+            "Documents created and read back one at a time, {OPS} of each, through the same \
+             mutator and fetcher every platform uses. Measured with `performance.now()` in the \
+             browser and with a wall clock natively, so the two are the same operation counted \
+             the same way."
+        ),
+    )
+    .group(create)
+    .group(read);
+    report(&family, "document_ops");
+}
+
+/// The storage engine underneath, in the browser. Regolith is the same engine
+/// on every target, so this is where a browser-only cost would show up first.
+#[wasm_bindgen_test]
+async fn browser_storage() {
+    let store = RegolithStore::in_memory().expect("an in-memory store");
+    let value = vec![0xa5u8; 256];
+
+    let started = now();
+    let mut txn = store.new_txn(false).await.expect("a write transaction");
+    for seq in 0..OPS {
+        txn.set(format!("key{seq:08}").as_bytes(), &value)
+            .await
+            .expect("the write to succeed");
+    }
+    txn.commit().await.expect("the commit to succeed");
+    let write = ops_per_s(OPS, now() - started);
+
+    let started = now();
+    let txn = store.new_txn(true).await.expect("a read transaction");
+    for seq in 0..OPS {
+        let got = txn
+            .get(format!("key{seq:08}").as_bytes())
+            .await
+            .expect("the read to succeed");
+        assert!(got.is_some(), "every key written must be readable");
+    }
+    let read = ops_per_s(OPS, now() - started);
+
+    // A commit per write rather than one for all of them: the difference
+    // between the two is what batching is worth in a browser.
+    let started = now();
+    for seq in 0..OPS {
+        let mut txn = store.new_txn(false).await.expect("a write transaction");
+        txn.set(format!("solo{seq:08}").as_bytes(), &value)
+            .await
+            .expect("the write to succeed");
+        txn.commit().await.expect("the commit to succeed");
+    }
+    let per_commit = ops_per_s(OPS, now() - started);
+
+    let family = Family::new(
+        "Browser storage",
+        format!(
+            "The regolith key/value path in a browser tab: {OPS} operations of a 256 byte value. \
+             `batched write` puts every write in one transaction; `write per commit` opens and \
+             commits one per write, and the gap between them is what batching buys."
+        ),
+    )
+    .trust(Trust::Clean)
+    .group(
+        Group::higher_better("key/value", "ops/s")
+            .row(Row::new("batched write", write))
+            .row(Row::new("read", read))
+            .row(Row::new("write per commit", per_commit)),
+    );
+    report(&family, "browser_storage");
+}

--- a/crates/wasm/tests/perf.rs
+++ b/crates/wasm/tests/perf.rs
@@ -97,6 +97,7 @@ fn document(field_count: usize, seq: usize) -> Document {
 /// purpose: that is what puts a browser column beside the native ones instead
 /// of a separate table nothing lines up with.
 #[wasm_bindgen_test]
+#[allow(clippy::arc_with_non_send_sync)]
 async fn document_ops() {
     let mut create = Group::higher_better("create", "ops/s").over("fields");
     let mut read = Group::higher_better("read", "ops/s").over("fields");

--- a/justfile
+++ b/justfile
@@ -853,11 +853,15 @@ perf-compare baseline current threshold="5":
 
 # Serve the dashboard. It fetches its run documents, which a file:// page
 # cannot do in every browser.
+#
+# Loopback only. The default binds every interface, which would put a page
+# naming this machine's CPU, core count and memory on the local network while
+# printing a 127.0.0.1 URL.
 [doc("Serve the local performance dashboard on :8099.")]
 [group('misc')]
 perf-serve dir="perf-site" port="8099":
     @echo "http://127.0.0.1:{{ port }}/"
-    python3 -m http.server {{ port }} --directory {{ dir }}
+    python3 -m http.server {{ port }} --bind 127.0.0.1 --directory {{ dir }}
 
 # Remove build output. Leaves .tooling/ alone.
 [group('misc')]

--- a/justfile
+++ b/justfile
@@ -751,6 +751,114 @@ embedding-server *args:
 bench *args:
     cargo bench --workspace {{ args }}
 
+# ---------------------------------------------------------------------------
+# Performance site
+# ---------------------------------------------------------------------------
+#
+# The published dashboard reads run documents, not a rendered page: one run
+# answers "is this fast", the series answers "when did this change". These
+# recipes produce the same documents CI does, so a number can be reproduced
+# locally before it is argued about.
+
+# Measure this machine and build the dashboard over it in ./perf-site.
+# Point a browser at perf-site/index.html when it finishes.
+[doc("Run the bench suite and build the performance dashboard locally.")]
+[group('test')]
+perf *families:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    families="{{ families }}"
+    if [ -z "$families" ]; then
+        families="$(ls benches/benches/*.rs | xargs -n1 basename | sed 's/\.rs$//' | grep -v '^common$')"
+    fi
+    out="$PWD/perf-out.jsonl"
+    crit="$PWD/perf-criterion"
+    rm -rf "$out" "$crit"
+    python3 tools/perf-site/loadguard.py --out perf-loadguard.json >/dev/null
+    for f in $families; do
+        echo "==> $f"
+        # Criterion records only the group name, so each target's output is
+        # filed under the target before the next one overwrites it. That is
+        # what gives every bench its own section on the page.
+        rm -rf target/criterion
+        DEFRA_BENCH_OUT="$out" cargo bench -p benches --bench "$f" || {
+            echo "perf: $f failed; its family will be absent" >&2
+        }
+        if [ -d target/criterion ]; then
+            mkdir -p "$crit/$f"
+            cp -R target/criterion/. "$crit/$f/"
+        fi
+    done
+    touch "$out"
+    commit="$(git rev-parse HEAD)"
+    rm -f "perf-platform.json"
+    DEFRA_BENCH_OUT="$out" cargo run -p defra-perf --bin collect -- \
+        --criterion-root "$crit" \
+        --out perf-platform.json --commit "$commit" \
+        --label "$(git rev-parse --abbrev-ref HEAD)" \
+        --target "$(rustc -vV | awk '/^host:/{print $2}')" \
+        --loadguard perf-loadguard.json
+    mkdir -p perf-site
+    cp tools/perf-site/index.html perf-site/index.html
+    python3 tools/perf-site/publish.py --site perf-site perf-platform.json
+    just perf-check
+    echo
+    echo "dashboard: file://$PWD/perf-site/index.html"
+
+# A bench target nobody runs measures nothing. This is the only thing standing
+# between adding a benchmark and it silently never appearing on the dashboard.
+[doc("Fail if a registered bench target is missing from the performance workflow.")]
+[group('check')]
+perf-matrix:
+    #!/usr/bin/env python3
+    import pathlib, re, sys
+    try:
+        import yaml
+    except ImportError:
+        sys.exit("perf-matrix: pyyaml is needed to read the workflow")
+    targets = set(re.findall(r'\[\[bench\]\]\nname = "([^"]+)"',
+                             pathlib.Path("benches/Cargo.toml").read_text()))
+    workflow = yaml.safe_load(open(".github/workflows/perf.yml"))
+    jobs = workflow["jobs"]
+    linux = {row["family"] for row in jobs["bench"]["strategy"]["matrix"]["include"]
+             if row["target"] == "x86_64-unknown-linux-gnu"}
+    quick = set(jobs["quick"]["env"]["QUICK_FAMILIES"].split())
+    problems = []
+    for name in sorted(targets - linux):
+        problems.append(f"  {name} is a bench target but the workflow never runs it")
+    for name in sorted(linux - targets):
+        problems.append(f"  {name} is in the workflow matrix but is not a bench target")
+    for name in sorted(quick - targets):
+        problems.append(f"  {name} is in QUICK_FAMILIES but is not a bench target")
+    if problems:
+        print("performance matrix is out of step with the bench targets:", file=sys.stderr)
+        print("\n".join(problems), file=sys.stderr)
+        sys.exit(1)
+    print(f"performance matrix: {len(targets)} bench target(s), all measured; "
+          f"{len(quick)} of them on every pull request")
+
+# Refuse a dashboard that would drop a family it collected. A blank section is
+# not an error to a browser, so nothing else catches this.
+[doc("Check the dashboard renders every family the run documents carry.")]
+[group('check')]
+perf-check dir="perf-site":
+    node tools/perf-site/render_check.mjs {{ dir }}
+
+# What changed against the newest run already on file.
+[doc("Compare two run documents with the noise rules CI uses.")]
+[group('test')]
+perf-compare baseline current threshold="5":
+    python3 tools/perf-site/compare.py --baseline {{ baseline }} \
+        --current {{ current }} --threshold {{ threshold }}
+
+# Serve the dashboard. It fetches its run documents, which a file:// page
+# cannot do in every browser.
+[doc("Serve the local performance dashboard on :8099.")]
+[group('misc')]
+perf-serve dir="perf-site" port="8099":
+    @echo "http://127.0.0.1:{{ port }}/"
+    python3 -m http.server {{ port }} --directory {{ dir }}
+
 # Remove build output. Leaves .tooling/ alone.
 [group('misc')]
 clean:

--- a/justfile
+++ b/justfile
@@ -818,11 +818,13 @@ perf-matrix:
         sys.exit("perf-matrix: pyyaml is needed to read the workflow")
     targets = set(re.findall(r'\[\[bench\]\]\nname = "([^"]+)"',
                              pathlib.Path("benches/Cargo.toml").read_text()))
-    workflow = yaml.safe_load(open(".github/workflows/perf.yml"))
-    jobs = workflow["jobs"]
-    linux = {row["family"] for row in jobs["bench"]["strategy"]["matrix"]["include"]
+    full = yaml.safe_load(open(".github/workflows/perf.yml"))
+    linux = {row["family"] for row in full["jobs"]["bench"]["strategy"]["matrix"]["include"]
              if row["target"] == "x86_64-unknown-linux-gnu"}
-    quick = set(jobs["quick"]["env"]["QUICK_FAMILIES"].split())
+    # The pull-request path is its own workflow: a skipped matrix job renders
+    # its matrix unexpanded, so the forty-job sweep is kept off a PR entirely.
+    pr = yaml.safe_load(open(".github/workflows/perf-pr.yml"))
+    quick = set(pr["jobs"]["quick"]["env"]["QUICK_FAMILIES"].split())
     problems = []
     for name in sorted(targets - linux):
         problems.append(f"  {name} is a bench target but the workflow never runs it")

--- a/tools/perf-site/artifact_sizes.py
+++ b/tools/perf-site/artifact_sizes.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Emit what each shipped artifact weighs, as one family record.
+
+Size is not a benchmark. It is read off an artifact that has already been
+built, and a bench process cannot build a release CLI or a wasm bundle without
+becoming a build script. So this runs where the artifacts are produced and
+writes the same family record a bench would, which is what puts it on the
+dashboard beside everything else.
+
+Every artifact is named on the command line as ``label=path``. An artifact that
+is missing is reported as missing and contributes no row: a shipped binary that
+failed to build must not be drawn as a zero-byte one.
+
+The wasm bundle is additionally reported compressed, because that is what a
+browser downloads and the raw number is not the one a user waits for. gzip is
+computed in-process; brotli is used only when the interpreter has it, and its
+absence is stated rather than passed over.
+"""
+
+import argparse
+import gzip
+import json
+import pathlib
+import sys
+
+try:
+    import brotli  # type: ignore
+except ImportError:
+    brotli = None
+
+
+def rows_for(label, path):
+    data = path.read_bytes()
+    rows = [{"name": f"{label}, raw", "value": len(data)}]
+    # Only the browser bundle travels compressed. Reporting a gzip size for a
+    # binary nobody serves over HTTP would be a number without a question.
+    if path.suffix == ".wasm":
+        rows.append(
+            {"name": f"{label}, gzip", "value": len(gzip.compress(data, compresslevel=9))}
+        )
+        if brotli is not None:
+            rows.append(
+                {
+                    "name": f"{label}, brotli",
+                    "value": len(brotli.compress(data, quality=11)),
+                }
+            )
+    return rows
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "artifacts",
+        nargs="+",
+        metavar="LABEL=PATH",
+        help="an artifact to weigh, e.g. defra=target/release/defra",
+    )
+    ap.add_argument("--out", required=True, help="append the family record here")
+    args = ap.parse_args()
+
+    rows, missing = [], []
+    for spec in args.artifacts:
+        if "=" not in spec:
+            print(f"artifact-sizes: {spec!r} is not LABEL=PATH", file=sys.stderr)
+            return 2
+        label, _, raw = spec.partition("=")
+        path = pathlib.Path(raw)
+        if not path.is_file():
+            missing.append(f"{label} ({raw})")
+            continue
+        rows.extend(rows_for(label, path))
+
+    note = (
+        "What each shipped artifact weighs. The browser bundle is also reported "
+        "compressed, because that is what a browser downloads."
+    )
+    if brotli is None:
+        note += " Brotli was not available on this runner, so only gzip is reported."
+    if missing:
+        note += (
+            " Not built on this runner, so not weighed: " + ", ".join(sorted(missing)) + "."
+        )
+    if not rows:
+        print(
+            "artifact-sizes: none of the named artifacts exist, so there is nothing "
+            "to weigh. Writing the family as absent rather than as zero.",
+            file=sys.stderr,
+        )
+
+    family = {
+        "title": "Artifact size",
+        "note": note,
+        # A byte count does not move because a runner was busy.
+        "trust": "clean" if rows else "absent",
+        "deterministic": True,
+        "groups": (
+            [
+                {
+                    "name": "Shipped artifacts",
+                    "unit": "B",
+                    "lower_is_better": True,
+                    "rows": rows,
+                }
+            ]
+            if rows
+            else []
+        ),
+    }
+    with open(args.out, "a") as f:
+        f.write(json.dumps({"family": "artifact_size", "data": family}) + "\n")
+    print(f"artifact-sizes: {len(rows)} row(s) recorded, {len(missing)} artifact(s) missing")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/perf-site/compare.py
+++ b/tools/perf-site/compare.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Compare two run documents and decide what actually regressed.
+
+The hard part is not computing a percentage, it is refusing to report one that
+means nothing. A run recorded while the host was busy can shift a figure by a
+quarter with no code change, so a comparison that treats every delta as signal
+produces alerts nobody trusts, and an alert nobody trusts is worse than none.
+
+Three rules keep a verdict honest:
+
+* **Both sides must be trusted.** If either run marked a family
+  ``contaminated`` or ``absent``, the comparison is reported as ``unverified``
+  and never as a pass or a regression.
+* **Ranges must separate.** A row carries the ``min`` and ``max`` seen across
+  repetitions. A delta counts only when the two ranges do not overlap: if the
+  new ``max`` still reaches the old ``min``, the runs did not measure a
+  difference, whatever their medians say. A row without a range skips this
+  test, which is correct for a deterministic count and is why a bench that
+  repeats a timing should always report one.
+* **A floor on top of that.** Non-overlapping ranges can still be a fraction of
+  a percent apart. A change under ``--threshold`` is noise regardless.
+
+Comparisons are per platform. A metric measured on Linux is not a baseline for
+the same metric measured in a browser, and pretending otherwise would produce a
+regression report on every run.
+"""
+
+import argparse
+import json
+import pathlib
+import sys
+
+PASS, REGRESSED, IMPROVED, NOISE, UNVERIFIED = (
+    "pass",
+    "regressed",
+    "improved",
+    "noise",
+    "unverified",
+)
+TRUSTED = "clean"
+
+
+def rows_of(doc, platform):
+    """Every comparable row on one platform, keyed the way the dashboard keys
+    them, carrying everything a verdict needs."""
+    out = {}
+    families = ((doc.get("platforms") or {}).get(platform) or {}).get("families") or {}
+    for fname, fam in families.items():
+        trust = (fam or {}).get("trust", "absent")
+        for group in (fam or {}).get("groups") or []:
+            unit = group.get("unit", "")
+            lower = bool(group.get("lower_is_better"))
+            for row in group.get("rows") or []:
+                value = row.get("value")
+                if not isinstance(value, (int, float)):
+                    continue
+                key = f"{fname}/{group.get('name')}/{row.get('name')}"
+                out[key] = {
+                    "value": float(value),
+                    "min": row.get("min"),
+                    "max": row.get("max"),
+                    "unit": unit,
+                    "lower": lower,
+                    "trust": trust,
+                    "family": fname,
+                }
+    return out
+
+
+def classify(before, after, threshold):
+    """Verdict, percentage and reason for one pair of measurements."""
+    if before["trust"] != TRUSTED:
+        return UNVERIFIED, None, f"the baseline's {before['family']} is {before['trust']}"
+    if after["trust"] != TRUSTED:
+        return UNVERIFIED, None, f"this run's {after['family']} is {after['trust']}"
+    if before["value"] == 0:
+        return UNVERIFIED, None, "the baseline measured zero, so there is no ratio to take"
+
+    pct = (after["value"] - before["value"]) / abs(before["value"]) * 100.0
+    if before["lower"]:
+        pct = -pct
+
+    if abs(pct) < threshold:
+        return NOISE, pct, f"within the {threshold:g}% threshold"
+
+    have_ranges = all(
+        isinstance(side[k], (int, float)) for side in (before, after) for k in ("min", "max")
+    )
+    if have_ranges and not (after["max"] < before["min"] or after["min"] > before["max"]):
+        return (
+            NOISE,
+            pct,
+            "the two runs' measured ranges overlap, so they did not measure a difference",
+        )
+
+    return (REGRESSED if pct < 0 else IMPROVED), pct, ""
+
+
+def compare(base, cur, threshold):
+    platforms = sorted(
+        set((base.get("platforms") or {})) & set((cur.get("platforms") or {}))
+    )
+    only_cur = sorted(set(cur.get("platforms") or {}) - set(base.get("platforms") or {}))
+    deltas = []
+    for platform in platforms:
+        b, c = rows_of(base, platform), rows_of(cur, platform)
+        for key in sorted(set(b) | set(c)):
+            if key not in b or key not in c:
+                deltas.append(
+                    {
+                        "platform": platform,
+                        "key": key,
+                        "verdict": UNVERIFIED,
+                        "pct": None,
+                        "reason": "only one of the two runs measured this",
+                        "before": (b.get(key) or {}).get("value"),
+                        "after": (c.get(key) or {}).get("value"),
+                        "unit": (b.get(key) or c.get(key) or {}).get("unit", ""),
+                    }
+                )
+                continue
+            verdict, pct, reason = classify(b[key], c[key], threshold)
+            deltas.append(
+                {
+                    "platform": platform,
+                    "key": key,
+                    "verdict": verdict,
+                    "pct": pct,
+                    "reason": reason,
+                    "before": b[key]["value"],
+                    "after": c[key]["value"],
+                    "unit": c[key]["unit"],
+                }
+            )
+    return deltas, platforms, only_cur
+
+
+def fmt(v, unit):
+    if not isinstance(v, (int, float)):
+        return "n/a"
+    if unit in ("B", "bytes"):
+        for limit, suffix in ((1 << 30, "GiB"), (1 << 20, "MiB"), (1024, "KiB")):
+            if abs(v) >= limit:
+                return f"{v / limit:.2f} {suffix}"
+        return f"{v:.0f} B"
+    a = abs(v)
+    if a >= 1e6:
+        return f"{v / 1e6:.2f}M"
+    if a >= 1e4:
+        return f"{v / 1e3:.1f}k"
+    if a >= 1:
+        return f"{v:,.2f}".rstrip("0").rstrip(".")
+    if a == 0:
+        return "0"
+    # Two decimals turn every sub-second timing into "0.01", which is the same
+    # string for a value and the value it regressed from. Significant figures
+    # keep the two distinguishable.
+    return f"{v:.4g}"
+
+
+def markdown(deltas, platforms, only_cur, base, cur, threshold, note=""):
+    regressed = [d for d in deltas if d["verdict"] == REGRESSED]
+    improved = [d for d in deltas if d["verdict"] == IMPROVED]
+    unverified = [d for d in deltas if d["verdict"] == UNVERIFIED]
+    compared = [d for d in deltas if d["verdict"] != UNVERIFIED]
+
+    out = ["## Performance", ""]
+    out.append(
+        f"`{(cur.get('commit') or '')[:12]}` ({cur.get('label') or 'this run'}) "
+        f"against `{(base.get('commit') or '')[:12]}` ({base.get('label') or 'baseline'}), "
+        f"threshold {threshold:g}%."
+    )
+    if note:
+        out.append("")
+        out.append(note)
+    out.append("")
+    if not platforms:
+        out.append(
+            "The two runs share no platform, so nothing was compared. This is a gap in "
+            "collection, not a result."
+        )
+        return "\n".join(out)
+    out.append(f"Platforms compared: {', '.join(f'`{p}`' for p in platforms)}.")
+    if only_cur:
+        out.append(
+            f"Measured only in this run, so not compared: {', '.join(f'`{p}`' for p in only_cur)}."
+        )
+    out.append("")
+
+    def table(title, rows):
+        if not rows:
+            return []
+        body = [f"### {title}", "", "| platform | metric | baseline | this run | change |", "|---|---|---:|---:|---:|"]
+        for d in sorted(rows, key=lambda r: abs(r["pct"] or 0), reverse=True):
+            body.append(
+                f"| `{d['platform']}` | {d['key']} | {fmt(d['before'], d['unit'])} | "
+                f"{fmt(d['after'], d['unit'])} | {d['pct']:+.1f}% |"
+            )
+        body.append("")
+        return body
+
+    out += table(f"Regressed ({len(regressed)})", regressed)
+    out += table(f"Improved ({len(improved)})", improved)
+
+    out.append(
+        f"{len(compared)} metric(s) compared, {len(unverified)} not comparable."
+    )
+    if unverified:
+        reasons = {}
+        for d in unverified:
+            reasons[d["reason"]] = reasons.get(d["reason"], 0) + 1
+        out.append("")
+        out.append("Not compared, and why:")
+        for reason, n in sorted(reasons.items(), key=lambda kv: -kv[1]):
+            out.append(f"- {n} × {reason}")
+    out.append("")
+    if regressed:
+        out.append(f"**Verdict: regressed** on {len(regressed)} metric(s).")
+    elif not compared:
+        out.append(
+            "**Verdict: unverified.** Nothing was comparable between these two runs, so this "
+            "is not a pass."
+        )
+    else:
+        out.append("**Verdict: no regression.**")
+    return "\n".join(out)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--baseline", required=True)
+    ap.add_argument("--current", required=True)
+    ap.add_argument(
+        "--threshold",
+        type=float,
+        default=5.0,
+        help="percent change below which a delta is noise (default 5)",
+    )
+    ap.add_argument("--markdown", help="write the report here as well as to stdout")
+    ap.add_argument(
+        "--note",
+        default="",
+        help="what this comparison did and did not measure, printed with the report",
+    )
+    ap.add_argument("--fail-on-regression", action="store_true")
+    args = ap.parse_args()
+
+    base = json.loads(pathlib.Path(args.baseline).read_text())
+    cur = json.loads(pathlib.Path(args.current).read_text())
+    deltas, platforms, only_cur = compare(base, cur, args.threshold)
+    report = markdown(deltas, platforms, only_cur, base, cur, args.threshold, args.note)
+    print(report)
+    if args.markdown:
+        pathlib.Path(args.markdown).write_text(report + "\n")
+
+    regressed = [d for d in deltas if d["verdict"] == REGRESSED]
+    if args.fail_on_regression and regressed:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/perf-site/index.html
+++ b/tools/perf-site/index.html
@@ -324,11 +324,18 @@ function heading(name,trust){
 ///
 /// The suite reports one family per bench target, so a run carries dozens of
 /// sections and scrolling past all of them to reach one is the whole cost of
-/// having measured everything. The index is the page's table of contents, and
-/// it names what is actually in this run rather than a fixed list.
-function sectionIndex(names){
-  if(names.length<3)return "";
-  const links=names.map(n=>`<a class="jump" href="#s-${esc(slug(n))}">${esc(n)}</a>`).join("");
+/// having measured everything.
+///
+/// Built by reading back the headings the page just produced, not from the list
+/// it expected to produce. A section can decline to draw at all: the
+/// cross-platform one renders nothing when a run has a single platform, and the
+/// trend renders nothing when no metric has a series. Predicting the list gave
+/// those a link to an anchor that was not on the page.
+function sectionIndex(html){
+  const seen=[...html.matchAll(/<h2 id="(s-[^"]+)"><span class="h2-name">([^<]*)<\/span>/g)]
+    .map(m=>({id:m[1],name:m[2]}));
+  if(seen.length<3)return "";
+  const links=seen.map(s=>`<a class="jump" href="#${esc(s.id)}">${esc(s.name)}</a>`).join("");
   return `<nav class="index" aria-label="Sections">${links}</nav>`;
 }
 
@@ -613,15 +620,13 @@ function draw(){
   const th=parseFloat($("#thresh").value);
   const fams=familiesOf(cur,platform);
   const baseFams=base?familiesOf(base,platform):{};
-  const ordered=Object.keys(fams).sort();
-  const titles=ordered.map(f=>fams[f]?.title||f);
-  let html=section("Overview",()=>overview(cur,base,platform,th));
-  html+=sectionIndex(["Overview",...titles,"Across platforms","Trend across every recorded run"]);
-  for(const fname of ordered)
-    html+=section(fams[fname]?.title||fname,()=>familySection(fname,fams[fname],baseFams[fname],th));
-  html+=section("Across platforms",()=>platformSection(cur,th));
-  html+=section("Trend",()=>trendSection(RUNS,platform,th));
-  $("#main").innerHTML=html;
+  const head=section("Overview",()=>overview(cur,base,platform,th));
+  let rest="";
+  for(const fname of Object.keys(fams).sort())
+    rest+=section(fams[fname]?.title||fname,()=>familySection(fname,fams[fname],baseFams[fname],th));
+  rest+=section("Across platforms",()=>platformSection(cur,th));
+  rest+=section("Trend",()=>trendSection(RUNS,platform,th));
+  $("#main").innerHTML=head+sectionIndex(head+rest)+rest;
   const tm=$("#trendmetric");
   if(tm)tm.addEventListener("change",e=>{TREND_METRIC=e.target.value;draw();});
 }

--- a/tools/perf-site/index.html
+++ b/tools/perf-site/index.html
@@ -1,0 +1,667 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>DefraDB Rust Performance</title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+:root{
+  --bg:#04080c; --panel:#0a1119; --panel-2:#0e1922; --line:#16242f; --line-2:#22323f;
+  --ink:#e6eef5; --mute:#7b8d9c;
+  --blue:#10CBFF; --blue-dim:#0b7fa6; --blue-soft:#08222d;
+  --bad:#ff5f52; --warn:#f0a93b;
+  --pad:26px;
+}
+*{box-sizing:border-box}
+html,body{margin:0;padding:0;background:var(--bg);color:var(--ink)}
+body{font-family:Inter,system-ui,-apple-system,sans-serif;font-size:15px;line-height:1.45;
+  -webkit-font-smoothing:antialiased}
+code,.mono,td.num,td.val,select{font-family:"JetBrains Mono",ui-monospace,monospace;font-variant-numeric:tabular-nums}
+a{color:var(--blue)}
+header{padding:20px var(--pad);border-bottom:1px solid var(--line);display:flex;flex-wrap:wrap;
+  gap:16px;align-items:center;background:linear-gradient(180deg,#071119 0%,var(--bg) 100%)}
+.brand{display:flex;align-items:center;gap:11px;min-width:0}
+.brand .logo{height:26px;width:auto;flex:none}
+h1{font-size:18px;font-weight:600;margin:0;letter-spacing:-.01em;color:var(--mute)}
+h2{font-size:12px;font-weight:600;margin:30px var(--pad) 12px;letter-spacing:.09em;
+  text-transform:uppercase;color:var(--mute);display:flex;flex-wrap:wrap;align-items:center;gap:8px}
+/* The title is its own element so it can wrap: an anonymous flex item beside a
+   growing rule cannot, and a long family name then ran off a narrow screen. */
+h2 .h2-name{min-width:0;overflow-wrap:break-word}
+h2 .rule{flex:1 1 40px;height:1px;background:var(--line);min-width:24px}
+main{padding-bottom:70px}
+.controls{margin-left:auto;display:flex;gap:10px;flex-wrap:wrap;align-items:flex-end}
+.controls > div{display:flex;flex-direction:column;min-width:0}
+label{font-size:11px;color:var(--mute);margin-bottom:4px;letter-spacing:.03em}
+select{background:var(--panel-2);color:var(--ink);border:1px solid var(--line-2);border-radius:7px;
+  padding:6px 9px;font-size:12px;width:186px;max-width:100%;min-width:0}
+select:focus-visible{outline:2px solid var(--blue-dim);outline-offset:1px;border-color:var(--blue-dim)}
+/* min() keeps the track from staying wider than the content box on a narrow
+   screen, which is what made the page itself scroll sideways. */
+.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(min(360px,100%),1fr));gap:14px;
+  padding:0 var(--pad);align-items:start}
+.grid.wide{grid-template-columns:minmax(0,1fr)}
+.card{background:var(--panel);border:1px solid var(--line);border-radius:11px;padding:16px;
+  cursor:zoom-in;position:relative;min-width:0}
+.card:hover{border-color:var(--line-2)}
+.card .scroll{max-height:48vh;overflow:auto;-webkit-overflow-scrolling:touch}
+.card::after{content:"expand";position:absolute;top:13px;right:15px;font-size:9px;
+  letter-spacing:.08em;text-transform:uppercase;color:var(--mute);opacity:0;transition:opacity .12s}
+.card:hover::after{opacity:.7}
+.card.zoomed{position:fixed;inset:18px;z-index:50;overflow:auto;cursor:zoom-out;
+  box-shadow:0 24px 90px rgba(0,0,0,.8)}
+.card.zoomed .scroll{max-height:none}
+.card.zoomed::after{content:"close  esc";opacity:.7}
+.zoom-backdrop{position:fixed;inset:0;background:rgba(2,5,8,.8);z-index:40}
+.card.broken{border-color:#43241f}
+.card.broken .note{color:var(--bad)}
+/* Room for the corner label, so it never sits on the title. */
+.card h3{margin:0 0 4px;font-size:14px;font-weight:600;padding-right:74px;overflow-wrap:break-word}
+.note{margin:0 0 12px;font-size:12px;color:var(--mute);line-height:1.45;overflow-wrap:break-word}
+.headline{font-size:27px;font-weight:600;letter-spacing:-.02em;margin:4px 0 12px;color:var(--blue)}
+.headline small{font-size:12px;font-weight:400;color:var(--mute);letter-spacing:0}
+table{width:100%;border-collapse:collapse;font-size:12.5px}
+th{text-align:left;font-size:10px;text-transform:uppercase;letter-spacing:.07em;color:var(--mute);
+  font-weight:500;padding:6px 8px;border-bottom:1px solid var(--line);white-space:nowrap}
+td{padding:6px 8px;border-bottom:1px solid var(--line);overflow-wrap:break-word}
+td.num{text-align:right;white-space:nowrap;overflow-wrap:normal}
+td.val{text-align:right;overflow-wrap:break-word}
+tr:last-child td{border-bottom:none}
+.up{color:var(--blue)} .down{color:var(--bad)} .flat{color:var(--mute)}
+.pill{display:inline-block;font-size:10px;padding:2px 7px;border-radius:99px;
+  vertical-align:middle;border:1px solid var(--line-2);color:var(--mute);text-transform:uppercase;
+  letter-spacing:.06em;font-weight:500;white-space:nowrap}
+h3 .pill{margin-left:8px}
+.pill.clean{color:var(--blue);border-color:#0d4257;background:var(--blue-soft)}
+.pill.contaminated{color:var(--warn);border-color:#43350f}
+.pill.absent{color:var(--mute)}
+.barcell{width:26%}
+.range{font-family:"JetBrains Mono",ui-monospace,monospace;color:var(--mute);font-size:10px}
+.bar{height:8px;border-radius:99px;background:#0d1720;overflow:hidden;min-width:40px}
+.bar i{display:block;height:100%;background:var(--blue-dim)}
+.bar i.regress{background:var(--bad)}
+.scroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
+.empty{padding:30px var(--pad);color:var(--mute);font-size:13px}
+svg.chart{display:block;width:100%;height:auto;overflow:visible}
+.legend{display:flex;gap:14px;flex-wrap:wrap;font-size:10.5px;color:var(--mute);margin-top:8px}
+.legend b{display:inline-block;width:9px;height:9px;border-radius:2px;margin-right:5px;vertical-align:middle}
+.tag{display:inline-block;font-size:10px;color:var(--mute);border:1px solid var(--line-2);
+  border-radius:5px;padding:1px 6px;margin:0 5px 4px 0}
+.index{display:flex;flex-wrap:wrap;gap:6px;padding:18px var(--pad) 0}
+.jump{font-size:11px;color:var(--mute);text-decoration:none;border:1px solid var(--line);
+  border-radius:6px;padding:3px 8px;background:var(--panel);white-space:nowrap}
+.jump:hover{color:var(--blue);border-color:var(--blue-dim)}
+.jump:focus-visible{outline:2px solid var(--blue-dim);outline-offset:1px}
+/* A jumped-to heading otherwise lands under the top edge of the viewport. */
+h2[id]{scroll-margin-top:14px}
+
+/* Wrapped controls should share the row evenly rather than leaving one
+   stranded, which starts well above the phone breakpoint. */
+@media (max-width:980px){
+  .controls{margin-left:0;width:100%}
+  .controls > div{flex:1 1 170px}
+  .controls select{width:100%}
+}
+@media (max-width:720px){
+  :root{--pad:14px}
+  header{padding:14px var(--pad);gap:12px}
+  .brand .logo{height:22px}
+  h1{font-size:16px}
+  h2{margin:22px var(--pad) 10px}
+  .controls > div{flex:1 1 150px}
+  .headline{font-size:22px}
+  .card{padding:13px}
+  .card .scroll{max-height:none}
+  .card.zoomed{inset:8px;padding:14px}
+  table{font-size:12px}
+  th,td{padding:5px 6px}
+  /* A label column that has given up all its width is unreadable however it
+     wraps, so it keeps a floor and the value beside it yields instead. */
+  td:first-child{min-width:6em}
+  /* The bar is a relative-magnitude cue for the number beside it. On a phone
+     it was taking a quarter of the row and pushing that number off the edge,
+     and the number is the part that has to survive. */
+  .barcell{display:none}
+  /* The measured spread belongs beside the value on a wide screen and under it
+     on a narrow one: inline, it doubled the column's width and pushed the
+     value itself off the edge. */
+  .range{display:block}
+}
+/* No hover means the corner label never appears, so it must not reserve space
+   either; a zoomed card still needs its way out to be visible without one. */
+@media (hover:none){
+  .card{cursor:default}
+  .card h3{padding-right:0}
+  .card::after{display:none}
+  .card.zoomed h3{padding-right:88px}
+  .card.zoomed::after{display:block;content:"tap to close";opacity:.8}
+}
+@media (prefers-reduced-motion:reduce){
+  *{transition:none!important;animation:none!important}
+}
+</style>
+<header>
+  <div class="brand">
+    <svg class="logo" viewBox="0 0 193 43" fill="none" role="img" aria-label="DefraDB"><g stroke="#10CBFF" stroke-width="1.875" stroke-linecap="round" stroke-linejoin="round"><path d="M12.309 15.5657L24.2088 8.5573C25.1555 8.00084 26.2323 7.70431 27.3304 7.69771C28.4284 7.69112 29.5088 7.97468 30.462 8.51973C31.4153 9.06478 32.2077 9.85196 32.759 10.8016C33.3103 11.7513 33.601 12.8297 33.6016 13.9278V19.5434"/><path d="M12.309 27.7552V15.5658"/><path d="M18.2589 31.2091L12.309 27.7551"/><path d="M18.2786 18.919L18.2349 30.5846"/><path d="M18.2593 31.2092L24.666 27.5323C25.7846 26.8752 26.7122 25.9375 27.3571 24.8118C28.002 23.6862 28.3418 22.4117 28.3429 21.1144L28.3875 13.6158"/><path d="M18.2785 18.919L27.7722 13.5165C28.3624 13.1755 29.032 12.9958 29.7136 12.9956C30.3953 12.9954 31.065 13.1747 31.6554 13.5154C32.2458 13.8561 32.7361 14.3462 33.077 14.9365C33.4179 15.5268 33.5974 16.1965 33.5974 16.8781V20.0214"/><path d="M30.2087 8.32791L27.1075 6.53002C25.4823 5.58789 23.6359 5.09466 21.7573 5.10084C19.8788 5.10703 18.0356 5.61241 16.4167 6.56523L6.39801 12.4616V31.8378L16.9162 37.8991L27.3786 31.7598C29.2706 30.6465 30.8394 29.0588 31.9298 27.1536C33.0202 25.2483 33.5945 23.0914 33.5959 20.8962V16.094"/></g><path d="M50.97 35V10.7H59.76C62.4 10.7 64.67 11.19 66.57 12.17C68.49 13.13 69.96 14.52 70.98 16.34C72.02 18.16 72.54 20.33 72.54 22.85C72.54 25.35 72.02 27.51 70.98 29.33C69.94 31.15 68.46 32.55 66.54 33.53C64.64 34.51 62.38 35 59.76 35H50.97ZM54.42 32.06H59.76C62.7 32.06 64.98 31.25 66.6 29.63C68.24 28.01 69.06 25.75 69.06 22.85C69.06 19.93 68.25 17.67 66.63 16.07C65.01 14.45 62.72 13.64 59.76 13.64H54.42V32.06ZM84.7763 35.36C82.8963 35.36 81.2663 34.98 79.8862 34.22C78.5062 33.44 77.4363 32.34 76.6763 30.92C75.9363 29.5 75.5662 27.84 75.5662 25.94C75.5662 24.04 75.9363 22.4 76.6763 21.02C77.4363 19.62 78.4962 18.54 79.8562 17.78C81.2163 17.02 82.8063 16.64 84.6263 16.64C86.3663 16.64 87.8663 16.99 89.1263 17.69C90.4063 18.39 91.3963 19.38 92.0963 20.66C92.7963 21.94 93.1463 23.46 93.1463 25.22V26.57H78.8062C78.9063 28.45 79.4763 29.92 80.5163 30.98C81.5763 32.02 82.9863 32.54 84.7463 32.54C85.9663 32.54 86.9962 32.29 87.8362 31.79C88.6763 31.27 89.2563 30.51 89.5763 29.51H92.9963C92.5563 31.37 91.6063 32.81 90.1463 33.83C88.7063 34.85 86.9163 35.36 84.7763 35.36ZM78.9263 24.11H89.9062C89.7463 22.63 89.1963 21.48 88.2563 20.66C87.3363 19.84 86.1163 19.43 84.5963 19.43C83.0963 19.43 81.8463 19.84 80.8463 20.66C79.8462 21.48 79.2063 22.63 78.9263 24.11ZM98.7469 35V19.58H95.0869V17H98.7769V12.83C98.7769 11.81 99.0569 11.05 99.6169 10.55C100.177 10.05 100.947 9.8 101.927 9.8H106.907V12.38H102.077V17H106.547V19.58H102.107V35H98.7469ZM110.638 35V20.48H108.898V17H112.498V20.36H113.758C114.258 19.26 115.028 18.4 116.068 17.78C117.128 17.16 118.368 16.85 119.788 16.85H121.258V19.73H119.608C117.808 19.73 116.418 20.26 115.438 21.32C114.458 22.38 113.968 23.81 113.968 25.61V35H110.638ZM129.141 35.33C127.101 35.33 125.491 34.83 124.311 33.83C123.151 32.81 122.571 31.48 122.571 29.84C122.571 28.12 123.151 26.79 124.311 25.85C125.471 24.89 127.141 24.41 129.321 24.41H135.471V23.6C135.471 20.82 133.941 19.43 130.881 19.43C128.381 19.43 126.871 20.37 126.351 22.25H122.961C123.261 20.47 124.111 19.09 125.511 18.11C126.931 17.13 128.741 16.64 130.941 16.64C133.441 16.64 135.351 17.23 136.671 18.41C138.011 19.59 138.681 21.29 138.681 23.51V31.52H140.301V35H136.701V32.24H135.441C134.821 33.2 133.971 33.96 132.891 34.52C131.811 35.06 130.561 35.33 129.141 35.33ZM129.591 32.63C130.671 32.63 131.661 32.41 132.561 31.97C133.461 31.53 134.171 30.93 134.691 30.17C135.211 29.41 135.471 28.58 135.471 27.68V26.87H129.531C127.011 26.87 125.751 27.81 125.751 29.69C125.751 30.59 126.091 31.31 126.771 31.85C127.451 32.37 128.391 32.63 129.591 32.63ZM144.732 35V10.7H153.522C156.162 10.7 158.432 11.19 160.332 12.17C162.252 13.13 163.722 14.52 164.742 16.34C165.782 18.16 166.302 20.33 166.302 22.85C166.302 25.35 165.782 27.51 164.742 29.33C163.702 31.15 162.222 32.55 160.302 33.53C158.402 34.51 156.142 35 153.522 35H144.732ZM148.182 32.06H153.522C156.462 32.06 158.742 31.25 160.362 29.63C162.002 28.01 162.822 25.75 162.822 22.85C162.822 19.93 162.012 17.67 160.392 16.07C158.772 14.45 156.482 13.64 153.522 13.64H148.182V32.06ZM170.888 35V10.7H182.678C184.098 10.7 185.328 10.95 186.368 11.45C187.408 11.95 188.218 12.67 188.798 13.61C189.398 14.53 189.698 15.63 189.698 16.91C189.698 18.25 189.288 19.37 188.468 20.27C187.648 21.15 186.688 21.72 185.588 21.98V22.1C186.408 22.22 187.228 22.52 188.048 23C188.868 23.48 189.548 24.15 190.088 25.01C190.628 25.85 190.898 26.9 190.898 28.16C190.898 29.54 190.568 30.74 189.908 31.76C189.268 32.78 188.368 33.58 187.208 34.16C186.048 34.72 184.718 35 183.218 35H170.888ZM174.338 32.06H182.498C184.058 32.06 185.278 31.7 186.158 30.98C187.038 30.26 187.478 29.23 187.478 27.89C187.478 26.53 187.038 25.51 186.158 24.83C185.278 24.15 184.068 23.81 182.528 23.81H174.338V32.06ZM174.338 20.99H182.258C183.518 20.99 184.498 20.67 185.198 20.03C185.918 19.39 186.278 18.49 186.278 17.33C186.278 16.13 185.918 15.22 185.198 14.6C184.498 13.96 183.518 13.64 182.258 13.64H174.338V20.99Z" fill="#9EA0A3"/></svg>
+    <h1>Rust Performance</h1>
+  </div>
+  <div class="controls">
+    <div><label for="cur">This run</label><select id="cur"></select></div>
+    <div><label for="base">Compared with</label><select id="base"></select></div>
+    <div><label for="plat">Platform</label><select id="plat"></select></div>
+    <div><label for="thresh">Highlight over</label>
+      <select id="thresh"><option value="1">1%</option><option value="3">3%</option>
+      <option value="5">5%</option><option value="10" selected>10%</option>
+      <option value="15">15%</option><option value="20">20%</option>
+      <option value="30">30%</option></select></div>
+  </div>
+</header>
+<main id="main"><div class="empty">Loading runs...</div></main>
+<script>
+const BLUE="#10CBFF", DIM="#3a4c5a", BAD="#ff5f52";
+const SERIES=["#10CBFF","#f0a93b","#8b7bff","#3ddc97","#ff8fa3","#67d5f5"];
+const $=s=>document.querySelector(s);
+const esc=s=>String(s??"").replace(/[&<>"]/g,c=>({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;"}[c]));
+const arr=v=>Array.isArray(v)?v:[];
+
+function fmt(n,unit){
+  if(n===null||n===undefined||!Number.isFinite(n))return"n/a";
+  if(unit==="%")return n.toFixed(2)+"%";
+  if(unit==="B"||unit==="bytes")return fmtBytes(n);
+  const a=Math.abs(n);
+  if(a>=1e9)return (n/1e9).toFixed(2)+"B";
+  if(a>=1e6)return (n/1e6).toFixed(2)+"M";
+  if(a>=1e4)return (n/1e3).toFixed(1)+"k";
+  if(a>=100)return Math.round(n).toLocaleString();
+  if(a>=1)return (Math.round(n*100)/100).toString();
+  if(a===0)return "0";
+  return n.toPrecision(3);
+}
+function fmtBytes(n){
+  if(!Number.isFinite(n))return String(n);
+  const a=Math.abs(n);
+  if(a>=1073741824)return (n/1073741824).toFixed(2)+" GiB";
+  if(a>=1048576)return (n/1048576).toFixed(2)+" MiB";
+  if(a>=1024)return (n/1024).toFixed(1)+" KiB";
+  return Math.round(n)+" B";
+}
+function pill(t){return t?`<span class="pill ${esc(t)}">${esc(t)}</span>`:""}
+
+/// A percentage change plus whether it is an improvement. Direction is always
+/// carried by the group that recorded the row, never inferred from the unit:
+/// "MiB/s" is a rate to maximise and "MiB" a footprint to minimise, and both
+/// contain "mib".
+function delta(cur,base,lowerIsBetter){
+  if(!Number.isFinite(cur)||!Number.isFinite(base)||base===0)return null;
+  const pct=100*(cur-base)/Math.abs(base);
+  return {pct,good:lowerIsBetter?pct<0:pct>0};
+}
+
+/// Chart geometry sized to the viewport it will actually be drawn in.
+///
+/// A viewBox is scaled into whatever width the card gives it, so a 1180-unit
+/// box inside a 340px phone renders its 10px labels at three. Sizing the box
+/// near the real pixel width keeps that scale close to 1, so a label ends up
+/// the size it claims to be.
+function chartBox(w,h){
+  const vw=(typeof window!=="undefined"&&window.innerWidth)||1280;
+  if(vw>720)return{w,h};
+  const avail=Math.max(260,vw-56);
+  return {w:Math.min(w,avail),h:Math.max(200,Math.min(h,Math.round(avail*0.82)))};
+}
+
+function lineChart(series,{w=560,h=230,xlab="",ylab=""}={}){
+  const all=series.flatMap(s=>s.pts);
+  if(!all.length)return `<p class="note">not measured yet</p>`;
+  const box=chartBox(w,h); w=box.w; h=box.h;
+  const xs=all.map(p=>p[0]),ys=all.map(p=>p[1]);
+  const x0=Math.min(...xs),x1=Math.max(...xs);
+  // A series can legitimately go below zero, and clamping the floor at zero
+  // would draw those points off the bottom of the box.
+  const y1=Math.max(...ys)||1, y0=Math.min(0,...ys);
+  const F=10, CH=F*0.62;
+
+  // The left margin is measured from the widest label rather than fixed, so a
+  // "1.07 GiB" tick cannot run off the edge and a "12" tick cannot leave a
+  // third of the plot empty.
+  const yLabels=[0,1,2,3,4].map(i=>fmt(y0+(y1-y0)*i/4,ylab));
+  const L=Math.min(Math.round(w*0.42),
+                   Math.max(34,Math.round(8+CH*Math.max(...yLabels.map(t=>t.length)))));
+  const R=12,T=12,TICK_ROW=15;
+  const span=w-L-R;
+  const labFits=!!xlab&&xlab.length*CH<=span;
+  const B=TICK_ROW+(labFits?14:0)+6;
+  const plot=h-T-B;
+  const px=v=>L+(x1===x0?span/2:(v-x0)/(x1-x0)*span);
+  const py=v=>T+(1-(v-y0)/((y1-y0)||1))*plot;
+
+  let grid="";
+  for(let i=0;i<=4;i++){
+    const y=py(y0+(y1-y0)*i/4);
+    grid+=`<line x1="${L}" x2="${w-R}" y1="${y.toFixed(1)}" y2="${y.toFixed(1)}" stroke="#101c25"/>`
+      +`<text x="${L-8}" y="${(y+3.4).toFixed(1)}" fill="#7b8d9c" font-size="${F}" text-anchor="end">${esc(yLabels[i])}</text>`;
+  }
+
+  let body="";
+  for(const s of series){
+    if(!s.pts.length)continue;
+    const pts=[...s.pts].sort((a,b)=>a[0]-b[0]);
+    const d=pts.map((q,i)=>`${i?"L":"M"}${px(q[0]).toFixed(1)},${py(q[1]).toFixed(1)}`).join("");
+    body+=`<path d="${d}" fill="none" stroke="${s.color}" stroke-width="${s.thick?2.2:1.4}"`
+      +`${s.dash?' stroke-dasharray="4 3"':""}/>`;
+    body+=pts.map(q=>`<circle cx="${px(q[0]).toFixed(1)}" cy="${py(q[1]).toFixed(1)}" r="${s.thick?2.7:2}" fill="${s.color}"/>`).join("");
+  }
+
+  // Thin the ticks to what the axis can hold. Every tick drawn is one a reader
+  // can read; a tick that would land on its neighbour is dropped rather than
+  // printed over it, and the last value is always kept because it is the end
+  // of the range.
+  const uniq=[...new Set(xs)].sort((a,b)=>a-b);
+  const widest=Math.max(...uniq.map(v=>fmt(v).length))*CH+12;
+  // Thinned by position, not by index. The axis is linear, so evenly spaced
+  // values are not evenly spaced pixels: over 0, 1, 10, 100 an index-based
+  // step keeps the first two, which then land on top of each other.
+  const shown=[];
+  for(const v of uniq)
+    if(!shown.length||px(v)-px(shown[shown.length-1])>=widest)shown.push(v);
+  const last=uniq[uniq.length-1];
+  if(shown[shown.length-1]!==last){
+    if(px(last)-px(shown[shown.length-1])>=widest)shown.push(last);
+    else shown[shown.length-1]=last;
+  }
+  const tickY=T+plot+TICK_ROW-3;
+  const ticks=shown.map(v=>`<text x="${px(v).toFixed(1)}" y="${tickY.toFixed(1)}" fill="#7b8d9c" font-size="${F}" text-anchor="middle">${esc(fmt(v))}</text>`).join("");
+
+  // The axis label gets its own baseline below the ticks, and when it is wider
+  // than the axis it moves into the legend instead of being clipped.
+  const axis=labFits
+    ? `<text x="${((L+w-R)/2).toFixed(1)}" y="${(h-4).toFixed(1)}" fill="#7b8d9c" font-size="${F}" text-anchor="middle">${esc(xlab)}</text>`
+    : "";
+  const legend=series.filter(s=>s.pts.length)
+    .map(s=>`<span><b style="background:${s.color}"></b>${esc(s.name)}</span>`);
+  if(xlab&&!labFits)legend.push(`<span>x axis: ${esc(xlab)}</span>`);
+
+  return `<svg class="chart" viewBox="0 0 ${w} ${h}" role="img" aria-label="${esc(ylab||xlab||"chart")}">`
+    +`${grid}${body}${ticks}${axis}</svg><div class="legend">${legend.join("")}</div>`;
+}
+
+/// The one table every comparison on this page is drawn with.
+function barTable(rows,threshold){
+  if(!rows.length)return `<p class="note">not measured in this run</p>`;
+  const max=Math.max(...rows.map(r=>Math.abs(r.cur||0)),1);
+  const anyBase=rows.some(r=>Number.isFinite(r.base));
+  return `<div class="scroll"><table><thead><tr><th>metric</th>
+    ${anyBase?'<th class="num">baseline</th>':""}<th class="num">this run</th>
+    ${anyBase?'<th class="num">delta</th>':""}<th class="barcell"></th></tr></thead><tbody>`
+    +rows.map(r=>{
+      const d=anyBase?delta(r.cur,r.base,r.lower):null;
+      const cls=!d?"flat":Math.abs(d.pct)<threshold?"flat":d.good?"up":"down";
+      const txt=!d?"":(d.pct>0?"+":"")+d.pct.toFixed(1)+"%";
+      const regress=d&&!d.good&&Math.abs(d.pct)>=threshold;
+      const range=Number.isFinite(r.min)&&Number.isFinite(r.max)
+        ? ` <span class="range">${esc(fmt(r.min,r.unit))} to ${esc(fmt(r.max,r.unit))}</span>`:"";
+      return `<tr><td>${esc(r.name)}</td>
+        ${anyBase?`<td class="num">${esc(fmt(r.base,r.unit))}</td>`:""}
+        <td class="num">${esc(fmt(r.cur,r.unit))}${range}</td>
+        ${anyBase?`<td class="num ${cls}">${txt}</td>`:""}
+        <td class="barcell"><div class="bar"><i class="${regress?"regress":""}" style="width:${(100*Math.abs(r.cur||0)/max).toFixed(1)}%"></i></div></td></tr>`;
+    }).join("")
+    +`</tbody></table></div>`;
+}
+
+/// A stable anchor for a section name, so the index can jump to it.
+const slug=s=>String(s).toLowerCase().replace(/[^a-z0-9]+/g,"-").replace(/^-|-$/g,"");
+
+/// A section heading. The name is its own element so it can wrap: an anonymous
+/// flex item beside a growing rule cannot, and a long family name then ran off
+/// the side of a narrow screen.
+function heading(name,trust){
+  return `<h2 id="s-${esc(slug(name))}"><span class="h2-name">${esc(name)}</span>${pill(trust)}<span class="rule"></span></h2>`;
+}
+
+/// Jump links to every section on the page.
+///
+/// The suite reports one family per bench target, so a run carries dozens of
+/// sections and scrolling past all of them to reach one is the whole cost of
+/// having measured everything. The index is the page's table of contents, and
+/// it names what is actually in this run rather than a fixed list.
+function sectionIndex(names){
+  if(names.length<3)return "";
+  const links=names.map(n=>`<a class="jump" href="#s-${esc(slug(n))}">${esc(n)}</a>`).join("");
+  return `<nav class="index" aria-label="Sections">${links}</nav>`;
+}
+
+function card(title,note,body,trust,wide){
+  return `<div class="card"${wide?' style="grid-column:1/-1"':""}><h3>${esc(title)}${pill(trust)}</h3>
+    ${note?`<p class="note">${note}</p>`:""}${body}</div>`;
+}
+
+// ---- reading a run document -------------------------------------------
+//
+// A family describes itself: its groups carry the unit and the direction, and
+// the dashboard renders any of them without knowing the family's name. That is
+// what stops a bench from being collected and drawn nowhere, which no amount of
+// per-family rendering code prevents.
+
+function platformsOf(run){ return Object.keys(run?.platforms||{}).sort(); }
+function familiesOf(run,platform){ return run?.platforms?.[platform]?.families||{}; }
+
+/// Every row in a run, keyed so the same measurement joins across runs and
+/// platforms. The key is the contract; it must not change once published.
+function scalars(run,platform){
+  const out=[];
+  const fams=familiesOf(run,platform);
+  for(const [fname,fam] of Object.entries(fams)){
+    if(!fam||fam.trust==="absent")continue;
+    for(const g of arr(fam.groups)){
+      for(const r of arr(g.rows)){
+        if(!Number.isFinite(r.value))continue;
+        out.push({key:`${fname}/${g.name}/${r.name}`,
+                  name:`${g.name} · ${r.name}`, family:fname, group:g.name,
+                  value:r.value, min:r.min, max:r.max,
+                  unit:g.unit, lower:!!g.lower_is_better});
+      }
+    }
+  }
+  return out;
+}
+
+function scalarMap(run,platform){
+  const m={};
+  for(const s of scalars(run,platform))m[s.key]=s;
+  return m;
+}
+
+/// One family, rendered from its own description.
+function familySection(fname,fam,baseFam,threshold){
+  if(!fam)return "";
+  const cards=[];
+  if(fam.trust==="absent"){
+    cards.push(card(fam.title||fname,
+      esc(fam.note||"")+" This family was not collected in this run.",
+      `<p class="note" style="margin:0">not measured in this run</p>`,"absent"));
+  }else{
+    for(const g of arr(fam.groups)){
+      const bg=arr(baseFam?.groups).find(x=>x.name===g.name);
+      const bmap={};
+      for(const r of arr(bg?.rows))bmap[r.name]=r.value;
+      const rows=arr(g.rows).filter(r=>Number.isFinite(r.value)).map(r=>({
+        name:r.name,cur:r.value,base:bmap[r.name],min:r.min,max:r.max,
+        unit:g.unit,lower:!!g.lower_is_better}));
+      const charted=rows.length>1&&arr(g.rows).every(r=>Number.isFinite(r.x));
+      let body="";
+      if(rows.length===1)
+        body+=`<div class="headline">${esc(fmt(rows[0].cur,g.unit))} <small>${esc(g.unit)}</small></div>`;
+      if(charted){
+        const pts=a=>arr(a).filter(r=>Number.isFinite(r.x)&&Number.isFinite(r.value)).map(r=>[r.x,r.value]);
+        body+=lineChart([{name:"baseline",color:DIM,dash:true,pts:pts(bg?.rows)},
+                         {name:"this run",color:BLUE,thick:true,pts:pts(g.rows)}],
+                        {xlab:g.x_label||"",ylab:g.unit});
+      }
+      body+=barTable(rows,threshold);
+      const note=(g.note?esc(g.note)+" ":"")
+        +`<span class="tag">${esc(g.unit||"unitless")}</span>`
+        +`<span class="tag">${g.lower_is_better?"lower is better":"higher is better"}</span>`;
+      cards.push(card(g.name,note,body,undefined,charted));
+    }
+    if(!cards.length)
+      cards.push(card(fam.title||fname,esc(fam.note||""),
+        `<p class="note" style="margin:0">the family was collected but recorded no groups</p>`,fam.trust));
+  }
+  const head=heading(fam.title||fname,fam.trust);
+  const intro=fam.note&&fam.trust!=="absent"
+    ? `<p class="note" style="padding:0 26px;margin:-4px 0 12px;max-width:70ch">${esc(fam.note)}</p>`:"";
+  return head+intro+`<div class="grid">${cards.join("")}</div>`;
+}
+
+/// The same measurement across every platform that recorded it. This is the
+/// question a cross-platform suite exists to answer, and no single-platform
+/// view can show it.
+function platformSection(run,threshold){
+  const plats=platformsOf(run);
+  if(plats.length<2)return "";
+  const maps=Object.fromEntries(plats.map(p=>[p,scalarMap(run,p)]));
+  const keys=[...new Set(plats.flatMap(p=>Object.keys(maps[p])))].sort();
+  const shared=keys.filter(k=>plats.filter(p=>maps[p][k]).length>1);
+  if(!shared.length)
+    return heading("Across platforms")+`<div class="grid">${card("No shared measurement",
+      "Every platform recorded something, but no metric was recorded on more than one of them, so there is nothing to line up.",
+      `<p class="note" style="margin:0">${plats.map(p=>`<span class="tag">${esc(p)}</span>`).join("")}</p>`)}</div>`;
+  const byFamily={};
+  for(const k of shared)(byFamily[k.split("/")[0]] ||= []).push(k);
+  const ref=plats[0];
+  const cards=Object.entries(byFamily).map(([fam,ks])=>{
+    const head=`<thead><tr><th>metric</th>${plats.map(p=>`<th class="num">${esc(p)}</th>`).join("")}</tr></thead>`;
+    const body=ks.map(k=>{
+      const any=plats.map(p=>maps[p][k]).find(Boolean);
+      const cells=plats.map(p=>{
+        const s=maps[p][k];
+        if(!s)return `<td class="num flat">n/a</td>`;
+        const b=maps[ref][k];
+        const d=p===ref?null:delta(s.value,b?.value,s.lower);
+        const cls=!d?"":Math.abs(d.pct)<threshold?"flat":d.good?"up":"down";
+        const rel=d?` <span class="${cls}" style="font-size:10px">${d.pct>0?"+":""}${d.pct.toFixed(0)}%</span>`:"";
+        return `<td class="num">${esc(fmt(s.value,s.unit))}${rel}</td>`;
+      }).join("");
+      return `<tr><td>${esc(k.split("/").slice(1).join(" · "))}</td>${cells}</tr>`;
+    }).join("");
+    return card(fam,`Every platform that recorded this family, against <code>${esc(ref)}</code>.`,
+      `<div class="scroll"><table>${head}<tbody>${body}</tbody></table></div>`,undefined,true);
+  });
+  return heading("Across platforms")+`<div class="grid wide">${cards.join("")}</div>`;
+}
+
+function overview(run,base,platform,threshold){
+  const p=run?.platforms?.[platform]||{};
+  const bmap=base?scalarMap(base,platform):{};
+  const all=scalars(run,platform).map(s=>({name:`${s.family} · ${s.name}`,cur:s.value,
+    base:bmap[s.key]?.value,min:s.min,max:s.max,unit:s.unit,lower:s.lower}));
+  const fams=Object.entries(familiesOf(run,platform))
+    .map(([k,v])=>`<tr><td>${esc(v?.title||k)}</td><td class="num">${pill(v?.trust)}</td></tr>`).join("");
+  const h=p.host||{};
+  const guard=p.loadguard||{};
+  const meta=`<table><tbody>
+    <tr><td>commit</td><td class="val">${esc((run.commit||"").slice(0,12))}</td></tr>
+    <tr><td>label</td><td class="val">${esc(run.label||"")}</td></tr>
+    <tr><td>recorded</td><td class="val">${esc(p.timestamp||run.timestamp||"")}</td></tr>
+    <tr><td>target</td><td class="val">${esc(platform)}</td></tr>
+    <tr><td>toolchain</td><td class="val">${esc(p.toolchain||"unknown")}</td></tr>
+    <tr><td>cpu</td><td class="val">${esc(h.cpu||"not recorded")}</td></tr>
+    <tr><td>cores / ram</td><td class="val">${esc(h.cores??"n/a")} / ${esc(h.ram_gib??"n/a")} GiB</td></tr>
+    <tr><td>load guard</td><td class="val ${guard.passed?"":"down"}">${guard.passed?"passed":"did not pass"}</td></tr>
+    <tr><td>metrics compared</td><td class="val">${all.filter(x=>Number.isFinite(x.base)).length} of ${all.length}</td></tr>
+  </tbody></table>`;
+  const warn=guard.passed?"":`<p class="note" style="color:var(--warn);margin:10px 0 0">${esc(guard.note||"The load guard did not pass.")}</p>`;
+  return heading("Overview")+`<div class="grid">
+    ${card("This run","",meta+warn)}
+    ${card("What each family reported",
+      "Every family the collector knows about. <code>absent</code> means the family was not collected in this run, never that it measured zero.",
+      `<div class="scroll"><table><tbody>${fams||'<tr><td class="note">nothing collected</td></tr>'}</tbody></table></div>`)}
+  </div><div class="grid wide">
+    ${card("Every number, side by side",
+      base?"Every value this run recorded on this platform, against the run selected above. Direction is carried per metric, so the delta column already knows which way is an improvement."
+          :"Every value this run recorded on this platform. Pick a run to compare with to fill the baseline column.",
+      barTable(all,threshold))}
+  </div>`;
+}
+
+function trendSection(runs,platform,threshold){
+  const byKey={},names={};
+  for(const r of runs){
+    const t=Date.parse(r.doc?.timestamp||r.doc?.platforms?.[platform]?.timestamp||"")||0;
+    for(const s of scalars(r.doc,platform)){
+      (byKey[s.key] ||= []).push([t,s.value]);
+      names[s.key]={name:`${s.family} · ${s.name}`,unit:s.unit};
+    }
+  }
+  const keys=Object.keys(byKey).sort();
+  if(!keys.length)return "";
+  if(!keys.includes(TREND_METRIC))TREND_METRIC=keys[0];
+  const pts=[...byKey[TREND_METRIC]].sort((a,b)=>a[0]-b[0]);
+  const x0=pts.length?pts[0][0]:0;
+  const series=[{name:names[TREND_METRIC].name,color:BLUE,thick:true,
+    pts:pts.map(q=>[(q[0]-x0)/86400000,q[1]])}];
+  const opts=keys.map(k=>`<option value="${esc(k)}"${k===TREND_METRIC?" selected":""}>${esc(names[k].name)}</option>`).join("");
+  const picker=`<p class="note" style="margin:0 0 10px">
+    <label for="trendmetric" style="display:inline;margin-right:7px">Metric</label>
+    <select id="trendmetric">${opts}</select></p>`;
+  return heading("Trend across every recorded run")+`<div class="grid wide">
+    ${card(names[TREND_METRIC].name+(names[TREND_METRIC].unit?` (${names[TREND_METRIC].unit})`:""),
+      `${pts.length} of ${runs.length} run(s) on file recorded this on <code>${esc(platform)}</code>. A step in this line is where the change happened.`,
+      picker+lineChart(series,{xlab:"days since the first run on file",ylab:names[TREND_METRIC].unit||"",w:1180,h:290}),
+      undefined,true)}</div>`;
+}
+
+let RUNS=[],TREND_METRIC=null;
+
+function showControls(on){ $(".controls").style.display=on?"":"none"; }
+
+function emptyState(title,detail){
+  showControls(false);
+  return `<div class="grid" style="padding-top:18px">
+    ${card(title,detail,
+      `<p class="note" style="margin:0 0 10px">Once a run is published this page shows, for every
+       recorded run and against any other run you pick:</p>
+       <table><tbody>
+         <tr><td>Every bench family</td><td class="num">rendered from its own description</td></tr>
+         <tr><td>Across platforms</td><td class="num">the same metric on Linux, macOS and WASM</td></tr>
+         <tr><td>Trend</td><td class="num">any metric across every run on file</td></tr>
+       </tbody></table>`)}
+    ${card("How a run gets here","",
+      `<p class="note" style="margin:0 0 10px">The performance workflow runs each bench family on
+       its own runner, per platform. <code>collect</code> folds a platform's families into one
+       platform document, <code>publish.py</code> merges the platforms into
+       <code>runs/&lt;commit&gt;.json</code> beside every earlier run, and this page reads the
+       whole set.</p>
+       <p class="note" style="margin:0">The run documents are the artifact; this page is only a
+       reader over them. Nothing is drawn from a run that does not exist, so an empty page means
+       no run has been published, not that a run measured zero.</p>`)}
+  </div>`;
+}
+
+async function boot(){
+  let manifest;
+  try{
+    const r=await fetch("runs/index.json",{cache:"no-store"});
+    if(!r.ok)throw new Error(r.status);
+    manifest=await r.json();
+  }catch(e){
+    $("#main").innerHTML=emptyState("No runs published yet",
+      "This page reads the run documents under <code>runs/</code>. There are none yet.");
+    return;
+  }
+  const list=arr(manifest.runs);
+  if(!list.length){
+    $("#main").innerHTML=emptyState("The run index is empty",
+      "<code>runs/index.json</code> exists but lists no runs, so there is nothing to plot.");
+    return;
+  }
+  RUNS=(await Promise.all(list.map(async m=>{
+    try{ return {meta:m,doc:await (await fetch("runs/"+m.file,{cache:"no-store"})).json()}; }
+    catch(e){ return null; }
+  }))).filter(Boolean);
+  if(!RUNS.length){
+    $("#main").innerHTML=emptyState("Every run document failed to load",
+      `The index lists ${list.length} run(s), but none of the files could be read.`);
+    return;
+  }
+  showControls(true);
+  const opt=r=>`<option value="${esc(r.meta.file)}">${esc((r.meta.commit||"").slice(0,10))} ${esc(r.meta.label||"")} ${esc((r.meta.timestamp||"").slice(0,16))}</option>`;
+  $("#cur").innerHTML=RUNS.map(opt).join("");
+  $("#base").innerHTML=`<option value="">(none)</option>`+RUNS.map(opt).join("");
+  if(RUNS.length>1)$("#base").value=RUNS[1].meta.file;
+  for(const el of ["#cur","#base","#plat","#thresh"])$(el).addEventListener("change",e=>{
+    if(e.target.id!=="plat")syncPlatforms();
+    draw();
+  });
+  syncPlatforms();
+  zoomable();
+  draw();
+}
+
+/// The platform list belongs to the selected run, so it is rebuilt whenever
+/// that changes, keeping the current choice when the new run also has it.
+function syncPlatforms(){
+  const cur=RUNS.find(r=>r.meta.file===$("#cur").value)?.doc;
+  const plats=platformsOf(cur);
+  const want=$("#plat").value;
+  $("#plat").innerHTML=plats.map(p=>`<option value="${esc(p)}">${esc(p)}</option>`).join("")
+    ||`<option value="">(none recorded)</option>`;
+  if(plats.includes(want))$("#plat").value=want;
+}
+
+/// Draw one section, or a card saying why it could not be drawn. One malformed
+/// family must not leave the page on "Loading runs..." forever: a dashboard
+/// that silently shows nothing is worse than one that shows a broken panel,
+/// because only the second is obviously wrong.
+function section(name,build){
+  try{ return build(); }
+  catch(e){
+    return heading(name)+`<div class="grid"><div class="card broken">
+      <h3>${esc(name)} failed to draw</h3>
+      <p class="note">${esc(String(e&&e.message||e))}</p>
+      <p class="note">The run document is on file; this section could not read it. Every other
+      section on this page still drew.</p></div></div>`;
+  }
+}
+
+function draw(){
+  const cur=RUNS.find(r=>r.meta.file===$("#cur").value)?.doc;
+  const base=RUNS.find(r=>r.meta.file===$("#base").value)?.doc||null;
+  const platform=$("#plat").value;
+  const th=parseFloat($("#thresh").value);
+  const fams=familiesOf(cur,platform);
+  const baseFams=base?familiesOf(base,platform):{};
+  const ordered=Object.keys(fams).sort();
+  const titles=ordered.map(f=>fams[f]?.title||f);
+  let html=section("Overview",()=>overview(cur,base,platform,th));
+  html+=sectionIndex(["Overview",...titles,"Across platforms","Trend across every recorded run"]);
+  for(const fname of ordered)
+    html+=section(fams[fname]?.title||fname,()=>familySection(fname,fams[fname],baseFams[fname],th));
+  html+=section("Across platforms",()=>platformSection(cur,th));
+  html+=section("Trend",()=>trendSection(RUNS,platform,th));
+  $("#main").innerHTML=html;
+  const tm=$("#trendmetric");
+  if(tm)tm.addEventListener("change",e=>{TREND_METRIC=e.target.value;draw();});
+}
+
+/// Click a panel to fill the viewport with it, escape or click again to
+/// return. Delegated from the document so it survives every redraw, and it
+/// keeps its hands off the controls inside a card.
+function zoomable(){
+  const backdrop=document.createElement("div");
+  backdrop.className="zoom-backdrop";
+  backdrop.hidden=true;
+  document.body.appendChild(backdrop);
+  const close=()=>{
+    for(const el of document.querySelectorAll(".card.zoomed"))el.classList.remove("zoomed");
+    backdrop.hidden=true;
+  };
+  backdrop.addEventListener("click",close);
+  document.addEventListener("keydown",e=>{ if(e.key==="Escape")close(); });
+  document.addEventListener("click",e=>{
+    if(e.target.closest("select,option,a,button,input,label"))return;
+    const card=e.target.closest(".card");
+    if(!card)return;
+    const was=card.classList.contains("zoomed");
+    close();
+    if(!was){ card.classList.add("zoomed"); backdrop.hidden=false; card.scrollTop=0; }
+  });
+}
+/// Charts are sized from the viewport, so a width change has to redraw them.
+/// Only a width change: a mobile browser fires resize when its address bar
+/// slides away, and redrawing on that would throw the reader's place away for
+/// a layout that did not move.
+let lastWidth=typeof window!=="undefined"?window.innerWidth:0;
+let resizeTimer=null;
+if(typeof window!=="undefined"&&window.addEventListener){
+  window.addEventListener("resize",()=>{
+    if(Math.abs(window.innerWidth-lastWidth)<40)return;
+    lastWidth=window.innerWidth;
+    clearTimeout(resizeTimer);
+    resizeTimer=setTimeout(()=>{ if(RUNS.length)draw(); },180);
+  });
+}
+boot();
+</script>

--- a/tools/perf-site/loadguard.py
+++ b/tools/perf-site/loadguard.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Decide whether this host is quiet enough for a timing to mean anything.
+
+Run *before* the benchmarks, never after: a guard that samples load once the
+suite has finished is measuring the suite. Its verdict is written to a file
+that `collect` folds into the platform document, and a missing or unreadable
+verdict is treated as "not certified quiet" rather than as a pass.
+
+The rule is the one-minute load average against the core count. A shared CI
+runner with other tenants on the box shows up here; a quiet one does not.
+Anything the platform cannot report leaves the guard failing closed, because
+"we could not tell" and "it was quiet" are different answers and only one of
+them is honest.
+"""
+
+import argparse
+import json
+import os
+import sys
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out", help="write the verdict here as well as to stdout")
+    ap.add_argument(
+        "--max-load-per-core",
+        type=float,
+        default=0.5,
+        help="one-minute load average per core above which the host is busy (default 0.5)",
+    )
+    args = ap.parse_args()
+
+    cores = os.cpu_count()
+    try:
+        load = os.getloadavg()
+    except (OSError, AttributeError) as e:
+        verdict = {
+            "passed": False,
+            "cores": cores,
+            "note": f"the load average is not available on this host ({e}), so it cannot be "
+            "certified quiet. Timing families are marked contaminated; deterministic "
+            "families stay comparable.",
+        }
+    else:
+        ceiling = (cores or 1) * args.max_load_per_core
+        passed = load[0] <= ceiling
+        verdict = {
+            "passed": passed,
+            "cores": cores,
+            "loadavg": list(load),
+            "ceiling": ceiling,
+            "note": (
+                f"one-minute load {load[0]:.2f} on {cores} core(s), at or under the "
+                f"{ceiling:.2f} ceiling: the host was quiet."
+                if passed
+                else f"one-minute load {load[0]:.2f} on {cores} core(s) exceeds the "
+                f"{ceiling:.2f} ceiling, so timing families are marked contaminated. "
+                "Binary size, allocation counts and other deterministic families stay "
+                "comparable."
+            ),
+        }
+
+    text = json.dumps(verdict, indent=1)
+    print(text)
+    if args.out:
+        with open(args.out, "w") as f:
+            f.write(text + "\n")
+    # Always exits 0: the verdict is data for the collector, not a gate. A
+    # busy runner should still produce a document that says it was busy.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/perf-site/publish.py
+++ b/tools/perf-site/publish.py
@@ -151,6 +151,11 @@ def main():
         merged = dict(existing["platforms"])
         merged.update(run["platforms"])
         run["platforms"] = merged
+        # A run is as old as its earliest platform, and the platforms already on
+        # file are part of it. Keeping the timestamp computed before the merge
+        # would date the run by whichever platform happened to publish last.
+        stamps = [p.get("timestamp") for p in merged.values() if p.get("timestamp")]
+        run["timestamp"] = min(stamps) if stamps else run.get("timestamp", "")
         print(f"publish: merged {len(run['platforms'])} platform(s) into the existing {commit[:12]}")
     target.write_text(json.dumps(run, indent=1, sort_keys=True) + "\n")
 

--- a/tools/perf-site/publish.py
+++ b/tools/perf-site/publish.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Merge this run's platform documents into the published history.
+
+The history is the point. A single rendered page per CI run answers "is this
+run fast" and nothing else: the moment it is replaced, the comparison it
+supported is gone. Keeping every run document and rendering from the whole set
+answers "when did this regress", which is the question a performance gate
+actually has to answer.
+
+Layout under the site root:
+
+    index.html          the dashboard, self-contained, reads the JSON below
+    runs/index.json     manifest, newest first
+    runs/<commit>.json  one document per run, every platform merged into it
+
+One `collect` invocation produces one *platform* document. This merges the
+platforms measured for a commit into the single run document the dashboard
+reads, so a platform that was added later shows up beside the ones that were
+always there rather than replacing them.
+
+The manifest is regenerated from the directory on every publish rather than
+appended to, so a run file that was removed cannot leave a dangling row behind
+and a run file added out of band is still picked up.
+"""
+
+import argparse
+import json
+import pathlib
+import sys
+
+KEEP = 200
+
+
+def load(path):
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"publish: cannot read {path}: {e}", file=sys.stderr)
+        return None
+
+
+def merge_platforms(docs):
+    """One run document from several platform documents of the same commit."""
+    commits = {d.get("commit") for d in docs}
+    if len(commits) != 1:
+        print(
+            "publish: the platform documents disagree about which commit they "
+            f"measured ({', '.join(sorted(str(c) for c in commits))}). Refusing to "
+            "merge them into one run: a run document that mixes commits cannot be "
+            "compared with anything.",
+            file=sys.stderr,
+        )
+        return None
+
+    platforms = {}
+    for doc in docs:
+        target = doc.get("target")
+        if not target:
+            print("publish: a platform document names no target, skipping it", file=sys.stderr)
+            continue
+        if target in platforms:
+            print(
+                f"publish: {target} was collected twice for this commit. Refusing to "
+                "pick one: re-run the collection against a fresh output directory.",
+                file=sys.stderr,
+            )
+            return None
+        platforms[target] = {
+            "timestamp": doc.get("timestamp", ""),
+            "toolchain": doc.get("toolchain", ""),
+            "host": doc.get("host", {}),
+            "loadguard": doc.get("loadguard", {}),
+            "families": doc.get("families", {}),
+        }
+
+    if not platforms:
+        print("publish: no usable platform document, nothing to file", file=sys.stderr)
+        return None
+
+    return {
+        "schema_version": 1,
+        "commit": docs[0].get("commit", ""),
+        "label": docs[0].get("label", ""),
+        # The run is as old as its earliest platform: a macOS runner that
+        # started twenty minutes late did not make the run newer.
+        "timestamp": min(p["timestamp"] for p in platforms.values() if p["timestamp"])
+        if any(p["timestamp"] for p in platforms.values())
+        else "",
+        "platforms": platforms,
+    }
+
+
+def summarize(doc, name):
+    """The manifest row for one run: enough to populate the picker without
+    fetching the run itself."""
+    platforms = doc.get("platforms", {})
+    trust = {}
+    for target, p in platforms.items():
+        for fam, body in (p.get("families") or {}).items():
+            level = (body or {}).get("trust", "absent")
+            # Worst level across platforms: a family clean on one runner and
+            # contaminated on another is not a clean family.
+            rank = {"clean": 0, "contaminated": 1, "absent": 2}
+            if rank.get(level, 2) >= rank.get(trust.get(fam, "clean"), 0):
+                trust[fam] = level
+    return {
+        "file": name,
+        "commit": doc.get("commit", ""),
+        "label": doc.get("label", ""),
+        "timestamp": doc.get("timestamp", ""),
+        "platforms": sorted(platforms),
+        "quiet_hosts": all(
+            (p.get("loadguard") or {}).get("passed") is True for p in platforms.values()
+        ),
+        "trust": trust,
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("platform_docs", nargs="+", help="platform documents from `collect`")
+    ap.add_argument("--site", required=True, help="site root to publish into")
+    ap.add_argument("--keep", type=int, default=KEEP, help=f"runs to retain (default {KEEP})")
+    args = ap.parse_args()
+
+    docs = [d for d in (load(pathlib.Path(p)) for p in args.platform_docs) if d is not None]
+    if not docs:
+        print("publish: none of the platform documents could be read", file=sys.stderr)
+        return 1
+
+    run = merge_platforms(docs)
+    if run is None:
+        return 1
+    commit = run["commit"]
+    if not commit:
+        print(
+            "publish: the merged run carries no commit, refusing to file it",
+            file=sys.stderr,
+        )
+        return 1
+
+    root = pathlib.Path(args.site)
+    runs = root / "runs"
+    runs.mkdir(parents=True, exist_ok=True)
+
+    # A re-run of the same commit merges into what is already on file rather
+    # than replacing it, so re-measuring one platform does not drop the others.
+    target = runs / f"{commit}.json"
+    existing = load(target) if target.exists() else None
+    if existing and existing.get("platforms"):
+        merged = dict(existing["platforms"])
+        merged.update(run["platforms"])
+        run["platforms"] = merged
+        print(f"publish: merged {len(run['platforms'])} platform(s) into the existing {commit[:12]}")
+    target.write_text(json.dumps(run, indent=1, sort_keys=True) + "\n")
+
+    entries = []
+    for f in sorted(runs.glob("*.json")):
+        if f.name == "index.json":
+            continue
+        doc = load(f)
+        if doc is not None:
+            entries.append(summarize(doc, f.name))
+    entries.sort(key=lambda e: e.get("timestamp") or "", reverse=True)
+
+    # Bounded, and the drop is reported rather than silent.
+    if len(entries) > args.keep:
+        for e in entries[args.keep:]:
+            (runs / e["file"]).unlink(missing_ok=True)
+        print(f"publish: pruned {len(entries) - args.keep} run(s) beyond the newest {args.keep}")
+        entries = entries[: args.keep]
+
+    (runs / "index.json").write_text(json.dumps({"runs": entries}, indent=1) + "\n")
+    newest = entries[0]
+    print(
+        f"publish: {len(entries)} run(s) on file, newest {newest['commit'][:12]} "
+        f"on {', '.join(newest['platforms']) or 'no platform'}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/perf-site/render_check.mjs
+++ b/tools/perf-site/render_check.mjs
@@ -28,7 +28,7 @@ const script = html.slice(html.indexOf("<script>") + 8, html.lastIndexOf("</scri
 // written, and `boot` depends on that to pick the run and the platform it
 // draws. Setting the values from here instead would test a path the browser
 // never takes.
-const nodes = {};
+let nodes = {};
 const node = (id) =>
   (nodes[id] ??= {
     _html: "",
@@ -100,12 +100,48 @@ if (!index.runs?.length) {
   process.exit(1);
 }
 
-new Function(script)();
-await new Promise((r) => setTimeout(r, 250));
-const out = node("#main").innerHTML;
+/// Render the page once, for one platform.
+///
+/// A run holds a platform per runner and the page draws one at a time, so
+/// checking only whichever the picker landed on leaves every other platform
+/// unverified. That is exactly the gap this check exists to close, so each one
+/// gets its own render against fresh stubs.
+async function render(platform) {
+  nodes = {};
+  // Seeded before boot because `syncPlatforms` reads the current value first
+  // and restores it when the new run also has that platform, which is the same
+  // path a browser takes when the reader changes runs.
+  if (platform) node("#plat").value = platform;
+  new Function(script)();
+  await new Promise((r) => setTimeout(r, 250));
+  return { html: node("#main").innerHTML, platform: node("#plat").value };
+}
 
 const failures = [];
+const newestRun = JSON.parse(readFileSync(`${site}/runs/${index.runs[0].file}`, "utf8"));
+const platforms = Object.keys(newestRun.platforms ?? {});
+if (!platforms.length) {
+  console.error("render check: the newest run records no platform");
+  process.exit(1);
+}
 
+let out = "";
+let checked = 0;
+let cardsTotal = 0;
+for (const wanted of platforms) {
+  const drawn = await render(wanted);
+  if (drawn.platform !== wanted) {
+    failures.push(`the page would not select ${wanted}; it drew ${drawn.platform || "nothing"}`);
+    continue;
+  }
+  out = drawn.html;
+  cardsTotal += (out.match(/<h3>/g) || []).length;
+  checked += 1;
+  verify(out, wanted, newestRun);
+}
+out = out || "";
+
+function verify(out, platform, newest) {
 // A section that throws is not a section that is missing, and until this
 // existed it was not a failure either: `section(name, build)` catches every
 // throw and emits the heading plus a `card broken` panel, which satisfies a
@@ -113,19 +149,10 @@ const failures = [];
 for (const m of out.matchAll(
   /<div class="card broken">\s*<h3>([^<]*)<\/h3>\s*<p class="note">([^<]*)<\/p>/g
 )) {
-  failures.push(`${m[1]}: ${m[2]}`);
+  failures.push(`${platform}: ${m[1]}: ${m[2]}`);
 }
-if (/class="card broken"/.test(out) && !failures.length) {
-  failures.push("a section rendered as a broken card, in a shape this check could not name");
-}
-
-// Every family the collector did not mark absent has data, so it owes the page
-// a section. The page draws one <h2> per family titled by the family itself,
-// so the title is what gets matched.
-const newest = JSON.parse(readFileSync(`${site}/runs/${index.runs[0].file}`, "utf8"));
-const platform = node("#plat").value;
-if (!platform) {
-  failures.push("the page selected no platform, so it drew no family");
+if (/class="card broken"/.test(out) && !failures.some((f) => f.startsWith(`${platform}:`))) {
+  failures.push(`${platform}: a section rendered as a broken card, in a shape this check could not name`);
 }
 // Nothing below may throw on a malformed document. A check that crashes
 // reports "the check broke", and the reader has to go and find out which
@@ -138,7 +165,7 @@ for (const [name, family] of Object.entries(families)) {
   const title = family.title || name;
   // The heading carries a trust pill after the title, so match the opening.
   if (!out.includes(`<span class="h2-name">${title}</span>`)) {
-    failures.push(`${name} was collected (trust=${family.trust}) but "${title}" is not on the page`);
+    failures.push(`${platform}: ${name} was collected (trust=${family.trust}) but "${title}" is not on the page`);
     continue;
   }
   drawn += 1;
@@ -149,23 +176,23 @@ for (const [name, family] of Object.entries(families)) {
   // document is the defect, not the page.
   if (!Array.isArray(family.groups)) {
     failures.push(
-      `${name} was collected (trust=${family.trust}) but its "groups" is ` +
+      `${platform}: ${name} was collected (trust=${family.trust}) but its "groups" is ` +
         `${family.groups === undefined ? "missing" : typeof family.groups}, not an array`
     );
     continue;
   }
   if (!family.groups.length) {
-    failures.push(`${name} was collected (trust=${family.trust}) but recorded no groups`);
+    failures.push(`${platform}: ${name} was collected (trust=${family.trust}) but recorded no groups`);
     continue;
   }
   for (const group of family.groups) {
     const rows = asArray(group?.rows).filter((r) => Number.isFinite(r?.value)).length;
     if (!rows) {
-      failures.push(`${name}/${group?.name} recorded no usable row`);
+      failures.push(`${platform}: ${name}/${group?.name} recorded no usable row`);
       continue;
     }
     if (!out.includes(`<h3>${group.name}`)) {
-      failures.push(`${name}/${group.name} has ${rows} row(s) but drew no card`);
+      failures.push(`${platform}: ${name}/${group.name} has ${rows} row(s) but drew no card`);
     }
   }
 }
@@ -175,20 +202,31 @@ if (!drawn) {
   );
 }
 const drewHeading = (name) => out.includes(`<span class="h2-name">${name}</span>`);
-if (!drewHeading("Overview")) failures.push("the overview section is missing");
+if (!drewHeading("Overview")) failures.push(`${platform}: the overview section is missing`);
 if (Object.keys(newest.platforms ?? {}).length > 1 && !drewHeading("Across platforms")) {
-  failures.push("the run has more than one platform but the cross-platform section is missing");
+  failures.push(`${platform}: the run has more than one platform but the cross-platform section is missing`);
 }
 if (index.runs.length && !drewHeading("Trend across every recorded run")) {
-  failures.push("the trend section is missing");
+  failures.push(`${platform}: the trend section is missing`);
 }
 if (out.length < 2000) {
-  failures.push(`the page rendered only ${out.length} bytes, which is not a populated dashboard`);
+  failures.push(`${platform}: the page rendered only ${out.length} bytes, which is not a populated dashboard`);
 }
 
-const cards = (out.match(/<h3>/g) || []).length;
+// The jump index is built by reading back the headings the page produced, so a
+// link that points at no heading means the two drifted. A dead anchor is silent
+// in a browser: the click simply does nothing.
+const headings = new Set([...out.matchAll(/<h2 id="([^"]+)"/g)].map((m) => m[1]));
+for (const m of out.matchAll(/<a class="jump" href="#([^"]+)"/g)) {
+  if (!headings.has(m[1])) {
+    failures.push(`${platform}: the index links to #${m[1]}, which is not a heading on the page`);
+  }
+}
+}
+
 console.log(
-  `render check: ${out.length} bytes, ${cards} cards, ${drawn} famil(ies) drawn on ${platform}, ` +
+  `render check: ${checked} of ${platforms.length} platform(s) verified ` +
+    `(${platforms.join(", ")}), ${cardsTotal} cards across them, ` +
     `${index.runs.length} run(s) on file`
 );
 

--- a/tools/perf-site/render_check.mjs
+++ b/tools/perf-site/render_check.mjs
@@ -1,0 +1,198 @@
+// Render the dashboard headlessly and refuse a publish that would drop a
+// family on the floor.
+//
+// The page reads run documents the benches produce. Nothing links the two, so
+// a bench can change the shape of what it records and the section that draws
+// it silently renders nothing: a blank section is not an error to a browser,
+// so the job stays green and the site goes quiet.
+//
+// This runs the page's own code over the documents about to be published and
+// fails when a family that was collected produced no section, so the failure
+// lands in CI rather than on the site.
+//
+// Usage: node tools/perf-site/render_check.mjs <site dir>
+
+import { readFileSync } from "node:fs";
+
+const site = process.argv[2];
+if (!site) {
+  console.error("usage: render_check.mjs <site dir>");
+  process.exit(2);
+}
+
+const html = readFileSync(`${site}/index.html`, "utf8");
+const script = html.slice(html.indexOf("<script>") + 8, html.lastIndexOf("</script>"));
+
+// Enough of a <select> for the page's own boot path to run unchanged: a
+// browser adopts the selected option's value the moment the options are
+// written, and `boot` depends on that to pick the run and the platform it
+// draws. Setting the values from here instead would test a path the browser
+// never takes.
+const nodes = {};
+const node = (id) =>
+  (nodes[id] ??= {
+    _html: "",
+    // The static markup marks 10% selected; the stub starts where the browser
+    // would, so a threshold-dependent class is computed against a real number.
+    value: id === "#thresh" ? "10" : "",
+    style: {},
+    addEventListener() {},
+    set innerHTML(v) {
+      this._html = v;
+      const opts = [...v.matchAll(/<option value="([^"]*)"([^>]*)>/g)];
+      if (opts.length) this.value = (opts.find((o) => /\bselected\b/.test(o[2])) || opts[0])[1];
+    },
+    get innerHTML() {
+      return this._html;
+    },
+  });
+
+// The page also wires up interaction it cannot use here: a zoom overlay it
+// builds and appends, and document-level listeners. None of it affects what
+// gets rendered, but it runs during boot, so it has to find something rather
+// than throw and take the whole check down with it. These stubs exist to let
+// boot reach the end, not to stand in for a browser: nothing below is
+// asserted on.
+const detached = () => ({
+  className: "",
+  hidden: false,
+  style: {},
+  classList: { add() {}, remove() {}, contains: () => false },
+  appendChild() {},
+  addEventListener() {},
+  closest: () => null,
+});
+
+globalThis.document = {
+  querySelector: (sel) => node(sel),
+  querySelectorAll: () => [],
+  createElement: () => detached(),
+  addEventListener() {},
+  body: { appendChild() {} },
+};
+// The page sizes its charts from the viewport and redraws when it changes, so
+// the check has to stand in for a window as well as a document. A fixed width
+// keeps the rendered output deterministic.
+globalThis.window = {
+  innerWidth: 1280,
+  innerHeight: 900,
+  addEventListener() {},
+  matchMedia: () => ({ matches: false, addEventListener() {} }),
+};
+
+globalThis.fetch = async (path) => {
+  try {
+    return { ok: true, json: async () => JSON.parse(readFileSync(`${site}/${path}`, "utf8")) };
+  } catch {
+    return { ok: false, status: 404 };
+  }
+};
+
+let index;
+try {
+  index = JSON.parse(readFileSync(`${site}/runs/index.json`, "utf8"));
+} catch {
+  console.error("render check: no runs/index.json, nothing to verify");
+  process.exit(1);
+}
+if (!index.runs?.length) {
+  console.error("render check: runs/index.json lists no runs");
+  process.exit(1);
+}
+
+new Function(script)();
+await new Promise((r) => setTimeout(r, 250));
+const out = node("#main").innerHTML;
+
+const failures = [];
+
+// A section that throws is not a section that is missing, and until this
+// existed it was not a failure either: `section(name, build)` catches every
+// throw and emits the heading plus a `card broken` panel, which satisfies a
+// naive heading assertion. Look for the panel first, and name it.
+for (const m of out.matchAll(
+  /<div class="card broken">\s*<h3>([^<]*)<\/h3>\s*<p class="note">([^<]*)<\/p>/g
+)) {
+  failures.push(`${m[1]}: ${m[2]}`);
+}
+if (/class="card broken"/.test(out) && !failures.length) {
+  failures.push("a section rendered as a broken card, in a shape this check could not name");
+}
+
+// Every family the collector did not mark absent has data, so it owes the page
+// a section. The page draws one <h2> per family titled by the family itself,
+// so the title is what gets matched.
+const newest = JSON.parse(readFileSync(`${site}/runs/${index.runs[0].file}`, "utf8"));
+const platform = node("#plat").value;
+if (!platform) {
+  failures.push("the page selected no platform, so it drew no family");
+}
+// Nothing below may throw on a malformed document. A check that crashes
+// reports "the check broke", and the reader has to go and find out which
+// family did it; a check that keeps going names the family in its own output.
+const asArray = (v) => (Array.isArray(v) ? v : []);
+const families = newest.platforms?.[platform]?.families ?? {};
+let drawn = 0;
+for (const [name, family] of Object.entries(families)) {
+  if (!family || family.trust === "absent") continue;
+  const title = family.title || name;
+  // The heading carries a trust pill after the title, so match the opening.
+  if (!out.includes(`<span class="h2-name">${title}</span>`)) {
+    failures.push(`${name} was collected (trust=${family.trust}) but "${title}" is not on the page`);
+    continue;
+  }
+  drawn += 1;
+
+  // A family that claims to be collected owes the page a group. The renderer
+  // degrades a malformed `groups` into an empty list and draws a card saying
+  // so, which is honest on the page but must still fail the publish: the run
+  // document is the defect, not the page.
+  if (!Array.isArray(family.groups)) {
+    failures.push(
+      `${name} was collected (trust=${family.trust}) but its "groups" is ` +
+        `${family.groups === undefined ? "missing" : typeof family.groups}, not an array`
+    );
+    continue;
+  }
+  if (!family.groups.length) {
+    failures.push(`${name} was collected (trust=${family.trust}) but recorded no groups`);
+    continue;
+  }
+  for (const group of family.groups) {
+    const rows = asArray(group?.rows).filter((r) => Number.isFinite(r?.value)).length;
+    if (!rows) {
+      failures.push(`${name}/${group?.name} recorded no usable row`);
+      continue;
+    }
+    if (!out.includes(`<h3>${group.name}`)) {
+      failures.push(`${name}/${group.name} has ${rows} row(s) but drew no card`);
+    }
+  }
+}
+if (!drawn) {
+  failures.push(
+    `no family on ${platform} was drawn; the newest run lists ${Object.keys(families).length}`
+  );
+}
+const drewHeading = (name) => out.includes(`<span class="h2-name">${name}</span>`);
+if (!drewHeading("Overview")) failures.push("the overview section is missing");
+if (Object.keys(newest.platforms ?? {}).length > 1 && !drewHeading("Across platforms")) {
+  failures.push("the run has more than one platform but the cross-platform section is missing");
+}
+if (index.runs.length && !drewHeading("Trend across every recorded run")) {
+  failures.push("the trend section is missing");
+}
+if (out.length < 2000) {
+  failures.push(`the page rendered only ${out.length} bytes, which is not a populated dashboard`);
+}
+
+const cards = (out.match(/<h3>/g) || []).length;
+console.log(
+  `render check: ${out.length} bytes, ${cards} cards, ${drawn} famil(ies) drawn on ${platform}, ` +
+    `${index.runs.length} run(s) on file`
+);
+
+if (failures.length) {
+  for (const f of failures) console.error(`render check: ${f}`);
+  process.exit(1);
+}

--- a/tools/perf/Cargo.toml
+++ b/tools/perf/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "defra-perf"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Benchmark reporting contract and run-document collector for the DefraDB performance site"
+publish = false
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+
+# Provenance, process accounting and the criterion harvest are native-only:
+# a browser has no `getrusage`, no `/proc`, and no directory of sample sets.
+# The reporting contract itself is pure serde, so a wasm benchmark links this
+# crate and describes what it measured in exactly the shape `collect` reads.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
+libc = "0.2"
+sysinfo = { version = "0.33", default-features = false, features = ["system"] }
+
+[[bin]]
+name = "collect"
+path = "src/bin/collect.rs"
+
+[lints]
+workspace = true

--- a/tools/perf/src/bin/collect.rs
+++ b/tools/perf/src/bin/collect.rs
@@ -58,6 +58,12 @@ fn main() {
         .unwrap_or_else(criterion::criterion_root);
     let harvested = criterion::harvest(&criterion_root, timing_trust);
     if harvested.is_empty() {
+        // The same refusal the harvested families get below: silently replacing
+        // a bench's own family with a stub saying nothing was collected would
+        // report a gap over data that exists.
+        if families.contains_key("criterion") {
+            die("a bench emitted a family named 'criterion', which the criterion harvester owns");
+        }
         families.insert(
             "criterion".to_string(),
             absent(

--- a/tools/perf/src/bin/collect.rs
+++ b/tools/perf/src/bin/collect.rs
@@ -1,0 +1,322 @@
+//! Assemble one platform document from every metric family the benches wrote.
+//!
+//! ```text
+//! cargo run -p defra-perf --bin collect -- \
+//!     --out platform-x86_64-unknown-linux-gnu.json \
+//!     --commit <sha> --label main --target x86_64-unknown-linux-gnu \
+//!     [--loadguard loadguard.json]
+//! ```
+//!
+//! Families come from `$DEFRA_BENCH_OUT` (JSON Lines) when it is set and from
+//! `./bench-out/*.json` otherwise. Criterion's own estimates are folded in as
+//! one more family, so every benchmark in the suite reaches the dashboard
+//! without a second copy of its timing living anywhere.
+//!
+//! Two rules this exists to enforce. A family that was not collected is
+//! written `trust: "absent"` and never as a zero, so a gap in collection
+//! renders as a gap. And a document is append-only once published: an existing
+//! `--out` is an error, never an overwrite.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use defra_perf::criterion;
+use defra_perf::emit::{Family, Trust};
+use defra_perf::run_meta;
+use serde_json::{json, Value};
+
+const USAGE: &str = "collect: assemble one platform document from every bench family.
+
+  cargo run -p defra-perf --bin collect -- --out <file.json> --commit <sha> \\
+      --label <label> --target <triple> [--loadguard <verdict.json>] \\
+      [--criterion-root <dir>]
+
+Families are read from $DEFRA_BENCH_OUT (JSON Lines) when set, else ./bench-out/*.json.";
+
+fn main() {
+    let Some(args) = parse_args() else { return };
+
+    let files = record_files();
+    let mut families = read_records(&files);
+    if families.is_empty() {
+        eprintln!(
+            "collect: no family records found in {}. Only the criterion family can be reported.",
+            describe(&files)
+        );
+    }
+
+    let guard = run_meta::load_guard(args.loadguard.as_deref());
+    let timing_trust = if guard.passed {
+        Trust::Clean
+    } else {
+        Trust::Contaminated
+    };
+
+    let criterion_root = args
+        .criterion_root
+        .clone()
+        .unwrap_or_else(criterion::criterion_root);
+    let harvested = criterion::harvest(&criterion_root, timing_trust);
+    if harvested.is_empty() {
+        families.insert(
+            "criterion".to_string(),
+            absent(
+                "Criterion benchmarks",
+                "No criterion sample sets were found under the target directory for this run.",
+            ),
+        );
+    }
+    for (name, family) in harvested {
+        let value = serde_json::to_value(family).unwrap_or_else(|e| die(&format!("{e}")));
+        if families.insert(name.clone(), value).is_some() {
+            die(&format!(
+                "a bench emitted a family named '{name}', which the criterion harvester owns"
+            ));
+        }
+    }
+
+    for (name, family) in families.iter_mut() {
+        apply_guard(name, family, timing_trust);
+    }
+
+    let document = json!({
+        "schema_version": 1,
+        "commit": args.commit,
+        "label": args.label,
+        "timestamp": run_meta::now_iso8601(),
+        "target": args.target,
+        "toolchain": run_meta::toolchain(),
+        "host": run_meta::host(),
+        "loadguard": guard,
+        "families": families,
+    });
+
+    write_new(&args.out, &format!("{:#}\n", document));
+    summarize(&args.out, &families, guard.passed);
+}
+
+/// Trust is only ever downgraded. A bench that declared its own doubt keeps
+/// it, and a deterministic family is immune to how busy the host was.
+fn apply_guard(name: &str, family: &mut Value, timing_trust: Trust) {
+    let deterministic = family
+        .get("deterministic")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let declared = match family.get("trust").and_then(Value::as_str) {
+        Some("clean") => Trust::Clean,
+        Some("contaminated") => Trust::Contaminated,
+        Some("absent") => Trust::Absent,
+        Some(other) => die(&format!(
+            "family '{name}': trust {other:?} is not one of clean, contaminated, absent"
+        )),
+        None => die(&format!("family '{name}' did not declare a trust level")),
+    };
+    let effective = if deterministic || declared == Trust::Absent {
+        declared
+    } else {
+        worst(declared, timing_trust)
+    };
+    family["trust"] = json!(match effective {
+        Trust::Clean => "clean",
+        Trust::Contaminated => "contaminated",
+        Trust::Absent => "absent",
+    });
+}
+
+fn worst(a: Trust, b: Trust) -> Trust {
+    let rank = |t| match t {
+        Trust::Clean => 0,
+        Trust::Contaminated => 1,
+        Trust::Absent => 2,
+    };
+    if rank(a) >= rank(b) {
+        a
+    } else {
+        b
+    }
+}
+
+fn absent(title: &str, note: &str) -> Value {
+    serde_json::to_value(Family::new(title, note).trust(Trust::Absent))
+        .unwrap_or_else(|e| die(&format!("{e}")))
+}
+
+struct Args {
+    out: PathBuf,
+    commit: String,
+    label: String,
+    target: String,
+    loadguard: Option<PathBuf>,
+    /// A tree whose immediate children are bench-target names. Defaults to
+    /// `$CARGO_TARGET_DIR/criterion`, which is flat and therefore reports one
+    /// unattributed family.
+    criterion_root: Option<PathBuf>,
+}
+
+/// `None` means `--help` was asked for and printed.
+fn parse_args() -> Option<Args> {
+    let argv: Vec<String> = std::env::args().skip(1).collect();
+
+    let mut out = None;
+    let mut commit = None;
+    let mut label = None;
+    let mut target = None;
+    let mut loadguard = None;
+    let mut criterion_root = None;
+    let mut foreign = Vec::new();
+
+    let mut i = 0;
+    while i < argv.len() {
+        let value = |i: &mut usize, flag: &str| -> String {
+            *i += 1;
+            argv.get(*i)
+                .cloned()
+                .unwrap_or_else(|| die(&format!("{flag} needs a value")))
+        };
+        match argv[i].as_str() {
+            "--out" => out = Some(PathBuf::from(value(&mut i, "--out"))),
+            "--commit" => commit = Some(value(&mut i, "--commit")),
+            "--label" => label = Some(value(&mut i, "--label")),
+            "--target" => target = Some(value(&mut i, "--target")),
+            "--loadguard" => loadguard = Some(PathBuf::from(value(&mut i, "--loadguard"))),
+            "--criterion-root" => {
+                criterion_root = Some(PathBuf::from(value(&mut i, "--criterion-root")))
+            }
+            "-h" | "--help" => {
+                println!("{USAGE}");
+                return None;
+            }
+            other => foreign.push(other.to_string()),
+        }
+        i += 1;
+    }
+
+    if !foreign.is_empty() {
+        die(&format!("unrecognized arguments: {}", foreign.join(" ")));
+    }
+    let Some(out) = out else {
+        eprintln!("{USAGE}");
+        std::process::exit(2);
+    };
+
+    Some(Args {
+        out,
+        commit: commit.unwrap_or_else(|| die("--commit is required")),
+        label: label.unwrap_or_else(|| die("--label is required")),
+        target: target.unwrap_or_else(run_meta::derived_target),
+        loadguard,
+        criterion_root,
+    })
+}
+
+fn record_files() -> Vec<PathBuf> {
+    match std::env::var_os("DEFRA_BENCH_OUT") {
+        Some(p) if !p.is_empty() => vec![PathBuf::from(p)],
+        _ => {
+            let mut files: Vec<PathBuf> = std::fs::read_dir("bench-out")
+                .into_iter()
+                .flatten()
+                .filter_map(|e| e.ok().map(|e| e.path()))
+                .filter(|p| p.extension().is_some_and(|x| x == "json"))
+                .collect();
+            files.sort();
+            files
+        }
+    }
+}
+
+fn describe(files: &[PathBuf]) -> String {
+    if files.is_empty() {
+        "$DEFRA_BENCH_OUT (unset) and ./bench-out/*.json (empty or missing)".to_string()
+    } else {
+        files
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+}
+
+fn read_records(files: &[PathBuf]) -> BTreeMap<String, Value> {
+    let mut out = BTreeMap::new();
+    for file in files {
+        let text = std::fs::read_to_string(file)
+            .unwrap_or_else(|e| die(&format!("read {}: {e}", file.display())));
+        for (n, line) in text.lines().enumerate() {
+            if line.trim().is_empty() {
+                continue;
+            }
+            let at = format!("{}:{}", file.display(), n + 1);
+            let record: Value = serde_json::from_str(line)
+                .unwrap_or_else(|e| die(&format!("{at}: malformed JSON: {e}")));
+            let Some(name) = record.get("family").and_then(Value::as_str) else {
+                die(&format!("{at}: record has no \"family\" string"))
+            };
+            let Some(data) = record.get("data") else {
+                die(&format!("{at}: family '{name}' has no \"data\""))
+            };
+            if out.insert(name.to_string(), data.clone()).is_some() {
+                die(&format!(
+                    "{at}: family '{name}' was emitted twice; a document records one measurement \
+                     per family. Collect against a fresh output file."
+                ));
+            }
+        }
+    }
+    out
+}
+
+/// A platform document is append-only once published, so an existing path is
+/// an error rather than an overwrite.
+fn write_new(path: &Path, body: &str) {
+    match path.parent() {
+        Some(dir) if !dir.as_os_str().is_empty() => std::fs::create_dir_all(dir)
+            .unwrap_or_else(|e| die(&format!("create {}: {e}", dir.display()))),
+        _ => {}
+    }
+    match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+    {
+        Ok(mut f) => {
+            use std::io::Write;
+            f.write_all(body.as_bytes())
+                .unwrap_or_else(|e| die(&format!("write {}: {e}", path.display())));
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => die(&format!(
+            "{} already exists. A platform document is append-only once published: re-measuring \
+             produces a new file, so a comparison can always be reproduced.",
+            path.display()
+        )),
+        Err(e) => die(&format!("create {}: {e}", path.display())),
+    }
+}
+
+fn summarize(path: &Path, families: &BTreeMap<String, Value>, quiet_host: bool) {
+    println!("collect: wrote {}", path.display());
+    for (name, family) in families {
+        let trust = family.get("trust").and_then(Value::as_str).unwrap_or("?");
+        let groups = family
+            .get("groups")
+            .and_then(Value::as_array)
+            .map(|g| g.len())
+            .unwrap_or(0);
+        let rows: usize = family
+            .get("groups")
+            .and_then(Value::as_array)
+            .map(|gs| {
+                gs.iter()
+                    .filter_map(|g| g.get("rows").and_then(Value::as_array).map(Vec::len))
+                    .sum()
+            })
+            .unwrap_or(0);
+        println!("  {name:<20} trust={trust:<13} {groups} group(s), {rows} row(s)");
+    }
+    println!("  {:<20} passed={quiet_host}", "loadguard");
+}
+
+fn die(why: &str) -> ! {
+    eprintln!("collect: {why}");
+    std::process::exit(1)
+}

--- a/tools/perf/src/criterion.rs
+++ b/tools/perf/src/criterion.rs
@@ -1,0 +1,168 @@
+//! Criterion's own estimates, folded into the run document.
+//!
+//! Every `bench_function` in the suite already produces a per-iteration
+//! estimate; harvesting the directory is what puts all of them on the
+//! dashboard without a second copy of the measurement living anywhere. A bench
+//! target therefore never reports its criterion timings itself: the two places
+//! that would have to agree instead read the one place criterion wrote.
+//!
+//! Criterion records a benchmark under its group name and nothing else, so the
+//! bench target that produced it is lost the moment two targets' output share
+//! a directory. The harvest reads a tree where each immediate child is a bench
+//! target, which is the layout the runner and `just perf` both hand it, and
+//! gives every target its own family so every target gets its own section on
+//! the page. A flat tree, which is what a bare `cargo bench` leaves behind, is
+//! still read: it becomes one family, named for being unattributed rather than
+//! pretending otherwise.
+
+#![allow(dead_code)]
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::emit::{Family, Group, Row, Trust};
+
+/// Where criterion left its sample sets for this run.
+pub fn criterion_root() -> PathBuf {
+    PathBuf::from(std::env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| "target".into()))
+        .join("criterion")
+}
+
+/// One family per bench target found under `root`, keyed by the target's name.
+///
+/// Empty when criterion recorded nothing, which the collector renders as an
+/// explicit gap rather than as a set of zeroes.
+pub fn harvest(root: &Path, trust: Trust) -> BTreeMap<String, Family> {
+    let mut out = BTreeMap::new();
+    for (target, dir) in targets(root) {
+        if let Some(family) = one_target(&target, &dir, trust) {
+            out.insert(format!("criterion_{target}"), family);
+        }
+    }
+    out
+}
+
+/// The bench targets under `root`. A directory holding a `new/estimates.json`
+/// anywhere beneath it is a criterion group, not a target, so a flat tree is
+/// reported as the single unattributed target it is.
+fn targets(root: &Path) -> Vec<(String, PathBuf)> {
+    let Ok(entries) = fs::read_dir(root) else {
+        return Vec::new();
+    };
+    let mut dirs: Vec<PathBuf> = entries
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.is_dir() && p.file_name().is_some_and(|n| n != "report"))
+        .collect();
+    dirs.sort();
+
+    // A per-target tree nests one more level than a flat one: `<target>/<group>/…`
+    // against `<group>/…`. Deciding on the shape rather than on a flag means a
+    // directory assembled either way still reads correctly.
+    let flat = dirs
+        .iter()
+        .any(|d| d.join("new").join("estimates.json").is_file());
+    if flat || dirs.is_empty() {
+        return vec![("unattributed".to_string(), root.to_path_buf())];
+    }
+    dirs.into_iter()
+        .filter_map(|d| {
+            let name = d.file_name()?.to_string_lossy().into_owned();
+            Some((name, d))
+        })
+        .collect()
+}
+
+fn one_target(target: &str, dir: &Path, trust: Trust) -> Option<Family> {
+    let mut found: Vec<(String, f64)> = Vec::new();
+    walk(dir, dir, 0, &mut found);
+    if found.is_empty() {
+        return None;
+    }
+    found.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut groups: BTreeMap<String, Vec<Row>> = BTreeMap::new();
+    for (id, median_ns) in found {
+        let (group, rest) = match id.split_once('/') {
+            Some((g, r)) => (g.to_string(), r.to_string()),
+            None => ("ungrouped".to_string(), id),
+        };
+        groups.entry(group).or_default().push(row(rest, median_ns));
+    }
+
+    // How criterion was driven is part of what the number means: a run taken at
+    // a reduced sample size is comparable with another run taken the same way
+    // and not with a full one, so the configuration travels with the
+    // measurement instead of being implied by the job that produced it.
+    let sampling = match std::env::var("DEFRA_BENCH_CRITERION_ARGS") {
+        Ok(args) if !args.trim().is_empty() => {
+            format!(" Criterion was driven with `{}`.", args.trim())
+        }
+        _ => " Criterion ran with its default sampling.".to_string(),
+    };
+    let title = if target == "unattributed" {
+        "Criterion benchmarks".to_string()
+    } else {
+        format!("{target} benchmarks")
+    };
+    let family = Family::new(
+        title,
+        format!(
+            "Median wall time per iteration, harvested from the sample sets criterion wrote for \
+             the `{target}` bench target. Lower is better.{sampling}"
+        ),
+    )
+    .trust(trust);
+    Some(groups.into_iter().fold(family, |f, (name, rows)| {
+        f.group(Group::lower_better(name, "ns/iter").rows(rows))
+    }))
+}
+
+/// A criterion benchmark id is a string, so `16` sorts before `4`. When every
+/// name in a group is a number the row carries it as its x, which both orders
+/// the table and lets the group draw as a curve instead of a list.
+fn row(name: String, median_ns: f64) -> Row {
+    match name.parse::<f64>() {
+        Ok(x) if x.is_finite() => Row::new(name, median_ns).at(x),
+        _ => Row::new(name, median_ns),
+    }
+}
+
+fn walk(dir: &Path, root: &Path, depth: usize, out: &mut Vec<(String, f64)>) {
+    // Criterion nests one directory per benchmark id segment. Eight is deeper
+    // than any id this suite produces and stops a symlink loop cheaply.
+    if depth > 8 {
+        return;
+    }
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    let mut subdirs: Vec<PathBuf> = entries
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.is_dir())
+        .collect();
+    subdirs.sort();
+    for sub in subdirs {
+        // The newest sample set is under `new/`; `base/` and any saved baseline
+        // beside it are older copies of the same benchmark.
+        if sub.file_name().is_some_and(|n| n == "new") {
+            let estimates = sub.join("estimates.json");
+            let id = sub.parent().and_then(|p| p.strip_prefix(root).ok());
+            if let (Some(median), Some(id)) = (median_ns(&estimates), id) {
+                out.push((id.to_string_lossy().replace('\\', "/"), median));
+            }
+            continue;
+        }
+        walk(&sub, root, depth + 1, out);
+    }
+}
+
+fn median_ns(path: &Path) -> Option<f64> {
+    let text = fs::read_to_string(path).ok()?;
+    let value: serde_json::Value = serde_json::from_str(&text).ok()?;
+    value
+        .get("median")?
+        .get("point_estimate")?
+        .as_f64()
+        .filter(|v| v.is_finite())
+}

--- a/tools/perf/src/criterion.rs
+++ b/tools/perf/src/criterion.rs
@@ -74,7 +74,7 @@ fn targets(root: &Path) -> Vec<(String, PathBuf)> {
 }
 
 fn one_target(target: &str, dir: &Path, trust: Trust) -> Option<Family> {
-    let mut found: Vec<(String, f64)> = Vec::new();
+    let mut found: Vec<(String, Estimate)> = Vec::new();
     walk(dir, dir, 0, &mut found);
     if found.is_empty() {
         return None;
@@ -82,12 +82,12 @@ fn one_target(target: &str, dir: &Path, trust: Trust) -> Option<Family> {
     found.sort_by(|a, b| a.0.cmp(&b.0));
 
     let mut groups: BTreeMap<String, Vec<Row>> = BTreeMap::new();
-    for (id, median_ns) in found {
+    for (id, estimate) in found {
         let (group, rest) = match id.split_once('/') {
             Some((g, r)) => (g.to_string(), r.to_string()),
             None => ("ungrouped".to_string(), id),
         };
-        groups.entry(group).or_default().push(row(rest, median_ns));
+        groups.entry(group).or_default().push(row(rest, estimate));
     }
 
     // How criterion was driven is part of what the number means: a run taken at
@@ -118,17 +118,32 @@ fn one_target(target: &str, dir: &Path, trust: Trust) -> Option<Family> {
     }))
 }
 
+/// Criterion's median for one benchmark, with the interval it is confident the
+/// true median lies in.
+struct Estimate {
+    median_ns: f64,
+    lower_ns: f64,
+    upper_ns: f64,
+}
+
 /// A criterion benchmark id is a string, so `16` sorts before `4`. When every
 /// name in a group is a number the row carries it as its x, which both orders
 /// the table and lets the group draw as a curve instead of a list.
-fn row(name: String, median_ns: f64) -> Row {
+///
+/// The confidence interval is carried as the row's range, and that is what
+/// makes a criterion row comparable honestly: a comparison refuses to call a
+/// delta real when the two runs' ranges overlap, and a row with no range gets
+/// judged on the threshold alone. Discarding the interval turned every noisy
+/// benchmark on a shared runner into a reported regression.
+fn row(name: String, estimate: Estimate) -> Row {
+    let row = Row::new(&name, estimate.median_ns).range(estimate.lower_ns, estimate.upper_ns);
     match name.parse::<f64>() {
-        Ok(x) if x.is_finite() => Row::new(name, median_ns).at(x),
-        _ => Row::new(name, median_ns),
+        Ok(x) if x.is_finite() => row.at(x),
+        _ => row,
     }
 }
 
-fn walk(dir: &Path, root: &Path, depth: usize, out: &mut Vec<(String, f64)>) {
+fn walk(dir: &Path, root: &Path, depth: usize, out: &mut Vec<(String, Estimate)>) {
     // Criterion nests one directory per benchmark id segment. Eight is deeper
     // than any id this suite produces and stops a symlink loop cheaply.
     if depth > 8 {
@@ -148,8 +163,8 @@ fn walk(dir: &Path, root: &Path, depth: usize, out: &mut Vec<(String, f64)>) {
         if sub.file_name().is_some_and(|n| n == "new") {
             let estimates = sub.join("estimates.json");
             let id = sub.parent().and_then(|p| p.strip_prefix(root).ok());
-            if let (Some(median), Some(id)) = (median_ns(&estimates), id) {
-                out.push((id.to_string_lossy().replace('\\', "/"), median));
+            if let (Some(estimate), Some(id)) = (estimate(&estimates), id) {
+                out.push((id.to_string_lossy().replace('\\', "/"), estimate));
             }
             continue;
         }
@@ -157,12 +172,30 @@ fn walk(dir: &Path, root: &Path, depth: usize, out: &mut Vec<(String, f64)>) {
     }
 }
 
-fn median_ns(path: &Path) -> Option<f64> {
+fn estimate(path: &Path) -> Option<Estimate> {
     let text = fs::read_to_string(path).ok()?;
     let value: serde_json::Value = serde_json::from_str(&text).ok()?;
-    value
-        .get("median")?
+    let median = value.get("median")?;
+    let point = median
         .get("point_estimate")?
         .as_f64()
-        .filter(|v| v.is_finite())
+        .filter(|v| v.is_finite())?;
+    let interval = median.get("confidence_interval");
+    let bound = |name: &str| {
+        interval
+            .and_then(|i| i.get(name))
+            .and_then(serde_json::Value::as_f64)
+            .filter(|v| v.is_finite())
+    };
+    // An older sample set without an interval still reports its median; it just
+    // has no range, and is then compared on the threshold alone.
+    let (lower, upper) = match (bound("lower_bound"), bound("upper_bound")) {
+        (Some(lower), Some(upper)) if lower <= upper => (lower, upper),
+        _ => (point, point),
+    };
+    Some(Estimate {
+        median_ns: point,
+        lower_ns: lower,
+        upper_ns: upper,
+    })
 }

--- a/tools/perf/src/emit.rs
+++ b/tools/perf/src/emit.rs
@@ -1,0 +1,218 @@
+//! The contract between a benchmark and the performance dashboard.
+//!
+//! A bench describes what it measured as one [`Family`]; the dashboard renders
+//! any family without knowing its name. That is the point. A page with a
+//! bespoke renderer per family silently draws nothing for a family nobody
+//! wrote code for, and a blank section is not an error to a browser, so the
+//! gap reaches the site instead of CI. Here the shape carries its own labels,
+//! units and direction, so the renderer is one function and a new bench lands
+//! on the page with no page edit at all.
+//!
+//! Records are appended to `$DEFRA_BENCH_OUT` as JSON Lines when it is set,
+//! and land in `./bench-out/<family>.json` otherwise so a single bench can be
+//! run standalone.
+
+#![allow(dead_code)]
+
+#[cfg(not(target_arch = "wasm32"))]
+use std::fs::{self, File, OpenOptions};
+#[cfg(not(target_arch = "wasm32"))]
+use std::io::Write;
+#[cfg(not(target_arch = "wasm32"))]
+use std::path::PathBuf;
+
+use serde::Serialize;
+
+/// How much a measurement can be believed.
+///
+/// Only ever downgraded: a bench that declares its own doubt keeps it, and the
+/// load guard can add doubt but never remove it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Trust {
+    /// Measured on a host certified quiet, or deterministic and immune to load.
+    Clean,
+    /// Measured, but on a host that was busy. Comparable only with care.
+    Contaminated,
+    /// Not measured in this run. Renders as a gap, never as a zero.
+    Absent,
+}
+
+/// One measurement inside a group.
+#[derive(Clone, Debug, Serialize)]
+pub struct Row {
+    pub name: String,
+    pub value: f64,
+    /// Extremes across repetitions, when the bench repeated the measurement.
+    /// A comparison only calls a delta real when two ranges do not overlap, so
+    /// a bench that can report these should.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max: Option<f64>,
+    /// Numeric x for the group's chart. A group whose rows all carry one is
+    /// drawn as a line; a group without is drawn as a table only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub x: Option<f64>,
+}
+
+impl Row {
+    pub fn new(name: impl Into<String>, value: f64) -> Self {
+        Row {
+            name: name.into(),
+            value,
+            min: None,
+            max: None,
+            x: None,
+        }
+    }
+
+    pub fn range(mut self, min: f64, max: f64) -> Self {
+        self.min = Some(min);
+        self.max = Some(max);
+        self
+    }
+
+    pub fn at(mut self, x: f64) -> Self {
+        self.x = Some(x);
+        self
+    }
+}
+
+/// A set of rows sharing a unit and a direction.
+#[derive(Clone, Debug, Serialize)]
+pub struct Group {
+    pub name: String,
+    pub unit: String,
+    /// Carried rather than guessed from the unit: "MiB/s" is a rate to
+    /// maximise and "MiB" is a footprint to minimise, and both contain "mib".
+    pub lower_is_better: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub x_label: Option<String>,
+    pub rows: Vec<Row>,
+}
+
+impl Group {
+    pub fn higher_better(name: impl Into<String>, unit: impl Into<String>) -> Self {
+        Group {
+            name: name.into(),
+            unit: unit.into(),
+            lower_is_better: false,
+            note: None,
+            x_label: None,
+            rows: Vec::new(),
+        }
+    }
+
+    pub fn lower_better(name: impl Into<String>, unit: impl Into<String>) -> Self {
+        Group {
+            lower_is_better: true,
+            ..Group::higher_better(name, unit)
+        }
+    }
+
+    pub fn note(mut self, note: impl Into<String>) -> Self {
+        self.note = Some(note.into());
+        self
+    }
+
+    /// Label the x axis, which is also what makes the group draw as a chart.
+    pub fn over(mut self, x_label: impl Into<String>) -> Self {
+        self.x_label = Some(x_label.into());
+        self
+    }
+
+    pub fn row(mut self, row: Row) -> Self {
+        self.rows.push(row);
+        self
+    }
+
+    pub fn rows(mut self, rows: impl IntoIterator<Item = Row>) -> Self {
+        self.rows.extend(rows);
+        self
+    }
+}
+
+/// Everything one bench target measured.
+#[derive(Clone, Debug, Serialize)]
+pub struct Family {
+    pub title: String,
+    pub note: String,
+    pub trust: Trust,
+    /// A family a busy host cannot move: a byte count, an allocation count, a
+    /// size. The load guard downgrades timing families and leaves these alone,
+    /// so a run taken on a noisy runner still compares them.
+    pub deterministic: bool,
+    pub groups: Vec<Group>,
+}
+
+impl Family {
+    pub fn new(title: impl Into<String>, note: impl Into<String>) -> Self {
+        Family {
+            title: title.into(),
+            note: note.into(),
+            trust: Trust::Clean,
+            deterministic: false,
+            groups: Vec::new(),
+        }
+    }
+
+    /// Mark a family whose result does not depend on how busy the host was.
+    pub fn deterministic(mut self) -> Self {
+        self.deterministic = true;
+        self
+    }
+
+    /// Declare doubt this bench knows about. The collector can add more.
+    pub fn trust(mut self, trust: Trust) -> Self {
+        self.trust = trust;
+        self
+    }
+
+    pub fn group(mut self, group: Group) -> Self {
+        self.groups.push(group);
+        self
+    }
+
+    /// The one record line a family becomes, whatever carries it.
+    ///
+    /// A native bench appends this to a file; a browser has no file and prints
+    /// it instead, behind a marker the runner greps for. Both go through here,
+    /// so the two transports cannot disagree about the shape.
+    pub fn record(&self, name: &str) -> String {
+        serde_json::json!({ "family": name, "data": self }).to_string()
+    }
+
+    /// Append this family to the run's records.
+    ///
+    /// `name` is the stable key the dashboard joins on across runs, so it must
+    /// not change once a run carrying it has been published.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn emit(self, name: &str) {
+        let line = format!("{}\n", self.record(name));
+        match std::env::var_os("DEFRA_BENCH_OUT") {
+            Some(p) if !p.is_empty() => {
+                let path = PathBuf::from(p);
+                let mut f = OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(&path)
+                    .unwrap_or_else(|e| panic!("open {}: {e}", path.display()));
+                f.write_all(line.as_bytes())
+                    .unwrap_or_else(|e| panic!("write {}: {e}", path.display()));
+            }
+            _ => {
+                let dir = PathBuf::from("bench-out");
+                fs::create_dir_all(&dir)
+                    .unwrap_or_else(|e| panic!("create {}: {e}", dir.display()));
+                let path = dir.join(format!("{name}.json"));
+                let mut f = File::create(&path)
+                    .unwrap_or_else(|e| panic!("create {}: {e}", path.display()));
+                f.write_all(line.as_bytes())
+                    .unwrap_or_else(|e| panic!("write {}: {e}", path.display()));
+            }
+        }
+    }
+}

--- a/tools/perf/src/lib.rs
+++ b/tools/perf/src/lib.rs
@@ -1,0 +1,26 @@
+//! The contract between a DefraDB benchmark and the performance dashboard.
+//!
+//! A bench describes what it measured as an [`emit::Family`]; `collect` folds
+//! every family a platform recorded into one platform document; `publish.py`
+//! merges the platforms of a commit into the run document the dashboard reads.
+//!
+//! The contract lives here rather than inside the bench crate so the two sides
+//! cannot drift: a bench that emits a family and the collector that reads one
+//! are compiled against the same types. It is also why `collect` builds in
+//! seconds instead of pulling the database in behind it, which matters when
+//! every platform in the matrix runs it.
+//!
+//! See `tools/perf-site/` for the dashboard those documents are read by.
+
+pub mod emit;
+
+// The browser can describe what it measured, but it cannot read a process's
+// peak RSS, name the host it ran on, or walk a criterion directory. Those live
+// behind the native gate so a wasm benchmark can link the contract without
+// dragging in what its target has no answer for.
+#[cfg(not(target_arch = "wasm32"))]
+pub mod criterion;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod measure;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod run_meta;

--- a/tools/perf/src/measure.rs
+++ b/tools/perf/src/measure.rs
@@ -1,0 +1,158 @@
+//! Sampling and process accounting shared by the benchmark suite.
+//!
+//! Everything here is deliberately exact rather than sampled. A peak read from
+//! the kernel is the peak; a peak polled from a background thread is the
+//! largest value a poll happened to catch, and reporting that as "peak" is a
+//! silent cap.
+
+#![allow(dead_code)]
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::time::Instant;
+
+use crate::emit::Row;
+
+/// Peak resident set size of this process since it started, in bytes.
+///
+/// `ru_maxrss` is kibibytes on Linux and bytes on the Apple platforms, which
+/// is a real and often-missed ABI difference. Returns `None` where the call
+/// is unavailable, so a caller reports a gap rather than a zero.
+pub fn peak_rss_bytes() -> Option<u64> {
+    #[cfg(unix)]
+    {
+        // SAFETY: `getrusage` writes into the caller-provided struct and reads
+        // nothing else; a zeroed `rusage` is a valid destination.
+        let mut usage: libc::rusage = unsafe { std::mem::zeroed() };
+        if unsafe { libc::getrusage(libc::RUSAGE_SELF, &mut usage) } != 0 {
+            return None;
+        }
+        let raw = usage.ru_maxrss as u64;
+        #[cfg(target_vendor = "apple")]
+        return Some(raw);
+        #[cfg(not(target_vendor = "apple"))]
+        return Some(raw * 1024);
+    }
+    #[cfg(not(unix))]
+    None
+}
+
+pub fn median(samples: &mut [f64]) -> f64 {
+    assert!(!samples.is_empty(), "median of an empty sample");
+    samples.sort_by(f64::total_cmp);
+    let mid = samples.len() / 2;
+    if samples.len().is_multiple_of(2) {
+        (samples[mid - 1] + samples[mid]) / 2.0
+    } else {
+        samples[mid]
+    }
+}
+
+pub fn min_max(samples: &[f64]) -> (f64, f64) {
+    assert!(!samples.is_empty(), "min_max of an empty sample");
+    samples
+        .iter()
+        .fold((samples[0], samples[0]), |(lo, hi), &x| {
+            (lo.min(x), hi.max(x))
+        })
+}
+
+/// Run `f` `reps` times and fold the samples into one row carrying its range.
+///
+/// The range is what lets a comparison refuse to call an overlap a change, so
+/// a repeated measurement should always report through here.
+pub fn repeat<F: FnMut() -> f64>(name: impl Into<String>, reps: usize, mut f: F) -> Row {
+    assert!(reps > 0, "a measurement needs at least one repetition");
+    let mut samples: Vec<f64> = (0..reps).map(|_| f()).collect();
+    let (lo, hi) = min_max(&samples);
+    Row::new(name, median(&mut samples)).range(lo, hi)
+}
+
+/// Operations per second from a closure that performs `ops` operations.
+pub fn ops_per_s<F: FnMut()>(ops: u64, mut f: F) -> f64 {
+    let start = Instant::now();
+    f();
+    let secs = start.elapsed().as_secs_f64();
+    if secs <= 0.0 {
+        return f64::NAN;
+    }
+    ops as f64 / secs
+}
+
+/// A global allocator that counts allocations, for the per-operation
+/// allocation budgets.
+///
+/// One `#[global_allocator]` exists per binary, so this is installed by the
+/// bench target that measures allocations and by nothing else.
+pub struct CountingAllocator;
+
+static ALLOCS: AtomicU64 = AtomicU64::new(0);
+static BYTES: AtomicU64 = AtomicU64::new(0);
+static LIVE: AtomicUsize = AtomicUsize::new(0);
+static PEAK_LIVE: AtomicUsize = AtomicUsize::new(0);
+
+// SAFETY: every method forwards to the system allocator with the same layout
+// it was given, so the allocation contract is the system allocator's. The
+// counters are plain atomics and touch no allocator state.
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+        let live = LIVE.fetch_add(layout.size(), Ordering::Relaxed) + layout.size();
+        PEAK_LIVE.fetch_max(live, Ordering::Relaxed);
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        LIVE.fetch_sub(layout.size(), Ordering::Relaxed);
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        if new_size > layout.size() {
+            BYTES.fetch_add((new_size - layout.size()) as u64, Ordering::Relaxed);
+            let live = LIVE.fetch_add(new_size - layout.size(), Ordering::Relaxed) + new_size
+                - layout.size();
+            PEAK_LIVE.fetch_max(live, Ordering::Relaxed);
+        } else {
+            LIVE.fetch_sub(layout.size() - new_size, Ordering::Relaxed);
+        }
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+/// What the counters have seen since [`reset`].
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Allocs {
+    pub count: u64,
+    pub bytes: u64,
+    pub peak_live_bytes: usize,
+}
+
+pub fn reset() {
+    ALLOCS.store(0, Ordering::SeqCst);
+    BYTES.store(0, Ordering::SeqCst);
+    PEAK_LIVE.store(LIVE.load(Ordering::SeqCst), Ordering::SeqCst);
+}
+
+pub fn taken() -> Allocs {
+    Allocs {
+        count: ALLOCS.load(Ordering::SeqCst),
+        bytes: BYTES.load(Ordering::SeqCst),
+        peak_live_bytes: PEAK_LIVE
+            .load(Ordering::SeqCst)
+            .saturating_sub(LIVE.load(Ordering::SeqCst)),
+    }
+}
+
+/// Allocations attributable to one operation, averaged over `ops` of them.
+pub fn per_op<F: FnMut()>(ops: u64, mut f: F) -> f64 {
+    assert!(
+        ops > 0,
+        "allocations per operation needs at least one operation"
+    );
+    reset();
+    f();
+    taken().count as f64 / ops as f64
+}

--- a/tools/perf/src/run_meta.rs
+++ b/tools/perf/src/run_meta.rs
@@ -1,0 +1,140 @@
+//! Provenance for a platform document: who measured, on what, and how quiet
+//! the host was.
+//!
+//! Anything that cannot be read is written as null, never as a plausible
+//! default. A run whose host could not be identified says so.
+
+#![allow(dead_code)]
+
+use std::path::Path;
+use std::process::Command;
+
+use serde::Serialize;
+use serde_json::Value;
+use sysinfo::System;
+
+/// The machine and toolchain a platform document was measured on.
+#[derive(Debug, Serialize)]
+pub struct Host {
+    pub cpu: Option<String>,
+    pub cores: Option<usize>,
+    pub ram_gib: Option<f64>,
+    pub os: String,
+    pub arch: String,
+    /// Which filesystem the stores were opened on, when the runner said.
+    pub store: Option<String>,
+}
+
+pub fn host() -> Host {
+    let mut sys = System::new();
+    sys.refresh_memory();
+    let cpus = sysinfo::System::new_all();
+    Host {
+        cpu: cpus.cpus().first().map(|c| c.brand().trim().to_string()),
+        cores: std::thread::available_parallelism().ok().map(|n| n.get()),
+        ram_gib: match sys.total_memory() {
+            0 => None,
+            bytes => Some((bytes as f64 / 1_073_741_824.0 * 10.0).round() / 10.0),
+        },
+        os: std::env::consts::OS.to_string(),
+        arch: std::env::consts::ARCH.to_string(),
+        store: std::env::var("DEFRA_BENCH_STORE")
+            .ok()
+            .filter(|s| !s.is_empty()),
+    }
+}
+
+pub fn toolchain() -> String {
+    match Command::new("rustc").arg("--version").output() {
+        Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).trim().to_string(),
+        Ok(o) => format!("unknown: rustc --version exited {}", o.status),
+        Err(e) => format!("unknown: rustc --version failed: {e}"),
+    }
+}
+
+/// Best guess at the triple when the caller did not name one. Good enough for
+/// a local run and never presented as authoritative: CI passes `--target`.
+pub fn derived_target() -> String {
+    format!(
+        "{}-{}-guessed",
+        std::env::consts::ARCH,
+        std::env::consts::OS
+    )
+}
+
+/// Whether the host was quiet while the benches ran.
+///
+/// Fails closed. The guard runs before the benchmarks, in its own CI step, and
+/// leaves its verdict in a file: measuring load *after* a benchmark measures
+/// the benchmark. When the file is missing or unreadable the host is not
+/// certified quiet, so timing families are marked contaminated rather than
+/// presumed clean.
+#[derive(Debug, Serialize)]
+pub struct LoadGuard {
+    pub passed: bool,
+    pub note: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<Value>,
+}
+
+pub fn load_guard(path: Option<&Path>) -> LoadGuard {
+    let Some(path) = path else {
+        return LoadGuard {
+            passed: false,
+            note: "No load guard was run, so the host is not certified quiet. Timing families \
+                   are marked contaminated; deterministic families stay comparable."
+                .into(),
+            detail: None,
+        };
+    };
+    let text = match std::fs::read_to_string(path) {
+        Ok(t) => t,
+        Err(e) => {
+            return LoadGuard {
+                passed: false,
+                note: format!(
+                    "could not read the load guard verdict at {}: {e}. The host is not certified \
+                     quiet, so timing families are marked contaminated.",
+                    path.display()
+                ),
+                detail: None,
+            };
+        }
+    };
+    let verdict: Value = match serde_json::from_str(&text) {
+        Ok(v) => v,
+        Err(e) => {
+            return LoadGuard {
+                passed: false,
+                note: format!(
+                    "the load guard verdict at {} is not JSON: {e}",
+                    path.display()
+                ),
+                detail: None,
+            };
+        }
+    };
+    let passed = verdict
+        .get("passed")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let note = verdict
+        .get("note")
+        .and_then(Value::as_str)
+        .unwrap_or(if passed {
+            "the host was quiet during collection"
+        } else {
+            "the host was not quiet, so timing families are marked contaminated"
+        })
+        .to_string();
+    LoadGuard {
+        passed,
+        note,
+        detail: Some(verdict),
+    }
+}
+
+/// UTC, second resolution, RFC 3339. The dashboard sorts runs on this.
+pub fn now_iso8601() -> String {
+    chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string()
+}


### PR DESCRIPTION
Adds a benchmark suite, a run-document history, and a dashboard published to
GitHub Pages from every push to `main`.

Nothing measured DefraDB in CI before this. There were 15 criterion targets that
nobody ran and no history to compare a number against.

## What lands

**`tools/perf`** is the contract. A bench describes what it measured as a
`Family` (title, groups, units, direction, optional ranges); `collect` folds
every family a platform recorded into one platform document with the host,
toolchain and load-guard verdict beside it. It builds in ~7s because it is
deliberately off the database's dependency graph: every platform in the matrix
runs it.

**`tools/perf-site`** is the dashboard, `publish.py`, `compare.py`,
`loadguard.py` and `render_check.mjs`. The page is data-driven: one generic
renderer draws any family from its own description, so a new bench appears on
the site with no page edit. `render_check.mjs` runs the page's own code
headlessly and fails the publish if a family that was collected drew nothing,
because a blank section is not an error to a browser.

**31 bench targets**, 16 of them new: end-to-end GraphQL, document read and
write, allocations per operation, peak RSS, cold start, artifact size, crypto,
access control, the replication wire, backup, codecs, events, identity, schema
validation, cursors and the replication filter. Plus a browser harness at
`crates/wasm/tests/perf.rs` running under `wasm-bindgen-test` in headless
Firefox.

## Honesty rules the pipeline enforces

* A family that was not collected is written `absent` and drawn as a gap, never
  as a zero.
* A timing taken on a runner the load guard failed is marked `contaminated`.
  Deterministic families (allocation counts, byte sizes) are immune to host load
  and stay comparable, which is decided by the bench, not guessed from the name.
* A comparison refuses to call a delta real unless both sides are trusted, the
  measured ranges do not overlap, and the change clears the threshold. A -19%
  move whose ranges overlap is reported as noise.
* `just perf-matrix` fails if a registered bench target is missing from the
  workflow, and it is the first CI step. A benchmark can no longer be added and
  silently never run.

## CI

Two paths, because a pull request and a release history want different things.

Every PR gets a quick check commented back onto it: four families on Linux,
measured against that PR's own merge base **on the same runner with the same
build profile**. Comparing a PR against published numbers built another way on
another machine is arithmetic over incomparable measurements, so the quick path
measures its own baseline and caches it by base commit, meaning only the first
PR after a merge pays for the second build. Measured locally at 1m41s of bench
time. Add the `perf-full` label for the whole matrix.

A push to `main` runs 40 bench jobs across Linux, macOS and the browser and
publishes the run.

## What this already found

* `check_doc_access` is linear in registered documents: 2.1us at 1, 328us at
  10,000. A query returning 1000 documents pays 21ms in access control alone.
* A filter does not reduce work without an index: at 1000 documents `filter_eq`
  costs the same as `scan_all`, 25.9ms both.
* Signing spans 17x by curve: ed25519 24us against secp256r1 422us. Token
  verification on every authenticated request spans 10x.
* Cold open grows to 6.8ms at 100 collections on the server profile and 12.6ms
  on the embedded one, which is slower past ten collections despite being faster
  below it.
* A document create makes 3165 allocations.
* `create_many` is worth 1.65x over single creates.
* Event publish is linear in subscriber count: 92ns at none, 123us at 512.

## Not covered, and why

`fulltext` and `index_scan` need index wiring through modules that are private
today; `kms` and `lens` need substantial service setup. Left as named gaps
rather than shallow benchmarks.

Top-level aggregates are absent from `query_e2e` because they do not parse:
`AggregateType::parse` in `crates/query/src/mapper/types.rs` matches `COUNT` and
`AVG`, so the dispatch in `query_parse/parser.rs` never fires for `_count`, and
the field falls through to the collection path where the collection name is
rejected as an argument. Benchmarking a shape the engine rejects would measure
its error path.

## Verification

`cargo fmt --all --check`, `cargo clippy --all -- -D warnings` and
`cargo clippy -p benches --benches -- -D warnings` are clean. Every bench target
was run. The dashboard was verified rendered at 360, 375, 414, 768 and 1400 CSS
pixels.

Absolute figures above are from local builds and are not release-profile
numbers; the ratios are the point until the first `main` run publishes.
