### PR TITLE
fix(db): traverse commits from live collection heads

### DIFF
--- a/crates/db/src/read/commits/mod.rs
+++ b/crates/db/src/read/commits/mod.rs
@@ -9,7 +9,7 @@ mod delta;
 use async_lock::Mutex as TokioMutex;
 use cid::Cid;
 use document::Document;
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashSet};
 use std::str::FromStr;
 use std::sync::Arc;
 use storage::corekv::{IterOptions, Store};
@@ -360,17 +360,28 @@ impl<S: Store> CommitsFetcher<S> {
         if options.doc_id.is_none() {
             let col_opts = IterOptions::new().with_prefix(b"/c/".to_vec());
             let mut col_iter = headstore.iterator(col_opts).await.map_err(Error::Storage)?;
+            let mut collection_ids = BTreeSet::new();
 
             while let Some(pair) = col_iter.next().await.map_err(Error::Storage)? {
-                let key_str = String::from_utf8_lossy(&pair.key);
-                let parts: Vec<&str> = key_str.split('/').collect();
-                if parts.len() >= 4 {
-                    if let Ok(cid) = Cid::from_str(parts[3]) {
-                        cids.push((cid, None));
-                    }
+                let Ok(key) = std::str::from_utf8(&pair.key) else {
+                    continue;
+                };
+                let Some((collection_id, _)) =
+                    key.strip_prefix("/c/").and_then(|key| key.split_once('/'))
+                else {
+                    continue;
+                };
+                if let Ok(collection_id) = collection_id.parse() {
+                    collection_ids.insert(collection_id);
                 }
             }
             col_iter.close().await.map_err(Error::Storage)?;
+
+            for collection_id in collection_ids {
+                let heads =
+                    crate::block::heads::live_collection_heads(&headstore, collection_id).await?;
+                cids.extend(heads.live.into_iter().map(|cid| (cid, None)));
+            }
         }
 
         let (doc_prefix, fixed_doc_id) = if let Some(ref doc_id) = options.doc_id {

--- a/crates/db/tests/read/commits_suite.rs
+++ b/crates/db/tests/read/commits_suite.rs
@@ -91,9 +91,80 @@ mod shared_owner_tests {
         Block, CrdtDelta, LwwDeltaPayload, Signature, SignatureHeader, SignatureType,
     };
     use document::{DocID, NormalValue};
+    use storage::corekv::Key;
+    use storage::keys::headstore::{HeadstoreColKey, HeadstoreColSuperseded};
 
     use db::read::commits::{CommitsFetcher, CommitsQueryOptions};
     use db::{VersionedFetcher, DB};
+
+    fn lww_block(value: &str, priority: u64, heads: Vec<cid::Cid>) -> Block {
+        let mut data = Vec::new();
+        ciborium::into_writer(&NormalValue::String(value.to_string()), &mut data).unwrap();
+        Block::new(
+            CrdtDelta::Lww(LwwDeltaPayload {
+                field_name: "name".to_string(),
+                schema_version_id: "v1".to_string(),
+                priority,
+                data,
+            }),
+            heads,
+            vec![],
+        )
+    }
+
+    #[tokio::test]
+    async fn collection_commit_depth_starts_from_live_heads() {
+        let db = Arc::new(DB::new(RegolithStore::in_memory().unwrap()).unwrap());
+        let parent = lww_block("parent", 1, vec![]);
+        let parent_cid = parent.generate_cid().unwrap();
+        let child = lww_block("child", 2, vec![parent_cid]);
+        let child_cid = child.generate_cid().unwrap();
+
+        let txn = db.new_txn(false).await.unwrap();
+        {
+            let blockstore = txn.blockstore().unwrap();
+            let headstore = txn.headstore().unwrap();
+            blockstore
+                .set(&parent_cid.to_bytes(), &parent.to_dag_cbor().unwrap())
+                .await
+                .unwrap();
+            blockstore
+                .set(&child_cid.to_bytes(), &child.to_dag_cbor().unwrap())
+                .await
+                .unwrap();
+            headstore
+                .set(&HeadstoreColKey::new(1, parent_cid).bytes(), &[])
+                .await
+                .unwrap();
+            headstore
+                .set(&HeadstoreColKey::new(1, child_cid).bytes(), &[])
+                .await
+                .unwrap();
+            headstore
+                .set(
+                    &HeadstoreColSuperseded::new(1, parent_cid, child_cid).bytes(),
+                    &[],
+                )
+                .await
+                .unwrap();
+        }
+        txn.commit().await.unwrap();
+
+        let commits_txn = db.new_txn(true).await.unwrap();
+        let commits = CommitsFetcher::new(Arc::new(Mutex::new(Some(commits_txn))))
+            .fetch_commits(&CommitsQueryOptions {
+                depth: Some(1),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(commits.len(), 1);
+        assert_eq!(
+            commits[0].get("cid").and_then(NormalValue::as_str),
+            Some(child_cid.to_string().as_str())
+        );
+    }
 
     #[tokio::test]
     async fn shared_field_cid_fans_out_to_every_owner() {


### PR DESCRIPTION
## Context

Collection head keys retain superseded heads. `_commits` treated every stored key as a traversal root, so historical commits could appear before the current head and consume the requested depth.

## Changes

- resolve live collection heads using the existing supersession markers
- start commit traversal from those heads, preserving ancestor traversal
- cover a retained parent and child with `depth: 1`, asserting only the live child is returned

## Testing

- `cargo test --profile super-dev -p db --test read commits` (6 passed)
- `cargo clippy --profile super-dev -p db -p defra-p2p-adapter --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Refs #1510
