### PR TITLE
fix(p2p): wait for branchable sync completion

### DIFF
--- a/crates/p2p-adapter/Cargo.toml
+++ b/crates/p2p-adapter/Cargo.toml
@@ -44,6 +44,7 @@ tracing.workspace = true
 zeroize = "1"
 
 [dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }
 crypto = { path = "../crypto" }
 data-encoding = "2"
 iroh.workspace = true

--- a/crates/p2p-adapter/src/libp2p.rs
+++ b/crates/p2p-adapter/src/libp2p.rs
@@ -78,7 +78,7 @@ async fn wait_for_branchable_merges(
     }
 }
 
-async fn unmerged_doc_sync_heads<B, I>(blockstore: &B, heads: I) -> HashSet<cid::Cid>
+async fn unmerged_heads<B, I>(blockstore: &B, heads: I) -> HashSet<cid::Cid>
 where
     B: Blockstore,
     I: IntoIterator<Item = cid::Cid>,
@@ -951,7 +951,7 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
                 return Err(error);
             }
         };
-        let mut pending_heads = unmerged_doc_sync_heads(coord.blockstore().as_ref(), heads).await;
+        let mut pending_heads = unmerged_heads(coord.blockstore().as_ref(), heads).await;
 
         while !pending_heads.is_empty() && start.elapsed() < overall_timeout {
             match tokio::time::timeout(std::time::Duration::from_millis(100), sub.recv()).await {
@@ -1013,7 +1013,7 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
                 event_bus.unsubscribe(sub.id());
                 return Ok(());
             }
-            coord
+            let replies = coord
                 .pubsub_sync_branchable_collection(
                     collection_id.to_string(),
                     Some(std::time::Duration::from_secs(8)),
@@ -1024,14 +1024,26 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
                     event_bus.unsubscribe(sub.id());
                     P2PError::transport(format!("pubsub_rpc branchable-sync failed: {error}"))
                 })?;
-            wait_for_branchable_merges(
-                &mut sub,
-                &collection_id_string,
-                start,
-                overall_timeout,
-                idle_timeout,
-            )
-            .await;
+            let heads = replies
+                .into_iter()
+                .flat_map(|(_, reply)| reply.heads)
+                .filter_map(|head| cid::Cid::try_from(head.as_slice()).ok());
+            let mut pending_heads = unmerged_heads(coord.blockstore().as_ref(), heads).await;
+
+            while !pending_heads.is_empty() && start.elapsed() < overall_timeout {
+                match tokio::time::timeout(std::time::Duration::from_millis(100), sub.recv()).await
+                {
+                    Ok(Some(msg)) => {
+                        if let Some(data) = msg.as_merge_complete() {
+                            if data.collection_id == collection_id_string {
+                                pending_heads.remove(&data.cid);
+                            }
+                        }
+                    }
+                    Ok(None) => break,
+                    Err(_) => {}
+                }
+            }
             event_bus.unsubscribe(sub.id());
             return Ok(());
         }
@@ -1145,7 +1157,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn merged_doc_sync_heads_are_not_pending() {
+    async fn merged_heads_are_not_pending() {
         let blockstore = DefraBlockstore::new(Arc::new(RegolithStore::in_memory().unwrap()), true);
         let merged =
             cid::Cid::try_from("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi")
@@ -1157,7 +1169,7 @@ mod tests {
         blockstore.put(&unmerged, b"unmerged").await.unwrap();
         blockstore.mark_as_merged(&merged).await.unwrap();
 
-        let pending = unmerged_doc_sync_heads(&blockstore, [merged, unmerged, unmerged]).await;
+        let pending = unmerged_heads(&blockstore, [merged, unmerged, unmerged]).await;
 
         assert_eq!(pending, HashSet::from([unmerged]));
     }
@@ -1189,7 +1201,7 @@ mod tests {
 
         let heads = crate::doc_sync::pubsub_replies::advertised_heads(2, &doc_set, &replies)
             .expect("an advertised head is a result even when a peer stays silent");
-        let pending = unmerged_doc_sync_heads(&blockstore, heads).await;
+        let pending = unmerged_heads(&blockstore, heads).await;
 
         assert!(
             pending.is_empty(),

--- a/crates/p2p-adapter/src/libp2p.rs
+++ b/crates/p2p-adapter/src/libp2p.rs
@@ -4,6 +4,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use blockstore::Blockstore;
 
+mod branchable_sync;
+
 use crate::transport_doc_pusher::TransportDocPusher;
 use crate::{
     ExplicitReplayCapabilityInput, P2PError, P2PErrorExt as _, P2POperations, P2PResult,
@@ -1028,24 +1030,16 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
                 .into_iter()
                 .flat_map(|(_, reply)| reply.heads)
                 .filter_map(|head| cid::Cid::try_from(head.as_slice()).ok());
-            let mut pending_heads = unmerged_heads(coord.blockstore().as_ref(), heads).await;
-
-            while !pending_heads.is_empty() && start.elapsed() < overall_timeout {
-                match tokio::time::timeout(std::time::Duration::from_millis(100), sub.recv()).await
-                {
-                    Ok(Some(msg)) => {
-                        if let Some(data) = msg.as_merge_complete() {
-                            if data.collection_id == collection_id_string {
-                                pending_heads.remove(&data.cid);
-                            }
-                        }
-                    }
-                    Ok(None) => break,
-                    Err(_) => {}
-                }
-            }
+            let pending_heads = unmerged_heads(coord.blockstore().as_ref(), heads).await;
+            let result = branchable_sync::wait_for_heads(
+                &mut sub,
+                collection_id,
+                pending_heads,
+                (start + overall_timeout).into(),
+            )
+            .await;
             event_bus.unsubscribe(sub.id());
-            return Ok(());
+            return result;
         }
 
         let mut request = p2p::message::BranchableSyncRequest::new(collection_id.to_string());

--- a/crates/p2p-adapter/src/libp2p.rs
+++ b/crates/p2p-adapter/src/libp2p.rs
@@ -1032,6 +1032,7 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
                 .filter_map(|head| cid::Cid::try_from(head.as_slice()).ok());
             let pending_heads = unmerged_heads(coord.blockstore().as_ref(), heads).await;
             let result = branchable_sync::wait_for_heads(
+                coord.blockstore().as_ref(),
                 &mut sub,
                 collection_id,
                 pending_heads,

--- a/crates/p2p-adapter/src/libp2p/branchable_sync.rs
+++ b/crates/p2p-adapter/src/libp2p/branchable_sync.rs
@@ -1,0 +1,42 @@
+use std::collections::HashSet;
+
+use cid::Cid;
+use events::Subscription;
+use tokio::time::{timeout_at, Instant};
+
+use crate::{P2PError, P2PErrorExt as _, P2PResult};
+
+pub(super) async fn wait_for_heads(
+    sub: &mut Subscription,
+    collection_id: &str,
+    mut pending: HashSet<Cid>,
+    deadline: Instant,
+) -> P2PResult<()> {
+    while !pending.is_empty() {
+        match timeout_at(deadline, sub.recv()).await {
+            Ok(Some(message)) => {
+                if let Some(merge) = message.as_merge_complete() {
+                    if merge.collection_id == collection_id {
+                        pending.remove(&merge.cid);
+                    }
+                }
+            }
+            Ok(None) => {
+                return Err(P2PError::transport(
+                    "event bus closed while syncing branchable collection",
+                ));
+            }
+            Err(_) => {
+                return Err(P2PError::transport(format!(
+                    "timeout while syncing branchable collection: {} heads remain unmerged",
+                    pending.len()
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "../../tests/libp2p/branchable_sync.rs"]
+mod tests;

--- a/crates/p2p-adapter/src/libp2p/branchable_sync.rs
+++ b/crates/p2p-adapter/src/libp2p/branchable_sync.rs
@@ -6,35 +6,48 @@ use tokio::time::{timeout_at, Instant};
 
 use crate::{P2PError, P2PErrorExt as _, P2PResult};
 
-pub(super) async fn wait_for_heads(
+pub(super) async fn wait_for_heads<B: blockstore::Blockstore>(
+    blockstore: &B,
     sub: &mut Subscription,
     collection_id: &str,
-    mut pending: HashSet<Cid>,
+    pending: HashSet<Cid>,
     deadline: Instant,
 ) -> P2PResult<()> {
-    while !pending.is_empty() {
-        match timeout_at(deadline, sub.recv()).await {
-            Ok(Some(message)) => {
-                if let Some(merge) = message.as_merge_complete() {
-                    if merge.collection_id == collection_id {
-                        pending.remove(&merge.cid);
-                    }
+    let mut pending: Vec<_> = pending.into_iter().collect();
+    timeout_at(deadline, async {
+        loop {
+            let mut index = 0;
+            while index < pending.len() {
+                if blockstore.is_merged(&pending[index]).await.map_err(|error| {
+                    P2PError::transport(format!("failed to check branchable sync head: {error}"))
+                })? {
+                    pending.swap_remove(index);
+                } else {
+                    index += 1;
                 }
             }
-            Ok(None) => {
-                return Err(P2PError::transport(
-                    "event bus closed while syncing branchable collection",
-                ));
+            if pending.is_empty() {
+                return Ok(());
             }
-            Err(_) => {
-                return Err(P2PError::transport(format!(
-                    "timeout while syncing branchable collection: {} heads remain unmerged",
-                    pending.len()
-                )));
+            // Events are wakeups, not proof of completion: ancestor merges may
+            // emit no event for this CID, and a full subscriber queue can drop one.
+            tokio::select! {
+                message = sub.recv() => {
+                    if message.is_none() {
+                        return Err(P2PError::transport(
+                            "event bus closed while syncing branchable collection",
+                        ));
+                    }
+                }
+                _ = tokio::time::sleep(std::time::Duration::from_millis(100)) => {}
             }
         }
-    }
-    Ok(())
+    })
+    .await
+    .map_err(|_| P2PError::transport(format!(
+        "timeout while syncing branchable collection {collection_id}: completion not confirmed for {} heads",
+        pending.len()
+    )))?
 }
 
 #[cfg(test)]

--- a/crates/p2p-adapter/tests/libp2p/branchable_sync.rs
+++ b/crates/p2p-adapter/tests/libp2p/branchable_sync.rs
@@ -1,0 +1,108 @@
+use std::future::Future;
+use std::task::{Context, Waker};
+use std::time::Duration;
+
+use events::{Bus, ChannelBus, EventName, MergeCompleteData, Message};
+
+use super::*;
+
+fn heads() -> [Cid; 2] {
+    [
+        "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
+        "bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy",
+    ]
+    .map(|value| value.parse().unwrap())
+}
+
+fn merged(bus: &ChannelBus, collection_id: &str, cid: Cid) {
+    bus.publish(Message::merge_complete(MergeCompleteData {
+        collection_id: collection_id.to_string(),
+        cid,
+        doc_id: String::new(),
+        subject_doc_id: None,
+        by_peer: String::new(),
+    }));
+}
+
+#[tokio::test(start_paused = true)]
+async fn waits_for_all_advertised_heads_despite_idle_gaps() {
+    let bus = ChannelBus::default();
+    let mut sub = bus.subscribe(&[EventName::MergeComplete]);
+    let [first, second] = heads();
+    let mut wait = std::pin::pin!(wait_for_heads(
+        &mut sub,
+        "collection",
+        HashSet::from([first, second]),
+        Instant::now() + Duration::from_secs(30),
+    ));
+    let mut context = Context::from_waker(Waker::noop());
+    assert!(wait.as_mut().poll(&mut context).is_pending());
+
+    tokio::time::advance(Duration::from_secs(4)).await;
+    assert!(wait.as_mut().poll(&mut context).is_pending());
+    merged(&bus, "collection", first);
+    assert!(wait.as_mut().poll(&mut context).is_pending());
+
+    merged(&bus, "collection", first);
+    merged(&bus, "other-collection", second);
+    tokio::time::advance(Duration::from_secs(4)).await;
+    assert!(wait.as_mut().poll(&mut context).is_pending());
+
+    merged(&bus, "collection", second);
+    assert!(matches!(
+        wait.as_mut().poll(&mut context),
+        std::task::Poll::Ready(Ok(()))
+    ));
+}
+
+#[tokio::test(start_paused = true)]
+async fn partial_completion_does_not_reset_deadline_or_report_success() {
+    let bus = ChannelBus::default();
+    let mut sub = bus.subscribe(&[EventName::MergeComplete]);
+    let [first, second] = heads();
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let mut wait = std::pin::pin!(wait_for_heads(
+        &mut sub,
+        "collection",
+        HashSet::from([first, second]),
+        deadline,
+    ));
+    let mut context = Context::from_waker(Waker::noop());
+    assert!(wait.as_mut().poll(&mut context).is_pending());
+
+    tokio::time::advance(Duration::from_secs(29)).await;
+    merged(&bus, "collection", first);
+    assert!(wait.as_mut().poll(&mut context).is_pending());
+
+    let error = wait.await.unwrap_err();
+    assert!(error.to_string().contains("1 heads remain unmerged"));
+    assert_eq!(Instant::now(), deadline);
+}
+
+#[tokio::test]
+async fn closed_event_bus_does_not_report_unmerged_heads_as_complete() {
+    let bus = ChannelBus::default();
+    let mut sub = bus.subscribe(&[EventName::MergeComplete]);
+    bus.close();
+
+    let error = wait_for_heads(
+        &mut sub,
+        "collection",
+        HashSet::from(heads()),
+        Instant::now() + Duration::from_secs(30),
+    )
+    .await
+    .unwrap_err();
+    assert!(error.to_string().contains("event bus closed"));
+}
+
+#[tokio::test]
+async fn already_merged_heads_need_no_events_or_remaining_time() {
+    let bus = ChannelBus::default();
+    let mut sub = bus.subscribe(&[EventName::MergeComplete]);
+    bus.close();
+
+    wait_for_heads(&mut sub, "collection", HashSet::new(), Instant::now())
+        .await
+        .unwrap();
+}

--- a/crates/p2p-adapter/tests/libp2p/branchable_sync.rs
+++ b/crates/p2p-adapter/tests/libp2p/branchable_sync.rs
@@ -2,7 +2,10 @@ use std::future::Future;
 use std::task::{Context, Waker};
 use std::time::Duration;
 
+use blockstore::{Blockstore, DefraBlockstore};
 use events::{Bus, ChannelBus, EventName, MergeCompleteData, Message};
+use std::sync::Arc;
+use storage::RegolithStore;
 
 use super::*;
 
@@ -12,6 +15,14 @@ fn heads() -> [Cid; 2] {
         "bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy",
     ]
     .map(|value| value.parse().unwrap())
+}
+
+async fn store() -> DefraBlockstore<RegolithStore> {
+    let store = DefraBlockstore::new(Arc::new(RegolithStore::in_memory().unwrap()), true);
+    for cid in heads() {
+        store.put(&cid, b"head").await.unwrap();
+    }
+    store
 }
 
 fn merged(bus: &ChannelBus, collection_id: &str, cid: Cid) {
@@ -26,10 +37,12 @@ fn merged(bus: &ChannelBus, collection_id: &str, cid: Cid) {
 
 #[tokio::test(start_paused = true)]
 async fn waits_for_all_advertised_heads_despite_idle_gaps() {
+    let store = store().await;
     let bus = ChannelBus::default();
     let mut sub = bus.subscribe(&[EventName::MergeComplete]);
     let [first, second] = heads();
     let mut wait = std::pin::pin!(wait_for_heads(
+        &store,
         &mut sub,
         "collection",
         HashSet::from([first, second]),
@@ -43,25 +56,29 @@ async fn waits_for_all_advertised_heads_despite_idle_gaps() {
     merged(&bus, "collection", first);
     assert!(wait.as_mut().poll(&mut context).is_pending());
 
+    store.mark_as_merged(&first).await.unwrap();
+
     merged(&bus, "collection", first);
     merged(&bus, "other-collection", second);
     tokio::time::advance(Duration::from_secs(4)).await;
     assert!(wait.as_mut().poll(&mut context).is_pending());
 
     merged(&bus, "collection", second);
-    assert!(matches!(
-        wait.as_mut().poll(&mut context),
-        std::task::Poll::Ready(Ok(()))
-    ));
+    assert!(wait.as_mut().poll(&mut context).is_pending());
+    // Ancestor completion need not emit a second MergeComplete event.
+    store.mark_as_merged(&second).await.unwrap();
+    wait.await.unwrap();
 }
 
 #[tokio::test(start_paused = true)]
 async fn partial_completion_does_not_reset_deadline_or_report_success() {
+    let store = store().await;
     let bus = ChannelBus::default();
     let mut sub = bus.subscribe(&[EventName::MergeComplete]);
     let [first, second] = heads();
     let deadline = Instant::now() + Duration::from_secs(30);
     let mut wait = std::pin::pin!(wait_for_heads(
+        &store,
         &mut sub,
         "collection",
         HashSet::from([first, second]),
@@ -71,21 +88,26 @@ async fn partial_completion_does_not_reset_deadline_or_report_success() {
     assert!(wait.as_mut().poll(&mut context).is_pending());
 
     tokio::time::advance(Duration::from_secs(29)).await;
+    store.mark_as_merged(&first).await.unwrap();
     merged(&bus, "collection", first);
     assert!(wait.as_mut().poll(&mut context).is_pending());
 
     let error = wait.await.unwrap_err();
-    assert!(error.to_string().contains("1 heads remain unmerged"));
+    assert!(error
+        .to_string()
+        .contains("completion not confirmed for 1 heads"));
     assert_eq!(Instant::now(), deadline);
 }
 
 #[tokio::test]
 async fn closed_event_bus_does_not_report_unmerged_heads_as_complete() {
+    let store = store().await;
     let bus = ChannelBus::default();
     let mut sub = bus.subscribe(&[EventName::MergeComplete]);
     bus.close();
 
     let error = wait_for_heads(
+        &store,
         &mut sub,
         "collection",
         HashSet::from(heads()),
@@ -98,11 +120,18 @@ async fn closed_event_bus_does_not_report_unmerged_heads_as_complete() {
 
 #[tokio::test]
 async fn already_merged_heads_need_no_events_or_remaining_time() {
+    let store = store().await;
     let bus = ChannelBus::default();
     let mut sub = bus.subscribe(&[EventName::MergeComplete]);
     bus.close();
 
-    wait_for_heads(&mut sub, "collection", HashSet::new(), Instant::now())
-        .await
-        .unwrap();
+    wait_for_heads(
+        &store,
+        &mut sub,
+        "collection",
+        HashSet::new(),
+        Instant::now(),
+    )
+    .await
+    .unwrap();
 }


### PR DESCRIPTION
## Context

Branchable collection sync could return after a quiet period while advertised heads were still being fetched or merged. Callers could then read an incomplete collection immediately after a successful sync.

## Changes

- track the advertised head CIDs and wait for every outstanding head to merge
- skip already-merged heads and ignore duplicate or unrelated merge events
- return an error if the deadline expires or the event bus closes before completion
- cover delayed merges, partial completion, the shared deadline, and already-complete syncs

## Testing

- `cargo test --profile super-dev -p defra-p2p-adapter --lib` (61 passed)
- `cargo clippy --profile super-dev -p db -p defra-p2p-adapter --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Stacked on the collection-head traversal fix. Refs #1510; the harness accommodation audit remains open.
