### PR TITLE
fix(p2p): stop Iroh endpoints when command owners drop

### DIFF
--- a/crates/p2p/src/iroh/endpoint.rs
+++ b/crates/p2p/src/iroh/endpoint.rs
@@ -176,6 +176,10 @@ pub async fn spawn_endpoint(
     Ok((command_tx, event_rx, replicators, task))
 }
 
+#[cfg(test)]
+#[path = "../../tests/unit/iroh_endpoint_lifecycle.rs"]
+mod lifecycle_tests;
+
 /// Main event loop processing incoming connections, gossip, and commands.
 async fn run_event_loop(
     endpoint: Endpoint,
@@ -224,12 +228,19 @@ async fn run_event_loop(
     }
 
     'endpoint: loop {
+        if command_rx.is_closed() {
+            break;
+        }
         tokio::select! {
             cmd = command_rx.recv() => {
                 let Some(cmd) = cmd else { break };
                 let mut pending_cmd = Some(cmd);
                 let mut processed = 0;
                 while let Some(cmd) = pending_cmd.take() {
+                    // Closing a channel does not discard its buffered commands.
+                    if command_rx.is_closed() {
+                        break 'endpoint;
+                    }
                     let should_shutdown = handle_command(
                         cmd,
                         &resources,

--- a/crates/p2p/src/iroh/endpoint.rs
+++ b/crates/p2p/src/iroh/endpoint.rs
@@ -225,7 +225,8 @@ async fn run_event_loop(
 
     'endpoint: loop {
         tokio::select! {
-            Some(cmd) = command_rx.recv() => {
+            cmd = command_rx.recv() => {
+                let Some(cmd) = cmd else { break };
                 let mut pending_cmd = Some(cmd);
                 let mut processed = 0;
                 while let Some(cmd) = pending_cmd.take() {
@@ -279,6 +280,9 @@ async fn run_event_loop(
             else => break,
         }
     }
+
+    // Reject queued and new commands before waiting for network teardown.
+    drop(command_rx);
 
     // Clean up
     let subscriptions_started = std::time::Instant::now();

--- a/crates/p2p/tests/iroh_lifecycle_tests.rs
+++ b/crates/p2p/tests/iroh_lifecycle_tests.rs
@@ -1,0 +1,54 @@
+#![cfg(feature = "iroh-transport")]
+
+use std::net::{IpAddr, Ipv4Addr};
+use std::time::Duration;
+
+use p2p::iroh::{
+    spawn_endpoint, IrohDiscoveryConfig, IrohEndpointConfig, IrohRelayModeConfig, IrohTransport,
+};
+use p2p::transport::P2PTransport;
+use tokio::task::JoinHandle;
+use tokio::time::timeout;
+
+fn config() -> IrohEndpointConfig {
+    IrohEndpointConfig {
+        relay_mode: IrohRelayModeConfig::Disabled,
+        discovery: IrohDiscoveryConfig::Disabled,
+        bind_addr: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+        ..Default::default()
+    }
+}
+
+async fn assert_endpoint_stopped(mut task: JoinHandle<()>) {
+    let result = timeout(Duration::from_secs(5), &mut task).await;
+    if result.is_err() {
+        task.abort();
+        let _ = task.await;
+    }
+    result
+        .expect("endpoint kept running after its last command sender was dropped")
+        .expect("endpoint task panicked");
+}
+
+#[tokio::test]
+async fn endpoint_stops_when_last_transport_clone_is_dropped() {
+    let config = config();
+    let key = config.secret_key.clone();
+    let (commands, _events, _replicators, task) = spawn_endpoint(config).await.unwrap();
+    let transport = IrohTransport::new(commands, key);
+    let last_transport = transport.clone();
+    drop(transport);
+
+    assert!(last_transport.connected_peers().await.unwrap().is_empty());
+    drop(last_transport);
+
+    assert_endpoint_stopped(task).await;
+}
+
+#[tokio::test]
+async fn endpoint_stops_when_command_sender_is_dropped_before_startup() {
+    let (commands, _events, _replicators, task) = spawn_endpoint(config()).await.unwrap();
+    drop(commands);
+
+    assert_endpoint_stopped(task).await;
+}

--- a/crates/p2p/tests/unit/iroh_endpoint_lifecycle.rs
+++ b/crates/p2p/tests/unit/iroh_endpoint_lifecycle.rs
@@ -1,0 +1,29 @@
+use super::*;
+use crate::iroh::{IrohDiscoveryConfig, IrohRelayModeConfig};
+use std::net::{IpAddr, Ipv4Addr};
+use std::time::Duration;
+
+#[tokio::test]
+async fn endpoint_discards_buffered_commands_when_last_sender_drops() {
+    let config = IrohEndpointConfig {
+        relay_mode: IrohRelayModeConfig::Disabled,
+        discovery: IrohDiscoveryConfig::Disabled,
+        bind_addr: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+        ..Default::default()
+    };
+    let (commands, _events, _replicators, mut task) = spawn_endpoint(config).await.unwrap();
+    let (reply, response) = oneshot::channel();
+    // The current-thread runtime cannot dispatch this command before the drop.
+    commands
+        .try_send(IrohCommand::ConnectedPeers { reply })
+        .unwrap();
+    drop(commands);
+
+    let stopped = tokio::time::timeout(Duration::from_secs(5), &mut task).await;
+    if stopped.is_err() {
+        task.abort();
+        let _ = task.await;
+    }
+    stopped.expect("endpoint did not stop").unwrap();
+    assert!(response.await.is_err(), "queued command was dispatched");
+}


### PR DESCRIPTION
## Context

Dropping the last Iroh transport handle leaves the endpoint running: the closed command channel disables its `select!` arm instead of entering cleanup.

## Changes

- Stop the endpoint when its last command sender is dropped.
- Reject queued and new commands before network teardown begins.
- Cover dropping the sender before startup and dropping the last transport clone.

## Testing

Both lifecycle regressions fail before the fix and pass afterward.

- [x] `cargo test --profile super-dev -p p2p --features iroh-transport --test iroh_lifecycle_tests` (2 passed)
- [x] `cargo clippy --profile super-dev -p p2p --features iroh-transport --tests -- -D warnings`
- [x] `cargo fmt --all -- --check`

Refs #1356
