### PR TITLE
fix(p2p): bound Iroh connection waits and cancel on close

### DIFF
--- a/crates/p2p/src/iroh/transport.rs
+++ b/crates/p2p/src/iroh/transport.rs
@@ -191,16 +191,21 @@ impl P2PTransport for IrohTransport {
     }
 
     async fn poll_until_connected(&self, peer_id: &PeerId, timeout: Duration) -> Result<()> {
-        let start = std::time::Instant::now();
-        loop {
-            let peers = self.connected_peers().await?;
-            if peers.iter().any(|p| p.as_str() == peer_id.as_str()) {
-                return Ok(());
+        let wait_for_peer = async {
+            loop {
+                let peers = self.connected_peers().await?;
+                if peers.contains(peer_id) {
+                    return Ok(());
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
             }
-            if start.elapsed() >= timeout {
-                return Err(Error::ConnectionTimeout(peer_id.to_string()));
+        };
+        tokio::select! {
+            biased;
+            _ = self.command_tx.closed() => Err(Error::ChannelSend),
+            result = tokio::time::timeout(timeout, wait_for_peer) => {
+                result.unwrap_or_else(|_| Err(Error::ConnectionTimeout(peer_id.to_string())))
             }
-            tokio::time::sleep(Duration::from_millis(50)).await;
         }
     }
 
@@ -582,6 +587,10 @@ impl P2PTransport for IrohTransport {
         result
     }
 }
+
+#[cfg(test)]
+#[path = "../../tests/iroh/transport_poll.rs"]
+mod poll_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/p2p/tests/iroh/transport_poll.rs
+++ b/crates/p2p/tests/iroh/transport_poll.rs
@@ -1,0 +1,137 @@
+use super::*;
+use futures::poll;
+use tokio::time::{advance, timeout, Instant};
+
+fn transport() -> (IrohTransport, mpsc::Receiver<IrohCommand>) {
+    let (tx, rx) = mpsc::channel(1);
+    (IrohTransport::new(tx, SecretKey::generate()), rx)
+}
+
+fn take_reply(commands: &mut mpsc::Receiver<IrohCommand>) -> oneshot::Sender<Result<Vec<PeerId>>> {
+    match commands.try_recv().expect("expected a peer-list request") {
+        IrohCommand::ConnectedPeers { reply } => reply,
+        _ => panic!("unexpected endpoint command"),
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn poll_succeeds_when_peer_connects() {
+    let (transport, mut commands) = transport();
+    let peer = PeerId::new("remote".into());
+    let waiting = transport.poll_until_connected(&peer, Duration::from_secs(5));
+    tokio::pin!(waiting);
+
+    assert!(poll!(&mut waiting).is_pending());
+    take_reply(&mut commands).send(Ok(vec![])).unwrap();
+    assert!(poll!(&mut waiting).is_pending());
+    advance(Duration::from_millis(50)).await;
+    assert!(poll!(&mut waiting).is_pending());
+    take_reply(&mut commands)
+        .send(Ok(vec![peer.clone()]))
+        .unwrap();
+
+    waiting.await.unwrap();
+}
+
+#[tokio::test(start_paused = true)]
+async fn poll_preserves_peer_listing_errors() {
+    let (transport, mut commands) = transport();
+    let peer = PeerId::new("remote".into());
+    let waiting = transport.poll_until_connected(&peer, Duration::from_secs(5));
+    tokio::pin!(waiting);
+
+    assert!(poll!(&mut waiting).is_pending());
+    take_reply(&mut commands)
+        .send(Err(Error::Transport("unavailable".into())))
+        .unwrap();
+
+    assert!(matches!(waiting.await, Err(Error::Transport(message)) if message == "unavailable"));
+}
+
+#[tokio::test(start_paused = true)]
+async fn poll_deadline_bounds_a_pending_reply() {
+    let (transport, mut commands) = transport();
+    let peer = PeerId::new("remote".into());
+    let waiting = transport.poll_until_connected(&peer, Duration::from_millis(10));
+    tokio::pin!(waiting);
+
+    assert!(poll!(&mut waiting).is_pending());
+    let _pending_reply = take_reply(&mut commands);
+    let result = timeout(Duration::from_millis(20), waiting)
+        .await
+        .expect("peer-list reply outlived the connection deadline");
+
+    assert!(matches!(result, Err(Error::ConnectionTimeout(id)) if id == peer.as_str()));
+}
+
+#[tokio::test(start_paused = true)]
+async fn poll_deadline_bounds_a_full_command_queue() {
+    let (transport, _commands) = transport();
+    let (reply, _response) = oneshot::channel();
+    assert!(transport
+        .command_tx
+        .try_send(IrohCommand::ConnectedPeers { reply })
+        .is_ok());
+    let peer = PeerId::new("remote".into());
+    let result = timeout(
+        Duration::from_millis(20),
+        transport.poll_until_connected(&peer, Duration::from_millis(10)),
+    )
+    .await
+    .expect("command queue outlived the connection deadline");
+
+    assert!(matches!(result, Err(Error::ConnectionTimeout(id)) if id == peer.as_str()));
+}
+
+#[tokio::test(start_paused = true)]
+async fn poll_deadline_can_be_shorter_than_the_poll_interval() {
+    let (transport, mut commands) = transport();
+    let peer = PeerId::new("remote".into());
+    let start = Instant::now();
+    let waiting = transport.poll_until_connected(&peer, Duration::from_millis(10));
+    tokio::pin!(waiting);
+
+    assert!(poll!(&mut waiting).is_pending());
+    take_reply(&mut commands).send(Ok(vec![])).unwrap();
+    let result = timeout(Duration::from_millis(20), waiting)
+        .await
+        .expect("poll interval outlived the connection deadline");
+
+    assert!(matches!(result, Err(Error::ConnectionTimeout(_))));
+    assert_eq!(start.elapsed(), Duration::from_millis(10));
+}
+
+#[tokio::test(start_paused = true)]
+async fn poll_stops_on_channel_closure_during_sleep() {
+    let (transport, mut commands) = transport();
+    let peer = PeerId::new("remote".into());
+    let waiting = transport.poll_until_connected(&peer, Duration::from_secs(5));
+    tokio::pin!(waiting);
+
+    assert!(poll!(&mut waiting).is_pending());
+    take_reply(&mut commands).send(Ok(vec![])).unwrap();
+    assert!(poll!(&mut waiting).is_pending());
+    commands.close();
+
+    assert!(matches!(
+        poll!(&mut waiting),
+        std::task::Poll::Ready(Err(Error::ChannelSend))
+    ));
+}
+
+#[tokio::test(start_paused = true)]
+async fn poll_stops_on_channel_closure_with_a_pending_reply() {
+    let (transport, mut commands) = transport();
+    let peer = PeerId::new("remote".into());
+    let waiting = transport.poll_until_connected(&peer, Duration::from_secs(5));
+    tokio::pin!(waiting);
+
+    assert!(poll!(&mut waiting).is_pending());
+    let _pending_reply = take_reply(&mut commands);
+    commands.close();
+
+    assert!(matches!(
+        poll!(&mut waiting),
+        std::task::Poll::Ready(Err(Error::ChannelSend))
+    ));
+}


### PR DESCRIPTION
## Context

`poll_until_connected` checks its timeout only between requests. A full command queue or missing reply can keep it waiting indefinitely, and channel closure does not interrupt its polling sleep.

## Changes

- Apply one deadline to the entire connection wait, including command sends and replies.
- Stop immediately when the endpoint closes its command receiver.
- Add paused-clock tests for blocked sends, missing replies, short deadlines, and channel closure, while preserving successful connections and transport errors.

## Testing

Five new regressions fail before the fix and pass afterward.

- [x] `cargo test --profile super-dev -p p2p --features iroh-transport --lib --test iroh_lifecycle_tests` (384 unit tests and 2 lifecycle tests passed)
- [x] `cargo clippy --profile super-dev -p p2p --features iroh-transport,libp2p-transport --tests -- -D warnings`
- [x] `cargo fmt --all -- --check`

Refs #1356
