### PR TITLE
fix(cli): initialize node identity from the configured key type

### DIFF
--- a/crates/cli/src/commands/start/mod.rs
+++ b/crates/cli/src/commands/start/mod.rs
@@ -1,6 +1,7 @@
 //! Start command implementation
 
 mod node;
+mod node_identity;
 mod p2p;
 mod run;
 mod server;

--- a/crates/cli/src/commands/start/node.rs
+++ b/crates/cli/src/commands/start/node.rs
@@ -164,7 +164,7 @@ impl Node {
         config: &Config,
         peer_keypair: Option<p2p::Keypair>,
         user_identity: Option<std::sync::Arc<identity::RawIdentity>>,
-        node_identity_did: Option<String>,
+        node_identity: Option<Arc<identity::RawIdentity>>,
         se_key: Option<[u8; 32]>,
     ) -> Result<ServerSetup> {
         info!("Using unified ACP store (namespace isolated in main database)");
@@ -179,7 +179,7 @@ impl Node {
             user_identity,
             acp_store,
             zanzibar_store,
-            node_identity_did,
+            node_identity,
             se_key,
         )
         .await
@@ -195,17 +195,12 @@ impl Node {
         info!("Root directory: {}", config.rootdir.display());
         info!("Data directory: {}", config.data_path().display());
 
-        // Initialize peer keypair from keyring (if P2P enabled and keyring not disabled)
-        let (peer_keypair, node_identity_did) =
-            if !config.net.p2p_disabled && !config.keyring.disabled {
-                let (kp, did) = Self::init_peer_key(&config)?;
-                (Some(kp), Some(did))
-            } else if !config.net.p2p_disabled {
-                info!("Keyring disabled, using ephemeral peer identity");
-                (None, None)
-            } else {
-                (None, None)
-            };
+        let node_identity = super::node_identity::resolve(&config, user_identity.clone())?;
+        let peer_keypair = if !config.net.p2p_disabled && !config.keyring.disabled {
+            Some(Self::init_peer_key(&config)?)
+        } else {
+            None
+        };
 
         // Load the cluster-shared searchable-encryption key from the keyring
         // (Go's getOrCreateSearchableEncryptionKey). `None` when SE or the
@@ -239,7 +234,7 @@ impl Node {
                     user_identity.clone(),
                     acp_store,
                     zanzibar_store,
-                    node_identity_did.clone(),
+                    node_identity.clone(),
                     se_key,
                 )
                 .await?
@@ -259,7 +254,7 @@ impl Node {
                     &config,
                     peer_keypair,
                     user_identity.clone(),
-                    node_identity_did.clone(),
+                    node_identity.clone(),
                     se_key,
                 )
                 .await?

--- a/crates/cli/src/commands/start/node_identity.rs
+++ b/crates/cli/src/commands/start/node_identity.rs
@@ -1,0 +1,85 @@
+use std::sync::Arc;
+
+use identity::{FullIdentity, IdentityKeyType, RawIdentity};
+use zeroize::Zeroizing;
+
+use crate::config::Config;
+use crate::error::{Error, Result};
+
+const NODE_IDENTITY_KEY: &str = "node-identity-key";
+
+pub(super) fn resolve(
+    config: &Config,
+    explicit: Option<Arc<RawIdentity>>,
+) -> Result<Option<Arc<RawIdentity>>> {
+    if explicit.is_some() {
+        return Ok(explicit);
+    }
+    if config.keyring.disabled {
+        return if config.development {
+            generate(&config.datastore.default_key_type).map(|identity| Some(Arc::new(identity)))
+        } else {
+            Ok(None)
+        };
+    }
+
+    let keyring = crate::commands::open_keyring(config)?;
+    load_or_create(keyring.as_ref(), &config.datastore.default_key_type)
+        .map(|identity| Some(Arc::new(identity)))
+}
+
+fn generate(key_type: &str) -> Result<RawIdentity> {
+    let key_type: IdentityKeyType = key_type.parse().map_err(|_| {
+        Error::InvalidConfig("default-key-type must be ed25519, secp256k1, or secp256r1".into())
+    })?;
+    let key = crypto::generate_key(key_type.into())?;
+    Ok(RawIdentity::from_identity_key_type(key_type, key.raw())?)
+}
+
+fn persist(keyring: &dyn keyring::Keyring, identity: &RawIdentity) -> Result<()> {
+    let mut encoded = Zeroizing::new(format!("{}:", identity.identity_key_type()).into_bytes());
+    encoded.extend_from_slice(identity.priv_key().raw());
+    keyring
+        .set(NODE_IDENTITY_KEY, &encoded)
+        .map_err(|error| Error::Keyring(error.to_string()))
+}
+
+fn load_or_create(keyring: &dyn keyring::Keyring, default_type: &str) -> Result<RawIdentity> {
+    let encoded = match keyring.get(NODE_IDENTITY_KEY) {
+        Ok(encoded) => encoded,
+        Err(keyring::Error::NotFound(_)) => {
+            let identity = generate(default_type)?;
+            persist(keyring, &identity)?;
+            return Ok(identity);
+        }
+        Err(error) => return Err(Error::Keyring(error.to_string())),
+    };
+
+    // Legacy Go identities are raw secp256k1 keys; their random bytes may contain ':'.
+    let legacy = encoded.len() == 32;
+    let (key_type, key_bytes) = if legacy {
+        (IdentityKeyType::Secp256k1, encoded.as_slice())
+    } else {
+        let separator = encoded
+            .iter()
+            .position(|byte| *byte == b':')
+            .ok_or_else(|| {
+                Error::InvalidIdentity("node-identity-key is missing its key type".into())
+            })?;
+        let key_type = std::str::from_utf8(&encoded[..separator])
+            .ok()
+            .and_then(|name| name.parse::<IdentityKeyType>().ok())
+            .ok_or_else(|| Error::InvalidIdentity("invalid node-identity-key type".into()))?;
+        (key_type, &encoded[separator + 1..])
+    };
+    let identity = RawIdentity::from_identity_key_type(key_type, key_bytes)
+        .map_err(|_| Error::InvalidIdentity("invalid node-identity-key bytes".into()))?;
+    if legacy {
+        persist(keyring, &identity)?;
+    }
+    Ok(identity)
+}
+
+#[cfg(test)]
+#[path = "../../../tests/start/node_identity.rs"]
+mod tests;

--- a/crates/cli/src/commands/start/p2p.rs
+++ b/crates/cli/src/commands/start/p2p.rs
@@ -14,7 +14,7 @@ impl Node {
     ///
     /// If a peer key exists in the keyring, it is loaded and converted to a libp2p Keypair.
     /// If no peer key exists, a new Ed25519 key is generated and stored in the keyring.
-    pub(super) fn init_peer_key(config: &Config) -> Result<(p2p::Keypair, String)> {
+    pub(super) fn init_peer_key(config: &Config) -> Result<p2p::Keypair> {
         use keyring::PEER_KEY;
 
         let kr = crate::commands::open_keyring(config)?;
@@ -23,9 +23,7 @@ impl Node {
         match kr.get(PEER_KEY) {
             Ok(key_bytes) => {
                 info!("Loaded existing peer key from keyring");
-                let did = Self::derive_and_log_identity_did(&key_bytes)?;
-                let keypair = Self::keypair_from_ed25519_bytes(&key_bytes)?;
-                Ok((keypair, did))
+                Self::keypair_from_ed25519_bytes(&key_bytes)
             }
             Err(keyring::Error::NotFound(_)) => {
                 info!("Generating new peer key");
@@ -38,24 +36,10 @@ impl Node {
                 kr.set(PEER_KEY, key_bytes)
                     .map_err(|e| Error::Keyring(e.to_string()))?;
 
-                let did = Self::derive_and_log_identity_did(key_bytes)?;
-                let keypair = Self::keypair_from_ed25519_bytes(key_bytes)?;
-                Ok((keypair, did))
+                Self::keypair_from_ed25519_bytes(key_bytes)
             }
             Err(e) => Err(Error::Keyring(e.to_string())),
         }
-    }
-
-    /// Derive and log the node's DID from peer key bytes.
-    fn derive_and_log_identity_did(key_bytes: &[u8]) -> Result<String> {
-        use identity::{Identity, IdentityKeyType, RawIdentity};
-
-        let identity = RawIdentity::from_identity_key_type(IdentityKeyType::Ed25519, key_bytes)?;
-        let did = identity
-            .did()
-            .map_err(|e| Error::Keyring(format!("failed to derive DID: {}", e)))?;
-        info!("Node identity DID: {}", did);
-        Ok(did.to_string())
     }
 
     /// Convert Ed25519 key bytes to libp2p Keypair.

--- a/crates/cli/src/commands/start/server.rs
+++ b/crates/cli/src/commands/start/server.rs
@@ -27,7 +27,7 @@ impl Node {
         user_identity: Option<std::sync::Arc<identity::RawIdentity>>,
         acp_store: Arc<dyn acp::AcpStore>,
         zanzibar_store: Arc<dyn acp::ZanzibarStore>,
-        node_identity_did: Option<String>,
+        node_identity: Option<Arc<identity::RawIdentity>>,
         se_key: Option<[u8; 32]>,
     ) -> Result<ServerSetup> {
         let user_did = match &user_identity {
@@ -43,8 +43,12 @@ impl Node {
         };
 
         let identity_key_bytes = user_identity.as_ref().map(|id| id.private_key_bytes());
+        let node_did = node_identity
+            .as_ref()
+            .map(|identity| identity.did())
+            .transpose()?;
 
-        if let (Some(did), Some(identity)) = (&user_did, &user_identity) {
+        if let (Some(did), Some(identity)) = (&node_did, &node_identity) {
             defra_core::signing::store_identity(
                 did.as_ref(),
                 defra_core::signing::SigningConfig {
@@ -80,9 +84,9 @@ impl Node {
 
         let mut db_options =
             db::DbOptions::new().with_max_txn_retries(config.datastore.max_txn_retries);
-        if let Some(identity) = user_identity.as_ref() {
+        if let Some(identity) = node_identity.as_ref() {
             db_options = db_options.with_node_identity_arc(identity.clone());
-            info!("Database configured with user identity");
+            info!("Database configured with node identity");
         }
         let embedding_api_key = if config.embedding.api_key_env.is_empty() {
             String::new()
@@ -137,7 +141,7 @@ impl Node {
             event_bus.clone(),
             config,
             peer_keypair,
-            user_identity,
+            node_identity,
             se_key,
         )
         .await?;
@@ -317,7 +321,7 @@ impl Node {
             acp_setup: &acp_setup,
             zanzibar_store,
             user_did: user_did.as_ref(),
-            node_identity_did,
+            node_identity_did: node_did.map(|did| did.to_string()),
         })?;
         #[cfg(feature = "postgres")]
         let pg_server = Self::build_pg_server(

--- a/crates/cli/src/commands/start/server_http.rs
+++ b/crates/cli/src/commands/start/server_http.rs
@@ -82,6 +82,7 @@ impl Node {
 
         let remote_signer_did = defra_core::signing::find_remote_signer_did();
         let user_identity_present = user_did.is_some();
+        let node_identity_present = node_identity_did.is_some();
         let signing_did = remote_signer_did
             .clone()
             .or_else(|| user_did.map(ToString::to_string))
@@ -89,6 +90,7 @@ impl Node {
         server = server.with_node_options(sanitized_node_options(
             config,
             user_identity_present,
+            node_identity_present,
             signing_did.is_some() && !config.datastore.no_signing,
         ));
         if let Some(did) = signing_did {

--- a/crates/cli/src/commands/start/server_http/node_options.rs
+++ b/crates/cli/src/commands/start/server_http/node_options.rs
@@ -8,7 +8,8 @@ fn seconds_as_nanos(seconds: u64) -> u64 {
 
 pub(super) fn sanitized_node_options(
     config: &Config,
-    user_identity_present: bool,
+    _user_identity_present: bool,
+    node_identity_present: bool,
     signing_enabled: bool,
 ) -> Map<String, Value> {
     let redacted = |present: bool| present.then_some("<redacted>");
@@ -25,7 +26,7 @@ pub(super) fn sanitized_node_options(
     #[cfg(not(feature = "sourcehub"))]
     let (sourcehub_chain_id, sourcehub_grpc_address, sourcehub_comet_address) = ("", "", "");
     #[cfg(feature = "sourcehub")]
-    let document_signer_present = user_identity_present
+    let document_signer_present = _user_identity_present
         && matches!(
             config.acp.document_type,
             AcpDocumentType::SourceHub | AcpDocumentType::HubRs
@@ -59,7 +60,7 @@ pub(super) fn sanitized_node_options(
         },
         "DB": {
             "MaxTxnRetries": config.datastore.max_txn_retries,
-            "Identity": redacted(user_identity_present),
+            "Identity": redacted(node_identity_present),
             "EnableSigning": signing_enabled,
             "SearchableEncryptionKey": redacted(
                 !config.datastore.no_searchable_encryption && !config.keyring.disabled
@@ -124,7 +125,7 @@ mod tests {
         config.api.allowed_origins = vec!["https://private.example".into()];
         config.api.privkey_path = "/private/tls/key.pem".into();
 
-        let options = sanitized_node_options(&config, true, true);
+        let options = sanitized_node_options(&config, true, true, true);
 
         assert_eq!(options["DisableP2P"], false);
         assert_eq!(options["Store"]["Store"], "memory");

--- a/crates/cli/tests/node_identity_tests.rs
+++ b/crates/cli/tests/node_identity_tests.rs
@@ -1,0 +1,250 @@
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+use std::time::Duration;
+
+use crypto::KeyType;
+use serde_json::Value;
+
+struct RunningNode {
+    child: Child,
+    url: String,
+    client: reqwest::Client,
+}
+
+impl Drop for RunningNode {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+impl RunningNode {
+    async fn start(root: &Path, key_type: &str, flags: &[&str]) -> Self {
+        let port = portpicker::pick_unused_port().expect("unused HTTP port");
+        let address = format!("127.0.0.1:{port}");
+        let log_path = root.join("node.log");
+        let log = std::fs::File::create(&log_path).unwrap();
+        let child = Command::new(env!("CARGO_BIN_EXE_defra"))
+            .arg("--rootdir")
+            .arg(root)
+            .args(["--url", &address])
+            .args([
+                "start",
+                "--store",
+                "memory",
+                "--no-p2p",
+                "--default-key-type",
+                key_type,
+            ])
+            .args(flags)
+            .env("DEFRA_KEYRING_SECRET", "node-identity-test-secret")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(log)
+            .spawn()
+            .expect("start node");
+        let mut node = Self {
+            child,
+            url: format!("http://{address}"),
+            client: reqwest::Client::builder()
+                .no_proxy()
+                .timeout(Duration::from_secs(5))
+                .build()
+                .unwrap(),
+        };
+        tokio::time::timeout(Duration::from_secs(15), async {
+            loop {
+                assert!(
+                    node.child.try_wait().unwrap().is_none(),
+                    "node exited during startup: {}",
+                    std::fs::read_to_string(&log_path).unwrap_or_default()
+                );
+                if let Ok(response) = node
+                    .client
+                    .get(format!("{}/health-check", node.url))
+                    .send()
+                    .await
+                {
+                    if response.status().is_success() {
+                        break;
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("node did not become healthy");
+        node
+    }
+
+    async fn identity(&self) -> Value {
+        self.client
+            .get(format!("{}/api/v0/node/identity", self.url))
+            .send()
+            .await
+            .unwrap()
+            .error_for_status()
+            .unwrap()
+            .json()
+            .await
+            .unwrap()
+    }
+
+    async fn query(&self, query: &str) -> Value {
+        let result: Value = self
+            .client
+            .post(format!("{}/api/v0/graphql", self.url))
+            .json(&serde_json::json!({"query": query}))
+            .send()
+            .await
+            .unwrap()
+            .error_for_status()
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        assert!(result["errors"].is_null(), "query failed: {result}");
+        result["data"].clone()
+    }
+}
+
+#[tokio::test]
+async fn development_node_uses_the_requested_identity_key_type_without_p2p() {
+    for (name, expected) in [
+        ("ed25519", KeyType::Ed25519),
+        ("secp256k1", KeyType::Secp256k1),
+        ("secp256r1", KeyType::Secp256r1),
+    ] {
+        let root = tempfile::tempdir().unwrap();
+        let node = RunningNode::start(root.path(), name, &["--development", "--no-keyring"]).await;
+        let response = node.identity().await;
+        let did = response["DID"].as_str().expect("generated node identity");
+        assert_eq!(crypto::parse_did_key(did).unwrap().0, expected);
+        assert!(response["PeerID"].is_null());
+    }
+}
+
+#[tokio::test]
+async fn persisted_node_identity_survives_a_default_key_type_change() {
+    let root = tempfile::tempdir().unwrap();
+    let node = RunningNode::start(root.path(), "secp256r1", &[]).await;
+    let before = node.identity().await;
+    let did = before["DID"].as_str().expect("persisted node identity");
+    assert_eq!(crypto::parse_did_key(did).unwrap().0, KeyType::Secp256r1);
+    drop(node);
+
+    let restarted = RunningNode::start(root.path(), "ed25519", &[]).await;
+    assert_eq!(restarted.identity().await["DID"], before["DID"]);
+}
+
+#[tokio::test]
+async fn generated_identity_signs_commits_unless_signing_is_disabled() {
+    for no_signing in [false, true] {
+        let root = tempfile::tempdir().unwrap();
+        let mut flags = vec!["--development", "--no-keyring"];
+        if no_signing {
+            flags.push("--no-signing");
+        }
+        let node = RunningNode::start(root.path(), "secp256k1", &flags).await;
+        let identity = node.identity().await;
+        let did = identity["DID"].as_str().unwrap();
+        let (key_type, public_bytes) = crypto::parse_did_key(did).unwrap();
+        let public_key = crypto::public_key_from_bytes(key_type, &public_bytes).unwrap();
+        node.client
+            .post(format!("{}/api/v0/schema", node.url))
+            .body("type Users { name: String }")
+            .send()
+            .await
+            .unwrap()
+            .error_for_status()
+            .unwrap();
+        node.query(r#"mutation { add_Users(input: {name: "Alice"}) { _docID } }"#)
+            .await;
+        let result = node
+            .query("query { _commits { signature { identity } } }")
+            .await;
+        let commits = result["_commits"].as_array().unwrap();
+        assert!(!commits.is_empty());
+        let signed: Vec<_> = commits
+            .iter()
+            .filter(|commit| !commit["signature"].is_null())
+            .collect();
+        if no_signing {
+            assert!(signed.is_empty(), "--no-signing was ignored: {result}");
+        } else {
+            assert!(
+                !signed.is_empty(),
+                "generated identity did not sign: {result}"
+            );
+            for commit in signed {
+                assert_eq!(
+                    commit["signature"]["identity"],
+                    hex::encode(public_key.raw())
+                );
+            }
+        }
+        let options: Value = node
+            .client
+            .get(format!("{}/api/v0/node/options", node.url))
+            .send()
+            .await
+            .unwrap()
+            .error_for_status()
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        assert_eq!(options["DB"]["Identity"], "<redacted>");
+        assert_eq!(options["DB"]["EnableSigning"], !no_signing);
+    }
+}
+
+#[tokio::test]
+async fn generated_identity_does_not_authenticate_http_requests() {
+    let root = tempfile::tempdir().unwrap();
+    let node =
+        RunningNode::start(root.path(), "secp256k1", &["--development", "--no-keyring"]).await;
+    assert!(node.identity().await["DID"].is_string());
+
+    let response = node
+        .client
+        .post(format!("{}/api/v0/acp/document/policy", node.url))
+        .body("")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
+    assert!(response
+        .text()
+        .await
+        .unwrap()
+        .contains("policy creator can not be empty"));
+}
+
+#[tokio::test]
+async fn explicit_identity_overrides_the_generation_default() {
+    use crypto::Key;
+    use identity::Identity;
+
+    let root = tempfile::tempdir().unwrap();
+    let key = crypto::generate_ed25519().unwrap();
+    let key_hex = hex::encode(key.raw());
+    let expected = identity::RawIdentity::from_private_key(key)
+        .unwrap()
+        .did()
+        .unwrap();
+    let node = RunningNode::start(
+        root.path(),
+        "invalid",
+        &["--no-keyring", "--identity", &key_hex],
+    )
+    .await;
+    assert_eq!(node.identity().await["DID"], expected.as_str());
+}
+
+#[tokio::test]
+async fn production_without_keyring_or_explicit_identity_stays_anonymous() {
+    let root = tempfile::tempdir().unwrap();
+    let node = RunningNode::start(root.path(), "ed25519", &["--no-keyring"]).await;
+    assert!(node.identity().await.get("DID").is_none());
+}

--- a/crates/cli/tests/start/node_identity.rs
+++ b/crates/cli/tests/start/node_identity.rs
@@ -1,0 +1,94 @@
+use super::*;
+use identity::Identity;
+use keyring::Keyring;
+
+#[test]
+fn keyring_identity_roundtrips_all_supported_types_without_rotation() {
+    for name in ["ed25519", "secp256k1", "secp256r1"] {
+        let root = tempfile::tempdir().unwrap();
+        let keyring = keyring::FileKeyring::open(root.path(), b"test-secret").unwrap();
+        let first = load_or_create(&keyring, name).unwrap();
+        assert_eq!(first.identity_key_type().to_string(), name);
+        let encoded = keyring.get(NODE_IDENTITY_KEY).unwrap();
+        assert!(encoded.starts_with(format!("{name}:").as_bytes()));
+
+        let reopened = keyring::FileKeyring::open(root.path(), b"test-secret").unwrap();
+        let loaded = load_or_create(&reopened, "not-a-key-type").unwrap();
+        assert_eq!(loaded.did().unwrap(), first.did().unwrap());
+        assert_eq!(reopened.get(NODE_IDENTITY_KEY).unwrap(), encoded);
+    }
+}
+
+#[test]
+fn legacy_key_is_migrated_without_changing_its_identity() {
+    let root = tempfile::tempdir().unwrap();
+    let keyring = keyring::FileKeyring::open(root.path(), b"test-secret").unwrap();
+    let mut bytes = [1; 32];
+    bytes[4] = b':';
+    let expected = RawIdentity::from_identity_key_type(IdentityKeyType::Secp256k1, &bytes).unwrap();
+    keyring.set(NODE_IDENTITY_KEY, &bytes).unwrap();
+
+    let loaded = load_or_create(&keyring, "ed25519").unwrap();
+
+    assert_eq!(loaded.did().unwrap(), expected.did().unwrap());
+    let encoded = keyring.get(NODE_IDENTITY_KEY).unwrap();
+    assert!(encoded.starts_with(b"secp256k1:"));
+    assert_eq!(&encoded[b"secp256k1:".len()..], &bytes);
+}
+
+#[test]
+fn invalid_stored_identity_is_not_replaced_or_exposed() {
+    let root = tempfile::tempdir().unwrap();
+    let keyring = keyring::FileKeyring::open(root.path(), b"test-secret").unwrap();
+    for bytes in [
+        b"ed25519:private-material".as_slice(),
+        b"private-material:unknown",
+        b"private-material",
+        b"",
+        &[0; 32],
+    ] {
+        keyring.set(NODE_IDENTITY_KEY, bytes).unwrap();
+        let error = load_or_create(&keyring, "secp256k1").unwrap_err();
+        assert!(!error.to_string().contains("private-material"));
+        assert_eq!(keyring.get(NODE_IDENTITY_KEY).unwrap().as_slice(), bytes);
+    }
+}
+
+#[test]
+fn invalid_default_type_does_not_write_a_key() {
+    let root = tempfile::tempdir().unwrap();
+    let keyring = keyring::FileKeyring::open(root.path(), b"test-secret").unwrap();
+    assert!(matches!(
+        load_or_create(&keyring, "aes256"),
+        Err(Error::InvalidConfig(_))
+    ));
+    assert!(matches!(
+        keyring.get(NODE_IDENTITY_KEY),
+        Err(keyring::Error::NotFound(_))
+    ));
+}
+
+#[test]
+fn explicit_identity_takes_precedence_without_opening_the_keyring() {
+    let mut config = Config::default();
+    config.datastore.default_key_type = "invalid".into();
+    let explicit = Arc::new(generate("secp256r1").unwrap());
+
+    let loaded = resolve(&config, Some(explicit.clone())).unwrap().unwrap();
+
+    assert!(Arc::ptr_eq(&loaded, &explicit));
+}
+
+#[test]
+fn disabled_keyring_only_generates_an_identity_in_development() {
+    let mut config = Config::default();
+    config.keyring.disabled = true;
+    assert!(resolve(&config, None).unwrap().is_none());
+
+    config.development = true;
+    config.datastore.default_key_type = "ed25519".into();
+    let first = resolve(&config, None).unwrap().unwrap();
+    let second = resolve(&config, None).unwrap().unwrap();
+    assert_eq!(first.identity_key_type(), IdentityKeyType::Ed25519);
+    assert_ne!(first.did().unwrap(), second.did().unwrap());
+}

--- a/crates/query/src/runner/plan.rs
+++ b/crates/query/src/runner/plan.rs
@@ -219,6 +219,17 @@ pub(crate) fn build_plan(
     acp_filter: Option<AcpFilter>,
     query_limits: QueryLimits,
 ) -> Result<Box<dyn PlanNode>> {
+    // Materialized ID lookups have already resolved aliases to canonical IDs.
+    // Rechecking the input aliases would discard those documents.
+    let scan_doc_ids = match &source {
+        ScanSource::Docs(docs) if select.doc_ids.is_some() && !docs.is_empty() => Some(
+            docs.iter()
+                .filter_map(|doc| doc.doc_id().map(str::to_owned))
+                .collect(),
+        ),
+        _ => select.doc_ids.clone(),
+    };
+
     // Create ScanNode with a document source, filter, and docIDs
     let scan = ScanNode::new(collection.clone(), mapping.clone());
     let mut scan = match source {
@@ -280,8 +291,8 @@ pub(crate) fn build_plan(
     if let Some(ref filter) = filter_for_scan {
         scan = scan.with_filter(filter.clone());
     }
-    if let Some(ref doc_ids) = select.doc_ids {
-        scan = scan.with_doc_ids(doc_ids.clone());
+    if let Some(doc_ids) = scan_doc_ids {
+        scan = scan.with_doc_ids(doc_ids);
     }
 
     let mut plan: Box<dyn PlanNode> = Box::new(scan);

--- a/tools/integration-test/tests/backup/restore.rs
+++ b/tools/integration-test/tests/backup/restore.rs
@@ -1,6 +1,7 @@
 use std::process::Command;
 
 use integration_test::{for_each_runtime, DefraClient, NodeKind, TestCluster};
+use serde_json::json;
 
 async fn backup_restore_test(cluster: TestCluster) {
     let client = cluster.client(0);
@@ -101,55 +102,62 @@ async fn backup_restore_test(cluster: TestCluster) {
     backup_import(&client, node_url, &full_path).expect("backup_import full failed");
 
     // 8. Verify restored data
-    let restored_users = client
-        .query("query { User { _docID name } }")
-        .expect("query users after restore");
-    let users = restored_users["User"].as_array().expect("users not array");
-    assert_eq!(users.len(), 2, "expected 2 users after restore");
+    assert_restored_users(&client, &[(&alice_id, "Alice"), (&bob_id, "Bob")]);
 
     let restored_posts = client
-        .query("query { Post { _docID title } }")
+        .query("query { Post(order: {title: ASC}) { _docID title } }")
         .expect("query posts after restore");
     let posts = restored_posts["Post"].as_array().expect("posts not array");
     assert_eq!(posts.len(), 3, "expected 3 posts after restore");
 
-    // 9. Verify doc IDs match originals (CID stability)
-    let user_ids: Vec<&str> = users.iter().filter_map(|u| u["_docID"].as_str()).collect();
-    assert!(
-        user_ids.contains(&alice_id.as_str()),
-        "Alice doc ID should match after restore"
-    );
-    assert!(
-        user_ids.contains(&bob_id.as_str()),
-        "Bob doc ID should match after restore"
-    );
+    for (post, title) in posts.iter().zip(["Hello World", "P2P Guide", "Rust Tips"]) {
+        assert_eq!(post["title"], title);
+    }
 
-    // 10. Truncate User only
+    // 9. Truncate User only
     client
         .collection_truncate("User")
         .expect("truncate User for partial restore");
 
-    // 11. Partial restore (Users only)
+    // 10. Partial restore (Users only)
     backup_import(&client, node_url, &users_path).expect("backup_import users failed");
 
-    // 12. Verify: 2 users restored, 3 posts untouched
-    let final_users = client
-        .query("query { User { _docID } }")
-        .expect("query users after partial restore");
-    assert_eq!(
-        final_users["User"].as_array().expect("not array").len(),
-        2,
-        "expected 2 users after partial restore"
-    );
+    // 11. Verify: 2 users restored, 3 posts untouched
+    assert_restored_users(&client, &[(&alice_id, "Alice"), (&bob_id, "Bob")]);
 
     let final_posts = client
-        .query("query { Post { _docID } }")
+        .query("query { Post(order: {title: ASC}) { _docID title } }")
         .expect("query posts after partial restore");
     assert_eq!(
-        final_posts["Post"].as_array().expect("not array").len(),
-        3,
-        "expected 3 posts still present"
+        final_posts, restored_posts,
+        "partial restore must leave posts unchanged"
     );
+}
+
+fn assert_restored_users(client: &DefraClient, expected: &[(&str, &str)]) {
+    let restored = client
+        .query("query { User(order: {name: ASC}) { _docID name } }")
+        .expect("query users after restore");
+    let users = restored["User"].as_array().expect("users not array");
+    assert_eq!(users.len(), expected.len());
+
+    // JSON import recreates genesis blocks, so signed DocIDs may change.
+    // Original IDs must still resolve as aliases of the restored documents.
+    for (user, (original_id, name)) in users.iter().zip(expected) {
+        assert_eq!(user["name"], *name);
+        let by_original_id = client
+            .query(&format!(
+                r#"query {{ User(docID: "{original_id}") {{ _docID name }} }}"#
+            ))
+            .expect("query restored user by original ID");
+        assert_eq!(by_original_id["User"], json!([user]));
+        let filtered = client
+            .query(&format!(
+                r#"query {{ User(docID: "{original_id}", filter: {{name: {{_neq: "{name}"}}}}) {{ _docID name }} }}"#
+            ))
+            .expect("query restored user with non-matching filter");
+        assert_eq!(filtered["User"], json!([]));
+    }
 }
 
 fn backup_export(

--- a/tools/integration-test/tests/encryption/acp.rs
+++ b/tools/integration-test/tests/encryption/acp.rs
@@ -1,9 +1,9 @@
 use std::time::Duration;
 
-use integration_test::node::{DefraNode, RustNode};
+use integration_test::node::RustNode;
 use integration_test::{
-    for_each_runtime, generate_identity, poll_until, users_schema_with_policy, TestCluster,
-    USER_ACP_POLICY,
+    for_each_runtime, generate_identity, poll_until, users_schema_with_policy, BinarySource,
+    TestCluster, USER_ACP_POLICY,
 };
 
 async fn encrypted_acp_test(cluster: TestCluster) {
@@ -160,14 +160,16 @@ for_each_runtime!(encrypted_acp, encrypted_acp_test, .with_acp_local().with_encr
 /// the peer pulls through the ACP read gate, exactly as the oracle does.
 #[tokio::test]
 async fn rust_encrypted_branchable_collection_grant_merges_on_peer() {
-    let binary = RustNode::from_workspace().binary_path().to_path_buf();
-    RustNode::build().expect("build rust binary");
+    if std::env::var_os("DEFRA_RUST_BINARY").is_none() {
+        RustNode::build().expect("build rust binary");
+    }
+    let binary = integration_test::rust_binary();
     let jack = generate_identity(&binary).expect("jack identity");
     let node1_id = generate_identity(&binary).expect("node1 identity");
 
     let cluster = TestCluster::builder()
         .rust_nodes(2)
-        .skip_build()
+        .with_rust_binary(BinarySource::Path(binary))
         .with_p2p()
         .with_acp_local()
         .with_encryption()


### PR DESCRIPTION
## Context

`--default-key-type` was saved in configuration but never used at startup. Nodes without an explicit `--identity` did not load or generate a database identity, and the HTTP identity endpoint fell back to the unrelated P2P peer key.

## Changes

- Load or create `node-identity-key` using the configured key type. Keep existing identities when the default changes, migrate legacy raw keys without changing their DID, and reject malformed keys without replacing them.
- Generate an ephemeral identity in development mode with `--no-keyring`; otherwise keep anonymous startup when neither a keyring nor an explicit identity is available.
- Wire the node identity into the database, P2P, and HTTP signing while preserving explicit `--identity` precedence and keeping caller permissions separate.
- Cover persistence, key types, malformed keys, signing, `--no-signing`, and anonymous requests. Encryption defaults and the existing secp256r1 signing guard are unchanged.

## Testing

- [x] CLI library and integration tests with default features and `release-full`, including six identity-loader tests and six live-node regressions.
- [x] Strict CLI clippy across all targets with default features and `release-full`.
- [x] Rust identity integration suite: 23 passed.
- [x] Rust ACP integration suite: 109 passed.
- [x] Rust P2P replication scenarios: 2 passed.
- [x] `cargo fmt --all --check` and `git diff --check`.

Integration checks used the rebuilt binary, an isolated root directory, and `RUST_LOG=info` so the harness could detect readiness.

Refs #1422
