### PR TITLE
fix(p2p): wait for coordinator shutdown cleanup

### DIFF
--- a/crates/p2p/src/sync/coordinator/mod.rs
+++ b/crates/p2p/src/sync/coordinator/mod.rs
@@ -71,7 +71,7 @@ use acp::DocumentACP;
 use blockstore::Blockstore;
 use cid::Cid;
 use parking_lot::Mutex;
-use tokio::sync::{Notify, OwnedSemaphorePermit, Semaphore};
+use tokio::sync::{watch, Notify, OwnedSemaphorePermit, Semaphore};
 use tokio::task::JoinHandle;
 
 use crate::bitswap::{AccessMode, ReplicatorRegistry};
@@ -265,6 +265,7 @@ struct SyncShutdownState {
     /// remains the single source of truth and stays a plain atomic because it
     /// is read on hot paths.
     shutdown_notify: Notify,
+    shutdown_complete: watch::Sender<bool>,
     background_tasks: Mutex<Vec<JoinHandle<()>>>,
     non_authoritative_broadcast_slots: Arc<Semaphore>,
     non_authoritative_broadcast_high_water: AtomicUsize,
@@ -354,6 +355,7 @@ impl SyncShutdownHandle {
             inner: Arc::new(SyncShutdownState {
                 is_shutting_down: AtomicBool::new(false),
                 shutdown_notify: Notify::new(),
+                shutdown_complete: watch::channel(false).0,
                 background_tasks: Mutex::new(Vec::new()),
                 non_authoritative_broadcast_slots: Arc::new(Semaphore::new(
                     NON_AUTHORITATIVE_BROADCAST_TASK_LIMIT,
@@ -403,25 +405,36 @@ impl SyncShutdownHandle {
         notified.await;
     }
 
+    /// Wait for registered tasks to finish, including cancellation cleanup.
+    /// Concurrent callers share teardown; cancelling a caller does not stop it.
     pub async fn shutdown(&self) {
-        if !self.begin_shutdown() {
-            return;
+        let mut complete = self.inner.shutdown_complete.subscribe();
+        if self.begin_shutdown() {
+            let shutdown = self.clone();
+            tokio::spawn(async move {
+                shutdown
+                    .drain_background_tasks(BACKGROUND_TASK_SHUTDOWN_TIMEOUT)
+                    .await;
+                shutdown.inner.shutdown_complete.send_replace(true);
+            });
         }
-
-        self.drain_background_tasks(BACKGROUND_TASK_SHUTDOWN_TIMEOUT)
-            .await;
+        let _ = complete.wait_for(|complete| *complete).await;
     }
 
-    fn register_task(&self, handle: JoinHandle<()>) {
+    fn spawn_task<F>(&self, future: F) -> bool
+    where
+        F: std::future::Future<Output = ()> + Send + 'static,
+    {
         let mut tasks = self.inner.background_tasks.lock();
+        if self.is_shutting_down() {
+            return false;
+        }
         // Retire completed handles on every registration so retained handles
         // track live tasks instead of total spawn count (#1099).
         tasks.retain(|task| !task.is_finished());
-        if self.is_shutting_down() {
-            handle.abort();
-        } else {
-            tasks.push(handle);
-        }
+        // Hold the registry lock through spawning so shutdown cannot miss the task.
+        tasks.push(tokio::spawn(future));
+        true
     }
 
     fn try_acquire_non_authoritative_broadcast_slot(&self) -> Option<OwnedSemaphorePermit> {
@@ -555,29 +568,26 @@ impl SyncShutdownHandle {
                 })
         });
 
-        let started = tokio::time::Instant::now();
-
-        for handle in &mut handles {
-            let elapsed = started.elapsed();
-            let Some(remaining) = timeout.checked_sub(elapsed) else {
-                break;
-            };
-
-            match tokio::time::timeout(remaining, handle).await {
-                Ok(Ok(())) | Ok(Err(_)) => {}
-                Err(_) => {
-                    tracing::debug!(
-                        timeout_ms = timeout.as_millis() as u64,
-                        "Coordinator background task exceeded shutdown drain window; aborting remaining tasks"
-                    );
-                    break;
-                }
-            }
-        }
-
-        for handle in handles {
-            if !handle.is_finished() {
+        let deadline = tokio::time::Instant::now() + timeout;
+        let mut handles = handles.into_iter();
+        while let Some(mut handle) = handles.next() {
+            if tokio::time::timeout_at(deadline, &mut handle)
+                .await
+                .is_err()
+            {
+                tracing::debug!(
+                    timeout_ms = timeout.as_millis() as u64,
+                    "Coordinator background task exceeded shutdown drain window; aborting remaining tasks"
+                );
                 handle.abort();
+                for pending in handles.as_slice() {
+                    pending.abort();
+                }
+                let _ = handle.await;
+                for pending in handles {
+                    let _ = pending.await;
+                }
+                return;
             }
         }
     }
@@ -961,13 +971,9 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     where
         F: std::future::Future<Output = ()> + Send + 'static,
     {
-        if self.runtime.shutdown.is_shutting_down() {
+        if !self.runtime.shutdown.spawn_task(future) {
             tracing::debug!(task = task_name, "Skipping background task during shutdown");
-            return;
         }
-
-        let handle = tokio::spawn(future);
-        self.runtime.shutdown.register_task(handle);
     }
 
     /// Spawn mutation-adjacent gossip/artifact work in a distinct bounded
@@ -997,11 +1003,10 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             );
             return;
         };
-        let handle = tokio::spawn(async move {
+        self.runtime.shutdown.spawn_task(async move {
             future.await;
             drop(permit);
         });
-        self.runtime.shutdown.register_task(handle);
     }
 
     pub(crate) fn spawn_pending_dag_fetch_task<F>(
@@ -1095,6 +1100,10 @@ mod dag_fetch_limiter_tests {
 }
 
 #[cfg(test)]
+#[path = "../../../tests/coordinator/shutdown.rs"]
+mod shutdown_completion_tests;
+
+#[cfg(test)]
 mod shutdown_tests {
     use super::broadcast::tests::TestTransport;
     use super::{
@@ -1184,10 +1193,10 @@ mod shutdown_tests {
         let completed = Arc::new(AtomicBool::new(false));
         let completed_for_task = Arc::clone(&completed);
 
-        shutdown.register_task(tokio::spawn(async move {
+        shutdown.spawn_task(async move {
             tokio::time::sleep(Duration::from_millis(50)).await;
             completed_for_task.store(true, Ordering::SeqCst);
-        }));
+        });
 
         shutdown.shutdown().await;
 
@@ -1228,13 +1237,20 @@ mod shutdown_tests {
 
     /// #1099: completed handles must not accumulate for the process lifetime.
     #[tokio::test]
-    async fn register_task_prunes_finished_handles() {
+    async fn spawn_task_prunes_finished_handles() {
         let shutdown = SyncShutdownHandle::new(4);
         let mut handles = Vec::new();
         for _ in 0..50 {
-            let handle = tokio::spawn(async {});
-            handles.push(handle.abort_handle());
-            shutdown.register_task(handle);
+            shutdown.spawn_task(async {});
+            handles.push(
+                shutdown
+                    .inner
+                    .background_tasks
+                    .lock()
+                    .last()
+                    .unwrap()
+                    .abort_handle(),
+            );
         }
 
         let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
@@ -1243,9 +1259,9 @@ mod shutdown_tests {
             tokio::time::sleep(Duration::from_millis(5)).await;
         }
 
-        shutdown.register_task(tokio::spawn(async {
+        shutdown.spawn_task(async {
             tokio::time::sleep(Duration::from_secs(5)).await;
-        }));
+        });
 
         assert!(
             shutdown.retained_task_count() <= 2,
@@ -1330,25 +1346,21 @@ mod shutdown_tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn shutdown_uses_single_global_budget_for_background_tasks() {
         let shutdown = SyncShutdownHandle::new(4);
 
         for _ in 0..3 {
-            shutdown.register_task(tokio::spawn(async move {
+            shutdown.spawn_task(async move {
                 tokio::time::sleep(Duration::from_secs(10)).await;
-            }));
+            });
         }
 
         let started = tokio::time::Instant::now();
         shutdown.shutdown().await;
         let elapsed = started.elapsed();
 
-        assert!(
-            elapsed < Duration::from_secs(7),
-            "shutdown should use one shared deadline, got {:?}",
-            elapsed
-        );
+        assert_eq!(elapsed, BACKGROUND_TASK_SHUTDOWN_TIMEOUT);
     }
 
     /// #1309: a periodic loop must exit on the shutdown signal, not at the end

--- a/crates/p2p/src/sync/coordinator/mod.rs
+++ b/crates/p2p/src/sync/coordinator/mod.rs
@@ -265,7 +265,8 @@ struct SyncShutdownState {
     /// remains the single source of truth and stays a plain atomic because it
     /// is read on hot paths.
     shutdown_notify: Notify,
-    shutdown_complete: watch::Sender<bool>,
+    shutdown_complete: watch::Receiver<bool>,
+    shutdown_complete_tx: Mutex<Option<watch::Sender<bool>>>,
     background_tasks: Mutex<Vec<JoinHandle<()>>>,
     non_authoritative_broadcast_slots: Arc<Semaphore>,
     non_authoritative_broadcast_high_water: AtomicUsize,
@@ -283,6 +284,7 @@ enum PendingDagFetchTask {
 }
 
 const BACKGROUND_TASK_SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(500);
+const BACKGROUND_TASK_ABORT_TIMEOUT: Duration = Duration::from_secs(5);
 const NON_AUTHORITATIVE_BROADCAST_TASK_LIMIT: usize = 32;
 
 /// Shared limiter for poll-based DAG fetches.
@@ -351,11 +353,13 @@ pub struct SyncShutdownHandle {
 
 impl SyncShutdownHandle {
     fn new(pending_dag_fetch_task_limit: usize) -> Self {
+        let (shutdown_complete_tx, shutdown_complete) = watch::channel(false);
         Self {
             inner: Arc::new(SyncShutdownState {
                 is_shutting_down: AtomicBool::new(false),
                 shutdown_notify: Notify::new(),
-                shutdown_complete: watch::channel(false).0,
+                shutdown_complete,
+                shutdown_complete_tx: Mutex::new(Some(shutdown_complete_tx)),
                 background_tasks: Mutex::new(Vec::new()),
                 non_authoritative_broadcast_slots: Arc::new(Semaphore::new(
                     NON_AUTHORITATIVE_BROADCAST_TASK_LIMIT,
@@ -405,20 +409,27 @@ impl SyncShutdownHandle {
         notified.await;
     }
 
-    /// Wait for registered tasks to finish, including cancellation cleanup.
+    /// Wait for registered tasks within the graceful and cancellation budgets.
     /// Concurrent callers share teardown; cancelling a caller does not stop it.
     pub async fn shutdown(&self) {
-        let mut complete = self.inner.shutdown_complete.subscribe();
+        let mut complete = self.inner.shutdown_complete.clone();
         if self.begin_shutdown() {
             let shutdown = self.clone();
+            // The drain owns the only sender, so cancellation or panic closes
+            // the channel instead of leaving other shutdown callers parked.
+            let sender = self.inner.shutdown_complete_tx.lock().take();
             tokio::spawn(async move {
                 shutdown
                     .drain_background_tasks(BACKGROUND_TASK_SHUTDOWN_TIMEOUT)
                     .await;
-                shutdown.inner.shutdown_complete.send_replace(true);
+                if let Some(sender) = sender {
+                    sender.send_replace(true);
+                }
             });
         }
-        let _ = complete.wait_for(|complete| *complete).await;
+        if complete.wait_for(|complete| *complete).await.is_err() {
+            tracing::warn!("Coordinator shutdown drain stopped before completing");
+        }
     }
 
     fn spawn_task<F>(&self, future: F) -> bool
@@ -571,10 +582,13 @@ impl SyncShutdownHandle {
         let deadline = tokio::time::Instant::now() + timeout;
         let mut handles = handles.into_iter();
         while let Some(mut handle) = handles.next() {
-            if tokio::time::timeout_at(deadline, &mut handle)
-                .await
-                .is_err()
-            {
+            let result = tokio::time::timeout_at(deadline, &mut handle).await;
+            if let Ok(Err(error)) = &result {
+                if error.is_panic() {
+                    tracing::warn!(%error, "Coordinator background task panicked");
+                }
+            }
+            if result.is_err() {
                 tracing::debug!(
                     timeout_ms = timeout.as_millis() as u64,
                     "Coordinator background task exceeded shutdown drain window; aborting remaining tasks"
@@ -583,9 +597,21 @@ impl SyncShutdownHandle {
                 for pending in handles.as_slice() {
                     pending.abort();
                 }
-                let _ = handle.await;
-                for pending in handles {
-                    let _ = pending.await;
+                let remaining = handles.len() + 1;
+                let join = async move {
+                    for pending in std::iter::once(handle).chain(handles) {
+                        if let Err(error) = pending.await {
+                            if error.is_panic() {
+                                tracing::warn!(%error, "Coordinator background task panicked");
+                            }
+                        }
+                    }
+                };
+                if tokio::time::timeout(BACKGROUND_TASK_ABORT_TIMEOUT, join)
+                    .await
+                    .is_err()
+                {
+                    tracing::warn!(remaining, "Timed out joining cancelled coordinator tasks");
                 }
                 return;
             }

--- a/crates/p2p/src/sync/coordinator/push_worker.rs
+++ b/crates/p2p/src/sync/coordinator/push_worker.rs
@@ -171,13 +171,12 @@ pub(super) fn spawn_push_workers<T>(
 {
     for _ in 0..context.backlog.worker_count() {
         let context = Arc::clone(&context);
-        let handle = tokio::spawn(async move {
+        shutdown.spawn_task(async move {
             while let Some(job) = context.backlog.next_job().await {
                 let completion = run_push_job(&context, &job).await;
                 context.backlog.job_done(&job, completion);
             }
         });
-        shutdown.register_task(handle);
     }
 }
 

--- a/crates/p2p/tests/coordinator/shutdown.rs
+++ b/crates/p2p/tests/coordinator/shutdown.rs
@@ -1,0 +1,133 @@
+use super::SyncShutdownHandle;
+use std::sync::Arc;
+use tokio::sync::oneshot;
+
+#[tokio::test(start_paused = true)]
+async fn concurrent_shutdown_callers_wait_for_task_completion() {
+    let shutdown = SyncShutdownHandle::new(1);
+    let (release, wait) = oneshot::channel();
+    shutdown.spawn_task(async move {
+        let _ = wait.await;
+    });
+
+    let first = tokio::spawn({
+        let shutdown = shutdown.clone();
+        async move { shutdown.shutdown().await }
+    });
+    shutdown.cancelled().await;
+
+    let second = shutdown.shutdown();
+    tokio::pin!(second);
+    tokio::select! {
+        biased;
+        _ = &mut second => panic!("shutdown returned while a registered task was still running"),
+        _ = tokio::task::yield_now() => {}
+    }
+
+    release.send(()).unwrap();
+    second.await;
+    first.await.unwrap();
+    shutdown.shutdown().await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn shutdown_joins_aborted_tasks_before_returning() {
+    let shutdown = SyncShutdownHandle::new(1);
+    let resource = Arc::new(());
+    let retained = Arc::downgrade(&resource);
+    let (started, running) = oneshot::channel();
+
+    shutdown.spawn_task(async {});
+    shutdown.spawn_task(async move {
+        let _resource = resource;
+        started.send(()).unwrap();
+        std::future::pending::<()>().await;
+    });
+    running.await.unwrap();
+
+    shutdown.shutdown().await;
+
+    assert!(
+        retained.upgrade().is_none(),
+        "aborted task still owns its resource"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn cancelling_the_first_shutdown_caller_does_not_detach_tasks() {
+    let shutdown = SyncShutdownHandle::new(1);
+    let resource = Arc::new(());
+    let retained = Arc::downgrade(&resource);
+    let (started, running) = oneshot::channel();
+    shutdown.spawn_task(async move {
+        let _resource = resource;
+        started.send(()).unwrap();
+        std::future::pending::<()>().await;
+    });
+    running.await.unwrap();
+
+    let first = tokio::spawn({
+        let shutdown = shutdown.clone();
+        async move { shutdown.shutdown().await }
+    });
+    shutdown.cancelled().await;
+    first.abort();
+    assert!(first.await.unwrap_err().is_cancelled());
+
+    shutdown.shutdown().await;
+
+    assert!(
+        retained.upgrade().is_none(),
+        "cancelling shutdown detached the task"
+    );
+}
+
+#[tokio::test]
+async fn shutdown_rejects_new_tasks_without_spawning_them() {
+    let shutdown = SyncShutdownHandle::new(1);
+    shutdown.shutdown().await;
+    let resource = Arc::new(());
+    let retained = Arc::downgrade(&resource);
+
+    assert!(!shutdown.spawn_task(async move {
+        let _resource = resource;
+        panic!("task started after shutdown");
+    }));
+
+    assert!(
+        retained.upgrade().is_none(),
+        "rejected task was detached instead of dropped"
+    );
+    assert_eq!(shutdown.retained_task_count(), 0);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn task_registration_racing_shutdown_does_not_leave_resources_alive() {
+    for _ in 0..32 {
+        let shutdown = SyncShutdownHandle::new(1);
+        let resource = Arc::new(());
+        let retained = Arc::downgrade(&resource);
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+        let registration = tokio::spawn({
+            let shutdown = shutdown.clone();
+            let barrier = barrier.clone();
+            async move {
+                barrier.wait().await;
+                let task_shutdown = shutdown.clone();
+                shutdown.spawn_task(async move {
+                    let _resource = resource;
+                    task_shutdown.cancelled().await;
+                });
+            }
+        });
+
+        barrier.wait().await;
+        shutdown.shutdown().await;
+        registration.await.unwrap();
+
+        assert!(
+            retained.upgrade().is_none(),
+            "registration raced past the drain"
+        );
+    }
+}

--- a/crates/p2p/tests/coordinator/shutdown.rs
+++ b/crates/p2p/tests/coordinator/shutdown.rs
@@ -6,7 +6,10 @@ use tokio::sync::oneshot;
 async fn concurrent_shutdown_callers_wait_for_task_completion() {
     let shutdown = SyncShutdownHandle::new(1);
     let (release, wait) = oneshot::channel();
+    let resource = Arc::new(());
+    let retained = Arc::downgrade(&resource);
     shutdown.spawn_task(async move {
+        let _resource = resource;
         let _ = wait.await;
     });
 
@@ -27,7 +30,34 @@ async fn concurrent_shutdown_callers_wait_for_task_completion() {
     release.send(()).unwrap();
     second.await;
     first.await.unwrap();
+    assert!(retained.upgrade().is_none());
     shutdown.shutdown().await;
+}
+
+#[tokio::test]
+async fn abandoned_drain_releases_shutdown_waiters() {
+    let shutdown = SyncShutdownHandle::new(1);
+    assert!(shutdown.begin_shutdown());
+    // Model a drain future dropped before its first poll.
+    drop(shutdown.inner.shutdown_complete_tx.lock().take());
+    tokio::time::timeout(std::time::Duration::from_secs(1), shutdown.shutdown())
+        .await
+        .expect("shutdown waited forever after losing its drain");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn shutdown_bounds_joining_a_non_cooperative_task() {
+    let shutdown = SyncShutdownHandle::new(1);
+    let (release, blocked) = std::sync::mpsc::channel();
+    let (started, ready) = oneshot::channel();
+    shutdown.spawn_task(async move {
+        started.send(()).unwrap();
+        let _ = blocked.recv();
+    });
+    ready.await.unwrap();
+    let result = tokio::time::timeout(std::time::Duration::from_secs(7), shutdown.shutdown()).await;
+    let _ = release.send(());
+    result.expect("shutdown exceeded its cancellation budget");
 }
 
 #[tokio::test(start_paused = true)]


### PR DESCRIPTION
## Context

Coordinator shutdown returned immediately to concurrent callers and aborted timed-out tasks without joining them. Cancelling the first shutdown caller could also detach the tasks being drained, leaving them holding resources after shutdown appeared complete.

## Changes

- Share teardown completion across callers and keep cleanup running if a caller is cancelled.
- Keep one 500 ms graceful-drain budget, then abort and join remaining tasks before reporting completion.
- Spawn and register background work under the same lock so shutdown cannot miss a newly started task.
- Add deterministic cleanup regressions, rejected-task coverage, and a registration/shutdown race test.

## Testing

The three cleanup regressions fail before the fix and pass afterward.

- [x] P2P unit tests: 334 with default features; 453 with both transports.
- [x] Strict P2P clippy across all targets with default features and both transports.
- [x] Embedded shutdown integration tests: 6 passed, including persistent-store reopening.
- [x] Rust-to-Rust write contention integration tests: 3 passed.
- [x] Full-feature CLI build.
- [x] `cargo fmt --all --check` and `git diff --check`.

Refs #1356
