### PR TITLE
fix(http): honor configured TLS certificates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1378,6 +1378,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-server"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1df331683d982a0b9492b38127151e6453639cd34926eb9c07d4cd8c6d22bfc"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "either",
+ "fs-err",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.9.0",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls 0.23.37",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower-service",
+]
+
+[[package]]
 name = "backon"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2086,6 +2108,7 @@ dependencies = [
  "portpicker",
  "query",
  "rand 0.9.2",
+ "rcgen",
  "replication-filter",
  "reqwest 0.12.28",
  "schema",
@@ -3468,6 +3491,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
+ "axum-server",
  "base64 0.22.1",
  "cid",
  "crypto",
@@ -3483,6 +3507,7 @@ dependencies = [
  "lens",
  "query",
  "rand 0.8.5",
+ "rustls 0.23.37",
  "schema",
  "serde",
  "serde_json",
@@ -4451,6 +4476,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs-err"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91aa448ca50d7e79433bdf3ee8d99215430d2ec02ade5aefab2a073a1822e8a"
+dependencies = [
+ "autocfg",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -131,6 +131,8 @@ otel = ["telemetry/otlp"]
 
 [dev-dependencies]
 cid.workspace = true
+tokio = { workspace = true, features = ["process"] }
+rcgen = "0.13"
 toml = "0.9"
 tempfile = "3.17"
 portpicker = "0.1"

--- a/crates/cli/src/commands/start/node.rs
+++ b/crates/cli/src/commands/start/node.rs
@@ -191,6 +191,21 @@ impl Node {
         config: Config,
         user_identity: Option<std::sync::Arc<identity::RawIdentity>>,
     ) -> Result<Self> {
+        config.api.validate()?;
+        // Reject invalid TLS before starting stores or background tasks.
+        let tls = if config.api.tls_enabled() {
+            Some(
+                defra_http::TlsConfig::from_pem_file(
+                    &config.api.pubkey_path,
+                    &config.api.privkey_path,
+                )
+                .await
+                .map_err(|e| crate::error::Error::InvalidConfig(format!("HTTP TLS: {e}")))?,
+            )
+        } else {
+            None
+        };
+
         info!("Initializing DefraDB node");
         info!("Root directory: {}", config.rootdir.display());
         info!("Data directory: {}", config.data_path().display());
@@ -223,7 +238,7 @@ impl Node {
         }
 
         // Initialize storage, database, and set up P2P and HTTP server
-        let servers = match config.datastore.store {
+        let mut servers = match config.datastore.store {
             DatastoreType::Memory => {
                 info!("Using in-memory datastore");
                 let acp_store: Arc<dyn acp::AcpStore> = Arc::new(acp::MemoryAcpStore::new());
@@ -265,6 +280,10 @@ impl Node {
                 .await?
             }
         };
+
+        if let Some(tls) = tls {
+            servers.http_server = servers.http_server.with_tls(tls);
+        }
 
         let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
 

--- a/crates/cli/src/commands/start/node.rs
+++ b/crates/cli/src/commands/start/node.rs
@@ -188,9 +188,19 @@ impl Node {
     /// Create a new node
     #[doc(hidden)]
     pub async fn new(
-        config: Config,
+        mut config: Config,
         user_identity: Option<std::sync::Arc<identity::RawIdentity>>,
     ) -> Result<Self> {
+        if config.api.pubkey_path.is_empty() && config.api.privkey_path.is_empty() {
+            let cert = config.rootdir.join("certs/server.crt");
+            let key = config.rootdir.join("certs/server.key");
+            if cert.is_file() {
+                config.api.pubkey_path = cert.display().to_string();
+            }
+            if key.is_file() {
+                config.api.privkey_path = key.display().to_string();
+            }
+        }
         config.api.validate()?;
         // Reject invalid TLS before starting stores or background tasks.
         let tls = if config.api.tls_enabled() {

--- a/crates/cli/src/commands/start/run.rs
+++ b/crates/cli/src/commands/start/run.rs
@@ -11,7 +11,12 @@ impl Node {
     #[doc(hidden)]
     pub async fn run(mut self) -> Result<()> {
         info!("DefraDB node started");
-        info!("API endpoint: http://{}", self.config.api.address);
+        let scheme = if self.config.api.tls_enabled() {
+            "https"
+        } else {
+            "http"
+        };
+        info!("API endpoint: {scheme}://{}", self.config.api.address);
 
         // Start HTTP server
         let http_task: Option<JoinHandle<()>> = if let Some(server) = self.http_server.take() {

--- a/crates/cli/tests/tls_tests.rs
+++ b/crates/cli/tests/tls_tests.rs
@@ -1,0 +1,244 @@
+//! Exercise TLS configuration through the running CLI, not just the config fields.
+
+use std::path::Path;
+use std::time::Duration;
+
+use rcgen::generate_simple_self_signed;
+use reqwest::{Certificate, Client, StatusCode};
+use tempfile::TempDir;
+use tokio::process::{Child, Command};
+use tokio::time::{sleep, timeout};
+
+struct RunningNode {
+    child: Child,
+    root: TempDir,
+    address: String,
+}
+
+impl RunningNode {
+    fn start(root: TempDir, tls: bool) -> Self {
+        let port = portpicker::pick_unused_port().expect("available port");
+        let address = format!("127.0.0.1:{port}");
+        let log = std::fs::File::create(root.path().join("node.log")).unwrap();
+        let mut command = Command::new(env!("CARGO_BIN_EXE_defra"));
+        command
+            .args([
+                "start",
+                "--no-keyring",
+                "--no-p2p",
+                "--store",
+                "memory",
+                "--url",
+            ])
+            .arg(&address)
+            .arg("--rootdir")
+            .arg(root.path())
+            .env("RUST_LOG", "info")
+            .stdout(log.try_clone().unwrap())
+            .stderr(log)
+            .kill_on_drop(true);
+        if tls {
+            command
+                .arg("--pubkeypath")
+                .arg(root.path().join("cert.pem"))
+                .arg("--privkeypath")
+                .arg(root.path().join("key.pem"));
+        }
+        Self {
+            child: command.spawn().unwrap(),
+            root,
+            address,
+        }
+    }
+
+    fn logs(&self) -> String {
+        std::fs::read_to_string(self.root.path().join("node.log")).unwrap()
+    }
+
+    async fn healthy(&mut self, client: &Client, scheme: &str) {
+        let url = format!("{scheme}://{}/health-check", self.address);
+        let result = timeout(Duration::from_secs(20), async {
+            loop {
+                assert!(self.child.try_wait().unwrap().is_none(), "{}", self.logs());
+                if let Ok(response) = client.get(&url).send().await {
+                    assert_eq!(response.status(), StatusCode::OK);
+                    assert_eq!(response.json::<String>().await.unwrap(), "Healthy");
+                    break;
+                }
+                sleep(Duration::from_millis(50)).await;
+            }
+        })
+        .await;
+        assert!(result.is_ok(), "node not healthy at {url}: {}", self.logs());
+    }
+
+    async fn stop(&mut self) {
+        self.child.kill().await.unwrap();
+    }
+}
+
+fn write_certificate(root: &Path) -> Certificate {
+    let certified = generate_simple_self_signed(vec!["127.0.0.1".into()]).unwrap();
+    std::fs::write(root.join("cert.pem"), certified.cert.pem()).unwrap();
+    std::fs::write(root.join("key.pem"), certified.key_pair.serialize_pem()).unwrap();
+    Certificate::from_der(certified.cert.der()).unwrap()
+}
+
+fn client(certificate: Option<Certificate>) -> Client {
+    let mut builder = Client::builder()
+        .use_rustls_tls()
+        .no_proxy()
+        .timeout(Duration::from_secs(2));
+    if let Some(certificate) = certificate {
+        builder = builder.add_root_certificate(certificate);
+    }
+    builder.build().unwrap()
+}
+
+#[tokio::test]
+async fn certificate_flags_serve_https_and_reject_plaintext() {
+    let root = tempfile::tempdir().unwrap();
+    let certificate = write_certificate(root.path());
+    let trusted = client(Some(certificate.clone()));
+    let untrusted = client(None);
+    let mut node = RunningNode::start(root, true);
+    node.healthy(&trusted, "https").await;
+
+    let response = trusted
+        .get(format!("https://{}/health-check", node.address))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.version(), reqwest::Version::HTTP_2);
+    assert_eq!(response.status(), StatusCode::OK);
+
+    assert!(untrusted
+        .get(format!("https://{}/health-check", node.address))
+        .send()
+        .await
+        .is_err());
+    assert!(trusted
+        .get(format!("http://{}/health-check", node.address))
+        .send()
+        .await
+        .is_err());
+    // Failed handshakes must not kill the listener or block other clients.
+    let _idle_connection = tokio::net::TcpStream::connect(&node.address).await.unwrap();
+    node.healthy(&client(Some(certificate)), "https").await;
+    assert!(node.logs().contains(&format!("https://{}", node.address)));
+    node.stop().await;
+}
+
+#[tokio::test]
+async fn node_shutdown_closes_existing_https_connections() {
+    let root = tempfile::tempdir().unwrap();
+    let certificate = write_certificate(root.path());
+    let mut config = cli::config::Config {
+        rootdir: root.path().to_path_buf(),
+        ..Default::default()
+    };
+    config.datastore.store = cli::config::DatastoreType::Memory;
+    config.net.p2p_disabled = true;
+    config.keyring.disabled = true;
+    config.api.address = format!(
+        "127.0.0.1:{}",
+        portpicker::pick_unused_port().expect("available port")
+    );
+    config.api.pubkey_path = root.path().join("cert.pem").display().to_string();
+    config.api.privkey_path = root.path().join("key.pem").display().to_string();
+    let url = format!("https://{}/health-check", config.api.address);
+    let client = Client::builder()
+        .use_rustls_tls()
+        .no_proxy()
+        .add_root_certificate(certificate)
+        .http1_only()
+        .min_tls_version(reqwest::tls::Version::TLS_1_2)
+        .max_tls_version(reqwest::tls::Version::TLS_1_2)
+        .timeout(Duration::from_secs(2))
+        .build()
+        .unwrap();
+    let node = cli::commands::Node::new(config, None).await.unwrap();
+    let shutdown = node.shutdown_tx.clone();
+    let task = tokio::spawn(node.run());
+    timeout(Duration::from_secs(10), async {
+        loop {
+            if let Ok(response) = client.get(&url).send().await {
+                assert_eq!(response.status(), StatusCode::OK);
+                assert_eq!(response.version(), reqwest::Version::HTTP_11);
+                assert_eq!(response.json::<String>().await.unwrap(), "Healthy");
+                break;
+            }
+            sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .unwrap();
+
+    shutdown.send(()).await.unwrap();
+    timeout(Duration::from_secs(5), task)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    // The client retains its keep-alive connection after consuming the body.
+    assert!(client.get(&url).send().await.is_err());
+}
+
+#[tokio::test]
+async fn absent_certificate_flags_keep_plain_http() {
+    let mut node = RunningNode::start(tempfile::tempdir().unwrap(), false);
+    node.healthy(&client(None), "http").await;
+    node.stop().await;
+}
+
+#[tokio::test]
+async fn config_file_enables_tls_with_root_relative_paths() {
+    let root = tempfile::tempdir().unwrap();
+    let certificate = write_certificate(root.path());
+    let mut config = cli::config::Config::default();
+    config.api.pubkey_path = "cert.pem".into();
+    config.api.privkey_path = "key.pem".into();
+    std::fs::write(
+        root.path().join("config.yaml"),
+        serde_yaml::to_string(&config).unwrap(),
+    )
+    .unwrap();
+    let mut node = RunningNode::start(root, false);
+    node.healthy(&client(Some(certificate)), "https").await;
+    node.stop().await;
+}
+
+#[tokio::test]
+async fn invalid_tls_configuration_fails_before_serving() {
+    for case in ["missing", "bad certificate", "bad key", "mismatched key"] {
+        let root = tempfile::tempdir().unwrap();
+        write_certificate(root.path());
+        match case {
+            "missing" => std::fs::remove_file(root.path().join("cert.pem")).unwrap(),
+            "bad certificate" => {
+                std::fs::write(root.path().join("cert.pem"), "not a certificate").unwrap();
+            }
+            "bad key" => {
+                std::fs::write(root.path().join("key.pem"), "not a private key").unwrap();
+            }
+            "mismatched key" => {
+                let other = generate_simple_self_signed(vec!["127.0.0.1".into()]).unwrap();
+                std::fs::write(root.path().join("key.pem"), other.key_pair.serialize_pem())
+                    .unwrap();
+            }
+            _ => unreachable!(),
+        }
+        let mut node = RunningNode::start(root, true);
+        let status = timeout(Duration::from_secs(10), node.child.wait())
+            .await
+            .unwrap_or_else(|_| panic!("{case}: invalid TLS allowed startup: {}", node.logs()))
+            .unwrap();
+        assert!(!status.success(), "{case}: {}", node.logs());
+        assert!(node.logs().contains("TLS"), "{case}: {}", node.logs());
+        assert!(
+            !node.logs().contains("DefraDB node started"),
+            "{}",
+            node.logs()
+        );
+    }
+}

--- a/crates/cli/tests/tls_tests.rs
+++ b/crates/cli/tests/tls_tests.rs
@@ -34,6 +34,7 @@ impl RunningNode {
             .arg("--rootdir")
             .arg(root.path())
             .env("RUST_LOG", "info")
+            .env("TOKIO_WORKER_THREADS", "2")
             .stdout(log.try_clone().unwrap())
             .stderr(log)
             .kill_on_drop(true);
@@ -241,4 +242,51 @@ async fn invalid_tls_configuration_fails_before_serving() {
             node.logs()
         );
     }
+}
+
+#[tokio::test]
+async fn default_certificate_directory_enables_https() {
+    let root = tempfile::tempdir().unwrap();
+    let certificate = write_certificate(root.path());
+    let certs = root.path().join("certs");
+    std::fs::create_dir(&certs).unwrap();
+    std::fs::rename(root.path().join("cert.pem"), certs.join("server.crt")).unwrap();
+    std::fs::rename(root.path().join("key.pem"), certs.join("server.key")).unwrap();
+    let mut node = RunningNode::start(root, false);
+    node.healthy(&client(Some(certificate)), "https").await;
+    assert!(client(None)
+        .get(format!("http://{}/health-check", node.address))
+        .send()
+        .await
+        .is_err());
+    node.stop().await;
+}
+
+#[tokio::test]
+async fn partial_default_certificate_pair_fails_before_serving() {
+    for filename in ["server.crt", "server.key"] {
+        let root = tempfile::tempdir().unwrap();
+        let certs = root.path().join("certs");
+        std::fs::create_dir(&certs).unwrap();
+        std::fs::write(certs.join(filename), "incomplete pair").unwrap();
+        let mut node = RunningNode::start(root, false);
+        let status = timeout(Duration::from_secs(10), node.child.wait())
+            .await
+            .expect("startup did not reject the incomplete certificate pair")
+            .unwrap();
+        assert!(!status.success(), "{}", node.logs());
+        assert!(!node.logs().contains("DefraDB node started"));
+    }
+}
+
+#[tokio::test]
+async fn explicit_certificates_override_default_directory() {
+    let root = tempfile::tempdir().unwrap();
+    let certificate = write_certificate(root.path());
+    let certs = root.path().join("certs");
+    std::fs::create_dir(&certs).unwrap();
+    std::fs::write(certs.join("server.crt"), "unused certificate").unwrap();
+    let mut node = RunningNode::start(root, true);
+    node.healthy(&client(Some(certificate)), "https").await;
+    node.stop().await;
 }

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -48,6 +48,8 @@ serde_json.workspace = true
 
 # HTTP server
 axum.workspace = true
+axum-server = { version = "0.8", features = ["tls-rustls-no-provider"] }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 tower.workspace = true
 tower-http.workspace = true
 hyper.workspace = true

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -104,6 +104,7 @@ pub mod query_context;
 pub mod route_permissions;
 pub mod router;
 pub mod server;
+mod tls;
 pub mod validation;
 
 #[cfg(any(test, feature = "test-utils"))]
@@ -121,6 +122,7 @@ pub use router::{
     ReplicatorInfo, TransactionOperations, TransportPeerId, ViewOperations, MANAGE_UNAUTHORIZED,
 };
 pub use server::{Server, ServerConfig, DEFAULT_MAX_BACKUP_SIZE};
+pub use tls::TlsConfig;
 
 #[cfg(any(test, feature = "test-utils"))]
 pub use mock::{

--- a/crates/http/src/server.rs
+++ b/crates/http/src/server.rs
@@ -89,6 +89,7 @@ impl Default for ServerConfig {
 /// HTTP server for DefraDB.
 pub struct Server {
     config: ServerConfig,
+    tls: Option<crate::TlsConfig>,
     executor: Arc<dyn QueryExecutor>,
     rest: Option<Arc<dyn RestOperations>>,
     p2p: Option<Arc<dyn P2POperations>>,
@@ -119,6 +120,7 @@ impl Server {
     pub fn new<E: QueryExecutor + 'static>(executor: E) -> Self {
         Self {
             config: ServerConfig::default(),
+            tls: None,
             executor: Arc::new(executor),
             rest: None,
             p2p: None,
@@ -149,6 +151,7 @@ impl Server {
     pub fn with_config<E: QueryExecutor + 'static>(executor: E, config: ServerConfig) -> Self {
         Self {
             config,
+            tls: None,
             executor: Arc::new(executor),
             rest: None,
             p2p: None,
@@ -179,6 +182,7 @@ impl Server {
     pub fn from_arc(executor: Arc<dyn QueryExecutor>) -> Self {
         Self {
             config: ServerConfig::default(),
+            tls: None,
             executor,
             rest: None,
             p2p: None,
@@ -209,6 +213,7 @@ impl Server {
     pub fn from_arc_with_config(executor: Arc<dyn QueryExecutor>, config: ServerConfig) -> Self {
         Self {
             config,
+            tls: None,
             executor,
             rest: None,
             p2p: None,
@@ -233,6 +238,12 @@ impl Server {
             node_identity_did: None,
             dev_mode: false,
         }
+    }
+
+    /// Serve HTTPS using a previously validated certificate and private key.
+    pub fn with_tls(mut self, config: crate::TlsConfig) -> Self {
+        self.tls = Some(config);
+        self
     }
 
     /// Set REST operations for collection/document endpoints.
@@ -676,9 +687,14 @@ impl Server {
             ))
         })?;
 
-        tracing::info!("Providing HTTP API at http://{}", self.config.address);
+        let scheme = if self.tls.is_some() { "https" } else { "http" };
+        tracing::info!("Providing HTTP API at {scheme}://{}", self.config.address);
 
-        axum::serve(listener, router).await.map_err(|e| {
+        let result = match self.tls {
+            Some(tls) => tls.serve(listener, router).await,
+            None => axum::serve(listener, router).await,
+        };
+        result.map_err(|e| {
             tracing::error!(error = %e, "HTTP server encountered fatal error");
             crate::error::HttpError::Internal(format!("server error: {}", e))
         })?;

--- a/crates/http/src/tls.rs
+++ b/crates/http/src/tls.rs
@@ -1,0 +1,62 @@
+//! HTTPS configuration and connection shutdown.
+
+use std::io;
+use std::net::SocketAddr;
+use std::path::Path;
+use std::sync::Arc;
+
+use axum::Router;
+use axum_server::tls_rustls::RustlsConfig;
+use rustls::pki_types::{pem::PemObject, CertificateDer, PrivateKeyDer};
+use tokio::net::TcpListener;
+
+/// A validated TLS certificate chain and matching private key.
+pub struct TlsConfig(RustlsConfig);
+
+impl TlsConfig {
+    /// Load PEM files before starting the server. Invalid or mismatched keys
+    /// are rejected rather than falling back to plaintext.
+    pub async fn from_pem_file(cert: impl AsRef<Path>, key: impl AsRef<Path>) -> io::Result<Self> {
+        let cert = cert.as_ref().to_path_buf();
+        let key = key.as_ref().to_path_buf();
+        tokio::task::spawn_blocking(move || {
+            let certificates = CertificateDer::pem_file_iter(&cert)
+                .and_then(Iterator::collect::<std::result::Result<Vec<_>, _>>)
+                .map_err(|e| io::Error::other(format!("certificate {}: {e}", cert.display())))?;
+            let key = PrivateKeyDer::from_pem_file(&key)
+                .map_err(|e| io::Error::other(format!("private key {}: {e}", key.display())))?;
+            // Select the provider explicitly: other transports can enable a
+            // different provider in the same binary.
+            let mut config = rustls::ServerConfig::builder_with_provider(Arc::new(
+                rustls::crypto::ring::default_provider(),
+            ))
+            .with_safe_default_protocol_versions()
+            .map_err(io::Error::other)?
+            .with_no_client_auth()
+            .with_single_cert(certificates, key)
+            .map_err(io::Error::other)?;
+            config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+            Ok(Self(RustlsConfig::from_config(Arc::new(config))))
+        })
+        .await
+        .map_err(io::Error::other)?
+    }
+
+    pub(crate) async fn serve(self, listener: TcpListener, router: Router) -> io::Result<()> {
+        let shutdown = ShutdownOnDrop(axum_server::Handle::new());
+        axum_server::from_tcp_rustls(listener.into_std()?, self.0)?
+            .handle(shutdown.0.clone())
+            .serve(router.into_make_service())
+            .await
+    }
+}
+
+// Node shutdown cancels the server future. Also notify its connection tasks
+// so established keep-alive connections cannot continue serving requests.
+struct ShutdownOnDrop(axum_server::Handle<SocketAddr>);
+
+impl Drop for ShutdownOnDrop {
+    fn drop(&mut self) {
+        self.0.shutdown();
+    }
+}


### PR DESCRIPTION
## Context
The certificate flags were accepted and made CLI clients select HTTPS, but the server still listened in plaintext. Invalid certificate paths also allowed startup to succeed.

## Changes
- Serve HTTPS when both certificate paths are configured, preserving plain HTTP otherwise.
- Validate the certificate chain and matching key before starting stores or background tasks.
- Support HTTP/1.1 and HTTP/2 and close established TLS connections when the server is cancelled.
- Cover flag and config-file wiring, rejected plaintext and untrusted certificates, malformed credentials, and shutdown.

## Testing
The missing-certificate regression reproduced the original bug before the fix.

- [x] CLI and HTTP unit/integration targets: 457 passed, one existing ignored test.
- [x] Five live TLS regressions in both default and release-full + Iroh builds.
- [x] Existing Rust document-lifecycle integration test.
- [x] Strict clippy for all CLI/HTTP targets, default and release-full + Iroh.
- [x] Formatting and diff checks.

Refs #1422