### PR TITLE
fix(p2p): drain Iroh tasks without late registrations

### DIFF
--- a/crates/p2p/src/iroh/endpoint.rs
+++ b/crates/p2p/src/iroh/endpoint.rs
@@ -6,12 +6,13 @@
 //! - Commands from the `IrohTransport` facade
 
 use std::collections::{HashMap, HashSet};
+use std::future::Future;
 use std::sync::Arc;
 
 use iroh::{Endpoint, EndpointId};
 use iroh_gossip::net::Gossip;
 use tokio::sync::{mpsc, oneshot};
-use tokio::task::JoinHandle;
+use tokio::task::{AbortHandle, JoinHandle, JoinSet};
 use tracing::{debug, warn};
 
 use crate::bitswap::ReplicatorRegistry;
@@ -31,6 +32,10 @@ use super::peer_map::{parse_endpoint_id, PeerMap};
 use super::protocols;
 
 const MAX_COMMAND_BATCH: usize = 16;
+
+#[cfg(test)]
+#[path = "../../tests/iroh/task_shutdown.rs"]
+mod task_shutdown_tests;
 
 /// Shared handles to the endpoint's long-lived state, cloneable into spawned
 /// tasks (dials, incoming connections, gossip heals).
@@ -59,61 +64,33 @@ pub(super) struct ActiveSync {
     pub(super) abort_handle: tokio::task::AbortHandle,
 }
 
-pub(super) type SpawnedTasks = Arc<parking_lot::Mutex<Vec<JoinHandle<()>>>>;
+pub(super) type SpawnedTasks = Arc<parking_lot::Mutex<Option<JoinSet<()>>>>;
 pub(super) type PendingPushLogReplies =
     Arc<parking_lot::Mutex<HashMap<String, oneshot::Sender<PushLogReply>>>>;
 
-pub(super) fn track_task(spawned_tasks: &SpawnedTasks, task: JoinHandle<()>) {
+pub(super) fn spawn_task(
+    spawned_tasks: &SpawnedTasks,
+    future: impl Future<Output = ()> + Send + 'static,
+) -> Option<AbortHandle> {
     let mut tasks = spawned_tasks.lock();
-    // The heal sweep (#1092) pushes tasks on a timer, so finished handles must
-    // be dropped here or the vec grows without bound over a node's lifetime.
-    tasks.retain(|task| !task.is_finished());
-    tasks.push(task);
+    let tasks = tasks.as_mut()?;
+    // Reap completed work so periodic gossip healing does not grow the set.
+    while let Some(result) = tasks.try_join_next() {
+        if let Err(error) = result {
+            if !error.is_cancelled() {
+                debug!(%error, "Tracked Iroh spawned task failed");
+            }
+        }
+    }
+    Some(tasks.spawn(future))
 }
 
 async fn shutdown_tracked_tasks(spawned_tasks: SpawnedTasks) {
-    let mut tasks = {
-        let mut guard = spawned_tasks.lock();
-        std::mem::take(&mut *guard)
-    };
-
-    if tasks.is_empty() {
-        return;
-    }
-
-    debug!(
-        task_count = tasks.len(),
-        "Aborting tracked Iroh spawned tasks during shutdown"
-    );
-    for task in &tasks {
-        task.abort();
-    }
-
-    let shutdown_start = std::time::Instant::now();
-    let timeout = std::time::Duration::from_secs(5);
-    while let Some(task) = tasks.pop() {
-        let remaining = timeout.saturating_sub(shutdown_start.elapsed());
-        if remaining.is_zero() {
-            warn!(
-                remaining_tasks = tasks.len() + 1,
-                "Timed out draining tracked Iroh spawned tasks during shutdown"
-            );
-            break;
-        }
-        match tokio::time::timeout(remaining, task).await {
-            Ok(Ok(())) => {}
-            Ok(Err(error)) if error.is_cancelled() => {}
-            Ok(Err(error)) => {
-                debug!(%error, "Tracked Iroh spawned task failed during shutdown");
-            }
-            Err(_) => {
-                warn!(
-                    remaining_tasks = tasks.len() + 1,
-                    "Timed out waiting for tracked Iroh spawned task during shutdown"
-                );
-                break;
-            }
-        }
+    // Closing registration under the spawn lock also covers child tasks
+    // scheduled by work that was already running when shutdown began.
+    let tasks = spawned_tasks.lock().take();
+    if let Some(mut tasks) = tasks {
+        tasks.shutdown().await;
     }
 }
 
@@ -201,7 +178,7 @@ async fn run_event_loop(
     let raw_topics: Arc<parking_lot::Mutex<std::collections::HashSet<String>>> =
         Arc::new(parking_lot::Mutex::new(std::collections::HashSet::new()));
     let mut active_syncs: HashMap<u64, ActiveSync> = HashMap::new();
-    let spawned_tasks: SpawnedTasks = Arc::new(parking_lot::Mutex::new(Vec::new()));
+    let spawned_tasks: SpawnedTasks = Arc::new(parking_lot::Mutex::new(Some(JoinSet::new())));
     let mut next_query_id: u64 = 1;
 
     let heal_enabled = gossip_heal_config.enabled();
@@ -270,7 +247,7 @@ async fn run_event_loop(
                         let pending_pushlog_replies = Arc::clone(&pending_pushlog_replies);
                         let subscription_senders = snapshot_subscription_senders(&subscriptions);
                         let event_tx = event_tx.clone();
-                        let task = tokio::spawn(async move {
+                        let _ = spawn_task(&spawned_tasks, async move {
                             handle_incoming(
                                 incoming,
                                 &resources,
@@ -280,7 +257,6 @@ async fn run_event_loop(
                             )
                             .await;
                         });
-                        track_task(&spawned_tasks, task);
                     }
                     None => break,
                 }
@@ -297,8 +273,10 @@ async fn run_event_loop(
 
     // Clean up
     let subscriptions_started = std::time::Instant::now();
+    let mut readers = Vec::with_capacity(subscriptions.len());
     for (_, sub) in subscriptions.drain() {
         sub.reader_task.abort();
+        readers.push(sub.reader_task);
     }
     warn!(
         elapsed_ms = subscriptions_started.elapsed().as_millis(),
@@ -316,6 +294,9 @@ async fn run_event_loop(
 
     let tracked_started = std::time::Instant::now();
     shutdown_tracked_tasks(spawned_tasks).await;
+    for reader in readers {
+        let _ = reader.await;
+    }
     warn!(
         elapsed_ms = tracked_started.elapsed().as_millis(),
         "Iroh endpoint shutdown: tracked spawned tasks drained"

--- a/crates/p2p/src/iroh/endpoint.rs
+++ b/crates/p2p/src/iroh/endpoint.rs
@@ -85,12 +85,30 @@ pub(super) fn spawn_task(
     Some(tasks.spawn(future))
 }
 
-async fn shutdown_tracked_tasks(spawned_tasks: SpawnedTasks) {
+async fn shutdown_tracked_tasks(spawned_tasks: SpawnedTasks, readers: Vec<JoinHandle<()>>) {
     // Closing registration under the spawn lock also covers child tasks
     // scheduled by work that was already running when shutdown began.
     let tasks = spawned_tasks.lock().take();
-    if let Some(mut tasks) = tasks {
-        tasks.shutdown().await;
+    let task_count = tasks.as_ref().map_or(0, JoinSet::len) + readers.len();
+    for reader in &readers {
+        reader.abort();
+    }
+    let drain = async move {
+        if let Some(mut tasks) = tasks {
+            tasks.shutdown().await;
+        }
+        for reader in readers {
+            let _ = reader.await;
+        }
+    };
+    if tokio::time::timeout(std::time::Duration::from_secs(5), drain)
+        .await
+        .is_err()
+    {
+        warn!(
+            task_count,
+            "Timed out draining Iroh tasks after cancellation"
+        );
     }
 }
 
@@ -293,13 +311,10 @@ async fn run_event_loop(
     );
 
     let tracked_started = std::time::Instant::now();
-    shutdown_tracked_tasks(spawned_tasks).await;
-    for reader in readers {
-        let _ = reader.await;
-    }
-    warn!(
+    shutdown_tracked_tasks(spawned_tasks, readers).await;
+    debug!(
         elapsed_ms = tracked_started.elapsed().as_millis(),
-        "Iroh endpoint shutdown: tracked spawned tasks drained"
+        "Iroh endpoint shutdown: task drain finished"
     );
 
     let gossip_started = std::time::Instant::now();

--- a/crates/p2p/src/iroh/endpoint_commands.rs
+++ b/crates/p2p/src/iroh/endpoint_commands.rs
@@ -18,7 +18,7 @@ use crate::QueryId;
 use super::addr::{endpoint_addr_from_parts, endpoint_ticket_string};
 use super::command::IrohCommand;
 use super::endpoint::{
-    peer_direct_addr, snapshot_subscription_senders, track_task, ActiveSync, EndpointResources,
+    peer_direct_addr, snapshot_subscription_senders, spawn_task, ActiveSync, EndpointResources,
     PendingPushLogReplies, SpawnedTasks, SubscriptionSenders, TopicSubscription,
 };
 use super::endpoint_rpc::{
@@ -122,11 +122,10 @@ pub(super) async fn handle_command(
                 subscription_senders: snapshot_subscription_senders(subscriptions),
                 event_tx: event_tx.clone(),
             };
-            let task = tokio::spawn(async move {
+            let _ = spawn_task(spawned_tasks, async move {
                 let result = handle_dial(ctx, &peer_id, addrs).await;
                 let _ = reply.send(result);
             });
-            track_task(spawned_tasks, task);
         }
         IrohCommand::Disconnect { peer_id, reply } => {
             let result = handle_disconnect(peer_id, resources);
@@ -168,7 +167,7 @@ pub(super) async fn handle_command(
             let direct_addr = peer_direct_addr(peer_map, &peer_id);
             let endpoint = endpoint.clone();
             let connection_cache = Arc::clone(connection_cache);
-            let task = tokio::spawn(async move {
+            let _ = spawn_task(spawned_tasks, async move {
                 let result = handle_request_response(
                     &endpoint,
                     &peer_id,
@@ -180,7 +179,6 @@ pub(super) async fn handle_command(
                 .await;
                 let _ = reply.send(result);
             });
-            track_task(spawned_tasks, task);
         }
         IrohCommand::Subscribe { topic, reply } => {
             let result =
@@ -236,7 +234,7 @@ pub(super) async fn handle_command(
             reply_msg,
             reply,
         } => {
-            let task = tokio::spawn(async move {
+            let _ = spawn_task(spawned_tasks, async move {
                 let result = async {
                     protocols::write_message(&mut send_stream, &reply_msg).await?;
                     send_stream.finish().map_err(|e| {
@@ -247,7 +245,6 @@ pub(super) async fn handle_command(
                 .await;
                 let _ = reply.send(result);
             });
-            track_task(spawned_tasks, task);
         }
         IrohCommand::SendTwoStreamRequest {
             peer_id,
@@ -259,7 +256,7 @@ pub(super) async fn handle_command(
             let pending_pushlog_replies = pending_pushlog_replies.clone();
             let connection_cache = Arc::clone(connection_cache);
             let message_id = request.message_id.clone();
-            let task = tokio::spawn(async move {
+            let _ = spawn_task(spawned_tasks, async move {
                 let request_peer_id = peer_id.clone();
                 let request_message_id = message_id.clone();
                 let result = async move {
@@ -283,7 +280,6 @@ pub(super) async fn handle_command(
                 .await;
                 let _ = reply.send(result);
             });
-            track_task(spawned_tasks, task);
         }
         IrohCommand::SendTwoStreamResponse {
             peer_id,
@@ -295,7 +291,7 @@ pub(super) async fn handle_command(
             let direct_addr = peer_direct_addr(peer_map, &peer_id);
             let endpoint = endpoint.clone();
             let connection_cache = Arc::clone(connection_cache);
-            let task = tokio::spawn(async move {
+            let _ = spawn_task(spawned_tasks, async move {
                 let result = handle_send_only(
                     &endpoint,
                     &peer_id,
@@ -307,7 +303,6 @@ pub(super) async fn handle_command(
                 .await;
                 let _ = reply.send(result);
             });
-            track_task(spawned_tasks, task);
         }
         IrohCommand::SendDocSyncRequest {
             peer_id,
@@ -318,7 +313,7 @@ pub(super) async fn handle_command(
             let endpoint = endpoint.clone();
             let connection_cache = Arc::clone(connection_cache);
             let event_tx = event_tx.clone();
-            let task = tokio::spawn(async move {
+            let _ = spawn_task(spawned_tasks, async move {
                 let result: crate::error::Result<crate::message::DocSyncReply> =
                     handle_request_response(
                         &endpoint,
@@ -344,7 +339,6 @@ pub(super) async fn handle_command(
                     }
                 }
             });
-            track_task(spawned_tasks, task);
         }
         IrohCommand::SendBranchableSyncRequest {
             peer_id,
@@ -355,7 +349,7 @@ pub(super) async fn handle_command(
             let endpoint = endpoint.clone();
             let connection_cache = Arc::clone(connection_cache);
             let event_tx = event_tx.clone();
-            let task = tokio::spawn(async move {
+            let _ = spawn_task(spawned_tasks, async move {
                 let result: crate::error::Result<crate::message::BranchableSyncReply> =
                     handle_request_response(
                         &endpoint,
@@ -381,7 +375,6 @@ pub(super) async fn handle_command(
                     }
                 }
             });
-            track_task(spawned_tasks, task);
         }
         IrohCommand::SendDocSyncResponse {
             peer_id,
@@ -391,7 +384,7 @@ pub(super) async fn handle_command(
             let direct_addr = peer_direct_addr(peer_map, &peer_id);
             let endpoint = endpoint.clone();
             let connection_cache = Arc::clone(connection_cache);
-            let task = tokio::spawn(async move {
+            let _ = spawn_task(spawned_tasks, async move {
                 let result = handle_fire_and_forget(
                     &endpoint,
                     &peer_id,
@@ -403,7 +396,6 @@ pub(super) async fn handle_command(
                 .await;
                 let _ = reply.send(result);
             });
-            track_task(spawned_tasks, task);
         }
         IrohCommand::SendBranchableSyncResponse {
             peer_id,
@@ -413,7 +405,7 @@ pub(super) async fn handle_command(
             let direct_addr = peer_direct_addr(peer_map, &peer_id);
             let endpoint = endpoint.clone();
             let connection_cache = Arc::clone(connection_cache);
-            let task = tokio::spawn(async move {
+            let _ = spawn_task(spawned_tasks, async move {
                 let result = handle_fire_and_forget(
                     &endpoint,
                     &peer_id,
@@ -425,14 +417,13 @@ pub(super) async fn handle_command(
                 .await;
                 let _ = reply.send(result);
             });
-            track_task(spawned_tasks, task);
         }
         IrohCommand::SendDocSyncResponseToken {
             mut send_stream,
             reply_msg,
             reply,
         } => {
-            let task = tokio::spawn(async move {
+            let _ = spawn_task(spawned_tasks, async move {
                 let result = async {
                     protocols::write_message(&mut send_stream, &reply_msg).await?;
                     send_stream.finish().map_err(|e| {
@@ -443,14 +434,13 @@ pub(super) async fn handle_command(
                 .await;
                 let _ = reply.send(result);
             });
-            track_task(spawned_tasks, task);
         }
         IrohCommand::SendBranchableSyncResponseToken {
             mut send_stream,
             reply_msg,
             reply,
         } => {
-            let task = tokio::spawn(async move {
+            let _ = spawn_task(spawned_tasks, async move {
                 let result = async {
                     protocols::write_message(&mut send_stream, &reply_msg).await?;
                     send_stream.finish().map_err(|e| {
@@ -461,7 +451,6 @@ pub(super) async fn handle_command(
                 .await;
                 let _ = reply.send(result);
             });
-            track_task(spawned_tasks, task);
         }
         IrohCommand::SendCarRequest {
             peer_id,
@@ -472,7 +461,7 @@ pub(super) async fn handle_command(
             let endpoint = endpoint.clone();
             let connection_cache = Arc::clone(connection_cache);
             let event_tx = event_tx.clone();
-            let task = tokio::spawn(async move {
+            let _ = spawn_task(spawned_tasks, async move {
                 let result = handle_car_request_response(
                     &endpoint,
                     &peer_id,
@@ -484,7 +473,6 @@ pub(super) async fn handle_command(
                 .await;
                 let _ = reply.send(result);
             });
-            track_task(spawned_tasks, task);
         }
         IrohCommand::SendCarResponse {
             peer_id,
@@ -494,7 +482,7 @@ pub(super) async fn handle_command(
             let direct_addr = peer_direct_addr(peer_map, &peer_id);
             let endpoint = endpoint.clone();
             let connection_cache = Arc::clone(connection_cache);
-            let task = tokio::spawn(async move {
+            let _ = spawn_task(spawned_tasks, async move {
                 let result = handle_fire_and_forget(
                     &endpoint,
                     &peer_id,
@@ -506,7 +494,6 @@ pub(super) async fn handle_command(
                 .await;
                 let _ = reply.send(result);
             });
-            track_task(spawned_tasks, task);
         }
         IrohCommand::SendSEArtifacts {
             peer_id,
@@ -516,7 +503,7 @@ pub(super) async fn handle_command(
             let direct_addr = peer_direct_addr(peer_map, &peer_id);
             let endpoint = endpoint.clone();
             let connection_cache = Arc::clone(connection_cache);
-            let task = tokio::spawn(async move {
+            let _ = spawn_task(spawned_tasks, async move {
                 let result = handle_fire_and_forget(
                     &endpoint,
                     &peer_id,
@@ -528,7 +515,6 @@ pub(super) async fn handle_command(
                 .await;
                 let _ = reply.send(result);
             });
-            track_task(spawned_tasks, task);
         }
         IrohCommand::SendSEQueryRequest {
             peer_id,
@@ -538,7 +524,7 @@ pub(super) async fn handle_command(
             let direct_addr = peer_direct_addr(peer_map, &peer_id);
             let endpoint = endpoint.clone();
             let connection_cache = Arc::clone(connection_cache);
-            let task = tokio::spawn(async move {
+            let _ = spawn_task(spawned_tasks, async move {
                 let result = handle_fire_and_forget(
                     &endpoint,
                     &peer_id,
@@ -550,7 +536,6 @@ pub(super) async fn handle_command(
                 .await;
                 let _ = reply.send(result);
             });
-            track_task(spawned_tasks, task);
         }
         IrohCommand::SendSEQueryResponse {
             peer_id,
@@ -560,7 +545,7 @@ pub(super) async fn handle_command(
             let direct_addr = peer_direct_addr(peer_map, &peer_id);
             let endpoint = endpoint.clone();
             let connection_cache = Arc::clone(connection_cache);
-            let task = tokio::spawn(async move {
+            let _ = spawn_task(spawned_tasks, async move {
                 let result = handle_fire_and_forget(
                     &endpoint,
                     &peer_id,
@@ -572,7 +557,6 @@ pub(super) async fn handle_command(
                 .await;
                 let _ = reply.send(result);
             });
-            track_task(spawned_tasks, task);
         }
         IrohCommand::SendManageRequest {
             peer_id,
@@ -582,7 +566,7 @@ pub(super) async fn handle_command(
             let direct_addr = peer_direct_addr(peer_map, &peer_id);
             let endpoint = endpoint.clone();
             let connection_cache = Arc::clone(connection_cache);
-            let task = tokio::spawn(async move {
+            let _ = spawn_task(spawned_tasks, async move {
                 let result = handle_fire_and_forget(
                     &endpoint,
                     &peer_id,
@@ -594,7 +578,6 @@ pub(super) async fn handle_command(
                 .await;
                 let _ = reply.send(result);
             });
-            track_task(spawned_tasks, task);
         }
         IrohCommand::SendManageResponse {
             peer_id,
@@ -604,7 +587,7 @@ pub(super) async fn handle_command(
             let direct_addr = peer_direct_addr(peer_map, &peer_id);
             let endpoint = endpoint.clone();
             let connection_cache = Arc::clone(connection_cache);
-            let task = tokio::spawn(async move {
+            let _ = spawn_task(spawned_tasks, async move {
                 let result = handle_fire_and_forget(
                     &endpoint,
                     &peer_id,
@@ -616,7 +599,6 @@ pub(super) async fn handle_command(
                 .await;
                 let _ = reply.send(result);
             });
-            track_task(spawned_tasks, task);
         }
         IrohCommand::SendManageQueryRequest {
             peer_id,
@@ -626,7 +608,7 @@ pub(super) async fn handle_command(
             let direct_addr = peer_direct_addr(peer_map, &peer_id);
             let endpoint = endpoint.clone();
             let connection_cache = Arc::clone(connection_cache);
-            let task = tokio::spawn(async move {
+            let _ = spawn_task(spawned_tasks, async move {
                 let result = handle_fire_and_forget(
                     &endpoint,
                     &peer_id,
@@ -638,7 +620,6 @@ pub(super) async fn handle_command(
                 .await;
                 let _ = reply.send(result);
             });
-            track_task(spawned_tasks, task);
         }
         IrohCommand::SendManageQueryResponse {
             peer_id,
@@ -648,7 +629,7 @@ pub(super) async fn handle_command(
             let direct_addr = peer_direct_addr(peer_map, &peer_id);
             let endpoint = endpoint.clone();
             let connection_cache = Arc::clone(connection_cache);
-            let task = tokio::spawn(async move {
+            let _ = spawn_task(spawned_tasks, async move {
                 let result = handle_fire_and_forget(
                     &endpoint,
                     &peer_id,
@@ -660,7 +641,6 @@ pub(super) async fn handle_command(
                 .await;
                 let _ = reply.send(result);
             });
-            track_task(spawned_tasks, task);
         }
         IrohCommand::SyncBlocks {
             root,
@@ -677,16 +657,13 @@ pub(super) async fn handle_command(
                 Arc::clone(connection_cache),
                 event_tx.clone(),
             );
-            let task = tokio::spawn(async move {
+            let task = spawn_task(spawned_tasks, async move {
                 handle_block_sync(resources, query_id, root, providers, missing).await;
             });
-            active_syncs.insert(
-                query_id.0,
-                ActiveSync {
-                    abort_handle: task.abort_handle(),
-                },
-            );
-            let _ = reply.send(Ok(query_id));
+            if let Some(abort_handle) = task {
+                active_syncs.insert(query_id.0, ActiveSync { abort_handle });
+                let _ = reply.send(Ok(query_id));
+            }
         }
         IrohCommand::CancelSync { query_id, reply } => {
             if let Some(sync) = active_syncs.remove(&query_id.0) {
@@ -818,11 +795,10 @@ async fn handle_dial(
         Arc::clone(&ctx.pending_pushlog_replies),
         ctx.event_tx.clone(),
     );
-    let task = tokio::spawn(async move {
+    let _ = spawn_task(&ctx.resources.spawned_tasks, async move {
         super::endpoint_streams::handle_connection_streams(connection, endpoint_id, stream_context)
             .await;
     });
-    track_task(&ctx.resources.spawned_tasks, task);
 
     Ok(())
 }
@@ -1106,7 +1082,7 @@ fn handle_publish(
         .encode_gossip_payload()
         .map_err(|error| crate::error::Error::CborSerialization(error.to_string()))?;
 
-    let task = tokio::spawn(async move {
+    let _ = spawn_task(spawned_tasks, async move {
         let sender = if let Some(sender) = sender {
             sender
         } else {
@@ -1134,7 +1110,6 @@ fn handle_publish(
             );
         }
     });
-    track_task(spawned_tasks, task);
 
     Ok(message_id)
 }
@@ -1157,7 +1132,7 @@ fn handle_publish_raw(
     let initial_peers: Vec<iroh::EndpointId> = peer_map.lock().endpoint_ids().collect();
     let message_id = MessageId::new(uuid::Uuid::new_v4().to_string());
 
-    let task = tokio::spawn(async move {
+    let _ = spawn_task(spawned_tasks, async move {
         let sender = if let Some(sender) = sender {
             sender
         } else {
@@ -1199,7 +1174,6 @@ fn handle_publish_raw(
             );
         }
     });
-    track_task(spawned_tasks, task);
 
     Ok(message_id)
 }

--- a/crates/p2p/src/iroh/endpoint_streams.rs
+++ b/crates/p2p/src/iroh/endpoint_streams.rs
@@ -12,7 +12,7 @@ use crate::message::{Message, PushLogReply};
 use crate::transport::{PeerId, TransportEvent};
 
 use super::endpoint::{
-    track_task, EndpointResources, PendingPushLogReplies, SpawnedTasks, SubscriptionSenders,
+    spawn_task, EndpointResources, PendingPushLogReplies, SpawnedTasks, SubscriptionSenders,
 };
 use super::gossip_heal;
 use super::peer_map::{endpoint_id_to_peer_id, PeerMap};
@@ -98,10 +98,9 @@ pub(super) async fn handle_incoming(
         Arc::clone(pending_pushlog_replies),
         event_tx.clone(),
     );
-    let task = tokio::spawn(async move {
+    let _ = spawn_task(&resources.spawned_tasks, async move {
         handle_connection_streams(connection, remote_id, context).await;
     });
-    track_task(&resources.spawned_tasks, task);
 }
 
 /// Shared state for every stream accepted on one authenticated connection.
@@ -148,7 +147,7 @@ pub(super) async fn handle_connection_streams(
         let event_tx = context.event_tx.clone();
         let pending_pushlog_replies = context.pending_pushlog_replies.clone();
         let node_identity = context.node_identity.clone();
-        let task = tokio::spawn(async move {
+        let _ = spawn_task(&context.spawned_tasks, async move {
             let tag = match protocols::read_stream_tag(&mut recv).await {
                 Ok(tag) => tag,
                 Err(e) => {
@@ -170,7 +169,6 @@ pub(super) async fn handle_connection_streams(
                 debug!("Stream error from {}: {}", peer_id, e);
             }
         });
-        track_task(&context.spawned_tasks, task);
     }
 
     let fully_disconnected = context.peer_map.lock().decrement_connections(&remote_id);

--- a/crates/p2p/src/iroh/gossip_heal.rs
+++ b/crates/p2p/src/iroh/gossip_heal.rs
@@ -31,7 +31,7 @@ use iroh::EndpointId;
 use tracing::{debug, warn};
 
 use super::endpoint::{
-    join_peer_to_subscription_senders, snapshot_subscription_senders, track_task,
+    join_peer_to_subscription_senders, snapshot_subscription_senders, spawn_task,
     EndpointResources, SubscriptionSenders, TopicSubscription,
 };
 use super::endpoint_rpc::{close_peer_connections, connect_with_direct_addr_fallback};
@@ -292,10 +292,9 @@ pub(super) fn spawn_peer_connected_heal(
             return;
         }
         let senders = senders.clone();
-        let task = tokio::spawn(async move {
+        let _ = spawn_task(&spawned_tasks, async move {
             join_peer_to_subscription_senders(&senders, endpoint_id).await;
         });
-        track_task(&spawned_tasks, task);
         return;
     }
     // Refresh even with no persistent subscriptions: ephemeral publishers
@@ -305,10 +304,9 @@ pub(super) fn spawn_peer_connected_heal(
     res.healer.note_connected(endpoint_id, Instant::now());
     let res = res.clone();
     let senders = senders.clone();
-    let task = tokio::spawn(async move {
+    let _ = spawn_task(&spawned_tasks, async move {
         refresh_peer(&res, &senders, endpoint_id, HealContext::PeerConnected).await;
     });
-    track_task(&spawned_tasks, task);
 }
 
 /// Periodic sweep: refresh due peers and drop injected connections to
@@ -325,10 +323,9 @@ pub(super) fn sweep(res: &EndpointResources, subscriptions: &HashMap<String, Top
     for endpoint_id in res.healer.due_peers(&connected, Instant::now()) {
         let task_res = res.clone();
         let senders = senders.clone();
-        let task = tokio::spawn(async move {
+        let _ = spawn_task(&res.spawned_tasks, async move {
             refresh_peer(&task_res, &senders, endpoint_id, HealContext::Sweep).await;
         });
-        track_task(&res.spawned_tasks, task);
     }
 }
 
@@ -413,11 +410,10 @@ async fn dial_and_inject(
 
     if let Some(previous) = res.healer.store_conn(endpoint_id, conn) {
         let grace = res.healer.config().superseded_close_grace;
-        let task = tokio::spawn(async move {
+        let _ = spawn_task(&res.spawned_tasks, async move {
             tokio::time::sleep(grace).await;
             previous.close(0u32.into(), b"gossip-refresh");
         });
-        track_task(&res.spawned_tasks, task);
     }
     Ok(())
 }

--- a/crates/p2p/tests/iroh/task_shutdown.rs
+++ b/crates/p2p/tests/iroh/task_shutdown.rs
@@ -1,0 +1,117 @@
+use std::future::{pending, Future};
+use std::sync::Arc;
+
+use super::{shutdown_tracked_tasks, spawn_task, SpawnedTasks};
+
+fn registry() -> SpawnedTasks {
+    Arc::new(parking_lot::Mutex::new(Some(tokio::task::JoinSet::new())))
+}
+
+fn spawn(tasks: &SpawnedTasks, future: impl Future<Output = ()> + Send + 'static) {
+    let _ = spawn_task(tasks, future);
+}
+
+#[tokio::test]
+async fn shutdown_rejects_new_work_without_polling_it() {
+    let tasks = registry();
+    shutdown_tracked_tasks(tasks.clone()).await;
+    let resource = Arc::new(());
+    let retained = Arc::downgrade(&resource);
+    spawn(&tasks, async move {
+        let _resource = resource;
+        panic!("work started after shutdown");
+    });
+    assert!(
+        retained.upgrade().is_none(),
+        "rejected work retained its resources"
+    );
+}
+
+struct SpawnOnDrop {
+    tasks: SpawnedTasks,
+    resource: Arc<()>,
+}
+
+impl Drop for SpawnOnDrop {
+    fn drop(&mut self) {
+        let resource = self.resource.clone();
+        spawn(&self.tasks, async move {
+            let _resource = resource;
+            pending::<()>().await;
+        });
+    }
+}
+
+#[tokio::test]
+async fn shutdown_joins_tasks_and_rejects_work_spawned_during_cleanup() {
+    let tasks = registry();
+    let resource = Arc::new(());
+    let retained = Arc::downgrade(&resource);
+    let guard = SpawnOnDrop {
+        tasks: tasks.clone(),
+        resource,
+    };
+    let (started, ready) = tokio::sync::oneshot::channel();
+    spawn(&tasks, async move {
+        let _guard = guard;
+        started.send(()).unwrap();
+        pending::<()>().await;
+    });
+    ready.await.unwrap();
+    shutdown_tracked_tasks(tasks).await;
+    assert!(
+        retained.upgrade().is_none(),
+        "late-spawned task escaped shutdown"
+    );
+}
+
+#[tokio::test]
+async fn spawning_reaps_completed_tasks_and_preserves_individual_cancellation() {
+    let tasks = registry();
+    let completed = spawn_task(&tasks, async {}).unwrap();
+    while !completed.is_finished() {
+        tokio::task::yield_now().await;
+    }
+    let resource = Arc::new(());
+    let retained = Arc::downgrade(&resource);
+    let running = spawn_task(&tasks, async move {
+        let _resource = resource;
+        pending::<()>().await;
+    })
+    .unwrap();
+    assert_eq!(tasks.lock().as_ref().unwrap().len(), 1);
+    running.abort();
+    shutdown_tracked_tasks(tasks.clone()).await;
+    assert!(retained.upgrade().is_none());
+    assert!(tasks.lock().is_none());
+    shutdown_tracked_tasks(tasks).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_spawn_and_shutdown_release_all_resources() {
+    let tasks = registry();
+    let resource = Arc::new(());
+    let retained = Arc::downgrade(&resource);
+    let barrier = Arc::new(tokio::sync::Barrier::new(65));
+    let mut callers = tokio::task::JoinSet::new();
+    for _ in 0..64 {
+        let tasks = tasks.clone();
+        let resource = resource.clone();
+        let barrier = barrier.clone();
+        callers.spawn(async move {
+            barrier.wait().await;
+            spawn(&tasks, async move {
+                let _resource = resource;
+                pending::<()>().await;
+            });
+        });
+    }
+    drop(resource);
+    barrier.wait().await;
+    shutdown_tracked_tasks(tasks.clone()).await;
+    while let Some(result) = callers.join_next().await {
+        result.unwrap();
+    }
+    assert!(tasks.lock().is_none());
+    assert!(retained.upgrade().is_none());
+}

--- a/crates/p2p/tests/iroh/task_shutdown.rs
+++ b/crates/p2p/tests/iroh/task_shutdown.rs
@@ -14,7 +14,7 @@ fn spawn(tasks: &SpawnedTasks, future: impl Future<Output = ()> + Send + 'static
 #[tokio::test]
 async fn shutdown_rejects_new_work_without_polling_it() {
     let tasks = registry();
-    shutdown_tracked_tasks(tasks.clone()).await;
+    shutdown_tracked_tasks(tasks.clone(), vec![]).await;
     let resource = Arc::new(());
     let retained = Arc::downgrade(&resource);
     spawn(&tasks, async move {
@@ -58,7 +58,7 @@ async fn shutdown_joins_tasks_and_rejects_work_spawned_during_cleanup() {
         pending::<()>().await;
     });
     ready.await.unwrap();
-    shutdown_tracked_tasks(tasks).await;
+    shutdown_tracked_tasks(tasks, vec![]).await;
     assert!(
         retained.upgrade().is_none(),
         "late-spawned task escaped shutdown"
@@ -69,9 +69,13 @@ async fn shutdown_joins_tasks_and_rejects_work_spawned_during_cleanup() {
 async fn spawning_reaps_completed_tasks_and_preserves_individual_cancellation() {
     let tasks = registry();
     let completed = spawn_task(&tasks, async {}).unwrap();
-    while !completed.is_finished() {
-        tokio::task::yield_now().await;
-    }
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        while !completed.is_finished() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("completed task was not reaped");
     let resource = Arc::new(());
     let retained = Arc::downgrade(&resource);
     let running = spawn_task(&tasks, async move {
@@ -81,10 +85,10 @@ async fn spawning_reaps_completed_tasks_and_preserves_individual_cancellation() 
     .unwrap();
     assert_eq!(tasks.lock().as_ref().unwrap().len(), 1);
     running.abort();
-    shutdown_tracked_tasks(tasks.clone()).await;
+    shutdown_tracked_tasks(tasks.clone(), vec![]).await;
     assert!(retained.upgrade().is_none());
     assert!(tasks.lock().is_none());
-    shutdown_tracked_tasks(tasks).await;
+    shutdown_tracked_tasks(tasks, vec![]).await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -108,10 +112,40 @@ async fn concurrent_spawn_and_shutdown_release_all_resources() {
     }
     drop(resource);
     barrier.wait().await;
-    shutdown_tracked_tasks(tasks.clone()).await;
+    shutdown_tracked_tasks(tasks.clone(), vec![]).await;
     while let Some(result) = callers.join_next().await {
         result.unwrap();
     }
     assert!(tasks.lock().is_none());
     assert!(retained.upgrade().is_none());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn shutdown_bounds_non_cooperative_tasks_and_readers() {
+    for reader in [false, true] {
+        let tasks = registry();
+        let (release, blocked) = std::sync::mpsc::channel();
+        let (started, ready) = tokio::sync::oneshot::channel();
+        let work = async move {
+            started.send(()).unwrap();
+            // Deliberately model a synchronous section that cannot be aborted.
+            let _ = blocked.recv();
+        };
+        let readers = if reader {
+            vec![tokio::spawn(work)]
+        } else {
+            spawn(&tasks, work);
+            vec![]
+        };
+        ready.await.unwrap();
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(7),
+            shutdown_tracked_tasks(tasks.clone(), readers),
+        )
+        .await;
+        // Release even on failure so the test runtime can shut down.
+        let _ = release.send(());
+        result.expect("shutdown exceeded its task drain budget");
+        assert!(tasks.lock().is_none());
+    }
 }

--- a/crates/p2p/tests/iroh_lifecycle_tests.rs
+++ b/crates/p2p/tests/iroh_lifecycle_tests.rs
@@ -3,6 +3,7 @@
 use std::net::{IpAddr, Ipv4Addr};
 use std::time::Duration;
 
+use multihash_codetable::{Code, MultihashDigest};
 use p2p::iroh::{
     spawn_endpoint, IrohDiscoveryConfig, IrohEndpointConfig, IrohRelayModeConfig, IrohTransport,
 };
@@ -51,4 +52,37 @@ async fn endpoint_stops_when_command_sender_is_dropped_before_startup() {
     drop(commands);
 
     assert_endpoint_stopped(task).await;
+}
+
+#[tokio::test]
+async fn shutdown_joins_subscriptions_and_syncs_with_a_full_event_queue() {
+    let config = config();
+    let key = config.secret_key.clone();
+    let (commands, events, _replicators, task) = spawn_endpoint(config).await.unwrap();
+    let transport = IrohTransport::new(commands, key);
+    transport.subscribe(p2p::DefraTopic::DocSync).await.unwrap();
+    transport
+        .subscribe_raw("shutdown-test".into())
+        .await
+        .unwrap();
+
+    // Keep the receiver idle so failed syncs block delivering their completion.
+    let root = cid::Cid::new_v1(0x55, Code::Sha2_256.digest(b"shutdown"));
+    timeout(Duration::from_secs(5), async {
+        for _ in 0..300 {
+            transport.sync_blocks(root, vec![], vec![]).await.unwrap();
+        }
+        while events.capacity() != 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("syncs did not fill the event queue");
+    drop(transport);
+
+    assert_endpoint_stopped(task).await;
+    assert!(
+        events.is_closed(),
+        "a task retained the endpoint's event sender"
+    );
 }


### PR DESCRIPTION
## Context
Iroh shutdown drained a snapshot of task handles while running tasks could still register children. Those children escaped cleanup. Block-sync tasks also kept only abort handles, so shutdown could not join them.

This follows #1698 in the Iroh lifecycle stack.

## Changes
- Spawn and register work under one lock, and close registration before draining.
- Use Tokio JoinSet to abort and join tracked tasks, including block syncs.
- Join subscription readers before finishing endpoint teardown.
- Cover late registration, cleanup-spawned work, concurrent spawning, and a full event queue with active subscriptions and syncs.

## Testing
Both late-registration regressions fail before the fix and pass afterward.

- [x] P2P library tests with both transports: 459 passed.
- [x] Iroh endpoint lifecycle tests: three passed.
- [x] Live Iroh replication and persistent-node restart test.
- [x] Full-feature CLI build with Iroh.
- [x] Strict P2P clippy for all targets with both transports.
- [x] Formatting and diff checks.

Refs #1356