### PR TITLE
fix(crdt): accept 4-byte Float32 deltas in CompositeDAG

### DIFF
--- a/crates/crdt/src/composite.rs
+++ b/crates/crdt/src/composite.rs
@@ -325,10 +325,15 @@ impl CompositeDAG {
                     data,
                 },
             ) => {
-                if data.len() != 8 {
+                let expected = match kind {
+                    NumericKind::Float32 => 4,
+                    NumericKind::Int64 | NumericKind::Float64 => 8,
+                };
+                if data.len() != expected {
                     return Err(Error::MergeError(format!(
-                        "invalid counter increment data for field '{}': expected 8 bytes, got {}",
+                        "invalid counter increment data for field '{}': expected {} bytes, got {}",
                         field_name,
+                        expected,
                         data.len()
                     )));
                 }
@@ -498,11 +503,18 @@ impl ReplicatedData for CompositeDAG {
             }
 
             // Validate Counter data length if applicable
-            if let FieldDelta::Counter { data, .. } = field_delta {
-                if data.len() != 8 {
+            if let (FieldCrdtType::Counter { kind, .. }, FieldDelta::Counter { data, .. }) =
+                (crdt_type, field_delta)
+            {
+                let expected = match kind {
+                    NumericKind::Float32 => 4,
+                    NumericKind::Int64 | NumericKind::Float64 => 8,
+                };
+                if data.len() != expected {
                     return Err(Error::MergeError(format!(
-                        "invalid counter increment data for field '{}': expected 8 bytes, got {}",
+                        "invalid counter increment data for field '{}': expected {} bytes, got {}",
                         field_name,
+                        expected,
                         data.len()
                     )));
                 }

--- a/crates/crdt/tests/composite_tests.rs
+++ b/crates/crdt/tests/composite_tests.rs
@@ -464,3 +464,69 @@ fn test_composite_delta_empty_field_name_rejected() {
         .to_string()
         .contains("field_name cannot be empty"));
 }
+
+#[tokio::test]
+async fn test_composite_float32_counter_accepts_4_bytes() {
+    let store = RegolithStore::in_memory().unwrap();
+    let mut composite = CompositeDAG::new(DocId::new_unchecked("doc1"), "v1".to_string());
+    composite.register_counter_field("score".to_string(), true, NumericKind::Float32);
+
+    let ctx = Context {
+        doc_id: DocId::new_unchecked("doc1"),
+        schema_version: "v1".to_string(),
+        is_create: false,
+    };
+
+    let mut delta = CompositeDelta::new(b"doc1".to_vec(), "v1".to_string(), 10).unwrap();
+    delta
+        .add_field_delta(
+            "score".to_string(),
+            FieldDelta::Counter {
+                priority: 10,
+                nonce: 1,
+                data: 1.5f32.to_be_bytes().to_vec(),
+            },
+        )
+        .unwrap();
+
+    let mut txn = store.new_txn(false).await.unwrap();
+    let result = composite.merge(&mut *txn, &ctx, &delta).await.unwrap();
+    assert_eq!(result, MergeResult::Applied);
+    txn.commit().await.unwrap();
+
+    let txn = store.new_txn(true).await.unwrap();
+    let count_key = b"/data/v1/doc1/score".to_vec();
+    let count_bytes = txn.get(&count_key).await.unwrap().unwrap();
+    let count = f32::from_be_bytes(count_bytes.as_ref().try_into().unwrap());
+    assert_eq!(count, 1.5f32);
+}
+
+#[tokio::test]
+async fn test_composite_counter_rejects_wrong_length() {
+    let store = RegolithStore::in_memory().unwrap();
+    let mut composite = CompositeDAG::new(DocId::new_unchecked("doc1"), "v1".to_string());
+    composite.register_counter_field("count".to_string(), true, NumericKind::Int64);
+
+    let ctx = Context {
+        doc_id: DocId::new_unchecked("doc1"),
+        schema_version: "v1".to_string(),
+        is_create: false,
+    };
+
+    let mut delta = CompositeDelta::new(b"doc1".to_vec(), "v1".to_string(), 10).unwrap();
+    delta
+        .add_field_delta(
+            "count".to_string(),
+            FieldDelta::Counter {
+                priority: 10,
+                nonce: 1,
+                data: vec![0u8; 4],
+            },
+        )
+        .unwrap();
+
+    let mut txn = store.new_txn(false).await.unwrap();
+    let result = composite.merge(&mut *txn, &ctx, &delta).await;
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("expected 8 bytes"));
+}


### PR DESCRIPTION
Follow-up to #883 (Float32 counter support).

**Bug:** the direct `Counter` path stores Float32 deltas as 4 bytes (`counter.rs`), but both `CompositeDAG` validation gates (`apply_field_delta` and `merge` pre-validation in `crates/crdt/src/composite.rs`) hardcoded `data.len() != 8`. Any Float32 counter field merged through the document-level path — the path real writes take — was rejected with `expected 8 bytes`, and an 8-byte payload for a Float32 field passed validation only to be silently truncated by `data[..4]`.

**Fix:** branch the expected length on `NumericKind` (4 for Float32, 8 for Int64/Float64) in both gates.

**Tests:** added `test_composite_float32_counter_accepts_4_bytes` and `test_composite_counter_rejects_wrong_length` to `crates/crdt/tests/composite_tests.rs`.

**Verified:**
- `cargo test -p crdt` — all pass
- `cargo clippy -p crdt --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean