### PR TITLE
fix(cli): harden GraphQL input building against control chars and bad keys

### DIFF
--- a/crates/cli/src/commands/client/document.rs
+++ b/crates/cli/src/commands/client/document.rs
@@ -135,7 +135,7 @@ impl DocumentAddArgs {
         let data = get_data_from_args(&self.document, &self.file)?;
         let parsed: JsonValue = serde_json::from_str(&data)?;
 
-        let input_str = json_to_graphql_input(&parsed);
+        let input_str = json_to_graphql_input(&parsed)?;
         let query = format!(
             r#"mutation {{ add_{collection}(input: {input}) {{ _docID }} }}"#,
             collection = collection,

--- a/crates/cli/src/commands/client/validation.rs
+++ b/crates/cli/src/commands/client/validation.rs
@@ -35,6 +35,8 @@ pub fn validate_identifier(name: &str) -> Result<()> {
 /// Escape special characters in a string for use in GraphQL string literals.
 ///
 /// This prevents injection attacks when interpolating user input into GraphQL queries.
+/// Control characters without a short escape are emitted as `\uXXXX`,
+/// matching the REST layer (`query::rest`) and Go's `valueToGQL`.
 pub fn escape_graphql_string(s: &str) -> String {
     let mut result = String::with_capacity(s.len());
     for c in s.chars() {
@@ -44,6 +46,11 @@ pub fn escape_graphql_string(s: &str) -> String {
             '\n' => result.push_str("\\n"),
             '\r' => result.push_str("\\r"),
             '\t' => result.push_str("\\t"),
+            '\u{0008}' => result.push_str("\\b"),
+            '\u{000C}' => result.push_str("\\f"),
+            c if (c as u32) < 0x20 || (c as u32) == 0x7F => {
+                result.push_str(&format!("\\u{:04X}", c as u32));
+            }
             _ => result.push(c),
         }
     }
@@ -54,24 +61,33 @@ pub fn escape_graphql_string(s: &str) -> String {
 ///
 /// GraphQL input objects use unquoted keys: `{name: "Alice", age: 30}`
 /// instead of JSON's `{"name": "Alice", "age": 30}`.
-pub fn json_to_graphql_input(value: &serde_json::Value) -> String {
+///
+/// Object keys are written unquoted into the mutation, so a key that is
+/// not a valid GraphQL name (e.g. containing `)`, `{`, whitespace) is
+/// rejected here with `InvalidIdentifier` instead of emitting a
+/// malformed query or a server-side parse error.
+pub fn json_to_graphql_input(value: &serde_json::Value) -> Result<String> {
     use serde_json::Value;
     match value {
         Value::Object(map) => {
-            let fields: Vec<String> = map
-                .iter()
-                .map(|(k, v)| format!("{}: {}", k, json_to_graphql_input(v)))
-                .collect();
-            format!("{{{}}}", fields.join(", "))
+            let mut fields = Vec::with_capacity(map.len());
+            for (k, v) in map {
+                validate_identifier(k)?;
+                fields.push(format!("{}: {}", k, json_to_graphql_input(v)?));
+            }
+            Ok(format!("{{{}}}", fields.join(", ")))
         }
         Value::Array(arr) => {
-            let items: Vec<String> = arr.iter().map(json_to_graphql_input).collect();
-            format!("[{}]", items.join(", "))
+            let mut items = Vec::with_capacity(arr.len());
+            for item in arr {
+                items.push(json_to_graphql_input(item)?);
+            }
+            Ok(format!("[{}]", items.join(", ")))
         }
-        Value::String(s) => format!("\"{}\"", escape_graphql_string(s)),
-        Value::Number(n) => n.to_string(),
-        Value::Bool(b) => b.to_string(),
-        Value::Null => "null".to_string(),
+        Value::String(s) => Ok(format!("\"{}\"", escape_graphql_string(s))),
+        Value::Number(n) => Ok(n.to_string()),
+        Value::Bool(b) => Ok(b.to_string()),
+        Value::Null => Ok("null".to_string()),
     }
 }
 
@@ -124,6 +140,14 @@ mod tests {
     }
 
     #[test]
+    fn test_escape_graphql_string_control_chars() {
+        assert_eq!(escape_graphql_string("a\u{0008}b"), "a\\bb");
+        assert_eq!(escape_graphql_string("a\u{000C}b"), "a\\fb");
+        assert_eq!(escape_graphql_string("a\u{0000}b"), "a\\u0000b");
+        assert_eq!(escape_graphql_string("a\u{0007}b"), "a\\u0007b");
+    }
+
+    #[test]
     fn test_escape_graphql_string_injection_attempt() {
         // Malicious input that tries to break out of a GraphQL string
         let malicious = r#"bae-123"}) { _docID }} mutation { delete_Users(docIDs: ["all"#;
@@ -141,5 +165,34 @@ mod tests {
             escaped,
             r#"bae-123\"}) { _docID }} mutation { delete_Users(docIDs: [\"all"#
         );
+    }
+
+    #[test]
+    fn test_json_to_graphql_input_scalars() {
+        use serde_json::json;
+        assert_eq!(json_to_graphql_input(&json!(null)).unwrap(), "null");
+        assert_eq!(json_to_graphql_input(&json!(true)).unwrap(), "true");
+        assert_eq!(json_to_graphql_input(&json!(42)).unwrap(), "42");
+        assert_eq!(
+            json_to_graphql_input(&json!("a\u{0008}b")).unwrap(),
+            "\"a\\bb\""
+        );
+    }
+
+    #[test]
+    fn test_json_to_graphql_input_rejects_invalid_keys() {
+        use serde_json::json;
+        assert!(json_to_graphql_input(&json!({"na)me": 1})).is_err());
+        assert!(json_to_graphql_input(&json!({"na me": 1})).is_err());
+        assert!(json_to_graphql_input(&json!({"user": {"na}me": 1}})).is_err());
+        assert!(json_to_graphql_input(&json!([{"na)me": 1}])).is_err());
+    }
+
+    #[test]
+    fn test_json_to_graphql_input_valid_object() {
+        use serde_json::json;
+        let result = json_to_graphql_input(&json!({"name": "Alice", "age": 30})).unwrap();
+        assert!(result.contains("name: \"Alice\""));
+        assert!(result.contains("age: 30"));
     }
 }


### PR DESCRIPTION
**Bugs** (`crates/cli/src/commands/client/validation.rs`, used by `document add`):

1. `escape_graphql_string` passed control characters without a short escape (backspace, form feed, NUL, etc.) through raw. The REST layer (`crates/query/src/rest/gql.rs`, tested in `rest/tests.rs`) encodes them as `\\b`, `\\f`, `\\uXXXX` per Go `valueToGQL` (`encoding/json.Marshal`) parity — the CLI copy diverged.
2. `json_to_graphql_input` interpolated object keys unquoted and infallibly, so a key like `na)me` emitted a malformed mutation that failed server-side instead of being rejected client-side (the REST layer refuses non-`Name` keys).

**Fix:** escape `\\b`/`\\f`/`\\uXXXX` like the REST layer; make `json_to_graphql_input` fallible (`Result`) validating keys via the existing `validate_identifier`, and propagate with `?` at the `document add` call site.

**Tests:** `test_escape_graphql_string_control_chars`, `test_json_to_graphql_input_scalars`, `test_json_to_graphql_input_rejects_invalid_keys`, `test_json_to_graphql_input_valid_object`.

**Verified:**
- `cargo test -p cli --lib` — 76 passed, 1 ignored (rustc 1.95 + protoc; default 1.92 toolchain cannot resolve wasmtime 46 — pre-existing env limitation)
- `cargo clippy -p cli --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean