### PR TITLE
fix(http): reject peer addresses with whitespace at validation

### DIFF
--- a/crates/http/src/validation.rs
+++ b/crates/http/src/validation.rs
@@ -54,6 +54,17 @@ pub fn validate_multiaddr(address: &str) -> Result<(), HttpError> {
         return Err(HttpError::BadRequest("address cannot be empty".to_string()));
     }
 
+    // None of the accepted shapes (multiaddr, iroh URI, bare endpoint
+    // ID) may contain whitespace or control characters. Rejecting them
+    // here fails fast with 400 instead of a confusing transport-layer
+    // error deeper in the stack.
+    if address.chars().any(|c| c.is_whitespace() || c.is_control()) {
+        return Err(HttpError::BadRequest(format!(
+            "invalid peer address '{}': must not contain whitespace or control characters",
+            address
+        )));
+    }
+
     Ok(())
 }
 
@@ -334,6 +345,16 @@ mod tests {
     #[test]
     fn test_validate_multiaddr_invalid() {
         assert!(validate_multiaddr("").is_err());
+    }
+
+    #[test]
+    fn test_validate_multiaddr_rejects_inner_whitespace() {
+        assert!(validate_multiaddr("!!! not an addr !!!").is_err());
+        assert!(validate_multiaddr("/ip4/127.0.0.1/tcp/9000 ").is_err());
+        assert!(validate_multiaddr(" /ip4/127.0.0.1/tcp/9000").is_err());
+        assert!(validate_multiaddr("/ip4/127.0.0.1/ tcp/9000").is_err());
+        assert!(validate_multiaddr("iroh://abc 123").is_err());
+        assert!(validate_multiaddr("/ip4/127.0.0.1/tcp/9000\n").is_err());
     }
 
     #[test]


### PR DESCRIPTION
**Bug:** `validate_multiaddr` (`crates/http/src/validation.rs`) accepted any non-empty string, so garbage like `'!!! not an addr !!!'` passed HTTP 400-validation and failed deep in the libp2p/iroh transport with a confusing error. Fail-fast at the edge is this module's stated purpose.

**Fix:** reject addresses containing whitespace or control characters. Conservative by design: none of the accepted shapes (libp2p multiaddr, `iroh://` URI, bare endpoint ID — all pinned by the existing `test_validate_multiaddr_valid`) may contain such characters, and full validation still happens in the P2P transport layer.

**Tests:** added `test_validate_multiaddr_rejects_inner_whitespace`.

**Verified:**
- `cargo test -p defra-http --lib` — 143 passed (rustc 1.95 + protoc)
- `cargo clippy -p defra-http --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean