### PR TITLE
feat(storage): support configurable replicator retry schedules

### DIFF
--- a/crates/storage/src/stores/mod.rs
+++ b/crates/storage/src/stores/mod.rs
@@ -26,7 +26,8 @@ pub use headstore::Headstore;
 pub use multistore::Multistore;
 pub use peerstore::Peerstore;
 pub use retry_info::{
-    rewrite_legacy_push_retry_doc_id, PushRetryMarker, PushRetryMarkerStats, RetryInfo, RetryScope,
+    rewrite_legacy_push_retry_doc_id, PushRetryMarker, PushRetryMarkerStats, RetryInfo,
+    RetrySchedule, RetryScope,
 };
 pub use rootstore::RootStore;
 pub use systemstore::Systemstore;

--- a/crates/storage/src/stores/peerstore.rs
+++ b/crates/storage/src/stores/peerstore.rs
@@ -128,6 +128,7 @@ async fn wait_before_marker_retry(_attempt: usize) {
 /// Peerstore provides storage for peer and replication metadata
 pub struct Peerstore<S: Store> {
     store: NamespacedStore<S>,
+    retry_schedule: super::RetrySchedule,
 }
 
 impl<S: Store> Peerstore<S> {
@@ -135,7 +136,14 @@ impl<S: Store> Peerstore<S> {
     pub fn new(store: Arc<S>) -> Self {
         Self {
             store: NamespacedStore::new(store, Namespace::Peerstore),
+            retry_schedule: super::RetrySchedule::default(),
         }
+    }
+
+    /// Set the runtime retry policy without rewriting persisted deadlines.
+    pub fn with_retry_schedule(mut self, schedule: super::RetrySchedule) -> Self {
+        self.retry_schedule = schedule;
+        self
     }
 
     /// Store a replicator's configuration.
@@ -329,7 +337,7 @@ impl<S: Store> Peerstore<S> {
         if !txn.has(&id_key.bytes()).await? {
             let mut info = super::RetryInfo::from_bytes(retry_info_bytes)
                 .unwrap_or_else(|_| super::RetryInfo::new_initial());
-            info.bump_for(peer_id);
+            info.bump_with_schedule(peer_id, &self.retry_schedule);
             txn.set(
                 &id_key.bytes(),
                 &info.to_bytes().map_err(crate::corekv::Error::Other)?,
@@ -421,7 +429,7 @@ impl<S: Store> Peerstore<S> {
                 let id_key = ReplicatorRetryIDKey::new(&peer);
                 if !txn.has(&id_key.bytes()).await? {
                     let mut info = super::RetryInfo::new_initial();
-                    info.bump_for(&peer);
+                    info.bump_with_schedule(&peer, &self.retry_schedule);
                     txn.set(
                         &id_key.bytes(),
                         &info.to_bytes().map_err(crate::corekv::Error::Other)?,
@@ -616,7 +624,7 @@ impl<S: Store> Peerstore<S> {
             if let Some(delay) = defer_for {
                 info.defer_for(delay);
             } else {
-                info.bump_for(peer_id);
+                info.bump_with_schedule(peer_id, &self.retry_schedule);
             }
             txn.set(&key, &info.to_bytes().map_err(crate::corekv::Error::Other)?)
                 .await?;

--- a/crates/storage/src/stores/retry_info.rs
+++ b/crates/storage/src/stores/retry_info.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 /// Retry information for failed replicator pushes.
 ///
 /// Tracks the number of retries and the next retry time using exponential
@@ -11,6 +12,31 @@ use web_time::{SystemTime, UNIX_EPOCH};
 /// Source parity: Go `cli/config/config.go`, default
 /// `replicator.retryintervals`.
 pub const RETRY_INTERVALS_SECS: &[u64] = &[30, 60, 120, 240, 480, 960, 1920];
+
+/// Non-empty retry intervals in seconds. The final interval is the retry cap.
+#[derive(Debug, Clone)]
+pub struct RetrySchedule(Cow<'static, [u64]>);
+
+impl RetrySchedule {
+    pub fn new(intervals: Vec<u64>) -> Result<Self, String> {
+        if intervals.is_empty() || intervals.contains(&0) {
+            return Err(
+                "replicator retry intervals must be a non-empty list of positive integers".into(),
+            );
+        }
+        Ok(Self(Cow::Owned(intervals)))
+    }
+
+    fn cap(&self, attempt: u32) -> u64 {
+        self.0[(attempt as usize).min(self.0.len() - 1)]
+    }
+}
+
+impl Default for RetrySchedule {
+    fn default() -> Self {
+        Self(Cow::Borrowed(RETRY_INTERVALS_SECS))
+    }
+}
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct RetryInfo {
@@ -146,19 +172,23 @@ impl RetryInfo {
     /// retry rung.  The published Go-compatible ladder remains the cap while
     /// peers do not wake in lockstep after a fleet-wide outage.
     pub fn bump_for(&mut self, retry_key: &str) {
+        self.bump_with_schedule(retry_key, &RetrySchedule::default());
+    }
+
+    /// Advance using the configured ladder, preserving peer-scoped jitter.
+    pub fn bump_with_schedule(&mut self, retry_key: &str, schedule: &RetrySchedule) {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs();
-        let idx = (self.num_retries as usize).min(RETRY_INTERVALS_SECS.len() - 1);
-        let cap = RETRY_INTERVALS_SECS[idx];
+        let cap = schedule.cap(self.num_retries);
         let floor = (cap / 2).max(1);
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
         retry_key.hash(&mut hasher);
         self.num_retries.hash(&mut hasher);
         let delay = floor + hasher.finish() % (cap - floor + 1);
-        self.next_retry_unix = now + delay;
-        self.num_retries += 1;
+        self.next_retry_unix = now.saturating_add(delay);
+        self.num_retries = self.num_retries.saturating_add(1);
     }
 
     /// Move the next bounded pass to a different lexical marker prefix.

--- a/crates/storage/tests/retry_schedule.rs
+++ b/crates/storage/tests/retry_schedule.rs
@@ -1,0 +1,114 @@
+use std::sync::Arc;
+use storage::corekv::Store;
+use storage::stores::{Peerstore, RetryInfo, RetrySchedule};
+use storage::RegolithStore;
+use web_time::{SystemTime, UNIX_EPOCH};
+
+fn now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+
+#[test]
+fn retry_schedule_rejects_empty_and_zero_intervals() {
+    for intervals in [vec![], vec![0], vec![1, 0, 3]] {
+        assert!(RetrySchedule::new(intervals).is_err());
+    }
+}
+
+#[test]
+fn custom_intervals_advance_and_repeat_the_last_cap() {
+    let schedule = RetrySchedule::new(vec![1, 8, 100]).unwrap();
+    let mut info = RetryInfo::new_initial();
+    for (attempt, cap) in [1, 8, 100, 100].into_iter().enumerate() {
+        let before = now();
+        info.bump_with_schedule("peer", &schedule);
+        assert!(info.next_retry_unix >= before + (cap / 2).max(1));
+        assert!(info.next_retry_unix <= now() + cap);
+        assert_eq!(info.num_retries, attempt as u32 + 1);
+    }
+}
+
+#[test]
+fn default_schedule_preserves_existing_deadlines() {
+    for attempt in 0..10 {
+        let mut default = RetryInfo::new_initial();
+        default.num_retries = attempt;
+        let mut explicit = default.clone();
+        let before = now();
+        default.bump_for("peer");
+        explicit.bump_with_schedule("peer", &RetrySchedule::default());
+        assert!(explicit.next_retry_unix.abs_diff(default.next_retry_unix) <= now() - before);
+        assert_eq!(default.num_retries, explicit.num_retries);
+    }
+}
+
+#[test]
+fn retry_counter_and_deadline_saturate_instead_of_overflowing() {
+    let mut info = RetryInfo::new_initial();
+    info.num_retries = u32::MAX;
+    info.bump_with_schedule("peer", &RetrySchedule::new(vec![u64::MAX]).unwrap());
+    assert_eq!(info.num_retries, u32::MAX);
+    assert!(info.next_retry_unix > now());
+}
+
+async fn info(peerstore: &Peerstore<RegolithStore>) -> RetryInfo {
+    RetryInfo::from_bytes(&peerstore.get_retry_info("peer").await.unwrap().unwrap()).unwrap()
+}
+
+#[tokio::test]
+async fn configured_schedule_survives_scope_updates_and_reopen() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = Arc::new(RegolithStore::open(dir.path()).unwrap());
+    let peerstore = Peerstore::new(store.clone())
+        .with_retry_schedule(RetrySchedule::new(vec![1, 600]).unwrap());
+    peerstore
+        .create_replicator("peer", b"replicator")
+        .await
+        .unwrap();
+    let before = now();
+    peerstore
+        .observe_push_head("peer", "doc", "collection")
+        .await
+        .unwrap();
+    let first = info(&peerstore).await;
+    assert!(first.next_retry_unix > before && first.next_retry_unix <= now() + 1);
+    assert_eq!(first.num_retries, 1);
+
+    peerstore
+        .observe_push_head("peer", "", "collection")
+        .await
+        .unwrap();
+    assert_eq!(
+        info(&peerstore).await.next_retry_unix,
+        first.next_retry_unix
+    );
+    let before = now();
+    peerstore.reschedule_retry_peer("peer", None).await.unwrap();
+    let second = info(&peerstore).await;
+    assert!(second.next_retry_unix >= before + 300 && second.next_retry_unix <= now() + 600);
+    drop(peerstore);
+    store.close().await.unwrap();
+    drop(store);
+
+    let reopened = Arc::new(RegolithStore::open(dir.path()).unwrap());
+    let peerstore =
+        Peerstore::new(reopened.clone()).with_retry_schedule(RetrySchedule::new(vec![1]).unwrap());
+    assert_eq!(
+        info(&peerstore).await.next_retry_unix,
+        second.next_retry_unix
+    );
+    assert_eq!(
+        peerstore.get_retry_documents("peer").await.unwrap().len(),
+        2
+    );
+    let before = now();
+    peerstore.reschedule_retry_peer("peer", None).await.unwrap();
+    let third = info(&peerstore).await;
+    assert!(third.next_retry_unix > before && third.next_retry_unix <= now() + 1);
+    assert_eq!(third.num_retries, 3);
+    drop(peerstore);
+    reopened.close().await.unwrap();
+}


### PR DESCRIPTION
## Context
Replicator retry delays are hardcoded in storage, so the configured intervals cannot influence the durable retry clock. This is the storage foundation for wiring the existing flag end to end.

## Changes
- Add a validated retry schedule with the existing default ladder and bounded jitter.
- Apply it to marker registration, legacy migration, and peer rescheduling.
- Keep stored retry records unchanged and preserve existing deadlines when reopening with a different schedule.
- Saturate retry counters and deadlines instead of overflowing.

## Testing
- [x] Full storage test suite.
- [x] Five regressions covering invalid intervals, rung progression, defaults, overflow, and persisted markers across reopen.
- [x] Strict storage clippy for all targets.
- [x] Formatting and diff checks.

Refs #1422