### PR TITLE
fix(p2p): honor configured replicator retry intervals

### DIFF
--- a/crates/cli/src/commands/start/mod.rs
+++ b/crates/cli/src/commands/start/mod.rs
@@ -676,6 +676,7 @@ impl StartArgs {
             config.embedding.api_key_env = api_key_env.clone();
         }
         config.api.validate()?;
+        config.retry_schedule()?;
         Ok(())
     }
 }

--- a/crates/cli/src/commands/start/server_p2p/iroh.rs
+++ b/crates/cli/src/commands/start/server_p2p/iroh.rs
@@ -19,6 +19,7 @@ impl Node {
         node_identity: Option<Arc<identity::RawIdentity>>,
         se_key: Option<[u8; 32]>,
     ) -> Result<P2PSetup> {
+        let retry_schedule = config.retry_schedule()?;
         info!("Initializing P2P network (iroh)");
 
         let sync_blockstore = Arc::new(blockstore::DefraBlockstore::new(store.clone(), true));
@@ -346,20 +347,26 @@ impl Node {
                 transport.clone(),
             );
 
-        let doc_pusher_impl = Arc::new(crate::transport_doc_pusher::DbTransportDocPusher::new(
-            database.clone(),
-            transport.clone(),
-            coordinator.head_hint_car_authority(),
-        ));
+        let doc_pusher_impl = Arc::new(
+            crate::transport_doc_pusher::DbTransportDocPusher::new(
+                database.clone(),
+                transport.clone(),
+                coordinator.head_hint_car_authority(),
+            )
+            .with_retry_schedule(retry_schedule.clone()),
+        );
         let doc_pusher_for_acp = doc_pusher_impl.clone();
         let doc_pusher: Arc<dyn crate::transport_doc_pusher::TransportDocPusher> = doc_pusher_impl;
 
-        let failure_recorder_task =
-            defra_p2p_adapter::spawn_failure_recorder(store.clone(), failure_rx);
+        let failure_recorder_task = defra_p2p_adapter::spawn_failure_recorder(
+            storage::stores::Peerstore::new(store.clone())
+                .with_retry_schedule(retry_schedule.clone()),
+            failure_rx,
+        );
         let se_repusher: Arc<dyn db::merge::SeArtifactRepusher> =
             replication.broadcast_mutator.clone();
         let retry_loop_task = defra_p2p_adapter::spawn_retry_loop(
-            store.clone(),
+            storage::stores::Peerstore::new(store.clone()).with_retry_schedule(retry_schedule),
             transport.clone(),
             doc_pusher.clone(),
             Some(se_repusher),

--- a/crates/cli/src/commands/start/server_p2p/libp2p.rs
+++ b/crates/cli/src/commands/start/server_p2p/libp2p.rs
@@ -18,6 +18,7 @@ impl Node {
         node_identity: Option<Arc<identity::RawIdentity>>,
         se_key: Option<[u8; 32]>,
     ) -> Result<P2PSetup> {
+        let retry_schedule = config.retry_schedule()?;
         info!("Initializing P2P network (libp2p)");
 
         let blockstore = Arc::new(blockstore::DefraBlockstore::new(store.clone(), true));
@@ -359,20 +360,26 @@ impl Node {
                 database.clone(),
             );
 
-        let doc_pusher_impl = Arc::new(crate::transport_doc_pusher::DbTransportDocPusher::new(
-            database.clone(),
-            p2p::Libp2pTransport::new(handle.clone()),
-            coordinator.head_hint_car_authority(),
-        ));
+        let doc_pusher_impl = Arc::new(
+            crate::transport_doc_pusher::DbTransportDocPusher::new(
+                database.clone(),
+                p2p::Libp2pTransport::new(handle.clone()),
+                coordinator.head_hint_car_authority(),
+            )
+            .with_retry_schedule(retry_schedule.clone()),
+        );
         let doc_pusher_for_acp = doc_pusher_impl.clone();
         let doc_pusher: Arc<dyn crate::transport_doc_pusher::TransportDocPusher> = doc_pusher_impl;
 
-        let failure_recorder_task =
-            defra_p2p_adapter::spawn_failure_recorder(store.clone(), failure_rx);
+        let failure_recorder_task = defra_p2p_adapter::spawn_failure_recorder(
+            storage::stores::Peerstore::new(store.clone())
+                .with_retry_schedule(retry_schedule.clone()),
+            failure_rx,
+        );
         let se_repusher: Arc<dyn db::merge::SeArtifactRepusher> =
             replication.broadcast_mutator.clone();
         let retry_loop_task = defra_p2p_adapter::spawn_retry_loop(
-            store.clone(),
+            storage::stores::Peerstore::new(store.clone()).with_retry_schedule(retry_schedule),
             p2p::Libp2pTransport::new(handle.clone()),
             doc_pusher.clone(),
             Some(se_repusher),

--- a/crates/cli/src/config/mod.rs
+++ b/crates/cli/src/config/mod.rs
@@ -43,8 +43,12 @@ pub struct Config {
     pub development: bool,
     pub secret_file: String,
     pub telemetry_disabled: bool,
-    #[serde(default)]
+    #[serde(default = "default_replicator_retry_intervals")]
     pub replicator_retry_intervals: Vec<u32>,
+}
+
+fn default_replicator_retry_intervals() -> Vec<u32> {
+    vec![30, 60, 120, 240, 480, 960, 1920]
 }
 
 impl Default for Config {
@@ -61,7 +65,7 @@ impl Default for Config {
             development: false,
             secret_file: ".env".to_string(),
             telemetry_disabled: false,
-            replicator_retry_intervals: vec![30, 60, 120, 240, 480, 960, 1920],
+            replicator_retry_intervals: default_replicator_retry_intervals(),
         }
     }
 }
@@ -103,7 +107,20 @@ impl Config {
         self.api.validate()?;
         self.net.validate()?;
         self.acp.validate()?;
+        self.retry_schedule()?;
         Ok(())
+    }
+
+    /// Runtime policy shared by head registration and persisted retry dispatch.
+    pub fn retry_schedule(&self) -> Result<storage::stores::RetrySchedule> {
+        storage::stores::RetrySchedule::new(
+            self.replicator_retry_intervals
+                .iter()
+                .copied()
+                .map(u64::from)
+                .collect(),
+        )
+        .map_err(Error::InvalidConfig)
     }
 
     /// Resolve the rootdir path

--- a/crates/cli/tests/retry_config.rs
+++ b/crates/cli/tests/retry_config.rs
@@ -1,0 +1,78 @@
+use clap::Parser;
+use cli::cli::{Cli, Command};
+use cli::config::Config;
+use storage::stores::RetryInfo;
+
+#[test]
+fn omitted_retry_intervals_keep_the_default_ladder() {
+    let mut value = serde_json::to_value(Config::default()).unwrap();
+    value
+        .as_object_mut()
+        .unwrap()
+        .remove("replicator_retry_intervals");
+    let config: Config = serde_json::from_value(value).unwrap();
+    config.validate().unwrap();
+    assert_eq!(
+        config.replicator_retry_intervals,
+        Config::default().replicator_retry_intervals
+    );
+}
+
+#[test]
+fn config_rejects_empty_or_zero_retry_intervals() {
+    for intervals in [vec![], vec![0], vec![1, 0, 3]] {
+        let config = Config {
+            replicator_retry_intervals: intervals,
+            ..Config::default()
+        };
+        assert!(config
+            .validate()
+            .unwrap_err()
+            .to_string()
+            .contains("replicator retry intervals"));
+    }
+}
+
+#[test]
+fn retry_flag_overrides_config_and_changes_the_runtime_schedule() {
+    let cli =
+        Cli::try_parse_from(["defra", "start", "--replicator-retry-intervals=1,600"]).unwrap();
+    let Command::Start(args) = cli.command else {
+        panic!("expected start command")
+    };
+    let mut config = Config::default();
+    args.apply_to_config(&mut config).unwrap();
+    assert_eq!(config.replicator_retry_intervals, [1, 600]);
+    let mut info = RetryInfo::new_initial();
+    let before = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    info.bump_with_schedule("peer", &config.retry_schedule().unwrap());
+    let after = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    assert!(info.next_retry_unix > before && info.next_retry_unix <= after + 1);
+}
+
+#[test]
+fn zero_retry_flag_is_rejected_before_startup() {
+    let cli = Cli::try_parse_from(["defra", "start", "--replicator-retry-intervals=1,0"]).unwrap();
+    let Command::Start(args) = cli.command else {
+        panic!("expected start command")
+    };
+    assert!(args.apply_to_config(&mut Config::default()).is_err());
+}
+
+#[test]
+fn malformed_retry_flags_are_rejected() {
+    for value in ["-1", "1,nope", "4294967296"] {
+        assert!(Cli::try_parse_from([
+            "defra",
+            "start",
+            &format!("--replicator-retry-intervals={value}")
+        ])
+        .is_err());
+    }
+}

--- a/crates/db/src/merge/push_docs.rs
+++ b/crates/db/src/merge/push_docs.rs
@@ -130,6 +130,7 @@ pub async fn push_existing_docs_by_id<S: Store + 'static, T: P2PTransport>(
     docs: &[(String, String)],
     filters: &p2p::ReplicationFilters,
     se_options: PushExistingDocsSeOptions<'_>,
+    replay_config: ReplayPushConfig,
     matcher: &dyn p2p::replicator::ReplicationFilterMatcher,
     car_authority: &p2p::sync::HeadHintCarAuthority,
 ) -> Result<(), String> {
@@ -142,7 +143,7 @@ pub async fn push_existing_docs_by_id<S: Store + 'static, T: P2PTransport>(
         &collections,
         filters,
         se_options,
-        ReplayPushConfig::default(),
+        replay_config,
         matcher,
         car_authority,
         Some(docs),
@@ -225,7 +226,8 @@ async fn push_existing_docs_with_config_and_allowlist<S: Store + 'static, T: P2P
     }
 
     let local_peer_id = transport.local_peer_id().to_string();
-    let peerstore = storage::stores::Peerstore::new(db.store().clone());
+    let peerstore = storage::stores::Peerstore::new(db.store().clone())
+        .with_retry_schedule(replay_config.retry_schedule.clone());
     let Some(retry_guard) = peerstore
         .acquire_replicator_retry_guard(peer_id.as_str())
         .await
@@ -534,7 +536,7 @@ async fn push_existing_docs_with_config_and_allowlist<S: Store + 'static, T: P2P
         }
     }
     tracing::debug!("all push tasks completed");
-    persist_replay_failures(db.store().clone(), peer_id, &replay_failures).await?;
+    persist_replay_failures(&peerstore, peer_id, &replay_failures).await?;
 
     if skipped_creator_docs > 0 {
         return Err(format!(

--- a/crates/db/src/merge/push_docs_replay.rs
+++ b/crates/db/src/merge/push_docs_replay.rs
@@ -28,6 +28,9 @@ pub const DEFAULT_REPLAY_SEND_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Clone)]
 pub struct ReplayPushConfig {
+    /// Retry schedule shared with live replication after replay fails.
+    pub retry_schedule: storage::stores::RetrySchedule,
+
     /// Maximum number of documents whose DAG blocks may be replayed concurrently.
     pub max_concurrent_document_tasks: usize,
 
@@ -55,7 +58,7 @@ pub struct ReplayDocumentFailure {
 /// not hold the peer writer across network waits, so the failure handoff must
 /// reacquire it before mutating the shared peer schedule.
 pub async fn persist_replay_failures<S: storage::corekv::Store>(
-    store: Arc<S>,
+    peerstore: &storage::stores::Peerstore<S>,
     peer_id: &PeerId,
     failures: &[ReplayDocumentFailure],
 ) -> Result<(), String> {
@@ -63,7 +66,6 @@ pub async fn persist_replay_failures<S: storage::corekv::Store>(
         return Ok(());
     }
 
-    let peerstore = storage::stores::Peerstore::new(store);
     let Some(_retry_guard) = peerstore
         .acquire_replicator_retry_guard(peer_id.as_str())
         .await
@@ -139,6 +141,7 @@ pub async fn persist_replay_failures<S: storage::corekv::Store>(
 impl Default for ReplayPushConfig {
     fn default() -> Self {
         Self {
+            retry_schedule: storage::stores::RetrySchedule::default(),
             max_concurrent_document_tasks: MAX_CONCURRENT_REPLAY_TASKS,
             max_concurrent_outbound_pushes: DEFAULT_MAX_CONCURRENT_REPLAY_SENDS,
             per_peer_rate_limit_burst: DEFAULT_REPLAY_RATE_LIMIT_BURST,

--- a/crates/db/tests/merge/push_docs_replay.rs
+++ b/crates/db/tests/merge/push_docs_replay.rs
@@ -16,6 +16,7 @@ async fn replay_push_gate_caps_concurrent_sends() {
         per_peer_rate_limit_burst: 100,
         per_peer_rate_limit_rate: 100.0,
         send_timeout: Duration::from_secs(1),
+        ..Default::default()
     }));
     let current = Arc::new(AtomicUsize::new(0));
     let max_seen = Arc::new(AtomicUsize::new(0));
@@ -55,6 +56,7 @@ async fn replay_push_gate_paces_after_peer_burst() {
         per_peer_rate_limit_burst: 1,
         per_peer_rate_limit_rate: 10.0,
         send_timeout: Duration::from_secs(1),
+        ..Default::default()
     });
     let peer = PeerId::new("peer-1".to_string());
 
@@ -79,11 +81,12 @@ fn record_max(max_seen: &AtomicUsize, value: usize) {
 }
 
 #[tokio::test]
-async fn unfinished_replay_is_persisted_and_marks_replicator_inactive() {
+async fn unfinished_replay_uses_configured_schedule_and_marks_replicator_inactive() {
     use storage::RegolithStore;
 
     let store = Arc::new(RegolithStore::in_memory().unwrap());
-    let peerstore = storage::stores::Peerstore::new(store.clone());
+    let peerstore = storage::stores::Peerstore::new(store.clone())
+        .with_retry_schedule(storage::stores::RetrySchedule::new(vec![3600]).unwrap());
     let peer = PeerId::new("peer-durable".to_string());
     let info =
         p2p::ReplicatorInfo::from_raw(peer.to_string(), vec!["collection".to_string()], Vec::new());
@@ -92,8 +95,12 @@ async fn unfinished_replay_is_persisted_and_marks_replicator_inactive() {
         .await
         .unwrap();
 
+    let before = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
     persist_replay_failures(
-        store,
+        &peerstore,
         &peer,
         &[ReplayDocumentFailure {
             doc_id: "doc-1".to_string(),
@@ -109,6 +116,12 @@ async fn unfinished_replay_is_persisted_and_marks_replicator_inactive() {
     assert_eq!(retries[0].scope, storage::stores::RetryScope::Document);
     assert!(!retries[0].is_collection_commit());
     assert!(!retries[0].retry_info.is_due());
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    assert!(retries[0].retry_info.next_retry_unix >= before + 1800);
+    assert!(retries[0].retry_info.next_retry_unix <= now + 3600);
     let saved = peerstore
         .get_replicator(peer.as_str())
         .await
@@ -140,7 +153,7 @@ async fn unfinished_replay_uses_the_peer_retry_writer() {
     let persistence_peer = peer.clone();
     let mut persistence = tokio::spawn(async move {
         persist_replay_failures(
-            store,
+            &storage::stores::Peerstore::new(store),
             &persistence_peer,
             &[ReplayDocumentFailure {
                 doc_id: "doc-1".to_string(),

--- a/crates/defra-node/src/p2p_runtime.rs
+++ b/crates/defra-node/src/p2p_runtime.rs
@@ -243,8 +243,10 @@ pub(super) async fn setup_p2p<S: storage::corekv::Store + 'static>(
 
     // Failure channel (required by replication loop)
     let failure_rx = db::merge::attach_failure_channel(&mut coordinator, 1024);
-    let failure_recorder_task =
-        defra_p2p_adapter::spawn_failure_recorder(store.clone(), failure_rx);
+    let failure_recorder_task = defra_p2p_adapter::spawn_failure_recorder(
+        storage::stores::Peerstore::new(store.clone()),
+        failure_rx,
+    );
 
     let coordinator = Arc::new(coordinator);
     coordinator
@@ -337,7 +339,7 @@ pub(super) async fn setup_p2p<S: storage::corekv::Store + 'static>(
     let doc_pusher_for_acp = doc_pusher_impl.clone();
     let doc_pusher: Arc<dyn defra_p2p_adapter::TransportDocPusher> = doc_pusher_impl;
     let retry_loop_task = defra_p2p_adapter::spawn_retry_loop(
-        store.clone(),
+        storage::stores::Peerstore::new(store.clone()),
         transport.clone(),
         doc_pusher.clone(),
         None,

--- a/crates/embedded/src/node_p2p.rs
+++ b/crates/embedded/src/node_p2p.rs
@@ -282,7 +282,7 @@ where
         event_bus.clone(),
     );
     let failure_recorder_task =
-        defra_p2p_adapter::spawn_failure_recorder(store.clone(), failure_rx);
+        defra_p2p_adapter::spawn_failure_recorder(Peerstore::new(store.clone()), failure_rx);
 
     let doc_pusher_impl = Arc::new(DbTransportDocPusher::new(
         database.clone(),
@@ -302,7 +302,7 @@ where
     let retry_doc_pusher = doc_pusher.clone();
     let retry_se_repusher = se_repusher.clone();
     let retry_loop_task = defra_p2p_adapter::spawn_retry_loop(
-        store.clone(),
+        Peerstore::new(store.clone()),
         p2p::Libp2pTransport::new(handle.clone()),
         doc_pusher.clone(),
         Some(se_repusher),
@@ -373,7 +373,7 @@ where
         let se_repusher = retry_se_repusher.clone();
         Box::pin(async move {
             defra_p2p_adapter::run_retry_pass(
-                &store,
+                &Peerstore::new(store),
                 &transport,
                 &doc_pusher,
                 Some(&se_repusher),
@@ -587,7 +587,7 @@ where
         event_bus.clone(),
     );
     let failure_recorder_task =
-        defra_p2p_adapter::spawn_failure_recorder(store.clone(), failure_rx);
+        defra_p2p_adapter::spawn_failure_recorder(Peerstore::new(store.clone()), failure_rx);
 
     let doc_pusher_impl = Arc::new(DbTransportDocPusher::new(
         database.clone(),
@@ -608,7 +608,7 @@ where
     let retry_doc_pusher = doc_pusher.clone();
     let retry_se_repusher = se_repusher.clone();
     let retry_loop_task = defra_p2p_adapter::spawn_retry_loop(
-        store.clone(),
+        Peerstore::new(store.clone()),
         transport.clone(),
         doc_pusher.clone(),
         Some(se_repusher),
@@ -676,7 +676,7 @@ where
         let se_repusher = retry_se_repusher.clone();
         Box::pin(async move {
             defra_p2p_adapter::run_retry_pass(
-                &store,
+                &Peerstore::new(store),
                 &transport,
                 &doc_pusher,
                 Some(&se_repusher),

--- a/crates/p2p-adapter/src/retry.rs
+++ b/crates/p2p-adapter/src/retry.rs
@@ -18,7 +18,7 @@ fn capacity_retry_delay(error: &str) -> Option<std::time::Duration> {
 /// retry writer. A success acknowledgement clears only the marker still
 /// covered by the acknowledged head fence.
 pub fn spawn_failure_recorder<S: storage::corekv::Store + 'static>(
-    store: Arc<S>,
+    peerstore: storage::stores::Peerstore<S>,
     mut failures: tokio::sync::mpsc::Receiver<p2p::sync::PushFailure>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
@@ -36,7 +36,6 @@ pub fn spawn_failure_recorder<S: storage::corekv::Store + 'static>(
                 continue;
             }
 
-            let peerstore = storage::stores::Peerstore::new(Arc::clone(&store));
             let _retry_guard = match peerstore
                 .acquire_replicator_retry_guard(&failure.peer_id)
                 .await
@@ -154,7 +153,7 @@ async fn redial_replicator<S, T>(
 
 /// Run one marker-plus-rederive retry pass for any transport.
 pub async fn run_retry_pass<S, T>(
-    store: &Arc<S>,
+    peerstore: &storage::stores::Peerstore<S>,
     transport: &T,
     doc_pusher: &Arc<dyn TransportDocPusher>,
     se_repusher: Option<&Arc<dyn db::merge::SeArtifactRepusher>>,
@@ -163,7 +162,6 @@ pub async fn run_retry_pass<S, T>(
     S: storage::corekv::Store + 'static,
     T: P2PTransport,
 {
-    let peerstore = storage::stores::Peerstore::new(Arc::clone(store));
     let peers = match peerstore.get_replicator_retry_peers().await {
         Ok(peers) => peers,
         Err(error) => {
@@ -187,7 +185,7 @@ pub async fn run_retry_pass<S, T>(
             }
         };
         if markers.is_empty() {
-            finish_peer(&peerstore, &peer_id_str, true).await;
+            finish_peer(peerstore, &peer_id_str, true).await;
             continue;
         }
         if !force && !markers.iter().any(|marker| marker.retry_info.is_due()) {
@@ -199,9 +197,9 @@ pub async fn run_retry_pass<S, T>(
             // Connectivity is part of the due retry attempt. Do not create a
             // second two-second redial clock for markers whose ladder has not
             // elapsed yet.
-            redial_replicator(&peerstore, transport, &peer_id).await;
+            redial_replicator(peerstore, transport, &peer_id).await;
             let _ = peerstore.reschedule_retry_peer(&peer_id_str, None).await;
-            finish_peer(&peerstore, &peer_id_str, false).await;
+            finish_peer(peerstore, &peer_id_str, false).await;
             continue;
         }
 
@@ -268,7 +266,7 @@ pub async fn run_retry_pass<S, T>(
             .get_retry_documents(&peer_id_str)
             .await
             .is_ok_and(|markers| markers.is_empty());
-        finish_peer(&peerstore, &peer_id_str, complete).await;
+        finish_peer(peerstore, &peer_id_str, complete).await;
     }
 }
 
@@ -288,7 +286,7 @@ async fn finish_peer<S: storage::corekv::Store>(
 
 /// Run the one durable retry clock used by CLI, embedded, and defra-node.
 pub fn spawn_retry_loop<S, T>(
-    store: Arc<S>,
+    peerstore: storage::stores::Peerstore<S>,
     transport: T,
     doc_pusher: Arc<dyn TransportDocPusher>,
     se_repusher: Option<Arc<dyn db::merge::SeArtifactRepusher>>,
@@ -298,13 +296,19 @@ where
     T: P2PTransport,
 {
     tokio::spawn(async move {
-        let peerstore = storage::stores::Peerstore::new(Arc::clone(&store));
         if let Err(error) = peerstore.migrate_legacy_push_retries().await {
             tracing::warn!(%error, "failed to migrate legacy push retries after restart");
         }
         loop {
             tokio::time::sleep(p2p::sync::PERSISTED_RETRY_SWEEP_INTERVAL).await;
-            run_retry_pass(&store, &transport, &doc_pusher, se_repusher.as_ref(), false).await;
+            run_retry_pass(
+                &peerstore,
+                &transport,
+                &doc_pusher,
+                se_repusher.as_ref(),
+                false,
+            )
+            .await;
         }
     })
 }
@@ -351,7 +355,7 @@ mod tests {
             .unwrap();
 
         let (tx, rx) = tokio::sync::mpsc::channel(2);
-        let task = spawn_failure_recorder(Arc::clone(&store), rx);
+        let task = spawn_failure_recorder(storage::stores::Peerstore::new(Arc::clone(&store)), rx);
 
         let (registered_tx, registered_rx) = tokio::sync::oneshot::channel();
         let mut announced = failure(false);

--- a/crates/p2p-adapter/src/transport_doc_pusher.rs
+++ b/crates/p2p-adapter/src/transport_doc_pusher.rs
@@ -94,6 +94,7 @@ pub struct DbTransportDocPusher<S: storage::corekv::Store, T: P2PTransport> {
     db: Arc<db::DB<S>>,
     transport: T,
     car_authority: p2p::sync::HeadHintCarAuthority,
+    retry_schedule: storage::stores::RetrySchedule,
     document_acp: std::sync::OnceLock<Arc<dyn acp::DocumentACP>>,
 }
 
@@ -107,6 +108,7 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> DbTransportDocPusher<
             db,
             transport,
             car_authority,
+            retry_schedule: storage::stores::RetrySchedule::default(),
             document_acp: std::sync::OnceLock::new(),
         }
     }
@@ -117,6 +119,11 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> DbTransportDocPusher<
         car_authority: p2p::sync::HeadHintCarAuthority,
     ) -> Arc<dyn TransportDocPusher> {
         Arc::new(Self::new(db, transport, car_authority))
+    }
+
+    pub fn with_retry_schedule(mut self, schedule: storage::stores::RetrySchedule) -> Self {
+        self.retry_schedule = schedule;
+        self
     }
 
     pub fn set_document_acp(&self, acp: Arc<dyn acp::DocumentACP>) {
@@ -143,7 +150,7 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
         se_key: Option<&[u8]>,
         se_identity_pubkey: Option<&[u8]>,
     ) -> P2PResult<()> {
-        db::merge::push_existing_docs(
+        db::merge::push_existing_docs_with_config(
             &self.transport,
             &self.db,
             self.document_acp.get().map(|acp| acp.as_ref()),
@@ -153,6 +160,10 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
             db::merge::PushExistingDocsSeOptions {
                 encryption_key: se_key,
                 identity_pubkey: se_identity_pubkey,
+            },
+            db::merge::ReplayPushConfig {
+                retry_schedule: self.retry_schedule.clone(),
+                ..Default::default()
             },
             &replication_filter::QueryReplicationFilterMatcher::new(),
             &self.car_authority,
@@ -182,6 +193,10 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
             docs,
             &filters,
             db::merge::PushExistingDocsSeOptions::default(),
+            db::merge::ReplayPushConfig {
+                retry_schedule: self.retry_schedule.clone(),
+                ..Default::default()
+            },
             &replication_filter::QueryReplicationFilterMatcher::new(),
             &self.car_authority,
         )

--- a/tools/integration-test/tests/p2p.rs
+++ b/tools/integration-test/tests/p2p.rs
@@ -32,3 +32,14 @@ mod transports;
 mod trust_boundary;
 #[path = "p2p/write_contention.rs"]
 mod write_contention;
+
+#[path = "replicator_retry_common.rs"]
+mod replicator_retry_common;
+
+#[tokio::test]
+async fn rust_replicator_retry_intervals() {
+    replicator_retry_common::retry_intervals_test(
+        integration_test::TestCluster::builder().with_p2p(),
+    )
+    .await;
+}

--- a/tools/integration-test/tests/p2p_iroh/main.rs
+++ b/tools/integration-test/tests/p2p_iroh/main.rs
@@ -6,6 +6,16 @@ mod connection;
 mod manage_relay_common;
 mod peer;
 mod replication;
+#[path = "../replicator_retry_common.rs"]
+mod replicator_retry_common;
 mod schema;
 mod support;
 mod sync;
+
+#[tokio::test]
+async fn iroh_replicator_retry_intervals() {
+    replicator_retry_common::retry_intervals_test(
+        integration_test::TestCluster::builder().with_iroh_transport(),
+    )
+    .await;
+}

--- a/tools/integration-test/tests/replicator_retry_common.rs
+++ b/tools/integration-test/tests/replicator_retry_common.rs
@@ -1,0 +1,77 @@
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use integration_test::TestClusterBuilder;
+
+pub async fn retry_intervals_test(builder: TestClusterBuilder) {
+    let mut cluster = builder
+        .rust_nodes(2)
+        .with_extra_rust_args(["--replicator-retry-intervals=1,3600"])
+        .build()
+        .await
+        .unwrap();
+    let sender = cluster.client(0);
+    let receiver = cluster.client(1);
+    for node in [&sender, &receiver] {
+        node.schema_add("type RetryDoc { name: String }").unwrap();
+    }
+    for index in 0..2 {
+        cluster
+            .wait_for_log(index, "p2p_listening", Duration::from_secs(15))
+            .await
+            .unwrap();
+    }
+    let addresses = receiver.p2p_info().unwrap();
+    let address = addresses[0].as_str().expect("receiver address");
+    sender.p2p_connect(&[address]).unwrap();
+    sender.p2p_replicator_set(&["RetryDoc"], address).unwrap();
+    cluster.nodes[1].process.kill();
+
+    let before = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    sender
+        .query(r#"mutation { add_RetryDoc(input: {name: "pending"}) { _docID } }"#)
+        .unwrap();
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .unwrap();
+    let url = format!("{}/api/v0/p2p/sync/status", cluster.api_url(0));
+    let mut last_status = serde_json::Value::Null;
+    let result = tokio::time::timeout(Duration::from_secs(30), async {
+        loop {
+            last_status = client
+                .get(&url)
+                .send()
+                .await
+                .unwrap()
+                .error_for_status()
+                .unwrap()
+                .json()
+                .await
+                .unwrap();
+            let markers = &last_status["push_retry_markers"];
+            if markers["document_markers"].as_u64() == Some(1) {
+                if let Some(deadline) = markers["oldest_scheduled_retry_unix"].as_u64() {
+                    // Reaching the second rung proves both the short initial delay
+                    // and the configured reschedule, not just the reported options.
+                    if deadline >= before + 1800 {
+                        let now = SystemTime::now()
+                            .duration_since(UNIX_EPOCH)
+                            .unwrap()
+                            .as_secs();
+                        assert!(deadline <= now + 3600);
+                        break;
+                    }
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await;
+    assert!(
+        result.is_ok(),
+        "retry did not reach the configured second interval: {last_status}"
+    );
+}


### PR DESCRIPTION
## Context
`--replicator-retry-intervals` was parsed and reported but never used by replication. Failure recording, replay, and the retry sweep each constructed a default schedule.

## Changes
- Wire the configured schedule through live failures, initial replay, and retry dispatch for libp2p and Iroh.
- Reject empty or zero-valued schedules before startup; preserve defaults when a config file omits the setting.
- Keep embedded and reusable node runtimes on the existing defaults.
- Exercise actual retry deadlines through both live transports rather than checking only reported options.

## Testing
- [x] Live libp2p and Iroh retry-schedule tests against the rebuilt node.
- [x] Existing filtered-replication recovery test.
- [x] CLI configuration and database replay regressions.
- [x] CLI, adapter, embedded, and node-runtime suites, apart from the baseline failure noted below.
- [x] Strict clippy across all affected crates and targets with both transports.
- [x] Formatting and diff checks.

The broader CLI suite fails `extract_peer_id_rejects_address_without_peer_id` with Iroh enabled. The same test fails on untouched main (`7751a95f5`); it was excluded only from the remaining-suite run.

Refs #1422