### PR TITLE
fix(query): abandon owned transactions on cancellation

### DIFF
--- a/crates/db/src/txn/registry/cleanup.rs
+++ b/crates/db/src/txn/registry/cleanup.rs
@@ -7,9 +7,8 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
     ///
     /// This method finds all transactions whose last observed request was more
     /// than `max_idle_age` ago and rolls them back, freeing resources. This
-    /// should be called periodically by a background task to prevent resource
-    /// leaks from dropped `TransactionGuard`s or orphaned HTTP transaction
-    /// handles.
+    /// can be called periodically for orphaned, non-owning transaction handles.
+    /// Owning `TransactionGuard`s clean up on drop without waiting for a sweep.
     ///
     /// Returns a `CleanupResult` containing both successfully cleaned transactions
     /// and any failures. Check `result.is_complete()` to verify all cleanups succeeded.
@@ -76,7 +75,7 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
                 warn!(
                     txn_id = %txn_id,
                     idle_secs,
-                    "Cleaning up idle transaction (orphaned HTTP handle or leaked TransactionGuard?)"
+                    "Cleaning up idle transaction"
                 );
 
                 // Try to take and discard the transaction

--- a/crates/db/src/txn/registry/lifecycle.rs
+++ b/crates/db/src/txn/registry/lifecycle.rs
@@ -254,6 +254,8 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
             self.broadcaster.clone(),
         ));
 
+        // Registration and returning the handle must be one poll: cancellation
+        // before the caller can construct its guard must not orphan an entry.
         self.transactions
             .write()
             .map_err(|_| TransactionError::lock_poisoned("failed to acquire write lock for begin"))?
@@ -266,6 +268,18 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl<S: Store + 'static> TransactionRegistry for DbTransactionRegistry<S> {
+    fn abandon(&self, handle: &TransactionHandle) {
+        let ctx = {
+            // A poisoned registry remains closed to queries, but dropping an
+            // uncommitted entry is safe and must still release its resources.
+            let mut transactions = self.transactions.write().unwrap_or_else(|e| e.into_inner());
+            transactions.remove(handle.as_str())
+        };
+        // Do not run destructors while holding the registry lock. Any in-flight
+        // context borrowers release the remaining storage references on drop.
+        drop(ctx);
+    }
+
     async fn begin(
         &self,
         readonly: bool,

--- a/crates/db/src/txn/registry/mod.rs
+++ b/crates/db/src/txn/registry/mod.rs
@@ -92,6 +92,8 @@ impl CleanupResult {
 /// returns an error, and `begin()`, `commit()`, and `rollback()` return errors.
 /// A poisoned lock indicates a panic and potential data corruption - continuing
 /// operation would be unsafe.
+/// Abandonment still removes entries from a poisoned map, without clearing its
+/// poison or attempting to commit, so cancellation can release resources.
 pub struct DbTransactionRegistry<S: Store> {
     db: Arc<DB<S>>,
     transactions: RwLock<HashMap<String, Arc<DbTransactionContext<S>>>>,

--- a/crates/db/tests/txn/guard.rs
+++ b/crates/db/tests/txn/guard.rs
@@ -1,0 +1,287 @@
+use std::sync::Arc;
+
+use db::{DbCollectionProvider, DbTransactionRegistry, LensedAutoCommitFetcher, DB};
+use query::TransactionError;
+use query::{QueryExecutor, QueryRequest, TransactionGuard, TransactionHandle};
+use storage::corekv::Store;
+use storage::RegolithStore;
+
+struct Fixture {
+    runner: Arc<dyn QueryExecutor>,
+    registry: Arc<DbTransactionRegistry<RegolithStore>>,
+}
+
+impl Fixture {
+    async fn new() -> Self {
+        let db = Arc::new(DB::new(RegolithStore::in_memory().unwrap()).unwrap());
+        for schema in query::parse_sdl("type Users { name: String }").unwrap() {
+            db.create_collection(schema).await.unwrap();
+        }
+        let registry = Arc::new(DbTransactionRegistry::new(db.clone()));
+        let runner = Arc::new(query::QueryRunner::with_arc_registry_and_provider(
+            LensedAutoCommitFetcher::new(db.clone()),
+            DbCollectionProvider::new_arc(db),
+            registry.clone(),
+        ));
+        Self { runner, registry }
+    }
+
+    async fn assert_discarded(&self, handle: &TransactionHandle) {
+        assert_eq!(self.registry.active_transaction_count().unwrap(), 0);
+        let response = self.runner.execute_in_txn(read(), handle).await;
+        assert!(
+            response.has_errors(),
+            "orphaned transaction is still accessible"
+        );
+        let response = self.runner.execute(read()).await;
+        assert!(!response.has_errors(), "{:?}", response.errors);
+        assert_eq!(response.data.unwrap()["Users"], serde_json::json!([]));
+        tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            self.registry.db().store().close(),
+        )
+        .await
+        .expect("abandoned transaction still holds the store open")
+        .unwrap();
+    }
+}
+
+fn read() -> QueryRequest {
+    QueryRequest::new("{ Users { name } }")
+}
+
+async fn create(guard: &TransactionGuard<'_, dyn QueryExecutor>) {
+    let response = guard
+        .execute(QueryRequest::new(
+            r#"mutation { add_Users(input: {name: "pending"}) { _docID } }"#,
+        ))
+        .await;
+    assert!(!response.has_errors(), "{:?}", response.errors);
+}
+
+#[tokio::test]
+async fn dropping_guard_discards_writes_despite_saved_handle() {
+    let fixture = Fixture::new().await;
+    let guard = TransactionGuard::begin(fixture.runner.as_ref(), false)
+        .await
+        .unwrap();
+    create(&guard).await;
+    let handle = guard.handle().unwrap().clone();
+    assert!(!guard.execute(read()).await.has_errors());
+    drop(guard);
+    fixture.assert_discarded(&handle).await;
+}
+
+#[tokio::test]
+async fn aborting_owner_removes_transaction() {
+    let fixture = Fixture::new().await;
+    let executor = fixture.runner.clone();
+    let (ready, handle) = tokio::sync::oneshot::channel();
+    let task = tokio::spawn(async move {
+        let guard = TransactionGuard::begin(executor.as_ref(), false)
+            .await
+            .unwrap();
+        create(&guard).await;
+        ready.send(guard.handle().unwrap().clone()).unwrap();
+        std::future::pending::<()>().await;
+        drop(guard);
+    });
+    let handle = handle.await.unwrap();
+    task.abort();
+    assert!(task.await.unwrap_err().is_cancelled());
+    fixture.assert_discarded(&handle).await;
+}
+
+#[test]
+fn guard_cleanup_does_not_require_a_running_runtime() {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let fixture = runtime.block_on(Fixture::new());
+    let guard = runtime
+        .block_on(TransactionGuard::begin(fixture.runner.as_ref(), false))
+        .unwrap();
+    runtime.block_on(create(&guard));
+    let handle = guard.handle().unwrap().clone();
+    drop(runtime);
+    drop(guard);
+    assert_eq!(fixture.registry.active_transaction_count().unwrap(), 0);
+    tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(fixture.assert_discarded(&handle));
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum PauseAt {
+    Begin,
+    Execute,
+    Commit,
+    Rollback,
+    AfterCommit,
+}
+
+#[tokio::test]
+async fn cancellation_while_finalization_waits_for_an_active_request_releases_the_transaction() {
+    use query::TransactionRegistry;
+
+    for commit in [false, true] {
+        let fixture = Fixture::new().await;
+        let guard = TransactionGuard::begin(fixture.runner.as_ref(), false)
+            .await
+            .unwrap();
+        create(&guard).await;
+        let handle = guard.handle().unwrap().clone();
+        let ctx = fixture
+            .registry
+            .get(&handle)
+            .into_result()
+            .unwrap()
+            .unwrap();
+        let action_lock = ctx.action_lock().unwrap();
+        let action = action_lock.lock().await;
+        let mut finalize = Box::pin(async move {
+            if commit {
+                guard.commit().await
+            } else {
+                guard.rollback().await
+            }
+        });
+        assert!(futures::poll!(&mut finalize).is_pending());
+        assert_eq!(fixture.registry.active_transaction_count().unwrap(), 0);
+        drop(finalize);
+        drop(action);
+        drop(ctx);
+        fixture.assert_discarded(&handle).await;
+    }
+}
+
+struct PausedExecutor {
+    inner: Arc<dyn QueryExecutor>,
+    at: PauseAt,
+}
+
+impl PausedExecutor {
+    async fn pause(&self, at: PauseAt) {
+        if self.at == at {
+            std::future::pending::<()>().await;
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl QueryExecutor for PausedExecutor {
+    async fn execute(&self, request: QueryRequest) -> query::QueryResponse {
+        self.inner.execute(request).await
+    }
+
+    async fn execute_in_txn(
+        &self,
+        request: QueryRequest,
+        handle: &TransactionHandle,
+    ) -> query::QueryResponse {
+        self.pause(PauseAt::Execute).await;
+        self.inner.execute_in_txn(request, handle).await
+    }
+
+    async fn begin_txn(&self, readonly: bool) -> Result<TransactionHandle, TransactionError> {
+        self.pause(PauseAt::Begin).await;
+        self.inner.begin_txn(readonly).await
+    }
+
+    async fn commit_txn(&self, handle: &TransactionHandle) -> Result<(), TransactionError> {
+        self.pause(PauseAt::Commit).await;
+        self.inner.commit_txn(handle).await?;
+        self.pause(PauseAt::AfterCommit).await;
+        Ok(())
+    }
+
+    async fn rollback_txn(&self, handle: &TransactionHandle) -> Result<(), TransactionError> {
+        self.pause(PauseAt::Rollback).await;
+        self.inner.rollback_txn(handle).await
+    }
+
+    fn abandon_txn(&self, handle: &TransactionHandle) {
+        self.inner.abandon_txn(handle);
+    }
+
+    async fn schema(&self) -> query::Result<String> {
+        self.inner.schema().await
+    }
+}
+
+#[tokio::test]
+async fn cancellation_at_each_guard_boundary_discards_uncommitted_state() {
+    for at in [
+        PauseAt::Begin,
+        PauseAt::Execute,
+        PauseAt::Commit,
+        PauseAt::Rollback,
+    ] {
+        let fixture = Fixture::new().await;
+        let executor = PausedExecutor {
+            inner: fixture.runner.clone(),
+            at,
+        };
+        if at == PauseAt::Begin {
+            let mut begin = Box::pin(TransactionGuard::begin(&executor, false));
+            assert!(futures::poll!(&mut begin).is_pending());
+            drop(begin);
+            assert_eq!(fixture.registry.active_transaction_count().unwrap(), 0);
+            continue;
+        }
+        let guard = TransactionGuard::begin(&executor, false).await.unwrap();
+        let handle = guard.handle().unwrap().clone();
+        let response = fixture
+            .runner
+            .execute_in_txn(
+                QueryRequest::new(r#"mutation { add_Users(input: {name: "pending"}) { _docID } }"#),
+                &handle,
+            )
+            .await;
+        assert!(!response.has_errors(), "{:?}", response.errors);
+        let mut operation = Box::pin(async move {
+            match at {
+                PauseAt::Execute => {
+                    guard.execute(read()).await;
+                }
+                PauseAt::Commit => {
+                    guard.commit().await.unwrap();
+                }
+                PauseAt::Rollback => {
+                    guard.rollback().await.unwrap();
+                }
+                _ => unreachable!(),
+            }
+        });
+        assert!(futures::poll!(&mut operation).is_pending());
+        drop(operation);
+        fixture.assert_discarded(&handle).await;
+    }
+}
+
+#[tokio::test]
+async fn cancellation_after_durable_commit_cannot_undo_it_or_discard_another_transaction() {
+    let fixture = Fixture::new().await;
+    let executor = PausedExecutor {
+        inner: fixture.runner.clone(),
+        at: PauseAt::AfterCommit,
+    };
+    let guard = TransactionGuard::begin(&executor, false).await.unwrap();
+    let response = guard
+        .execute(QueryRequest::new(
+            r#"mutation { add_Users(input: {name: "committed"}) { _docID } }"#,
+        ))
+        .await;
+    assert!(!response.has_errors(), "{:?}", response.errors);
+    let mut commit = Box::pin(guard.commit());
+    assert!(futures::poll!(&mut commit).is_pending());
+    assert_eq!(fixture.registry.active_transaction_count().unwrap(), 0);
+    let other = fixture.runner.begin_txn(false).await.unwrap();
+    drop(commit);
+    assert_eq!(fixture.registry.active_transaction_count().unwrap(), 1);
+    fixture.runner.rollback_txn(&other).await.unwrap();
+    let response = fixture.runner.execute(read()).await;
+    assert!(!response.has_errors(), "{:?}", response.errors);
+    assert_eq!(
+        response.data.unwrap()["Users"],
+        serde_json::json!([{"name": "committed"}])
+    );
+}

--- a/crates/db/tests/txn/main.rs
+++ b/crates/db/tests/txn/main.rs
@@ -2,5 +2,6 @@
 #[path = "../common/mod.rs"]
 mod common;
 
+mod guard;
 mod lifecycle;
 mod registry_suite;

--- a/crates/defra-node/src/embedded_query_identity_tests.rs
+++ b/crates/defra-node/src/embedded_query_identity_tests.rs
@@ -37,6 +37,8 @@ impl IdentityRecordingExecutor {
 
 #[async_trait::async_trait]
 impl QueryExecutor for IdentityRecordingExecutor {
+    fn abandon_txn(&self, _handle: &TransactionHandle) {}
+
     async fn execute(&self, request: QueryRequest) -> query::QueryResponse {
         self.record(&request);
         if self.remaining_conflicts.load(Ordering::SeqCst) > 0 {

--- a/crates/defra-node/src/signed_query_runtime/tests/executors.rs
+++ b/crates/defra-node/src/signed_query_runtime/tests/executors.rs
@@ -59,6 +59,8 @@ pub(super) fn test_signing_config() -> SigningConfig {
 
 #[async_trait::async_trait]
 impl QueryExecutor for TestExecution {
+    fn abandon_txn(&self, _handle: &TransactionHandle) {}
+
     async fn execute(&self, _request: QueryRequest) -> query::QueryResponse {
         match self {
             Self::Slow { started, completed } => {

--- a/crates/http/src/mock/query.rs
+++ b/crates/http/src/mock/query.rs
@@ -30,6 +30,8 @@ impl FailingMockExecutor {
 
 #[async_trait]
 impl QueryExecutor for FailingMockExecutor {
+    fn abandon_txn(&self, _handle: &TransactionHandle) {}
+
     async fn execute(&self, _request: QueryRequest) -> QueryResponse {
         QueryResponse::error("execution failed")
     }
@@ -101,6 +103,8 @@ impl Default for MockQueryExecutor {
 
 #[async_trait]
 impl QueryExecutor for MockQueryExecutor {
+    fn abandon_txn(&self, _handle: &TransactionHandle) {}
+
     async fn execute(&self, request: QueryRequest) -> QueryResponse {
         let query = request.query.to_lowercase();
 

--- a/crates/http/src/query_context.rs
+++ b/crates/http/src/query_context.rs
@@ -238,6 +238,8 @@ mod tests {
 
     #[async_trait]
     impl QueryExecutor for ConflictExecutor {
+        fn abandon_txn(&self, _handle: &TransactionHandle) {}
+
         async fn execute(&self, _request: QueryRequest) -> QueryResponse {
             if self.auto_commit_attempts.fetch_add(1, Ordering::SeqCst) < 2 {
                 QueryResponse::transaction_conflict("transaction conflict")
@@ -333,6 +335,8 @@ mod tests {
 
     #[async_trait]
     impl QueryExecutor for DacBypassRecorder {
+        fn abandon_txn(&self, _handle: &TransactionHandle) {}
+
         async fn execute(&self, _request: QueryRequest) -> QueryResponse {
             self.observed
                 .store(defra_core::dac_bypass::get_dac_bypass(), Ordering::SeqCst);

--- a/crates/query/src/executor.rs
+++ b/crates/query/src/executor.rs
@@ -342,6 +342,9 @@ pub trait QueryExecutor: MaybeSendSync {
     ///
     /// # Arguments
     /// * `readonly` - If true, the transaction cannot perform write operations
+    ///
+    /// Cancellation must not leave an entry behind: register the transaction
+    /// only when returning its handle, with no intervening await.
     async fn begin_txn(
         &self,
         readonly: bool,
@@ -364,6 +367,13 @@ pub trait QueryExecutor: MaybeSendSync {
         &self,
         handle: &TransactionHandle,
     ) -> std::result::Result<(), TransactionError>;
+
+    /// Remove an abandoned transaction without committing or spawning cleanup.
+    ///
+    /// Called by `TransactionGuard::drop`, including during runtime shutdown.
+    /// Already-finalized handles are a no-op. Requests holding a context may
+    /// finish, but must not make its uncommitted writes durable.
+    fn abandon_txn(&self, handle: &TransactionHandle);
 
     /// Get the GraphQL schema for introspection.
     async fn schema(&self) -> Result<String>;

--- a/crates/query/src/runner/executor.rs
+++ b/crates/query/src/runner/executor.rs
@@ -556,6 +556,10 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
         self.registry.rollback(handle).await
     }
 
+    fn abandon_txn(&self, handle: &TransactionHandle) {
+        self.registry.abandon(handle);
+    }
+
     async fn schema(&self) -> Result<String> {
         let collections = self.collections_map().await?;
         let mut schema_str = String::new();
@@ -810,6 +814,8 @@ mod tests {
     #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
     #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
     impl TransactionRegistry for SerialTxnRegistry {
+        fn abandon(&self, _handle: &TransactionHandle) {}
+
         async fn begin(
             &self,
             _readonly: bool,

--- a/crates/query/src/test_utils.rs
+++ b/crates/query/src/test_utils.rs
@@ -190,6 +190,10 @@ impl MockTxnRegistry {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl TransactionRegistry for MockTxnRegistry {
+    fn abandon(&self, handle: &TransactionHandle) {
+        self.transactions.lock().unwrap().remove(handle.as_str());
+    }
+
     async fn begin(
         &self,
         readonly: bool,

--- a/crates/query/src/txn/guard.rs
+++ b/crates/query/src/txn/guard.rs
@@ -1,4 +1,4 @@
-//! Transaction guard for compile-time safety.
+//! Owning transaction guard with synchronous cancellation cleanup.
 
 use crate::error::TransactionError;
 
@@ -9,13 +9,16 @@ use super::TransactionHandle;
 /// This type provides compile-time safety by consuming itself on `commit()` or
 /// `rollback()`, preventing use-after-finalization bugs.
 ///
-/// # Warning
+/// Dropping the guard removes the registry entry without committing, including
+/// when its task is aborted or the async runtime has stopped. Cloned handles
+/// are non-owning IDs and do not keep the entry alive. In-flight context users
+/// may delay storage release until they also finish or are dropped.
 ///
-/// If dropped without explicit `commit()` or `rollback()`, the guard will log
-/// an error but **cannot perform async rollback**. The transaction will remain
-/// in the registry until cleaned up by the idle transaction cleanup policy.
-/// Always ensure you call `commit()` or `rollback()` explicitly before the
-/// guard goes out of scope.
+/// Cancellation before finalization discards uncommitted writes. Once a commit
+/// becomes durable it cannot be undone, even if cancellation interrupts its
+/// post-commit callbacks. A cancelled commit therefore has an unknown outcome;
+/// do not blindly retry non-idempotent writes. A competing explicit finalizer
+/// that already removed the entry owns that outcome.
 ///
 /// # Example
 ///
@@ -43,6 +46,7 @@ use super::TransactionHandle;
 ///     Ok(responses)
 /// }
 /// ```
+#[must_use = "dropping the guard abandons the transaction"]
 pub struct TransactionGuard<'a, E: crate::QueryExecutor + ?Sized> {
     executor: &'a E,
     pub(crate) handle: Option<TransactionHandle>,
@@ -51,9 +55,7 @@ pub struct TransactionGuard<'a, E: crate::QueryExecutor + ?Sized> {
 impl<'a, E: crate::QueryExecutor + ?Sized> TransactionGuard<'a, E> {
     /// Begin a new transaction and return a guard for it.
     ///
-    /// The returned guard must be explicitly finalized with `commit()` or `rollback()`.
-    /// Dropping the guard without finalization will leak the transaction in the registry.
-    #[must_use = "TransactionGuard must be explicitly committed or rolled back"]
+    /// Dropping the returned guard abandons the transaction.
     pub async fn begin(
         executor: &'a E,
         readonly: bool,
@@ -82,39 +84,33 @@ impl<'a, E: crate::QueryExecutor + ?Sized> TransactionGuard<'a, E> {
     ///
     /// After calling this, the guard cannot be used again (compile-time enforced).
     pub async fn commit(mut self) -> std::result::Result<(), TransactionError> {
-        match self.handle.take() {
-            Some(handle) => self.executor.commit_txn(&handle).await,
-            None => Err(TransactionError::already_finalized(
-                "transaction already finalized",
-            )),
-        }
+        let handle = self
+            .handle
+            .as_ref()
+            .ok_or_else(|| TransactionError::already_finalized("transaction already finalized"))?;
+        self.executor.commit_txn(handle).await?;
+        self.handle = None;
+        Ok(())
     }
 
     /// Rollback the transaction and consume the guard.
     ///
     /// After calling this, the guard cannot be used again (compile-time enforced).
     pub async fn rollback(mut self) -> std::result::Result<(), TransactionError> {
-        match self.handle.take() {
-            Some(handle) => self.executor.rollback_txn(&handle).await,
-            None => Err(TransactionError::already_finalized(
-                "transaction already finalized",
-            )),
-        }
+        let handle = self
+            .handle
+            .as_ref()
+            .ok_or_else(|| TransactionError::already_finalized("transaction already finalized"))?;
+        self.executor.rollback_txn(handle).await?;
+        self.handle = None;
+        Ok(())
     }
 }
 
 impl<E: crate::QueryExecutor + ?Sized> Drop for TransactionGuard<'_, E> {
     fn drop(&mut self) {
         if let Some(handle) = &self.handle {
-            // Transaction was not finalized - this is a bug in user code.
-            // We can't do async rollback in drop, so we log an error.
-            // The transaction will remain in the registry until idle cleanup
-            // or explicit cleanup removes it.
-            tracing::error!(
-                txn_id = %handle,
-                "TransactionGuard dropped without commit/rollback - transaction leaked! \
-                 This is a BUG: always call commit() or rollback() explicitly."
-            );
+            self.executor.abandon_txn(handle);
         }
     }
 }

--- a/crates/query/src/txn/registry.rs
+++ b/crates/query/src/txn/registry.rs
@@ -18,6 +18,7 @@ pub trait TransactionRegistry: MaybeSendSync {
     /// Begin a new transaction.
     ///
     /// Returns a handle that can be used with `get()`, `commit()`, and `rollback()`.
+    /// Registration and returning the handle must not be separated by an await.
     async fn begin(
         &self,
         readonly: bool,
@@ -54,6 +55,11 @@ pub trait TransactionRegistry: MaybeSendSync {
         handle: &TransactionHandle,
     ) -> std::result::Result<(), TransactionError>;
 
+    /// Synchronously remove an abandoned entry without committing its writes.
+    /// Must be idempotent and work without an async runtime. Existing context
+    /// borrowers may delay resource release, but cannot finalize through this handle.
+    fn abandon(&self, handle: &TransactionHandle);
+
     /// Close a standalone query's implicit read transaction.
     ///
     /// `apply_read_effects` is false when query execution failed. The default
@@ -76,6 +82,8 @@ pub struct NoOpTransactionRegistry;
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl TransactionRegistry for NoOpTransactionRegistry {
+    fn abandon(&self, _handle: &TransactionHandle) {}
+
     async fn begin(
         &self,
         _readonly: bool,

--- a/crates/query/src/txn/tests.rs
+++ b/crates/query/src/txn/tests.rs
@@ -35,6 +35,10 @@ impl MockExecutor {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl crate::QueryExecutor for MockExecutor {
+    fn abandon_txn(&self, _handle: &TransactionHandle) {
+        self.rolled_back.store(true, Ordering::SeqCst);
+    }
+
     async fn execute(&self, _request: crate::QueryRequest) -> crate::QueryResponse {
         crate::QueryResponse::success(serde_json::json!({"mock": true}))
     }
@@ -92,6 +96,8 @@ impl FailingCommitExecutor {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl crate::QueryExecutor for FailingCommitExecutor {
+    fn abandon_txn(&self, _handle: &TransactionHandle) {}
+
     async fn execute(&self, _request: crate::QueryRequest) -> crate::QueryResponse {
         crate::QueryResponse::success(serde_json::json!({"mock": true}))
     }
@@ -161,6 +167,7 @@ async fn test_guard_commit_consumes_guard() {
     assert!(!executor.was_committed());
     guard.commit().await.unwrap();
     assert!(executor.was_committed());
+    assert!(!executor.was_rolled_back());
 }
 
 #[tokio::test]
@@ -188,7 +195,7 @@ async fn test_guard_multiple_executes_before_commit() {
 }
 
 #[tokio::test]
-async fn test_guard_drop_without_finalization_does_not_commit_or_rollback() {
+async fn test_guard_drop_without_finalization_abandons_transaction() {
     let executor = MockExecutor::new();
     {
         let _guard = TransactionGuard::begin(&executor, false).await.unwrap();
@@ -198,8 +205,8 @@ async fn test_guard_drop_without_finalization_does_not_commit_or_rollback() {
         "Dropping guard should not commit the transaction"
     );
     assert!(
-        !executor.was_rolled_back(),
-        "Dropping guard should not rollback (async not possible in Drop)"
+        executor.was_rolled_back(),
+        "Dropping guard must abandon the transaction"
     );
 }
 


### PR DESCRIPTION
## Context
Dropping `TransactionGuard` only logged an error, leaving uncommitted transactions registered. Commit and rollback also relinquished the handle before their futures completed.

## Changes
- Remove abandoned transactions synchronously, without relying on a runtime or cleanup task.
- Keep guard ownership until commit or rollback succeeds.
- Leave cloned and serialized handles non-owning; make repeated cleanup harmless.
- Document cancellation before registration, during finalization, and after a durable commit.

`QueryExecutor` and `TransactionRegistry` implementations must now implement or delegate the synchronous abandonment hook.

## Testing
Three real-database regressions reproduce the original leak and pass with the fix.

- [x] All 70 transaction tests, including abort, runtime shutdown, blocked finalization, and store release.
- [x] Complete query suite.
- [x] Node, embedded, and HTTP regression suites.
- [x] Strict native clippy across affected crates and targets.
- [x] CI-equivalent WASM clippy with and without default features.
- [x] Formatting and diff checks.

Refs #1693