### PR TITLE
feat(node): expose an owning embedded transaction guard

### DIFF
--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -35,6 +35,7 @@ mod node_acp;
 mod p2p_runtime;
 pub mod search_chunks;
 mod signed_query_runtime;
+mod transaction;
 pub mod version;
 
 use std::path::PathBuf;
@@ -68,6 +69,7 @@ pub use schema::CollectionVersion;
 pub use telemetry::{ConflictMetricsSnapshot, RetryLayerSnapshot};
 #[cfg(feature = "otel")]
 pub use telemetry::{TelemetryConfig, TelemetryHandle};
+pub use transaction::EmbeddedTransaction;
 
 #[cfg(not(target_arch = "wasm32"))]
 use signed_query_runtime::{
@@ -468,7 +470,8 @@ impl EmbeddedNode {
         self.event_bus.subscribe(event_names)
     }
 
-    /// Begin a transaction owned by this embedded node.
+    /// Begin a manually finalized transaction. Dropping its handle does not
+    /// roll it back; use [`Self::begin_transaction_guard`] for scope ownership.
     pub async fn begin_transaction(
         &self,
         readonly: bool,

--- a/crates/defra-node/src/transaction.rs
+++ b/crates/defra-node/src/transaction.rs
@@ -1,0 +1,65 @@
+use crate::{EmbeddedNode, QueryExecutor, QueryRequest, QueryResponse, TransactionHandle};
+use query::{TransactionError, TransactionGuard};
+
+/// An owning transaction that uses the node's signing and identity context.
+///
+/// Dropping it abandons uncommitted writes, including during task cancellation
+/// or runtime shutdown. Cloned handles are non-owning. Cancellation after a
+/// durable commit cannot undo it; see [`TransactionGuard`].
+#[must_use = "dropping the transaction abandons its uncommitted writes"]
+pub struct EmbeddedTransaction<'a> {
+    node: &'a EmbeddedNode,
+    guard: TransactionGuard<'a, dyn QueryExecutor>,
+}
+
+impl EmbeddedNode {
+    /// Begin a transaction that is abandoned automatically unless finalized.
+    ///
+    /// ```no_run
+    /// # async fn example(node: &defra_node::EmbeddedNode) -> Result<(), query::TransactionError> {
+    /// let txn = node.begin_transaction_guard(false).await?;
+    /// let response = txn.execute("mutation { add_Users(input: {name: \"Alice\"}) { _docID } }").await;
+    /// if response.has_errors() {
+    ///     txn.rollback().await
+    /// } else {
+    ///     txn.commit().await
+    /// }
+    /// # }
+    /// ```
+    pub async fn begin_transaction_guard(
+        &self,
+        readonly: bool,
+    ) -> Result<EmbeddedTransaction<'_>, TransactionError> {
+        let guard = TransactionGuard::begin(self.runner().as_ref(), readonly).await?;
+        Ok(EmbeddedTransaction { node: self, guard })
+    }
+}
+
+impl EmbeddedTransaction<'_> {
+    /// Borrow the non-owning ID for APIs that accept a transaction handle.
+    pub fn handle(&self) -> &TransactionHandle {
+        self.guard.handle().expect("active transaction")
+    }
+
+    /// Execute GraphQL with the node's signing and default identity context.
+    pub async fn execute(&self, query: &str) -> QueryResponse {
+        self.execute_request(QueryRequest::new(query)).await
+    }
+
+    /// Execute a prepared request, preserving any explicitly supplied identity.
+    pub async fn execute_request(&self, request: QueryRequest) -> QueryResponse {
+        self.node
+            .execute_request_in_txn(request, self.handle())
+            .await
+    }
+
+    /// Commit the writes and consume the owning transaction.
+    pub async fn commit(self) -> Result<(), TransactionError> {
+        self.guard.commit().await
+    }
+
+    /// Roll back the writes and consume the owning transaction.
+    pub async fn rollback(self) -> Result<(), TransactionError> {
+        self.guard.rollback().await
+    }
+}

--- a/crates/defra-node/tests/transaction_guard.rs
+++ b/crates/defra-node/tests/transaction_guard.rs
@@ -1,0 +1,131 @@
+use std::sync::Arc;
+
+use defra_node::{EmbeddedNode, QueryRequest, TransactionHandle};
+
+const CREATE: &str = r#"mutation { add_Users(input: {name: "Alice"}) { _docID } }"#;
+const READ: &str = "{ Users { name } }";
+
+async fn node() -> EmbeddedNode {
+    let node = EmbeddedNode::builder().build().await.unwrap();
+    node.add_schema("type Users { name: String }")
+        .await
+        .unwrap();
+    node
+}
+
+async fn assert_discarded(node: &EmbeddedNode, handle: &TransactionHandle) {
+    assert!(node
+        .execute_request_in_txn(QueryRequest::new(READ), handle)
+        .await
+        .has_errors());
+    let response = node.execute(READ).await;
+    assert!(!response.has_errors(), "{:?}", response.errors);
+    assert_eq!(response.data.unwrap()["Users"], serde_json::json!([]));
+}
+
+#[tokio::test]
+async fn dropped_guard_invalidates_saved_handle_and_discards_writes() {
+    let node = node().await;
+    let txn = node.begin_transaction_guard(false).await.unwrap();
+    let response = txn.execute(CREATE).await;
+    assert!(!response.has_errors(), "{:?}", response.errors);
+    let saved = txn.handle().clone();
+    drop(txn);
+    assert_discarded(&node, &saved).await;
+}
+
+#[tokio::test]
+async fn aborted_task_discards_owned_transaction() {
+    let node = Arc::new(node().await);
+    let owner = node.clone();
+    let (ready, handle) = tokio::sync::oneshot::channel();
+    let task = tokio::spawn(async move {
+        let txn = owner.begin_transaction_guard(false).await.unwrap();
+        let response = txn.execute(CREATE).await;
+        assert!(!response.has_errors(), "{:?}", response.errors);
+        ready.send(txn.handle().clone()).unwrap();
+        std::future::pending::<()>().await;
+        drop(txn);
+    });
+    let saved = handle.await.unwrap();
+    task.abort();
+    assert!(task.await.unwrap_err().is_cancelled());
+    assert_discarded(&node, &saved).await;
+}
+
+#[tokio::test]
+async fn explicit_commit_and_rollback_consume_the_guard() {
+    let node = node().await;
+    let txn = node.begin_transaction_guard(false).await.unwrap();
+    assert!(!txn.execute(CREATE).await.has_errors());
+    let saved = txn.handle().clone();
+    txn.rollback().await.unwrap();
+    assert_discarded(&node, &saved).await;
+
+    let txn = node.begin_transaction_guard(false).await.unwrap();
+    assert!(!txn.execute(CREATE).await.has_errors());
+    drop(txn.handle().clone());
+    assert!(!txn.execute(READ).await.has_errors());
+    txn.commit().await.unwrap();
+    let response = node.execute(READ).await;
+    assert!(!response.has_errors(), "{:?}", response.errors);
+    assert_eq!(
+        response.data.unwrap()["Users"],
+        serde_json::json!([{"name": "Alice"}])
+    );
+}
+
+#[tokio::test]
+async fn owned_transaction_keeps_node_signing_context() {
+    use crypto::Key;
+    use defra_core::signing::{SigningConfig, SigningKeyType};
+    use identity::{Identity, RawIdentity};
+
+    let key = crypto::generate_ed25519().unwrap();
+    let identity = RawIdentity::from_ed25519(key.clone()).unwrap();
+    let did = identity.did().unwrap().to_string();
+    let public_key_bytes = identity.public_key_bytes();
+    defra_core::signing::store_identity(
+        &did,
+        SigningConfig {
+            key_type: SigningKeyType::Ed25519,
+            private_key_bytes: key.raw().to_vec(),
+            public_key_hex: hex::encode(&public_key_bytes),
+            public_key_bytes,
+            remote_signer: None,
+            signing_authorization: None,
+        },
+    );
+    let node = EmbeddedNode::builder()
+        .with_node_identity_did(&did)
+        .build()
+        .await
+        .unwrap();
+    node.add_schema("type Users { name: String }")
+        .await
+        .unwrap();
+    let txn = node.begin_transaction_guard(false).await.unwrap();
+    let response = txn.execute(CREATE).await;
+    assert!(!response.has_errors(), "{:?}", response.errors);
+    let doc_id = response.data.unwrap()["add_Users"][0]["_docID"]
+        .as_str()
+        .unwrap()
+        .to_owned();
+    let query = format!(
+        r#"{{ _commits(docID: "{doc_id}", filter: {{fieldName: {{_eq: "_C"}}}}) {{ cid }} }}"#
+    );
+    let response = txn.execute(&query).await;
+    assert!(!response.has_errors(), "{:?}", response.errors);
+    let cid = response.data.unwrap()["_commits"][0]["cid"]
+        .as_str()
+        .unwrap()
+        .to_owned();
+    assert_eq!(
+        node.verified_block_signer_did_in_txn(&cid, txn.handle())
+            .await
+            .unwrap(),
+        did
+    );
+    txn.commit().await.unwrap();
+    assert_eq!(node.verified_block_signer_did(&cid).await.unwrap(), did);
+}


### PR DESCRIPTION
## Context
Embedded callers need cancellation-safe transaction ownership without using the raw executor, which bypasses the node's signing and default identity context.

## Changes
- Add `EmbeddedNode::begin_transaction_guard` and a non-cloneable `EmbeddedTransaction`.
- Route queries through the existing signed node execution path.
- Consume the guard on commit or rollback and abandon unfinished transactions on drop.
- Keep the existing manually finalized handle API unchanged.

## Testing
- [x] Drop and task-abort regressions with saved handle copies.
- [x] Explicit commit and rollback coverage.
- [x] Cryptographic signature verification before and after guarded commit.
- [x] Existing transaction signing test and complete node, embedded, and HTTP suites.
- [x] Strict native clippy, public example compilation, formatting, and diff checks.

Closes #1693