### PR TITLE
fix(p2p): serve smaller blocks after CAR size limits

### DIFF
--- a/crates/p2p/src/sync/car.rs
+++ b/crates/p2p/src/sync/car.rs
@@ -11,6 +11,10 @@ use cid::Cid;
 
 use crate::error::{Error, Result};
 
+#[cfg(test)]
+#[path = "../../tests/unit/car_collection.rs"]
+mod collection_tests;
+
 /// Maximum number of blocks allowed in a single CAR response.
 ///
 /// Prevents a malicious or faulty peer from causing the server to collect and
@@ -24,6 +28,9 @@ pub const CAR_MAX_BYTES: usize = 16 * 1024 * 1024;
 #[derive(Debug, Clone, Default)]
 pub struct CarCollectOutcome {
     pub blocks: Vec<(Cid, Bytes)>,
+    pub blockstore_hits: usize,
+    pub blockstore_misses: usize,
+    pub oversized_blocks: Vec<(Cid, usize)>,
     pub truncated_by_blocks: bool,
     pub truncated_by_bytes: bool,
 }
@@ -123,10 +130,10 @@ pub fn decode_car(data: &[u8]) -> Result<CarContents> {
 
 /// Traverse DAGs from a missing frontier, collecting reachable blocks.
 ///
-/// Collection is capped at [`CAR_MAX_BLOCKS`] blocks and [`CAR_MAX_BYTES`] total
-/// bytes.  If either limit is reached the function returns the blocks collected
-/// so far without error; the caller can detect truncation by checking whether
-/// the returned slice represents a complete DAG.
+/// Collection examines at most [`CAR_MAX_BLOCKS`] distinct CIDs and retains at
+/// most [`CAR_MAX_BYTES`] block bytes. Blocks that do not fit are skipped without
+/// walking their links, so later roots and siblings can still be served.
+/// The outcome distinguishes absent blocks, oversized blocks, and truncation.
 /// All roots share the same visited set and response limits, so overlapping
 /// branches are sent once and a large frontier cannot multiply the bounded
 /// CAR response size.
@@ -144,14 +151,17 @@ pub async fn collect_dag_blocks_from_roots<B: Blockstore>(
             continue;
         }
 
-        if outcome.blocks.len() >= CAR_MAX_BLOCKS {
+        if visited.len() > CAR_MAX_BLOCKS {
             outcome.truncated_by_blocks = true;
             break;
         }
 
         let data = match blockstore.get(&cid).await {
             Ok(Some(d)) => d,
-            Ok(None) => continue,
+            Ok(None) => {
+                outcome.blockstore_misses += 1;
+                continue;
+            }
             Err(e) => {
                 return Err(Error::BlockstoreError(format!(
                     "failed to get block {}: {}",
@@ -160,9 +170,13 @@ pub async fn collect_dag_blocks_from_roots<B: Blockstore>(
             }
         };
 
-        if total_bytes + data.len() > CAR_MAX_BYTES {
+        outcome.blockstore_hits += 1;
+        if data.len() > CAR_MAX_BYTES - total_bytes {
             outcome.truncated_by_bytes = true;
-            break;
+            if data.len() > CAR_MAX_BYTES {
+                outcome.oversized_blocks.push((cid, data.len()));
+            }
+            continue;
         }
         total_bytes += data.len();
 
@@ -179,7 +193,8 @@ pub async fn collect_dag_blocks_from_roots<B: Blockstore>(
     Ok(outcome)
 }
 
-/// Collect the exact requested blocks without walking descendant links.
+/// Collect exact requested blocks under the same limits as the recursive walk,
+/// without walking descendant links.
 pub async fn collect_exact_blocks<B: Blockstore>(
     blockstore: &B,
     cids: &[Cid],
@@ -192,14 +207,17 @@ pub async fn collect_exact_blocks<B: Blockstore>(
         if !visited.insert(*cid) {
             continue;
         }
-        if outcome.blocks.len() >= CAR_MAX_BLOCKS {
+        if visited.len() > CAR_MAX_BLOCKS {
             outcome.truncated_by_blocks = true;
             break;
         }
 
         let data = match blockstore.get(cid).await {
             Ok(Some(d)) => d,
-            Ok(None) => continue,
+            Ok(None) => {
+                outcome.blockstore_misses += 1;
+                continue;
+            }
             Err(e) => {
                 return Err(Error::BlockstoreError(format!(
                     "failed to get block {}: {}",
@@ -208,9 +226,13 @@ pub async fn collect_exact_blocks<B: Blockstore>(
             }
         };
 
-        if total_bytes + data.len() > CAR_MAX_BYTES {
+        outcome.blockstore_hits += 1;
+        if data.len() > CAR_MAX_BYTES - total_bytes {
             outcome.truncated_by_bytes = true;
-            break;
+            if data.len() > CAR_MAX_BYTES {
+                outcome.oversized_blocks.push((*cid, data.len()));
+            }
+            continue;
         }
 
         total_bytes += data.len();

--- a/crates/p2p/src/sync/car.rs
+++ b/crates/p2p/src/sync/car.rs
@@ -39,6 +39,50 @@ impl CarCollectOutcome {
     pub fn truncated(&self) -> bool {
         self.truncated_by_blocks || self.truncated_by_bytes
     }
+
+    async fn read_block<B: Blockstore>(
+        &mut self,
+        blockstore: &B,
+        cid: &Cid,
+        remaining: usize,
+    ) -> Result<Option<Bytes>> {
+        let size = blockstore.get_size(cid).await.map_err(|e| {
+            Error::BlockstoreError(format!("failed to get block size {}: {}", cid, e))
+        })?;
+        let Some(size) = size else {
+            self.blockstore_misses += 1;
+            return Ok(None);
+        };
+        if self.exceeds_budget(cid, size, remaining) {
+            self.blockstore_hits += 1;
+            return Ok(None);
+        }
+        let data = blockstore
+            .get(cid)
+            .await
+            .map_err(|e| Error::BlockstoreError(format!("failed to get block {}: {}", cid, e)))?;
+        let Some(data) = data else {
+            self.blockstore_misses += 1;
+            return Ok(None);
+        };
+        self.blockstore_hits += 1;
+        // Retain the payload check for stores without an immutable read snapshot.
+        if self.exceeds_budget(cid, data.len(), remaining) {
+            return Ok(None);
+        }
+        Ok(Some(data))
+    }
+
+    fn exceeds_budget(&mut self, cid: &Cid, size: usize, remaining: usize) -> bool {
+        if size <= remaining {
+            return false;
+        }
+        self.truncated_by_bytes = true;
+        if size > CAR_MAX_BYTES {
+            self.oversized_blocks.push((*cid, size));
+        }
+        true
+    }
 }
 
 /// Encode blocks as a CARv1 byte stream.
@@ -156,28 +200,12 @@ pub async fn collect_dag_blocks_from_roots<B: Blockstore>(
             break;
         }
 
-        let data = match blockstore.get(&cid).await {
-            Ok(Some(d)) => d,
-            Ok(None) => {
-                outcome.blockstore_misses += 1;
-                continue;
-            }
-            Err(e) => {
-                return Err(Error::BlockstoreError(format!(
-                    "failed to get block {}: {}",
-                    cid, e
-                )));
-            }
-        };
-
-        outcome.blockstore_hits += 1;
-        if data.len() > CAR_MAX_BYTES - total_bytes {
-            outcome.truncated_by_bytes = true;
-            if data.len() > CAR_MAX_BYTES {
-                outcome.oversized_blocks.push((cid, data.len()));
-            }
+        let Some(data) = outcome
+            .read_block(blockstore, &cid, CAR_MAX_BYTES - total_bytes)
+            .await?
+        else {
             continue;
-        }
+        };
         total_bytes += data.len();
 
         let refs = extract_links(&data);
@@ -212,28 +240,12 @@ pub async fn collect_exact_blocks<B: Blockstore>(
             break;
         }
 
-        let data = match blockstore.get(cid).await {
-            Ok(Some(d)) => d,
-            Ok(None) => {
-                outcome.blockstore_misses += 1;
-                continue;
-            }
-            Err(e) => {
-                return Err(Error::BlockstoreError(format!(
-                    "failed to get block {}: {}",
-                    cid, e
-                )));
-            }
-        };
-
-        outcome.blockstore_hits += 1;
-        if data.len() > CAR_MAX_BYTES - total_bytes {
-            outcome.truncated_by_bytes = true;
-            if data.len() > CAR_MAX_BYTES {
-                outcome.oversized_blocks.push((*cid, data.len()));
-            }
+        let Some(data) = outcome
+            .read_block(blockstore, cid, CAR_MAX_BYTES - total_bytes)
+            .await?
+        else {
             continue;
-        }
+        };
 
         total_bytes += data.len();
         outcome.blocks.push((*cid, data));

--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -3,6 +3,9 @@
 //! Verifies that DocSync and BranchableSync handlers enforce access checks
 //! in Controlled mode before processing requests.
 
+#[path = "../../../tests/unit/car_serving.rs"]
+mod car_serving;
+
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;

--- a/crates/p2p/src/sync/coordinator/event_handler/car.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/car.rs
@@ -77,15 +77,26 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         };
         let truncated = collected.truncated();
         let collected_count = collected.blocks.len();
+        let blockstore_hit_count = collected.blockstore_hits;
+        let blockstore_miss_count = collected.blockstore_misses;
+        if !collected.oversized_blocks.is_empty() {
+            tracing::warn!(
+                root_cid = %request.root_cid,
+                peer_id = %peer_id,
+                oversized_count = collected.oversized_blocks.len(),
+                oversized_blocks = ?collected.oversized_blocks.iter().take(4).collect::<Vec<_>>(),
+                max_block_bytes = crate::sync::car::CAR_MAX_BYTES,
+                "CAR request contains blocks exceeding the response byte limit"
+            );
+        }
         let blocks = self
             .filter_car_response_blocks(&peer_id, &request.root_cid, collected.blocks)
             .await;
         let kept_count = blocks.len();
         let filtered_count = collected_count.saturating_sub(kept_count);
-        let blockstore_miss_count = request.wanted_cids.len().saturating_sub(collected_count);
         self.manager.diagnostics.record_car_serve_counts(
             request.wanted_cids.len(),
-            collected_count,
+            blockstore_hit_count,
             kept_count,
             filtered_count,
         );
@@ -113,10 +124,11 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                     peer_id = %peer_id,
                     root_present = ?root_present,
                     requested_count = request.wanted_cids.len(),
-                    blockstore_hit_count = collected_count,
+                    blockstore_hit_count,
                     blockstore_miss_count,
                     filtered_count,
                     kept_count,
+                    truncated,
                     requested_cids = ?sample_cids(&request.wanted_cids),
                     requested_presence = ?requested_presence,
                     "CAR handler: no exact blocks served for selective request"

--- a/crates/p2p/tests/unit/car_collection.rs
+++ b/crates/p2p/tests/unit/car_collection.rs
@@ -1,0 +1,166 @@
+use std::sync::Arc;
+
+use blockstore::{Blockstore, DefraBlockstore};
+use cid::Cid;
+use defra_core::{Block, CrdtDelta, DAGLink, LwwDeltaPayload};
+use multihash_codetable::{Code, MultihashDigest};
+use storage::RegolithStore;
+
+use super::{collect_dag_blocks_from_roots, collect_exact_blocks, CAR_MAX_BLOCKS, CAR_MAX_BYTES};
+
+fn blockstore() -> DefraBlockstore<RegolithStore> {
+    DefraBlockstore::new(Arc::new(RegolithStore::in_memory().unwrap()), true)
+}
+
+async fn put(store: &impl Blockstore, data: &[u8]) -> Cid {
+    let cid = Cid::new_v1(0x71, Code::Sha2_256.digest(data));
+    store.put(&cid, data).await.unwrap();
+    cid
+}
+
+#[tokio::test]
+async fn oversized_block_does_not_hide_later_requested_blocks() {
+    let store = blockstore();
+    let oversized = put(&store, &vec![0; CAR_MAX_BYTES + 1]).await;
+    let small = put(&store, b"small").await;
+
+    for recursive in [false, true] {
+        let outcome = if recursive {
+            collect_dag_blocks_from_roots(&store, &[oversized, small]).await
+        } else {
+            collect_exact_blocks(&store, &[oversized, small]).await
+        }
+        .unwrap();
+
+        assert_eq!(outcome.blocks.len(), 1, "recursive={recursive}");
+        assert_eq!(outcome.blocks[0].0, small);
+        assert!(outcome.truncated_by_bytes);
+        assert_eq!(
+            outcome.oversized_blocks,
+            vec![(oversized, CAR_MAX_BYTES + 1)]
+        );
+        assert_eq!(outcome.blockstore_hits, 2);
+        assert_eq!(outcome.blockstore_misses, 0);
+    }
+}
+
+#[tokio::test]
+async fn aggregate_byte_limit_does_not_hide_smaller_blocks() {
+    let store = blockstore();
+    let large = put(&store, &vec![0; CAR_MAX_BYTES - 5]).await;
+    let deferred = put(&store, b"deferred").await;
+    let small = put(&store, b"small").await;
+
+    for recursive in [false, true] {
+        let outcome = if recursive {
+            collect_dag_blocks_from_roots(&store, &[large, deferred, small]).await
+        } else {
+            collect_exact_blocks(&store, &[large, deferred, small]).await
+        }
+        .unwrap();
+        assert_eq!(outcome.blocks.len(), 2);
+        assert_eq!(outcome.blocks[1].0, small);
+        assert_eq!(
+            outcome
+                .blocks
+                .iter()
+                .map(|(_, data)| data.len())
+                .sum::<usize>(),
+            CAR_MAX_BYTES
+        );
+        assert!(outcome.truncated_by_bytes);
+        assert!(outcome.oversized_blocks.is_empty());
+
+        let retry = collect_exact_blocks(&store, &[deferred]).await.unwrap();
+        assert_eq!(retry.blocks[0].0, deferred);
+        assert!(!retry.truncated());
+    }
+}
+
+#[tokio::test]
+async fn single_block_at_byte_limit_is_served() {
+    let store = blockstore();
+    for size in [CAR_MAX_BYTES - 1, CAR_MAX_BYTES] {
+        let cid = put(&store, &vec![0; size]).await;
+        for recursive in [false, true] {
+            let outcome = if recursive {
+                collect_dag_blocks_from_roots(&store, &[cid]).await
+            } else {
+                collect_exact_blocks(&store, &[cid]).await
+            }
+            .unwrap();
+            assert_eq!(outcome.blocks.len(), 1);
+            assert_eq!(outcome.blocks[0].1.len(), size);
+            assert!(!outcome.truncated());
+            assert!(outcome.oversized_blocks.is_empty());
+        }
+    }
+}
+
+#[tokio::test]
+async fn missing_blocks_count_toward_work_limit_but_duplicates_do_not() {
+    let store = blockstore();
+    let last = put(&store, b"last").await;
+    let mut roots = Vec::new();
+    for i in 0..CAR_MAX_BLOCKS {
+        let cid = Cid::new_v1(0x71, Code::Sha2_256.digest(&i.to_le_bytes()));
+        roots.extend([cid, cid]);
+    }
+    roots.push(last);
+
+    for recursive in [false, true] {
+        let outcome = if recursive {
+            collect_dag_blocks_from_roots(&store, &roots).await
+        } else {
+            collect_exact_blocks(&store, &roots).await
+        }
+        .unwrap();
+        assert!(outcome.blocks.is_empty());
+        assert_eq!(outcome.blockstore_misses, CAR_MAX_BLOCKS);
+        assert_eq!(outcome.blockstore_hits, 0);
+        assert!(outcome.truncated_by_blocks);
+        assert!(!outcome.truncated_by_bytes);
+    }
+
+    roots.drain(..2);
+    let outcome = collect_exact_blocks(&store, &roots).await.unwrap();
+    assert_eq!(outcome.blocks[0].0, last);
+    assert_eq!(outcome.blockstore_misses, CAR_MAX_BLOCKS - 1);
+    assert!(!outcome.truncated());
+}
+
+#[tokio::test]
+async fn recursive_collection_keeps_sibling_and_its_descendants() {
+    let store = blockstore();
+    let oversized = put(&store, &vec![0; CAR_MAX_BYTES + 1]).await;
+    let leaf = put(&store, b"leaf").await;
+    let child = linked_block(vec![DAGLink::new("leaf", leaf)]);
+    let child = put(&store, &child).await;
+    let root = linked_block(vec![
+        DAGLink::new("oversized", oversized),
+        DAGLink::new("child", child),
+    ]);
+    let root = put(&store, &root).await;
+
+    let outcome = collect_dag_blocks_from_roots(&store, &[root])
+        .await
+        .unwrap();
+    let cids: Vec<_> = outcome.blocks.iter().map(|(cid, _)| *cid).collect();
+    assert_eq!(cids, vec![root, child, leaf]);
+    assert!(outcome.truncated_by_bytes);
+}
+
+fn linked_block(links: Vec<DAGLink>) -> Vec<u8> {
+    Block::new(
+        CrdtDelta::Lww(LwwDeltaPayload {
+            field_name: "value".to_owned(),
+            priority: 1,
+            schema_version_id: "version".to_owned(),
+            data: Vec::new(),
+        }),
+        Vec::new(),
+        links,
+    )
+    .to_dag_cbor()
+    .unwrap()
+}

--- a/crates/p2p/tests/unit/car_collection.rs
+++ b/crates/p2p/tests/unit/car_collection.rs
@@ -164,3 +164,71 @@ fn linked_block(links: Vec<DAGLink>) -> Vec<u8> {
     .to_dag_cbor()
     .unwrap()
 }
+
+struct SizeOnlyBlockstore(usize);
+
+#[async_trait::async_trait]
+impl Blockstore for SizeOnlyBlockstore {
+    async fn get(&self, _: &Cid) -> blockstore::Result<Option<bytes::Bytes>> {
+        panic!("block outside the response budget must not be read")
+    }
+
+    async fn get_size(&self, _: &Cid) -> blockstore::Result<Option<usize>> {
+        Ok(Some(self.0))
+    }
+
+    async fn put(&self, _: &Cid, _: &[u8]) -> blockstore::Result<()> {
+        unreachable!()
+    }
+    async fn put_many(&self, _: &[(&Cid, &[u8])]) -> blockstore::Result<()> {
+        unreachable!()
+    }
+    async fn has(&self, _: &Cid) -> blockstore::Result<bool> {
+        unreachable!()
+    }
+    async fn delete(&self, _: &Cid) -> blockstore::Result<()> {
+        unreachable!()
+    }
+    async fn all_cids(&self) -> blockstore::Result<Vec<Cid>> {
+        unreachable!()
+    }
+    fn hash_on_read(&self, _: bool) {
+        unreachable!()
+    }
+    async fn is_merged(&self, _: &Cid) -> blockstore::Result<bool> {
+        unreachable!()
+    }
+    async fn mark_as_merged(&self, _: &Cid) -> blockstore::Result<()> {
+        unreachable!()
+    }
+    async fn get_unmerged(&self) -> blockstore::Result<Vec<Cid>> {
+        unreachable!()
+    }
+}
+
+#[tokio::test]
+async fn size_preflight_skips_payload_reads_outside_the_budget() {
+    let cid = Cid::new_v1(0x71, Code::Sha2_256.digest(b"large"));
+    let store = SizeOnlyBlockstore(usize::MAX);
+    for recursive in [false, true] {
+        let outcome = if recursive {
+            collect_dag_blocks_from_roots(&store, &[cid]).await
+        } else {
+            collect_exact_blocks(&store, &[cid]).await
+        }
+        .unwrap();
+        assert!(outcome.blocks.is_empty());
+        assert_eq!(outcome.oversized_blocks, vec![(cid, usize::MAX)]);
+        assert_eq!(outcome.blockstore_hits, 1);
+        assert_eq!(outcome.blockstore_misses, 0);
+    }
+
+    let mut outcome = super::CarCollectOutcome::default();
+    assert!(outcome
+        .read_block(&SizeOnlyBlockstore(6), &cid, 5)
+        .await
+        .unwrap()
+        .is_none());
+    assert!(outcome.truncated_by_bytes);
+    assert!(outcome.oversized_blocks.is_empty());
+}

--- a/crates/p2p/tests/unit/car_serving.rs
+++ b/crates/p2p/tests/unit/car_serving.rs
@@ -1,0 +1,65 @@
+use super::*;
+use crate::sync::car::{decode_car, CAR_MAX_BYTES};
+
+#[tokio::test]
+async fn oversized_car_block_keeps_sibling_and_accurate_presence_counts() {
+    for allowed in [false, true] {
+        let peer = random_peer_id();
+        let transport = NoopTransport::new();
+        let store = Arc::new(RegolithStore::in_memory().unwrap());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let oversized_data = vec![0; CAR_MAX_BYTES + 1];
+        let oversized = Cid::new_v1(0x71, Code::Sha2_256.digest(&oversized_data));
+        let small_data = b"small";
+        let small = Cid::new_v1(0x71, Code::Sha2_256.digest(small_data));
+        let absent = Cid::new_v1(0x71, Code::Sha2_256.digest(b"absent"));
+        blockstore.put(&oversized, &oversized_data).await.unwrap();
+        blockstore.put(&small, small_data).await.unwrap();
+
+        let replicators = Arc::new(ReplicatorRegistry::new());
+        if allowed {
+            replicators.add_replicator("collection1", peer.as_str());
+        }
+        let (coordinator, _events) = SyncCoordinator::with_access_control_and_serve_gate(
+            transport.clone(),
+            blockstore,
+            SyncConfig::default(),
+            AccessMode::Controlled,
+            replicators,
+            Arc::new(NoOpCollectionStorage),
+            Arc::new(crate::replicator::EqOnlyFilterMatcher),
+            Arc::new(StaticDataClassifier {
+                collection_id: "collection1".to_owned(),
+            }),
+            Arc::new(LateBoundServeAcp::default()),
+        )
+        .await
+        .unwrap();
+
+        coordinator
+            .handle_transport_event(selective_car_fetch_event(
+                peer,
+                oversized,
+                vec![oversized, absent, small],
+            ))
+            .await
+            .unwrap();
+
+        let responses = transport.car_responses();
+        assert_eq!(responses.len(), 1);
+        let (_, blocks) = decode_car(&responses[0]).unwrap();
+        if allowed {
+            assert_eq!(blocks, vec![(small, small_data.to_vec())]);
+        } else {
+            assert!(
+                blocks.is_empty(),
+                "skipping oversized data must not bypass access control"
+            );
+        }
+        let diagnostics = coordinator.manager().diagnostics.snapshot();
+        assert_eq!(diagnostics.car_requested_cids, 3);
+        assert_eq!(diagnostics.car_present_cids, 2);
+        assert_eq!(diagnostics.car_served_cids, u64::from(allowed));
+        assert_eq!(diagnostics.car_filtered_cids, u64::from(!allowed));
+    }
+}

--- a/proofs/tests/behavioral/mutation.rs
+++ b/proofs/tests/behavioral/mutation.rs
@@ -1,0 +1,83 @@
+use anyhow::{bail, ensure, Context, Result};
+use defra_harness::TestCluster;
+use serde_json::Value;
+use std::process::Command;
+use std::time::Duration;
+
+/// Go can exit successfully with both mutation data and a commit error.
+/// Retry only explicit transaction aborts, never a failed convergence assertion.
+pub async fn execute(cluster: &TestCluster, node: usize, query: &str) -> Result<Value> {
+    let address = cluster.api_url(node).trim_start_matches("http://");
+    for attempt in 0..5 {
+        let output = Command::new(cluster.client(node).binary_path())
+            .args(["--url", address, "client", "query", query])
+            .output()
+            .context("execute mutation")?;
+        ensure!(
+            output.status.success(),
+            "mutation command failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8(output.stdout)?;
+        if let Some(data) = mutation_result(&stdout)? {
+            return Ok(data);
+        }
+        if attempt < 4 {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+    bail!("mutation aborted after five transaction conflicts: {query}")
+}
+
+fn mutation_result(stdout: &str) -> Result<Option<Value>> {
+    let start = stdout.find('{').context("mutation returned no JSON")?;
+    let response: Value = serde_json::from_str(&stdout[start..])?;
+    if let Some(errors) = response.get("errors").filter(|value| !value.is_null()) {
+        let errors = errors.as_array().context("invalid GraphQL errors")?;
+        if !errors.is_empty() {
+            if errors.iter().all(|error| {
+                error["message"].as_str() == Some("Transaction Conflict. Please retry")
+            }) {
+                return Ok(None);
+            }
+            bail!("mutation returned GraphQL errors: {response}");
+        }
+    }
+    let data = response
+        .get("data")
+        .filter(|data| !data.is_null())
+        .context("mutation returned no data")?;
+    Ok(Some(data.clone()))
+}
+
+#[test]
+fn commit_conflict_is_not_success_even_with_mutation_data() {
+    let response = r#"{"data":{"update_User":[{"_docID":"doc"}]},"errors":[{"message":"Transaction Conflict. Please retry"}]}"#;
+    assert!(mutation_result(response).unwrap().is_none());
+}
+
+#[test]
+fn unrelated_errors_are_not_retried_or_hidden_by_data() {
+    for errors in [
+        serde_json::json!([{"message": "invalid field"}]),
+        serde_json::json!([
+            {"message": "Transaction Conflict. Please retry"},
+            {"message": "invalid field"}
+        ]),
+    ] {
+        let response = serde_json::json!({"data": {"update_User": []}, "errors": errors});
+        assert!(mutation_result(&response.to_string()).is_err());
+    }
+}
+
+#[test]
+fn successful_response_requires_data_and_allows_cli_preamble() {
+    let result = mutation_result(
+        "------ Request Results ------\n{\"data\": {\"update_User\": []}, \"errors\": []}",
+    )
+    .unwrap();
+    assert_eq!(result, Some(serde_json::json!({"update_User": []})));
+    for invalid in ["", "not JSON", "{}", "{\"data\":null}", "{\"errors\":{}}"] {
+        assert!(mutation_result(invalid).is_err());
+    }
+}

--- a/proofs/tests/behavioral/parity.rs
+++ b/proofs/tests/behavioral/parity.rs
@@ -47,6 +47,9 @@
 //! sourcenetwork/defradb#5058 (sender never sees error replies — why the Go
 //! mode is silent). See defradb.rs#1134.
 
+#[path = "mutation.rs"]
+mod mutation;
+
 use crate::support;
 use defra_harness::{DefraClient, NodeKind, TestCluster};
 use std::collections::BTreeSet;
@@ -1284,18 +1287,21 @@ async fn run_indexed_lww_parity(
     }
 
     // Concurrent same-field LWW: node0 -> 20, node1 -> 99. Higher value wins (99).
-    cluster
-        .client(0)
-        .query(&format!(
-            r#"mutation {{ update_User(docID: "{id}", input: {{age: 20}}) {{ _docID }} }}"#
-        ))
-        .expect("node0 age=20");
-    cluster
-        .client(1)
-        .query(&format!(
-            r#"mutation {{ update_User(docID: "{id}", input: {{age: 99}}) {{ _docID }} }}"#
-        ))
-        .expect("node1 age=99");
+    for (node, age) in [(0, 20), (1, 99)] {
+        let updated = mutation::execute(
+            &cluster,
+            node,
+            &format!(
+                r#"mutation {{ update_User(docID: "{id}", input: {{age: {age}}}) {{ _docID }} }}"#
+            ),
+        )
+        .await
+        .unwrap_or_else(|error| panic!("[{label}] node{node} age={age}: {error:#}"));
+        assert_eq!(
+            updated["update_User"][0]["_docID"].as_str(),
+            Some(id.as_str())
+        );
+    }
 
     // MERGE PROOF: node1 locally wrote the winner (99), so its index-resolved
     // check is satisfied by its own write; require the identical commit DAG on


### PR DESCRIPTION
## Context
A block larger than the 16 MiB CAR payload limit stopped collection entirely, so smaller blocks later in the request or DAG were omitted too. Size-limited blocks were also counted as missing in serving diagnostics.

## Changes
- Skip blocks that do not fit and continue serving smaller roots and siblings.
- Bound each collection to 10,000 distinct CID lookups, including skipped and missing blocks.
- Distinguish missing, oversized, and served blocks in collection results and server diagnostics.

The response format and 16 MiB payload limit are unchanged. Requester-side size-limit notices follow in the next PR in this stack.

## Testing
Two regressions fail on unchanged main and pass with the fix.

- [x] Byte-limit boundaries, aggregate limits, sibling traversal, duplicate CIDs, and bounded lookups.
- [x] Serving authorization and presence-counter regressions.
- [x] P2P unit tests with default features and both transports enabled.
- [x] Strict clippy across all P2P features and targets.
- [x] Formatting and diff checks.

Refs #1557