### PR TITLE
fix(p2p): report unservable CAR blocks to fetch owners

### DIFF
--- a/crates/p2p/src/iroh/endpoint_rpc.rs
+++ b/crates/p2p/src/iroh/endpoint_rpc.rs
@@ -47,6 +47,7 @@ struct CarFetchAttempt {
 #[derive(Debug, Clone)]
 enum CarFetchOutcome {
     Success,
+    SizeLimited,
     InvalidPeerId(String),
     ConnectFailed(String),
     OpenBiFailed(String),
@@ -65,6 +66,7 @@ impl CarFetchOutcome {
     fn label(&self) -> &'static str {
         match self {
             Self::Success => "success",
+            Self::SizeLimited => "size_limited",
             Self::InvalidPeerId(_) => "invalid_peer_id",
             Self::ConnectFailed(_) => "connect_failed",
             Self::OpenBiFailed(_) => "open_bi_failed",
@@ -84,6 +86,7 @@ impl CarFetchOutcome {
             | Self::WriteFailed(detail)
             | Self::ReadFailed(detail) => Some(detail),
             Self::Success
+            | Self::SizeLimited
             | Self::EmptyResponse
             | Self::HeaderOnlyCar
             | Self::EventChannelClosed => None,
@@ -774,6 +777,8 @@ async fn try_fetch_from_provider(
     // "none returned usable blocks" WARN is suppressed when every provider
     // replies empty (issue #858 review round 3).
     let has_blocks = crate::sync::car::car_has_any_block(&car_data);
+    let has_notices =
+        crate::sync::car::decode_car_oversized(&car_data).is_ok_and(|notices| !notices.is_empty());
 
     debug!(
         provider = %provider,
@@ -803,7 +808,9 @@ async fn try_fetch_from_provider(
     }
     CarFetchAttempt {
         provider: provider.clone(),
-        outcome: if has_blocks {
+        outcome: if has_notices {
+            CarFetchOutcome::SizeLimited
+        } else if has_blocks {
             CarFetchOutcome::Success
         } else {
             CarFetchOutcome::HeaderOnlyCar
@@ -897,6 +904,7 @@ pub(super) async fn handle_block_sync(
     }
 
     let mut any_success = false;
+    let mut size_limited = false;
     let mut failures = Vec::new();
     let provider_count = providers.len();
     let kind = if missing.is_empty() {
@@ -912,7 +920,10 @@ pub(super) async fn handle_block_sync(
                 tasks.abort_all();
                 break;
             }
-            Ok(attempt) => failures.push(attempt),
+            Ok(attempt) => {
+                size_limited |= matches!(attempt.outcome, CarFetchOutcome::SizeLimited);
+                failures.push(attempt);
+            }
             Err(e) => {
                 debug!("Block sync task panicked: {}", e);
                 failures.push(CarFetchAttempt {
@@ -945,7 +956,10 @@ pub(super) async fn handle_block_sync(
     // are durable. An independent success event can otherwise overtake the
     // concurrently dispatched CAR response. Failures have no useful response
     // payload to order behind and retain the aggregate completion event.
+    // Size notices also complete at ingestion; do not overwrite that result
+    // with a generic failure or cancel another provider that can still help.
     if !any_success
+        && !size_limited
         && event_tx
             .send(TransportEvent::BitswapComplete {
                 query_id,
@@ -958,6 +972,10 @@ pub(super) async fn handle_block_sync(
         warn!("Event channel closed, cannot emit BitswapComplete");
     }
 }
+
+#[cfg(test)]
+#[path = "../../tests/unit/iroh_car_size.rs"]
+mod car_size_tests;
 
 #[cfg(test)]
 mod tests {
@@ -1006,7 +1024,7 @@ mod tests {
         assert!(summary.contains("+1 more"));
     }
 
-    async fn localhost_endpoint(alpns: Vec<Vec<u8>>) -> iroh::Endpoint {
+    pub(super) async fn localhost_endpoint(alpns: Vec<Vec<u8>>) -> iroh::Endpoint {
         iroh::Endpoint::builder(iroh::endpoint::presets::Minimal)
             .relay_mode(iroh::RelayMode::Disabled)
             .alpns(alpns)

--- a/crates/p2p/src/sync/car.rs
+++ b/crates/p2p/src/sync/car.rs
@@ -15,13 +15,17 @@ use crate::error::{Error, Result};
 #[path = "../../tests/unit/car_collection.rs"]
 mod collection_tests;
 
+#[cfg(test)]
+#[path = "../../tests/unit/car_size_notices.rs"]
+mod size_notice_tests;
+
 /// Maximum number of blocks allowed in a single CAR response.
 ///
 /// Prevents a malicious or faulty peer from causing the server to collect and
 /// send an arbitrarily large DAG in a single response.
 pub const CAR_MAX_BLOCKS: usize = 10_000;
 
-/// Maximum total byte size of a single CAR response (16 MiB).
+/// Maximum block payload bytes collected for a CAR response (16 MiB).
 pub const CAR_MAX_BYTES: usize = 16 * 1024 * 1024;
 
 /// Result of collecting blocks for a CAR response.
@@ -88,11 +92,22 @@ impl CarCollectOutcome {
 /// Encode blocks as a CARv1 byte stream.
 ///
 /// Format: varint-prefixed DAG-CBOR header, then varint-prefixed (CID + data) sections.
+#[cfg(test)]
 pub fn encode_car(roots: &[Cid], blocks: &[(&Cid, &[u8])]) -> Result<Vec<u8>> {
+    encode_car_response(roots, blocks, &[])
+}
+
+/// Rust CAR peers ignore unknown header fields. Keep ordinary responses byte
+/// identical, adding size-limit notices only when authorized blocks cannot fit.
+pub(crate) fn encode_car_response(
+    roots: &[Cid],
+    blocks: &[(&Cid, &[u8])],
+    oversized: &[(Cid, usize)],
+) -> Result<Vec<u8>> {
     let mut out = Vec::new();
 
     // Header: DAG-CBOR map {version: 1, roots: [CID]}
-    let header = encode_car_header(roots)?;
+    let header = encode_car_header(roots, oversized)?;
     write_varint_prefixed(&mut out, &header);
 
     // Each block: varint(len(cid_bytes + data)) + cid_bytes + data
@@ -344,7 +359,7 @@ fn extract_links(block_data: &[u8]) -> Vec<Cid> {
 // CIDs are stored as plain CBOR byte strings (no tag 42) since this
 // is an internal Rust-to-Rust protocol.
 
-fn encode_car_header(roots: &[Cid]) -> Result<Vec<u8>> {
+fn encode_car_header(roots: &[Cid], oversized: &[(Cid, usize)]) -> Result<Vec<u8>> {
     use ciborium::Value;
     let roots_val: Vec<Value> = roots
         .iter()
@@ -355,15 +370,79 @@ fn encode_car_header(roots: &[Cid]) -> Result<Vec<u8>> {
     // explicitly here. It previously came from a BTreeMap, which sorted the
     // keys; "roots" < "version" alphabetically, so this order reproduces the
     // existing bytes exactly. `car_header_bytes_unchanged_by_encoder` pins it.
-    let header = Value::Map(vec![
+    let mut fields = vec![
         (Value::Text("roots".into()), Value::Array(roots_val)),
         (Value::Text("version".into()), Value::Integer(1.into())),
-    ]);
+    ];
+    if !oversized.is_empty() {
+        fields.push((
+            Value::Text("oversized".into()),
+            Value::Array(
+                oversized
+                    .iter()
+                    .map(|(cid, size)| {
+                        Value::Array(vec![
+                            Value::Bytes(cid.to_bytes()),
+                            Value::Integer((*size as u64).into()),
+                        ])
+                    })
+                    .collect(),
+            ),
+        ));
+    }
+    let header = Value::Map(fields);
 
     let mut out = Vec::new();
     ciborium::into_writer(&header, &mut out)
         .map_err(|e| Error::Codec(format!("failed to encode CAR header: {}", e)))?;
     Ok(out)
+}
+
+/// Optional notices from a Rust peer, not proof of a block's size or absence.
+pub(crate) fn decode_car_oversized(data: &[u8]) -> Result<Vec<(Cid, usize)>> {
+    use ciborium::Value;
+    let mut cursor = data;
+    let header_len = read_varint(&mut cursor)?;
+    let header_len = usize::try_from(header_len)
+        .ok()
+        .filter(|length| *length <= cursor.len())
+        .ok_or_else(|| Error::Codec("CAR header length exceeds data".into()))?;
+    let header: Value = defra_core::cbor::from_slice(&cursor[..header_len])
+        .map_err(|e| Error::Codec(format!("invalid CAR header: {e}")))?;
+    let Value::Map(fields) = header else {
+        return Err(Error::Codec("CAR header is not a CBOR map".into()));
+    };
+    let mut notices = fields
+        .into_iter()
+        .filter_map(|(key, value)| (key == Value::Text("oversized".into())).then_some(value));
+    let Some(value) = notices.next() else {
+        return Ok(Vec::new());
+    };
+    let Value::Array(entries) = value else {
+        return Err(Error::Codec(
+            "CAR oversized notices must be an array".into(),
+        ));
+    };
+    if notices.next().is_some() || entries.len() > CAR_MAX_BLOCKS {
+        return Err(Error::Codec("invalid CAR oversized block notices".into()));
+    }
+    let invalid = || Error::Codec("invalid CAR oversized block notice".into());
+    let mut result = Vec::with_capacity(entries.len());
+    for entry in entries {
+        let Value::Array(pair) = entry else {
+            return Err(invalid());
+        };
+        let [Value::Bytes(cid), Value::Integer(size)] = pair.as_slice() else {
+            return Err(invalid());
+        };
+        let size = usize::try_from(i128::from(*size)).map_err(|_| invalid())?;
+        if size <= CAR_MAX_BYTES {
+            return Err(invalid());
+        }
+        let cid = Cid::try_from(cid.as_slice()).map_err(|_| invalid())?;
+        result.push((cid, size));
+    }
+    Ok(result)
 }
 
 fn decode_car_header(data: &[u8]) -> Result<Vec<Cid>> {

--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -1451,7 +1451,7 @@ async fn duplicate_car_ingest_defers_without_waiting_for_root_owner() {
     let mut completion = coordinator
         .manager()
         .rooted_car_completion_tracker()
-        .register(root_cid);
+        .register(root_cid, peer.clone());
 
     coordinator
         .handle_transport_event(TransportEvent::CarFetchResponse {
@@ -1486,7 +1486,7 @@ async fn duplicate_car_ingest_defers_without_waiting_for_root_owner() {
     let completion = coordinator
         .manager()
         .rooted_car_completion_tracker()
-        .register(root_cid);
+        .register(root_cid, peer.clone());
     coordinator
         .handle_transport_event(TransportEvent::CarFetchResponse {
             query_id: None,
@@ -1538,7 +1538,7 @@ async fn car_put_many_conflict_retries_before_publishing_one_success_completion(
     let completion = coordinator
         .manager()
         .rooted_car_completion_tracker()
-        .register(root_cid);
+        .register(root_cid, peer.clone());
 
     let ingest = {
         let coordinator = Arc::clone(&coordinator);

--- a/crates/p2p/src/sync/coordinator/dag_context.rs
+++ b/crates/p2p/src/sync/coordinator/dag_context.rs
@@ -163,10 +163,11 @@ impl DagFetchContext {
     pub(crate) fn track_rooted_car(
         &self,
         root_cid: Cid,
+        peer_id: &PeerId,
     ) -> Option<tokio::sync::oneshot::Receiver<crate::sync::manager::FetchCompletion>> {
         self.rooted_car_completions
             .as_ref()
-            .map(|tracker| tracker.register(root_cid))
+            .map(|tracker| tracker.register(root_cid, peer_id.clone()))
     }
 
     pub(crate) fn cancel_rooted_car_tracking(&self, root_cid: Cid) {

--- a/crates/p2p/src/sync/coordinator/dag_fetcher.rs
+++ b/crates/p2p/src/sync/coordinator/dag_fetcher.rs
@@ -49,6 +49,7 @@ enum FetchBatchOutcome {
     Partial,
     NoProgress,
     Deferred,
+    Unservable,
 }
 
 /// Outcome of one provider's poll window, as seen by the rotation loop.
@@ -62,6 +63,7 @@ enum ProviderWindowOutcome {
     Stalled,
     SendFailed,
     Deferred,
+    SizeLimit(Cid),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -69,6 +71,7 @@ enum FetchAttemptOutcome {
     Complete,
     Incomplete { remaining: usize },
     Deferred,
+    Unservable,
 }
 
 /// Fetch an entire DAG rooted at `root_cid`.
@@ -180,6 +183,11 @@ pub async fn poll_fetch_dag<B: Blockstore + 'static, T: P2PTransport>(
         .await
         {
             FetchAttemptOutcome::Complete => return,
+            FetchAttemptOutcome::Unservable => {
+                error!(root_cid = %root_cid, providers = ?providers.peers(),
+                    "Providers cannot serve the remaining DAG within their CAR byte limits; stopping this fetch");
+                return;
+            }
             FetchAttemptOutcome::Incomplete { remaining } => remaining_count = remaining,
             FetchAttemptOutcome::Deferred => {
                 diagnostics.record_pending_dag_fetch_deferred_contention();
@@ -295,7 +303,12 @@ async fn fetch_dag_attempt<B: Blockstore + 'static, T: P2PTransport>(
     // bounded descendant closure rooted at the already-known missing
     // frontier. This mirrors Go's one per-root blockservice session without
     // returning to an unbounded recursive historical-root walk.
-    let rooted_outcome = if let Some(rooted_watch) = car_missing_watch.as_deref() {
+    let rooted_wants = car_missing_watch
+        .as_deref()
+        .unwrap_or(std::slice::from_ref(&root_cid));
+    let rooted_outcome = if providers.cannot_serve(rooted_wants) {
+        ProviderWindowOutcome::SendFailed
+    } else if let Some(rooted_watch) = car_missing_watch.as_deref() {
         if context.needs_rooted_provider_discovery() {
             if transport.supports_cancellable_rooted_sync() {
                 poll_fetch_rooted_provider(
@@ -321,11 +334,23 @@ async fn fetch_dag_attempt<B: Blockstore + 'static, T: P2PTransport>(
         } else {
             ProviderWindowOutcome::SendFailed
         }
-    } else if try_car_fetch(transport, blockstore, &root_cid, providers.current()).await {
-        ProviderWindowOutcome::Partial
     } else {
-        ProviderWindowOutcome::SendFailed
+        poll_fetch_rooted_car(
+            &root_cid,
+            std::slice::from_ref(&root_cid),
+            transport,
+            blockstore,
+            providers.current(),
+            context,
+        )
+        .await
     };
+    if let ProviderWindowOutcome::SizeLimit(cid) = rooted_outcome {
+        // libp2p can fall back to Bitswap, whose limits are independent of CAR.
+        if transport.supports_cancellable_rooted_sync() {
+            providers.record_size_limit(cid);
+        }
+    }
     if rooted_outcome == ProviderWindowOutcome::Deferred {
         return FetchAttemptOutcome::Deferred;
     }
@@ -367,6 +392,7 @@ async fn fetch_dag_attempt<B: Blockstore + 'static, T: P2PTransport>(
     {
         FetchBatchOutcome::Complete => {}
         FetchBatchOutcome::Deferred => return FetchAttemptOutcome::Deferred,
+        FetchBatchOutcome::Unservable => return FetchAttemptOutcome::Unservable,
         FetchBatchOutcome::Partial | FetchBatchOutcome::NoProgress => {
             warn!(root_cid = %root_cid, "Failed to fetch root block");
             return FetchAttemptOutcome::Incomplete { remaining: 1 };
@@ -440,6 +466,7 @@ async fn fetch_dag_attempt<B: Blockstore + 'static, T: P2PTransport>(
                     );
                 }
                 FetchBatchOutcome::Deferred => return FetchAttemptOutcome::Deferred,
+                FetchBatchOutcome::Unservable => return FetchAttemptOutcome::Unservable,
             }
         }
         if !made_progress {
@@ -487,39 +514,6 @@ async fn emit_dag_ready(
     }
 }
 
-/// Root-absent DocSync/BranchableSync discovery retains the established CAR
-/// request seam. PushLog recovery already has the root and uses the cancellable
-/// rooted-provider probe below instead.
-async fn try_car_fetch<B: Blockstore, T: P2PTransport>(
-    transport: &T,
-    blockstore: &Arc<B>,
-    root_cid: &Cid,
-    source_peer: &PeerId,
-) -> bool {
-    match tokio::time::timeout(
-        Duration::from_secs(10),
-        transport.send_car_request(source_peer, *root_cid),
-    )
-    .await
-    {
-        Ok(Ok(())) => {}
-        Ok(Err(error)) => {
-            debug!(root_cid = %root_cid, error = %error, "CAR discovery request failed");
-            return false;
-        }
-        Err(_) => return false,
-    }
-
-    let start = Instant::now();
-    while start.elapsed() < Duration::from_secs(10) {
-        if matches!(blockstore.has(root_cid).await, Ok(true)) {
-            return true;
-        }
-        tokio::time::sleep(Duration::from_millis(100)).await;
-    }
-    false
-}
-
 /// Exercise the established libp2p CAR request protocol when the transport's
 /// block-sync primitive cannot express a recursive root request.  Sending the
 /// request and receiving its CAR response are separate streams on libp2p, so
@@ -542,7 +536,7 @@ async fn poll_fetch_rooted_car<B: Blockstore, T: P2PTransport>(
         return ProviderWindowOutcome::Complete;
     }
 
-    let mut completion = context.track_rooted_car(*root_cid);
+    let mut completion = context.track_rooted_car(*root_cid, source_peer);
 
     match tokio::time::timeout(
         Duration::from_secs(10),
@@ -572,7 +566,7 @@ async fn poll_fetch_rooted_car<B: Blockstore, T: P2PTransport>(
         }
     };
     let remaining_now = count_missing(blockstore, watch_cids).await;
-    if remaining_now < initially_missing {
+    if remaining_now < initially_missing && completion.is_none() {
         context.cancel_rooted_car_tracking(*root_cid);
         return observe(remaining_now);
     }
@@ -589,6 +583,9 @@ async fn poll_fetch_rooted_car<B: Blockstore, T: P2PTransport>(
                     if matches!(result, Ok(FetchCompletion::Deferred)) {
                         context.cancel_rooted_car_tracking(*root_cid);
                         return ProviderWindowOutcome::Deferred;
+                    }
+                    if let Ok(FetchCompletion::SizeLimit(cid)) = result {
+                        return ProviderWindowOutcome::SizeLimit(cid);
                     }
                     break;
                 },
@@ -663,6 +660,7 @@ async fn poll_fetch_rooted_provider<B: Blockstore, T: P2PTransport>(
     let mut outcome = ProviderWindowOutcome::Stalled;
     let mut transport_complete = false;
     let mut deferred = false;
+    let mut size_limit = None;
     while start.elapsed() < timeout && context.is_current() {
         let mut remaining = 0usize;
         for cid in watch_cids {
@@ -707,6 +705,10 @@ async fn poll_fetch_rooted_provider<B: Blockstore, T: P2PTransport>(
                             deferred = true;
                             break;
                         }
+                        FetchCompletion::SizeLimit(cid) => {
+                            size_limit = Some(cid);
+                            break;
+                        }
                     }
                 }
                 _ = tokio::time::sleep(Duration::from_millis(100)) => {}
@@ -719,7 +721,9 @@ async fn poll_fetch_rooted_provider<B: Blockstore, T: P2PTransport>(
     if let Err(error) = transport.cancel_sync(query_id).await {
         debug!(root_cid = %root_cid, query_id = query_id.0, error = %error, "Failed to cancel rooted CAR query");
     }
-    if deferred {
+    if let Some(cid) = size_limit {
+        ProviderWindowOutcome::SizeLimit(cid)
+    } else if deferred {
         ProviderWindowOutcome::Deferred
     } else {
         outcome
@@ -746,7 +750,22 @@ async fn poll_fetch_blocks_rotating<B: Blockstore, T: P2PTransport>(
     state: &mut ProviderFetchState<'_>,
     context: &DagFetchContext,
 ) -> FetchBatchOutcome {
+    let mut missing = Vec::new();
+    for cid in cids {
+        if !matches!(blockstore.has(cid).await, Ok(true)) {
+            missing.push(*cid);
+        }
+    }
+    if missing.is_empty() {
+        return FetchBatchOutcome::Complete;
+    }
+    let mut unservable = 0;
     for _ in 0..state.providers.len() {
+        if state.providers.cannot_serve(&missing) {
+            unservable += 1;
+            state.providers.advance();
+            continue;
+        }
         if *state.stall_budget == 0 {
             debug!(
                 root_cid = %root_cid,
@@ -777,9 +796,24 @@ async fn poll_fetch_blocks_rotating<B: Blockstore, T: P2PTransport>(
                 state.diagnostics.record_provider_rotation();
             }
             ProviderWindowOutcome::Deferred => return FetchBatchOutcome::Deferred,
+            ProviderWindowOutcome::SizeLimit(cid) => {
+                state.providers.record_size_limit(cid);
+                state.providers.advance();
+                state.diagnostics.record_provider_rotation();
+                unservable += 1;
+            }
         }
     }
-    FetchBatchOutcome::NoProgress
+    let remaining = count_missing(blockstore, &missing).await;
+    if remaining == 0 {
+        FetchBatchOutcome::Complete
+    } else if remaining < missing.len() {
+        FetchBatchOutcome::Partial
+    } else if unservable == state.providers.len() {
+        FetchBatchOutcome::Unservable
+    } else {
+        FetchBatchOutcome::NoProgress
+    }
 }
 
 /// Fetch one batch of exact blocks via the transport's block-sync path.
@@ -828,6 +862,7 @@ async fn poll_fetch_blocks<B: Blockstore, T: P2PTransport>(
     let completion_is_observable = completion.is_some();
     let mut transport_complete = false;
     let mut deferred = false;
+    let mut size_limit = None;
 
     let timeout = BLOCK_SYNC_COMPLETION_WATCHDOG;
     let start = Instant::now();
@@ -873,6 +908,10 @@ async fn poll_fetch_blocks<B: Blockstore, T: P2PTransport>(
                             deferred = true;
                             break;
                         }
+                        FetchCompletion::SizeLimit(cid) => {
+                            size_limit = Some(cid);
+                            break;
+                        }
                     }
                 }
                 _ = tokio::time::sleep(Duration::from_millis(100)) => {}
@@ -891,7 +930,9 @@ async fn poll_fetch_blocks<B: Blockstore, T: P2PTransport>(
             "Failed to cancel block-sync query after poll window"
         );
     }
-    if deferred {
+    if let Some(cid) = size_limit {
+        ProviderWindowOutcome::SizeLimit(cid)
+    } else if deferred {
         ProviderWindowOutcome::Deferred
     } else {
         outcome

--- a/crates/p2p/src/sync/coordinator/dag_fetcher.rs
+++ b/crates/p2p/src/sync/coordinator/dag_fetcher.rs
@@ -402,6 +402,7 @@ async fn fetch_dag_attempt<B: Blockstore + 'static, T: P2PTransport>(
     // Walk DAG, fetching missing blocks level by level. The walk stops as soon
     // as an iteration makes no progress (`!made_progress` below); the iteration
     // ceiling is only a defensive backstop, not a functional depth limit.
+    let mut unservable = false;
     for iteration in 0..MAX_DAG_WALK_ITERATIONS {
         let root_data = match blockstore.get(&root_cid).await {
             Ok(Some(data)) => data,
@@ -466,7 +467,7 @@ async fn fetch_dag_attempt<B: Blockstore + 'static, T: P2PTransport>(
                     );
                 }
                 FetchBatchOutcome::Deferred => return FetchAttemptOutcome::Deferred,
-                FetchBatchOutcome::Unservable => return FetchAttemptOutcome::Unservable,
+                FetchBatchOutcome::Unservable => unservable = true,
             }
         }
         if !made_progress {
@@ -487,6 +488,8 @@ async fn fetch_dag_attempt<B: Blockstore + 'static, T: P2PTransport>(
         info!(root_cid = %root_cid, doc_id = %context.doc_id, "DAG fetch complete");
         emit_dag_ready(event_tx, root_cid, context, &root_data).await;
         FetchAttemptOutcome::Complete
+    } else if unservable {
+        FetchAttemptOutcome::Unservable
     } else {
         FetchAttemptOutcome::Incomplete {
             remaining: remaining.len(),

--- a/crates/p2p/src/sync/coordinator/dag_fetcher_tests.rs
+++ b/crates/p2p/src/sync/coordinator/dag_fetcher_tests.rs
@@ -1,4 +1,7 @@
 use super::*;
+
+#[path = "../../../tests/unit/car_size_retry.rs"]
+mod car_size_retry;
 use crate::error::Result as P2PResult;
 use crate::message::{
     BranchableSyncReply, BranchableSyncRequest, DocSyncReply, DocSyncRequest, PushLogBroadcast,
@@ -60,6 +63,8 @@ struct TestTransport {
     stream_block_delay: Arc<Mutex<Duration>>,
     stream_completed: Arc<AtomicBool>,
     cancelled_before_stream_complete: Arc<AtomicBool>,
+    size_limited_providers:
+        Arc<Mutex<HashMap<String, (Cid, crate::sync::manager::BlockSyncCompletionTracker)>>>,
 }
 
 impl TestTransport {
@@ -99,6 +104,7 @@ impl TestTransport {
             stream_block_delay: Arc::new(Mutex::new(Duration::from_millis(10))),
             stream_completed: Arc::new(AtomicBool::new(false)),
             cancelled_before_stream_complete: Arc::new(AtomicBool::new(false)),
+            size_limited_providers: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -367,6 +373,16 @@ impl P2PTransport for TestTransport {
             .unwrap()
             .extend(providers.iter().map(|peer| peer.to_string()));
         let query_id = QueryId(call_index as u64 + 1);
+        if let Some((cid, completion)) = providers.first().and_then(|peer| {
+            self.size_limited_providers
+                .lock()
+                .unwrap()
+                .get(peer.as_str())
+                .cloned()
+        }) {
+            completion.size_limit(query_id, cid);
+            return Ok(query_id);
+        }
         if let Some(completion) = self.early_failure_completion.lock().unwrap().clone() {
             completion.complete(query_id, false);
             return Ok(query_id);

--- a/crates/p2p/src/sync/coordinator/dag_fetcher_tests.rs
+++ b/crates/p2p/src/sync/coordinator/dag_fetcher_tests.rs
@@ -379,6 +379,7 @@ impl P2PTransport for TestTransport {
                 .unwrap()
                 .get(peer.as_str())
                 .cloned()
+                .filter(|(cid, _)| missing.contains(cid))
         }) {
             completion.size_limit(query_id, cid);
             return Ok(query_id);

--- a/crates/p2p/src/sync/coordinator/dag_retry.rs
+++ b/crates/p2p/src/sync/coordinator/dag_retry.rs
@@ -33,12 +33,17 @@ pub(super) fn retry_backoff(attempt: u32) -> Duration {
 pub(super) struct ProviderRotation {
     peers: Vec<PeerId>,
     cursor: usize,
+    unservable: std::collections::HashMap<PeerId, cid::Cid>,
 }
 
 impl ProviderRotation {
     pub(super) fn new(peers: Vec<PeerId>) -> Self {
         debug_assert!(!peers.is_empty(), "DagFetchContext always has source_peer");
-        Self { peers, cursor: 0 }
+        Self {
+            peers,
+            cursor: 0,
+            unservable: std::collections::HashMap::new(),
+        }
     }
 
     pub(super) fn current(&self) -> &PeerId {
@@ -55,6 +60,16 @@ impl ProviderRotation {
 
     pub(super) fn peers(&self) -> &[PeerId] {
         &self.peers
+    }
+
+    pub(super) fn record_size_limit(&mut self, cid: cid::Cid) {
+        self.unservable.insert(self.current().clone(), cid);
+    }
+
+    pub(super) fn cannot_serve(&self, cids: &[cid::Cid]) -> bool {
+        self.unservable
+            .get(self.current())
+            .is_some_and(|cid| cids.contains(cid))
     }
 }
 

--- a/crates/p2p/src/sync/coordinator/event_handler/bitswap.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/bitswap.rs
@@ -9,6 +9,32 @@ use crate::error::Result;
 use crate::transport::P2PTransport;
 
 impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
+    pub(crate) async fn handle_car_size_limit(
+        &self,
+        query_id: crate::QueryId,
+        cid: Cid,
+    ) -> Result<()> {
+        if self
+            .manager
+            .block_sync_completion_tracker()
+            .size_limit(query_id, cid)
+        {
+            return Ok(());
+        }
+        if let Some(root_cid) = self.manager.take_query_root(query_id) {
+            self.manager
+                .block_sync_completion_tracker()
+                .cancel(query_id);
+            self.manager.record_pending_dag_fetch_failure(
+                &root_cid,
+                &format!("provider cannot serve oversized CAR block {cid}"),
+            );
+            self.retry_pending_root_after_bitswap(query_id, root_cid)
+                .await?;
+        }
+        Ok(())
+    }
+
     async fn retry_pending_root_after_bitswap(
         &self,
         query_id: crate::QueryId,

--- a/crates/p2p/src/sync/coordinator/event_handler/car.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/car.rs
@@ -1,14 +1,14 @@
 //! CAR fetch event handling for the sync coordinator.
 
 use blockstore::{verify_block_cid, Blockstore};
-use bytes::Bytes;
 use cid::Cid;
 
 use crate::bitswap::BlockClass;
 use crate::error::Result;
 use crate::message::CarFetchRequest;
 use crate::sync::car::{
-    collect_dag_blocks_from_roots, collect_exact_blocks, decode_car, encode_car,
+    collect_dag_blocks_from_roots, collect_exact_blocks, decode_car, decode_car_oversized,
+    encode_car_response, CarCollectOutcome,
 };
 use crate::sync::coordinator::SyncCoordinator;
 use crate::transport::{P2PTransport, PeerId};
@@ -18,6 +18,7 @@ use super::super::authorizer::AccessAuthorizer;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum CarIngestDisposition {
     Completed,
+    SizeLimit(Cid),
     /// A root or shared descendant already has a storage owner. Wake this
     /// fetch with a non-success terminal result so its sole paced retry/provider
     /// rotation can re-offer the response after the owner completes.
@@ -89,9 +90,10 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 "CAR request contains blocks exceeding the response byte limit"
             );
         }
-        let blocks = self
-            .filter_car_response_blocks(&peer_id, &request.root_cid, collected.blocks)
+        let served = self
+            .filter_car_response_blocks(&peer_id, &request.root_cid, collected)
             .await;
+        let blocks = served.blocks;
         let kept_count = blocks.len();
         let filtered_count = collected_count.saturating_sub(kept_count);
         self.manager.diagnostics.record_car_serve_counts(
@@ -139,7 +141,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             // the libp2p response handler errors on empty bytes and the
             // requester-side car_empty_responses counter stays at zero
             // (issue #858 review feedback).
-            let car_data = encode_car(&response_roots, &[])?;
+            let car_data = encode_car_response(&response_roots, &[], &served.oversized_blocks)?;
             if let Some(token) = token {
                 self.runtime
                     .transport
@@ -155,7 +157,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         }
 
         let block_refs: Vec<(&Cid, &[u8])> = blocks.iter().map(|(c, d)| (c, d.as_ref())).collect();
-        let car_data = encode_car(&response_roots, &block_refs)?;
+        let car_data = encode_car_response(&response_roots, &block_refs, &served.oversized_blocks)?;
 
         tracing::debug!(
             root_cid = %request.root_cid,
@@ -197,8 +199,8 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         &self,
         peer_id: &PeerId,
         root_cid: &Cid,
-        blocks: Vec<(Cid, Bytes)>,
-    ) -> Vec<(Cid, Bytes)> {
+        mut blocks: CarCollectOutcome,
+    ) -> CarCollectOutcome {
         if self.access.access_mode.is_open() {
             return blocks;
         }
@@ -206,7 +208,14 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         let peer_str = peer_id.to_string();
         let serve = self.serve_acp.get();
         let mut identity: Option<acp::Identity> = None;
-        let mut kept = Vec::with_capacity(blocks.len());
+        let candidates = std::mem::take(&mut blocks.blocks)
+            .into_iter()
+            .map(|(cid, data)| (cid, Some(data), None))
+            .chain(
+                std::mem::take(&mut blocks.oversized_blocks)
+                    .into_iter()
+                    .map(|(cid, size)| (cid, None, Some(size))),
+            );
         let rooted_grant = self
             .runtime
             .selective_car_access
@@ -227,62 +236,80 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             None
         };
 
-        for (cid, data) in blocks {
-            if granted_cids
+        for (cid, data, oversized) in candidates {
+            let granted = granted_cids
                 .as_ref()
-                .is_some_and(|cids| cids.contains(&cid))
-            {
-                kept.push((cid, data));
-                continue;
-            }
-
-            match self.classifier.classify(&cid, &data).await {
-                BlockClass::Allow => kept.push((cid, data)),
-                BlockClass::Deny => {
-                    tracing::debug!(
-                        cid = %cid,
-                        peer_id = %peer_id,
-                        "CAR handler: dropping block denied by classifier"
-                    );
+                .is_some_and(|cids| cids.contains(&cid));
+            // Authorize notices at the same boundary as block bytes, without
+            // retaining oversized payloads for the entire response.
+            let data = match data {
+                Some(data) => data,
+                None if granted => {
+                    blocks
+                        .oversized_blocks
+                        .push((cid, oversized.expect("oversized candidate")));
+                    continue;
                 }
-                BlockClass::Data(meta) => {
-                    if self
-                        .access
-                        .replicators
-                        .is_filtered_replicator(&meta.collection_id, &peer_str)
-                    {
-                        continue;
+                None => match self.manager.blockstore().get(&cid).await {
+                    Ok(Some(data)) => data,
+                    _ => continue,
+                },
+            };
+            let allowed = if granted {
+                true
+            } else {
+                match self.classifier.classify(&cid, &data).await {
+                    BlockClass::Allow => true,
+                    BlockClass::Deny => {
+                        tracing::debug!(
+                            cid = %cid,
+                            peer_id = %peer_id,
+                            "CAR handler: dropping block denied by classifier"
+                        );
+                        false
                     }
-                    if self
-                        .access
-                        .replicators
-                        .is_replicator(&meta.collection_id, &peer_str)
-                    {
-                        kept.push((cid, data));
-                        continue;
+                    BlockClass::Data(meta) => {
+                        if self
+                            .access
+                            .replicators
+                            .is_filtered_replicator(&meta.collection_id, &peer_str)
+                        {
+                            continue;
+                        }
+                        if self
+                            .access
+                            .replicators
+                            .is_replicator(&meta.collection_id, &peer_str)
+                        {
+                            true
+                        } else {
+                            let Some(serve) = serve else {
+                                continue;
+                            };
+                            if identity.is_none() {
+                                identity = Some(match serve.resolver.resolve(peer_id).await {
+                                    Some(did) => acp::Identity::Authenticated(did),
+                                    None => acp::Identity::Anonymous,
+                                });
+                            }
+                            serve
+                                .gate
+                                .may_read(identity.as_ref().expect("identity set"), &meta)
+                                .await
+                        }
                     }
-
-                    let Some(serve) = serve else {
-                        continue;
-                    };
-                    if identity.is_none() {
-                        identity = Some(match serve.resolver.resolve(peer_id).await {
-                            Some(did) => acp::Identity::Authenticated(did),
-                            None => acp::Identity::Anonymous,
-                        });
-                    }
-                    if serve
-                        .gate
-                        .may_read(identity.as_ref().expect("identity set"), &meta)
-                        .await
-                    {
-                        kept.push((cid, data));
-                    }
+                }
+            };
+            if allowed {
+                if let Some(size) = oversized {
+                    blocks.oversized_blocks.push((cid, size));
+                } else {
+                    blocks.blocks.push((cid, data));
                 }
             }
         }
 
-        kept
+        blocks
     }
 
     /// Re-derive the authority installed before a head hint after the sender
@@ -388,6 +415,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         }
 
         let (_roots, blocks) = decode_car(&car_data)?;
+        let oversized = decode_car_oversized(&car_data)?;
 
         if blocks.is_empty() {
             self.manager.diagnostics.record_car_empty_response();
@@ -400,7 +428,9 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 peer_id = %peer_id,
                 "Received empty CAR response (decoded 0 blocks)"
             );
-            return Ok(CarIngestDisposition::Completed);
+            return self
+                .car_size_limit_disposition(&peer_id, &root_cid, &oversized)
+                .await;
         }
 
         // Verify all block CIDs before storing (finding 03-35).
@@ -459,6 +489,46 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             "Stored blocks from CAR response"
         );
 
+        self.car_size_limit_disposition(&peer_id, &root_cid, &oversized)
+            .await
+    }
+
+    async fn car_size_limit_disposition(
+        &self,
+        peer_id: &PeerId,
+        root_cid: &Cid,
+        oversized: &[(Cid, usize)],
+    ) -> Result<CarIngestDisposition> {
+        if oversized.is_empty() {
+            return Ok(CarIngestDisposition::Completed);
+        }
+        let missing = match self
+            .manager
+            .blockstore()
+            .get(root_cid)
+            .await
+            .map_err(crate::error::Error::from_blockstore)?
+        {
+            Some(data) => {
+                crate::sync::manager::links::find_all_missing_links(
+                    self.manager.blockstore().as_ref(),
+                    &data,
+                )
+                .await?
+            }
+            None => vec![*root_cid],
+        };
+        let missing: std::collections::HashSet<_> = missing.into_iter().collect();
+        // A peer's notice is only meaningful for a CID in our own missing
+        // frontier. It must not veto a complete DAG or an unrelated document.
+        if let Some((cid, size)) = oversized.iter().find(|(cid, _)| missing.contains(cid)) {
+            tracing::warn!(
+                root_cid = %root_cid, peer_id = %peer_id, block_cid = %cid,
+                block_bytes = size,
+                "Provider cannot serve a required block within its CAR byte limit"
+            );
+            return Ok(CarIngestDisposition::SizeLimit(*cid));
+        }
         Ok(CarIngestDisposition::Completed)
     }
 }

--- a/crates/p2p/src/sync/coordinator/event_handler/mod.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/mod.rs
@@ -613,6 +613,8 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 car_data,
             } => {
                 let has_blocks = crate::sync::car::car_has_any_block(&car_data);
+                let has_notices = crate::sync::car::decode_car_oversized(&car_data)
+                    .is_ok_and(|notices| !notices.is_empty());
                 let result = self
                     .retry_retriable_event("car_fetch_response", || {
                         self.handle_car_fetch_response(peer_id.clone(), root_cid, car_data.clone())
@@ -623,15 +625,24 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                     Some(car::CarIngestDisposition::Completed) => {
                         self.manager
                             .rooted_car_completion_tracker()
-                            .complete(root_cid, true);
+                            .complete(root_cid, &peer_id, true);
                     }
                     Some(car::CarIngestDisposition::Busy) => {
-                        self.manager.rooted_car_completion_tracker().defer(root_cid);
+                        self.manager
+                            .rooted_car_completion_tracker()
+                            .defer(root_cid, &peer_id);
+                    }
+                    Some(car::CarIngestDisposition::SizeLimit(cid)) => {
+                        self.manager.rooted_car_completion_tracker().complete_with(
+                            root_cid,
+                            &peer_id,
+                            crate::sync::manager::FetchCompletion::SizeLimit(cid),
+                        );
                     }
                     None => {
                         self.manager
                             .rooted_car_completion_tracker()
-                            .complete(root_cid, false);
+                            .complete(root_cid, &peer_id, false);
                     }
                 }
                 // Iroh block-sync success is query-correlated with the CAR
@@ -639,13 +650,16 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 // Header-only responses retain the transport's aggregate
                 // failure completion after all providers have answered.
                 if let Some(query_id) = query_id {
-                    if has_blocks {
+                    if has_blocks || has_notices {
                         match disposition {
                             Some(car::CarIngestDisposition::Completed) => {
                                 self.handle_bitswap_complete(query_id, true, None).await?;
                             }
                             Some(car::CarIngestDisposition::Busy) => {
                                 self.handle_bitswap_deferred(query_id).await?;
+                            }
+                            Some(car::CarIngestDisposition::SizeLimit(cid)) => {
+                                self.handle_car_size_limit(query_id, cid).await?;
                             }
                             None => {
                                 self.handle_bitswap_complete(

--- a/crates/p2p/src/sync/coordinator/event_handler/mod.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/mod.rs
@@ -612,7 +612,8 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 root_cid,
                 car_data,
             } => {
-                let has_blocks = crate::sync::car::car_has_any_block(&car_data);
+                let has_blocks =
+                    !car_data.is_empty() && crate::sync::car::car_has_any_block(&car_data);
                 let has_notices = crate::sync::car::decode_car_oversized(&car_data)
                     .is_ok_and(|notices| !notices.is_empty());
                 let result = self
@@ -625,7 +626,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                     Some(car::CarIngestDisposition::Completed) => {
                         self.manager
                             .rooted_car_completion_tracker()
-                            .complete(root_cid, &peer_id, true);
+                            .complete(root_cid, &peer_id, has_blocks);
                     }
                     Some(car::CarIngestDisposition::Busy) => {
                         self.manager
@@ -653,7 +654,8 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                     if has_blocks || has_notices {
                         match disposition {
                             Some(car::CarIngestDisposition::Completed) => {
-                                self.handle_bitswap_complete(query_id, true, None).await?;
+                                self.handle_bitswap_complete(query_id, has_blocks, None)
+                                    .await?;
                             }
                             Some(car::CarIngestDisposition::Busy) => {
                                 self.handle_bitswap_deferred(query_id).await?;

--- a/crates/p2p/src/sync/manager/process/bitswap.rs
+++ b/crates/p2p/src/sync/manager/process/bitswap.rs
@@ -21,6 +21,7 @@ pub(crate) enum FetchCompletion {
     Success,
     Failure,
     Deferred,
+    SizeLimit(Cid),
 }
 
 impl FetchCompletion {
@@ -101,36 +102,62 @@ impl BlockSyncCompletionState {
 /// alone adds avoidable ownership latency at small admission capacities.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct RootedCarCompletionTracker {
-    waiters: std::sync::Arc<
-        parking_lot::Mutex<
-            std::collections::HashMap<Cid, tokio::sync::oneshot::Sender<FetchCompletion>>,
-        >,
-    >,
+    waiters: std::sync::Arc<parking_lot::Mutex<std::collections::HashMap<Cid, RootedCarWaiter>>>,
+}
+
+#[derive(Debug)]
+struct RootedCarWaiter {
+    peer: crate::transport::PeerId,
+    completion: tokio::sync::oneshot::Sender<FetchCompletion>,
 }
 
 impl RootedCarCompletionTracker {
     pub(crate) fn register(
         &self,
         root_cid: Cid,
+        peer_id: crate::transport::PeerId,
     ) -> tokio::sync::oneshot::Receiver<FetchCompletion> {
         let (tx, rx) = tokio::sync::oneshot::channel();
-        self.waiters.lock().insert(root_cid, tx);
+        self.waiters.lock().insert(
+            root_cid,
+            RootedCarWaiter {
+                peer: peer_id,
+                completion: tx,
+            },
+        );
         rx
     }
 
-    pub(crate) fn complete(&self, root_cid: Cid, success: bool) -> bool {
-        self.complete_with(root_cid, FetchCompletion::from_success(success))
+    pub(crate) fn complete(
+        &self,
+        root_cid: Cid,
+        peer_id: &crate::transport::PeerId,
+        success: bool,
+    ) -> bool {
+        self.complete_with(root_cid, peer_id, FetchCompletion::from_success(success))
     }
 
-    pub(crate) fn defer(&self, root_cid: Cid) -> bool {
-        self.complete_with(root_cid, FetchCompletion::Deferred)
+    pub(crate) fn defer(&self, root_cid: Cid, peer_id: &crate::transport::PeerId) -> bool {
+        self.complete_with(root_cid, peer_id, FetchCompletion::Deferred)
     }
 
-    fn complete_with(&self, root_cid: Cid, completion: FetchCompletion) -> bool {
-        let Some(waiter) = self.waiters.lock().remove(&root_cid) else {
+    pub(crate) fn complete_with(
+        &self,
+        root_cid: Cid,
+        peer_id: &crate::transport::PeerId,
+        completion: FetchCompletion,
+    ) -> bool {
+        let mut waiters = self.waiters.lock();
+        if !waiters
+            .get(&root_cid)
+            .is_some_and(|waiter| &waiter.peer == peer_id)
+        {
+            return false;
+        }
+        let Some(waiter) = waiters.remove(&root_cid) else {
             return false;
         };
-        let _ = waiter.send(completion);
+        let _ = waiter.completion.send(completion);
         true
     }
 
@@ -168,6 +195,10 @@ impl BlockSyncCompletionTracker {
 
     pub(crate) fn defer(&self, query_id: QueryId) -> bool {
         self.complete_with(query_id, FetchCompletion::Deferred)
+    }
+
+    pub(crate) fn size_limit(&self, query_id: QueryId, cid: Cid) -> bool {
+        self.complete_with(query_id, FetchCompletion::SizeLimit(cid))
     }
 
     fn complete_with(&self, query_id: QueryId, completion: FetchCompletion) -> bool {

--- a/crates/p2p/src/sync/replication/handlers.rs
+++ b/crates/p2p/src/sync/replication/handlers.rs
@@ -208,6 +208,9 @@ where
                     crate::sync::manager::FetchCompletion::Deferred => {
                         coordinator.handle_bitswap_deferred(query_id).await
                     }
+                    crate::sync::manager::FetchCompletion::SizeLimit(cid) => {
+                        coordinator.handle_car_size_limit(query_id, cid).await
+                    }
                 };
                 if let Err(error) = result {
                     tracing::warn!(

--- a/crates/p2p/tests/unit/car_serving.rs
+++ b/crates/p2p/tests/unit/car_serving.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::sync::car::{decode_car, CAR_MAX_BYTES};
+use crate::sync::car::{decode_car, decode_car_oversized, encode_car_response, CAR_MAX_BYTES};
 
 #[tokio::test]
 async fn oversized_car_block_keeps_sibling_and_accurate_presence_counts() {
@@ -50,11 +50,16 @@ async fn oversized_car_block_keeps_sibling_and_accurate_presence_counts() {
         let (_, blocks) = decode_car(&responses[0]).unwrap();
         if allowed {
             assert_eq!(blocks, vec![(small, small_data.to_vec())]);
+            assert_eq!(
+                decode_car_oversized(&responses[0]).unwrap(),
+                vec![(oversized, CAR_MAX_BYTES + 1)]
+            );
         } else {
             assert!(
                 blocks.is_empty(),
                 "skipping oversized data must not bypass access control"
             );
+            assert!(decode_car_oversized(&responses[0]).unwrap().is_empty());
         }
         let diagnostics = coordinator.manager().diagnostics.snapshot();
         assert_eq!(diagnostics.car_requested_cids, 3);
@@ -62,4 +67,94 @@ async fn oversized_car_block_keeps_sibling_and_accurate_presence_counts() {
         assert_eq!(diagnostics.car_served_cids, u64::from(allowed));
         assert_eq!(diagnostics.car_filtered_cids, u64::from(!allowed));
     }
+}
+
+#[tokio::test]
+async fn car_size_notice_stores_siblings_and_only_reports_missing_link() {
+    use crate::sync::manager::FetchCompletion;
+    use defra_core::{Block, CompositeDeltaPayload, CrdtDelta, DAGLink};
+
+    let peer = random_peer_id();
+    let store = Arc::new(RegolithStore::in_memory().unwrap());
+    let blockstore = Arc::new(DefraBlockstore::new(store, true));
+    let (coordinator, _events) = SyncCoordinator::new(
+        NoopTransport::new(),
+        blockstore.clone(),
+        SyncConfig::default(),
+    )
+    .await
+    .unwrap();
+    let large = Cid::new_v1(0x71, Code::Sha2_256.digest(b"large"));
+    let small_data = serde_ipld_dagcbor::to_vec(&ipld_core::ipld!({ "value": "small" })).unwrap();
+    let small = Cid::new_v1(0x71, Code::Sha2_256.digest(&small_data));
+    let root_data = Block::new(
+        CrdtDelta::Composite(CompositeDeltaPayload {
+            schema_version_id: "version".to_owned(),
+            priority: 1,
+            status: 1,
+        }),
+        vec![],
+        vec![DAGLink::new("large", large), DAGLink::new("small", small)],
+    )
+    .to_dag_cbor()
+    .unwrap();
+    let root = Cid::new_v1(0x71, Code::Sha2_256.digest(&root_data));
+    let data = encode_car_response(
+        &[root],
+        &[(&root, &root_data), (&small, &small_data)],
+        &[(large, CAR_MAX_BYTES + 1)],
+    )
+    .unwrap();
+    let completion = coordinator
+        .manager()
+        .block_sync_completion_tracker()
+        .register(QueryId(71));
+    coordinator
+        .handle_transport_event(TransportEvent::CarFetchResponse {
+            query_id: Some(QueryId(71)),
+            peer_id: peer.clone(),
+            root_cid: root,
+            car_data: data,
+        })
+        .await
+        .unwrap();
+    assert_eq!(completion.await.unwrap(), FetchCompletion::SizeLimit(large));
+    assert!(blockstore.has(&root).await.unwrap());
+    assert!(blockstore.has(&small).await.unwrap());
+
+    // A claim about a block already present must not veto this fetch.
+    let completion = coordinator
+        .manager()
+        .block_sync_completion_tracker()
+        .register(QueryId(72));
+    let data = encode_car_response(&[root], &[], &[(small, CAR_MAX_BYTES + 1)]).unwrap();
+    coordinator
+        .handle_transport_event(TransportEvent::CarFetchResponse {
+            query_id: Some(QueryId(72)),
+            peer_id: peer.clone(),
+            root_cid: root,
+            car_data: data,
+        })
+        .await
+        .unwrap();
+    assert_eq!(completion.await.unwrap(), FetchCompletion::Success);
+
+    let mut completion = coordinator
+        .manager()
+        .rooted_car_completion_tracker()
+        .register(root, peer);
+    let data = encode_car_response(&[root], &[], &[(large, CAR_MAX_BYTES + 1)]).unwrap();
+    coordinator
+        .handle_transport_event(TransportEvent::CarFetchResponse {
+            query_id: None,
+            peer_id: random_peer_id(),
+            root_cid: root,
+            car_data: data,
+        })
+        .await
+        .unwrap();
+    assert!(matches!(
+        completion.try_recv(),
+        Err(tokio::sync::oneshot::error::TryRecvError::Empty)
+    ));
 }

--- a/crates/p2p/tests/unit/car_serving.rs
+++ b/crates/p2p/tests/unit/car_serving.rs
@@ -122,7 +122,7 @@ async fn car_size_notice_stores_siblings_and_only_reports_missing_link() {
     assert!(blockstore.has(&root).await.unwrap());
     assert!(blockstore.has(&small).await.unwrap());
 
-    // A claim about a block already present must not veto this fetch.
+    // An irrelevant notice is not a size-limit result or successful progress.
     let completion = coordinator
         .manager()
         .block_sync_completion_tracker()
@@ -137,7 +137,7 @@ async fn car_size_notice_stores_siblings_and_only_reports_missing_link() {
         })
         .await
         .unwrap();
-    assert_eq!(completion.await.unwrap(), FetchCompletion::Success);
+    assert_eq!(completion.await.unwrap(), FetchCompletion::Failure);
 
     let mut completion = coordinator
         .manager()

--- a/crates/p2p/tests/unit/car_size_notices.rs
+++ b/crates/p2p/tests/unit/car_size_notices.rs
@@ -1,0 +1,61 @@
+use super::*;
+use ciborium::Value;
+use multihash_codetable::{Code, MultihashDigest};
+
+fn cid(data: &[u8]) -> Cid {
+    Cid::new_v1(0x71, Code::Sha2_256.digest(data))
+}
+
+#[test]
+fn legacy_decoder_keeps_useful_blocks_and_ignores_size_notices() {
+    let root = cid(b"oversized");
+    let small = cid(b"small");
+    let notices = [(root, CAR_MAX_BYTES + 1)];
+    let car = encode_car_response(&[root], &[(&small, b"small")], &notices).unwrap();
+    assert_eq!(decode_car_oversized(&car).unwrap(), notices);
+    assert_eq!(
+        decode_car(&car).unwrap(),
+        (vec![root], vec![(small, b"small".to_vec())])
+    );
+
+    let empty = encode_car_response(&[root], &[], &notices).unwrap();
+    assert!(!car_has_any_block(&empty));
+    assert_eq!(decode_car_oversized(&empty).unwrap(), notices);
+    assert!(decode_car_oversized(&encode_car(&[root], &[]).unwrap())
+        .unwrap()
+        .is_empty());
+}
+
+#[test]
+fn malformed_size_notices_are_rejected() {
+    let root = cid(b"root");
+    let notice = |size: i64| {
+        Value::Array(vec![
+            Value::Bytes(root.to_bytes()),
+            Value::Integer(size.into()),
+        ])
+    };
+    for value in [
+        Value::Bool(true),
+        Value::Array(vec![Value::Bool(true)]),
+        Value::Array(vec![notice(-1)]),
+        Value::Array(vec![notice(CAR_MAX_BYTES as i64)]),
+        Value::Array(vec![Value::Array(vec![
+            Value::Bytes(vec![0]),
+            Value::Integer((CAR_MAX_BYTES as u64 + 1).into()),
+        ])]),
+        Value::Array(vec![notice(CAR_MAX_BYTES as i64 + 1); CAR_MAX_BLOCKS + 1]),
+    ] {
+        let mut header = Vec::new();
+        ciborium::into_writer(
+            &Value::Map(vec![(Value::Text("oversized".into()), value)]),
+            &mut header,
+        )
+        .unwrap();
+        let mut car = Vec::new();
+        write_varint_prefixed(&mut car, &header);
+        assert!(decode_car_oversized(&car).is_err());
+    }
+    assert!(decode_car_oversized(&[]).is_err());
+    assert!(decode_car_oversized(&[127, 0]).is_err());
+}

--- a/crates/p2p/tests/unit/car_size_retry.rs
+++ b/crates/p2p/tests/unit/car_size_retry.rs
@@ -1,0 +1,67 @@
+use super::*;
+
+#[tokio::test(start_paused = true)]
+async fn size_limited_provider_is_not_retried_but_alternate_can_finish() {
+    for alternate in [false, true] {
+        let store = Arc::new(RegolithStore::in_memory().unwrap());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let child_data = encode_ipld(ipld!({ "value": "child" }));
+        let child = make_cid(&child_data);
+        let root_data = encode_ipld(ipld!({ "child": child }));
+        let root = make_cid(&root_data);
+        blockstore.put(&root, &root_data).await.unwrap();
+        let transport = TestTransport::new(
+            blockstore.clone(),
+            root,
+            root_data,
+            HashMap::new(),
+            HashMap::from([(child, child_data)]),
+        );
+        let completions = crate::sync::manager::BlockSyncCompletionTracker::default();
+        transport
+            .size_limited_providers
+            .lock()
+            .unwrap()
+            .insert("remote-peer".to_owned(), (child, completions.clone()));
+        let mut context = DagFetchContext::new(
+            "doc".to_owned(),
+            "collection".to_owned(),
+            String::new(),
+            PeerId::new("remote-peer".to_owned()),
+        )
+        .with_block_sync_completions(completions);
+        if alternate {
+            context = context.with_alternate_providers(vec![PeerId::new("alt-peer".to_owned())]);
+        }
+        let (tx, mut rx) = mpsc::channel(4);
+        let start = tokio::time::Instant::now();
+        poll_fetch_dag(
+            transport.clone(),
+            blockstore.clone(),
+            tx,
+            root,
+            context,
+            DagFetchLimiter::new(1),
+            diagnostics(),
+        )
+        .await;
+        assert!(
+            start.elapsed() < Duration::from_secs(2),
+            "must not wait for another retry attempt"
+        );
+        assert_eq!(
+            transport.sync_providers(),
+            if alternate {
+                vec!["remote-peer", "alt-peer"]
+            } else {
+                vec!["remote-peer"]
+            }
+        );
+        assert_eq!(
+            transport.cancelled_queries().len(),
+            if alternate { 2 } else { 1 }
+        );
+        assert_eq!(blockstore.has(&child).await.unwrap(), alternate);
+        assert_eq!(rx.try_recv().is_ok(), alternate);
+    }
+}

--- a/crates/p2p/tests/unit/car_size_retry.rs
+++ b/crates/p2p/tests/unit/car_size_retry.rs
@@ -1,6 +1,65 @@
 use super::*;
 
 #[tokio::test(start_paused = true)]
+async fn unservable_batch_does_not_hide_later_servable_blocks() {
+    let store = Arc::new(RegolithStore::in_memory().unwrap());
+    let blockstore = Arc::new(DefraBlockstore::new(store, true));
+    let blocks: HashMap<_, _> = (0..2050)
+        .map(|i| {
+            let data = encode_ipld(ipld!({ "value": i }));
+            (make_cid(&data), data)
+        })
+        .collect();
+    let links: Vec<_> = blocks.keys().copied().map(Ipld::Link).collect();
+    let root_data = encode_ipld(ipld!({ "children": links }));
+    let root = make_cid(&root_data);
+    blockstore.put(&root, &root_data).await.unwrap();
+    let missing =
+        crate::sync::manager::links::find_all_missing_links(blockstore.as_ref(), &root_data)
+            .await
+            .unwrap();
+    let oversized = missing[0];
+    let last = *missing.last().unwrap();
+    let transport = TestTransport::new(
+        blockstore.clone(),
+        root,
+        root_data,
+        HashMap::new(),
+        HashMap::from([(last, blocks[&last].clone())]),
+    );
+    let completions = crate::sync::manager::BlockSyncCompletionTracker::default();
+    transport
+        .size_limited_providers
+        .lock()
+        .unwrap()
+        .insert("remote-peer".into(), (oversized, completions.clone()));
+    let context = DagFetchContext::new(
+        "doc".into(),
+        "collection".into(),
+        String::new(),
+        PeerId::new("remote-peer".into()),
+    )
+    .with_block_sync_completions(completions);
+    let (tx, mut rx) = mpsc::channel(4);
+    poll_fetch_dag(
+        transport,
+        blockstore.clone(),
+        tx,
+        root,
+        context,
+        DagFetchLimiter::new(1),
+        diagnostics(),
+    )
+    .await;
+    assert!(
+        blockstore.has(&last).await.unwrap(),
+        "later batch was skipped"
+    );
+    assert!(!blockstore.has(&oversized).await.unwrap());
+    assert!(rx.try_recv().is_err(), "incomplete DAG reported ready");
+}
+
+#[tokio::test(start_paused = true)]
 async fn size_limited_provider_is_not_retried_but_alternate_can_finish() {
     for alternate in [false, true] {
         let store = Arc::new(RegolithStore::in_memory().unwrap());

--- a/crates/p2p/tests/unit/iroh_car_size.rs
+++ b/crates/p2p/tests/unit/iroh_car_size.rs
@@ -1,0 +1,100 @@
+use super::*;
+use crate::sync::car::{decode_car_oversized, encode_car_response, CAR_MAX_BYTES};
+use multihash_codetable::{Code, MultihashDigest};
+use tokio::sync::oneshot;
+
+async fn serve(endpoint: Endpoint, response: Vec<u8>, ready: Option<oneshot::Receiver<()>>) {
+    let connection = endpoint.accept().await.unwrap().await.unwrap();
+    let (mut send, mut recv) = connection.accept_bi().await.unwrap();
+    recv.read_to_end(4096).await.unwrap();
+    if let Some(ready) = ready {
+        ready.await.unwrap();
+    }
+    send.write_all(&response).await.unwrap();
+    send.finish().unwrap();
+    let _ = connection.closed().await;
+}
+
+#[tokio::test]
+async fn size_notice_does_not_cancel_alternate_provider_or_emit_generic_failure() {
+    tokio::time::timeout(std::time::Duration::from_secs(10), async {
+        for alternate in [false, true] {
+            let client = tests::localhost_endpoint(vec![]).await;
+            let limited = tests::localhost_endpoint(vec![protocols::ALPN_CAR.to_vec()]).await;
+            let healthy = tests::localhost_endpoint(vec![protocols::ALPN_CAR.to_vec()]).await;
+            let root = cid::Cid::new_v1(0x71, Code::Sha2_256.digest(b"block"));
+            let notice = encode_car_response(&[root], &[], &[(root, CAR_MAX_BYTES + 1)]).unwrap();
+            let limited_task = tokio::spawn(serve(limited.clone(), notice, None));
+            let (ready_tx, ready_rx) = oneshot::channel();
+            let healthy_task = alternate.then(|| {
+                tokio::spawn(serve(
+                    healthy.clone(),
+                    encode_car_response(&[root], &[(&root, b"block")], &[]).unwrap(),
+                    Some(ready_rx),
+                ))
+            });
+            let cache = new_connection_cache();
+            let peer_map = Arc::new(parking_lot::Mutex::new(PeerMap::new()));
+            let endpoints = if alternate {
+                vec![&limited, &healthy]
+            } else {
+                vec![&limited]
+            };
+            let mut providers = Vec::new();
+            for endpoint in endpoints {
+                let provider = PeerId::new(endpoint.id().to_string());
+                let addr = endpoint.addr().ip_addrs().next().copied().unwrap();
+                let connection =
+                    connect_with_cache(&client, &provider, protocols::ALPN_CAR, Some(addr), &cache)
+                        .await
+                        .unwrap();
+                peer_map
+                    .lock()
+                    .increment_connections(endpoint.id(), Some(addr), connection);
+                providers.push(provider);
+            }
+            let (tx, mut rx) = mpsc::channel(8);
+            let task = tokio::spawn(handle_block_sync(
+                BlockSyncResources::new(client.clone(), peer_map, cache, tx),
+                QueryId(88),
+                root,
+                providers,
+                vec![root],
+            ));
+            let Some(TransportEvent::CarFetchResponse {
+                query_id, car_data, ..
+            }) = rx.recv().await
+            else {
+                panic!("expected size-limit CAR response");
+            };
+            assert_eq!(query_id, Some(QueryId(88)));
+            assert_eq!(
+                decode_car_oversized(&car_data).unwrap(),
+                vec![(root, CAR_MAX_BYTES + 1)]
+            );
+            if alternate {
+                ready_tx.send(()).unwrap();
+                let Some(TransportEvent::CarFetchResponse { car_data, .. }) = rx.recv().await
+                else {
+                    panic!("size-limited response must not cancel the healthy provider");
+                };
+                assert!(crate::sync::car::car_has_any_block(&car_data));
+                assert!(decode_car_oversized(&car_data).unwrap().is_empty());
+            }
+            task.await.unwrap();
+            assert!(
+                rx.try_recv().is_err(),
+                "no generic failure may overwrite the size notice"
+            );
+            client.close().await;
+            limited.close().await;
+            healthy.close().await;
+            limited_task.abort();
+            if let Some(task) = healthy_task {
+                task.abort();
+            }
+        }
+    })
+    .await
+    .expect("CAR providers should finish promptly");
+}

--- a/crates/p2p/tests/unit/iroh_car_size.rs
+++ b/crates/p2p/tests/unit/iroh_car_size.rs
@@ -6,6 +6,10 @@ use tokio::sync::oneshot;
 async fn serve(endpoint: Endpoint, response: Vec<u8>, ready: Option<oneshot::Receiver<()>>) {
     let connection = endpoint.accept().await.unwrap().await.unwrap();
     let (mut send, mut recv) = connection.accept_bi().await.unwrap();
+    assert_eq!(
+        protocols::read_stream_tag(&mut recv).await.unwrap(),
+        protocols::STREAM_CAR
+    );
     recv.read_to_end(4096).await.unwrap();
     if let Some(ready) = ready {
         ready.await.unwrap();
@@ -20,8 +24,8 @@ async fn size_notice_does_not_cancel_alternate_provider_or_emit_generic_failure(
     tokio::time::timeout(std::time::Duration::from_secs(10), async {
         for alternate in [false, true] {
             let client = tests::localhost_endpoint(vec![]).await;
-            let limited = tests::localhost_endpoint(vec![protocols::ALPN_CAR.to_vec()]).await;
-            let healthy = tests::localhost_endpoint(vec![protocols::ALPN_CAR.to_vec()]).await;
+            let limited = tests::localhost_endpoint(vec![protocols::ALPN_MUX.to_vec()]).await;
+            let healthy = tests::localhost_endpoint(vec![protocols::ALPN_MUX.to_vec()]).await;
             let root = cid::Cid::new_v1(0x71, Code::Sha2_256.digest(b"block"));
             let notice = encode_car_response(&[root], &[], &[(root, CAR_MAX_BYTES + 1)]).unwrap();
             let limited_task = tokio::spawn(serve(limited.clone(), notice, None));
@@ -44,10 +48,9 @@ async fn size_notice_does_not_cancel_alternate_provider_or_emit_generic_failure(
             for endpoint in endpoints {
                 let provider = PeerId::new(endpoint.id().to_string());
                 let addr = endpoint.addr().ip_addrs().next().copied().unwrap();
-                let connection =
-                    connect_with_cache(&client, &provider, protocols::ALPN_CAR, Some(addr), &cache)
-                        .await
-                        .unwrap();
+                let connection = connect_with_cache(&client, &provider, Some(addr), &cache)
+                    .await
+                    .unwrap();
                 peer_map
                     .lock()
                     .increment_connections(endpoint.id(), Some(addr), connection);


### PR DESCRIPTION
## Context
The collector fix preserves useful sibling blocks, but receivers still need to distinguish an oversized block from a temporary provider miss.

## Changes
- Add optional oversized-block notices to Rust CAR responses, using the same authorization checks as block data.
- Store useful blocks before reporting a size limit, and accept notices only for the receiver's missing DAG frontier.
- Stop futile retries within a fetch while retaining alternate-provider recovery and libp2p's independent Bitswap fallback.
- Correlate two-stream completion with the responding peer and prevent generic failures from overwriting size-limit results.

The 16 MiB payload limit remains unchanged. Pending documents remain recoverable through the existing retry clock; older Rust peers ignore the optional notices.

## Testing
- [x] Full P2P package suite with both transports enabled, including 459 unit tests.
- [x] Default-feature unit tests and strict clippy for all-feature and Iroh-only configurations.
- [x] Malformed notices, authorization, missing-frontier validation, and peer correlation.
- [x] Retry termination and recovery through an alternate provider.
- [x] Real loopback Iroh exchange with a size-limited provider and a delayed healthy alternate.
- [x] Live two-node Iroh document sync and libp2p receiver-pull convergence.
- [x] Formatting and diff checks.

Closes #1557