### PR TITLE
feat(sync): a push can carry the grants that make what it registers readable

### DIFF
--- a/crates/cli/src/browser_sync_adapter.rs
+++ b/crates/cli/src/browser_sync_adapter.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use defra_core::browser_sync::{
     BrowserSyncDocument, BrowserSyncPull, BrowserSyncRequest, BrowserSyncResponse,
     DEFAULT_SYNC_PAGE_SIZE, MAX_SYNC_BODY_BYTES, MAX_SYNC_ID_BYTES, MAX_SYNC_PAGE_SIZE,
-    MAX_SYNC_PAYLOAD_BYTES,
+    MAX_SYNC_PAYLOAD_BYTES, MAX_SYNC_RELATIONSHIPS_PER_DOCUMENT,
 };
 use defra_http::router::{BrowserSyncError, BrowserSyncOperations, BrowserSyncResult};
 use storage::corekv::Store;
@@ -20,6 +20,14 @@ struct PendingSyncDocument {
     document: db::merge::ValidatedBrowserSyncDocument,
     collection: db::Collection,
     register_owner: Option<identity::Did>,
+    relationships: Vec<PendingRelationship>,
+}
+
+/// A grant from the push, resolved to the two subjects
+/// `add_actor_relationship` can represent.
+struct PendingRelationship {
+    relation: String,
+    target: identity::Did,
 }
 
 impl<S: Store + 'static> BrowserSyncAdapter<S> {
@@ -74,6 +82,7 @@ impl<S: Store + 'static> BrowserSyncAdapter<S> {
         identity: &Identity,
         bypass_dac: bool,
     ) -> BrowserSyncResult<PendingSyncDocument> {
+        let source = document;
         let document = self
             .engine
             .validate_document(document)
@@ -129,10 +138,12 @@ impl<S: Store + 'static> BrowserSyncAdapter<S> {
         } else {
             None
         };
+        let relationships = prepare_relationships(source, &collection, identity)?;
         Ok(PendingSyncDocument {
             document,
             collection,
             register_owner,
+            relationships,
         })
     }
 
@@ -153,11 +164,65 @@ impl<S: Store + 'static> BrowserSyncAdapter<S> {
             .await
             .map_err(|error| BrowserSyncError::Internal(error.to_string()))?;
         }
+        // Before the merge, so the document carries its grants by the time the
+        // merge announces it to peers.
+        self.apply_relationships(&document, &doc_id, identity)
+            .await?;
 
         self.engine
             .apply_validated_document(document.document, creator)
             .await
             .map_err(map_engine_error)
+    }
+
+    /// Apply the push's grants as the authenticated caller, never as the owner
+    /// the push registered: `add_actor_relationship` then allows exactly what a
+    /// second call to the relationship endpoint would, and a relay pushing
+    /// somebody else's DAG still gets `NotOwner`.
+    ///
+    /// `managing_relations` is empty, so a manager who is not the owner has to
+    /// use that endpoint, which resolves the policy's managers.
+    async fn apply_relationships(
+        &self,
+        document: &PendingSyncDocument,
+        doc_id: &str,
+        identity: &Identity,
+    ) -> BrowserSyncResult<()> {
+        if document.relationships.is_empty() {
+            return Ok(());
+        }
+        // Both established by `prepare_relationships` before anything in this
+        // request was applied.
+        let (Some(requestor), Some(policy)) =
+            (identity.did(), document.collection.schema().policy.as_ref())
+        else {
+            return Err(BrowserSyncError::Internal(
+                "sync relationships reached apply without a caller or a policy".into(),
+            ));
+        };
+        for relationship in &document.relationships {
+            self.document_acp
+                .add_actor_relationship(
+                    requestor,
+                    &relationship.target,
+                    &policy.id,
+                    &policy.resource_name,
+                    doc_id,
+                    &relationship.relation,
+                    &[],
+                )
+                .await
+                .map_err(|error| match error {
+                    acp::Error::NotOwner { .. } | acp::Error::NotManager { .. } => {
+                        BrowserSyncError::Forbidden(format!(
+                            "cannot grant '{}' on document {doc_id}: {error}",
+                            relationship.relation
+                        ))
+                    }
+                    error => BrowserSyncError::Internal(error.to_string()),
+                })?;
+        }
+        Ok(())
     }
 
     async fn pull_documents(
@@ -362,6 +427,66 @@ fn map_engine_error(error: db::merge::BrowserSyncError) -> BrowserSyncError {
         db::merge::BrowserSyncError::Storage(message) => BrowserSyncError::Internal(message),
         other => BrowserSyncError::Internal(other.to_string()),
     }
+}
+
+/// Resolve the push's grants before anything in the request is applied.
+///
+/// Who may grant stays with `add_actor_relationship`. This refuses only what
+/// that call cannot express: a caller with no DID, a collection with no policy,
+/// a target that is neither an actor nor the wildcard, and the immutable
+/// `owner` relation.
+fn prepare_relationships(
+    document: &BrowserSyncDocument,
+    collection: &db::Collection,
+    identity: &Identity,
+) -> BrowserSyncResult<Vec<PendingRelationship>> {
+    if document.relationships.is_empty() {
+        return Ok(Vec::new());
+    }
+    if document.relationships.len() > MAX_SYNC_RELATIONSHIPS_PER_DOCUMENT {
+        return Err(BrowserSyncError::InvalidInput(format!(
+            "sync document {} exceeds {MAX_SYNC_RELATIONSHIPS_PER_DOCUMENT} relationships",
+            document.doc_id
+        )));
+    }
+    if identity.did().is_none() {
+        return Err(BrowserSyncError::Forbidden(format!(
+            "sync relationships on document {} require an authenticated caller",
+            document.doc_id
+        )));
+    }
+    if collection.schema().policy.is_none() {
+        return Err(BrowserSyncError::InvalidInput(format!(
+            "collection '{}' has no policy to grant relationships under",
+            document.collection_id
+        )));
+    }
+
+    let mut prepared = Vec::with_capacity(document.relationships.len());
+    for relationship in &document.relationships {
+        validate_id("relation", &relationship.relation)?;
+        validate_id("relationship target", &relationship.target)?;
+        if relationship.relation == "owner" {
+            return Err(BrowserSyncError::InvalidInput(
+                "cannot add owner relation".into(),
+            ));
+        }
+        let target = if relationship.target == "*" {
+            identity::Did::wildcard()
+        } else {
+            identity::Did::try_from(relationship.target.clone()).map_err(|error| {
+                BrowserSyncError::InvalidInput(format!(
+                    "relationship target '{}' is not an actor DID: {error}",
+                    relationship.target
+                ))
+            })?
+        };
+        prepared.push(PendingRelationship {
+            relation: relationship.relation.clone(),
+            target,
+        });
+    }
+    Ok(prepared)
 }
 
 fn validate_optional_id(name: &str, value: Option<&str>) -> BrowserSyncResult<()> {

--- a/crates/cli/src/browser_sync_adapter_tests.rs
+++ b/crates/cli/src/browser_sync_adapter_tests.rs
@@ -3,7 +3,9 @@ use std::sync::Arc;
 
 use acp::{DocumentACP, LocalDocumentACP, MemoryAcpStore};
 use crypto::{Key as _, PrivateKey as _};
-use defra_core::browser_sync::{BrowserSyncPull, BrowserSyncRequest};
+use defra_core::browser_sync::{
+    BrowserSyncDocument, BrowserSyncPull, BrowserSyncRelationship, BrowserSyncRequest,
+};
 use defra_core::signing::{set_signing_config, SigningConfig, SigningKeyType};
 use document::{DocID, Document, NormalValue};
 use query::mutator::DocMutator;
@@ -686,4 +688,243 @@ async fn pull_skips_a_block_heavy_document_and_keeps_paginating() {
         "every loadable document must be served, including those after the block-heavy one"
     );
     assert!(!seen.contains(&heavy));
+}
+
+/// The window this field exists to close: a protected document is invisible to
+/// every other key until its owner grants a read, and the push announces it
+/// between the two. Both halves are asserted — without the grant the anonymous
+/// pull is empty, with it the document is there.
+#[tokio::test]
+async fn relationships_on_the_push_make_a_protected_document_readable_at_once() {
+    let source = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
+    source.create_collection(users_schema(true)).await.unwrap();
+    let owner = install_signing_identity();
+    let granted = create_document(&source, "Granted").await;
+    let ungranted = create_document(&source, "Ungranted").await;
+    set_signing_config(None);
+    let granted_doc_id = granted.doc_id.clone();
+    let ungranted_doc_id = ungranted.doc_id.clone();
+
+    let target = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
+    target.create_collection(users_schema(true)).await.unwrap();
+    let acp = Arc::new(LocalDocumentACP::new(Arc::new(MemoryAcpStore::new())));
+    let adapter = BrowserSyncAdapter::new_arc(target, acp.clone());
+
+    adapter
+        .sync(
+            BrowserSyncRequest {
+                documents: vec![
+                    BrowserSyncDocument {
+                        relationships: vec![BrowserSyncRelationship {
+                            relation: "reader".into(),
+                            target: "*".into(),
+                        }],
+                        ..granted
+                    },
+                    ungranted,
+                ],
+                pull: None,
+            },
+            Some(&owner),
+            false,
+        )
+        .await
+        .unwrap();
+
+    let anonymous = adapter
+        .sync(
+            BrowserSyncRequest {
+                documents: Vec::new(),
+                pull: Some(BrowserSyncPull::default()),
+            },
+            None,
+            false,
+        )
+        .await
+        .unwrap();
+    let seen: Vec<&str> = anonymous
+        .documents
+        .iter()
+        .map(|document| document.doc_id.as_str())
+        .collect();
+    assert_eq!(
+        seen,
+        vec![granted_doc_id.as_str()],
+        "only the document whose push carried a wildcard reader grant is visible anonymously"
+    );
+    assert!(!seen.contains(&ungranted_doc_id.as_str()));
+}
+
+/// The grant is applied as the caller, not as the owner the push established,
+/// so a relay pushing somebody else's DAG cannot attach one.
+#[tokio::test]
+async fn relationships_cannot_be_attached_to_a_foreign_signed_document() {
+    let source = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
+    source.create_collection(users_schema(true)).await.unwrap();
+    let alice = install_signing_identity();
+    let document = create_document(&source, "Alice").await;
+    set_signing_config(None);
+    let doc_id = document.doc_id.clone();
+
+    let target = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
+    target.create_collection(users_schema(true)).await.unwrap();
+    let acp = Arc::new(LocalDocumentACP::new(Arc::new(MemoryAcpStore::new())));
+    let adapter = BrowserSyncAdapter::new_arc(target, acp.clone());
+
+    let bob = "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH";
+    let error = adapter
+        .sync(
+            BrowserSyncRequest {
+                documents: vec![BrowserSyncDocument {
+                    relationships: vec![BrowserSyncRelationship {
+                        relation: "reader".into(),
+                        target: bob.into(),
+                    }],
+                    ..document.clone()
+                }],
+                pull: None,
+            },
+            Some(bob),
+            false,
+        )
+        .await
+        .expect_err("a caller who is not the owner must not be able to grant");
+    assert!(
+        matches!(error, defra_http::router::BrowserSyncError::Forbidden(_)),
+        "expected a forbidden grant, got {error:?}"
+    );
+    assert_eq!(
+        acp.get_doc_owner("users-policy", "users", &doc_id)
+            .await
+            .unwrap()
+            .map(|did| did.to_string()),
+        Some(alice.clone()),
+        "ownership must still follow the verified genesis creator"
+    );
+
+    // A refused grant does not leave the document stranded: Alice's own push
+    // lands the same grant.
+    adapter
+        .sync(
+            BrowserSyncRequest {
+                documents: vec![BrowserSyncDocument {
+                    relationships: vec![BrowserSyncRelationship {
+                        relation: "reader".into(),
+                        target: "*".into(),
+                    }],
+                    ..document
+                }],
+                pull: None,
+            },
+            Some(&alice),
+            false,
+        )
+        .await
+        .unwrap();
+    let anonymous = adapter
+        .sync(
+            BrowserSyncRequest {
+                documents: Vec::new(),
+                pull: Some(BrowserSyncPull::default()),
+            },
+            None,
+            false,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        anonymous
+            .documents
+            .iter()
+            .map(|document| document.doc_id.as_str())
+            .collect::<Vec<_>>(),
+        vec![doc_id.as_str()]
+    );
+}
+
+#[tokio::test]
+async fn relationships_require_an_authenticated_caller() {
+    let source = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
+    source.create_collection(users_schema(true)).await.unwrap();
+    install_signing_identity();
+    let document = create_document(&source, "Alice").await;
+    set_signing_config(None);
+
+    let target = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
+    target.create_collection(users_schema(true)).await.unwrap();
+    let acp = Arc::new(LocalDocumentACP::new(Arc::new(MemoryAcpStore::new())));
+    let adapter = BrowserSyncAdapter::new_arc(target, acp);
+
+    let error = adapter
+        .sync(
+            BrowserSyncRequest {
+                documents: vec![BrowserSyncDocument {
+                    relationships: vec![BrowserSyncRelationship {
+                        relation: "reader".into(),
+                        target: "*".into(),
+                    }],
+                    ..document
+                }],
+                pull: None,
+            },
+            None,
+            false,
+        )
+        .await
+        .expect_err("an anonymous caller has no DID to grant as");
+    assert!(matches!(
+        error,
+        defra_http::router::BrowserSyncError::Forbidden(_)
+    ));
+}
+
+#[tokio::test]
+async fn relationships_refuse_the_owner_relation_and_an_unbounded_list() {
+    let source = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
+    source.create_collection(users_schema(true)).await.unwrap();
+    let owner = install_signing_identity();
+    let document = create_document(&source, "Alice").await;
+    set_signing_config(None);
+
+    let target = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
+    target.create_collection(users_schema(true)).await.unwrap();
+    let acp = Arc::new(LocalDocumentACP::new(Arc::new(MemoryAcpStore::new())));
+    let adapter = BrowserSyncAdapter::new_arc(target, acp);
+
+    for relationships in [
+        vec![BrowserSyncRelationship {
+            relation: "owner".into(),
+            target: "*".into(),
+        }],
+        vec![BrowserSyncRelationship {
+            relation: "reader".into(),
+            target: "not-a-did".into(),
+        }],
+        vec![
+            BrowserSyncRelationship {
+                relation: "reader".into(),
+                target: "*".into(),
+            };
+            defra_core::browser_sync::MAX_SYNC_RELATIONSHIPS_PER_DOCUMENT + 1
+        ],
+    ] {
+        let error = adapter
+            .sync(
+                BrowserSyncRequest {
+                    documents: vec![BrowserSyncDocument {
+                        relationships: relationships.clone(),
+                        ..document.clone()
+                    }],
+                    pull: None,
+                },
+                Some(&owner),
+                false,
+            )
+            .await
+            .expect_err("expected a refusal for {relationships:?}");
+        assert!(
+            matches!(error, defra_http::router::BrowserSyncError::InvalidInput(_)),
+            "expected invalid input for {relationships:?}, got {error:?}"
+        );
+    }
 }

--- a/crates/db/src/merge/browser_sync.rs
+++ b/crates/db/src/merge/browser_sync.rs
@@ -270,6 +270,8 @@ impl<S: Store + 'static> BrowserSyncEngine<S> {
             collection_id: document_ref.collection_id.clone(),
             roots: roots.into_iter().map(|cid| cid.to_string()).collect(),
             blocks,
+            // Grants are node-local state, not part of the DAG a pull carries.
+            relationships: Vec::new(),
         };
         self.validate_document(&document)?;
         Ok(Some(document))

--- a/crates/db/tests/merge/browser_sync_tests.rs
+++ b/crates/db/tests/merge/browser_sync_tests.rs
@@ -82,6 +82,7 @@ fn validation_distinguishes_empty_and_over_limit_counts() {
         collection_id: "collection".into(),
         roots: Vec::new(),
         blocks: vec![block.clone()],
+        relationships: Vec::new(),
     };
     assert!(matches!(
         sync.validate_document(&empty_roots),

--- a/crates/defra-core/src/browser_sync.rs
+++ b/crates/defra-core/src/browser_sync.rs
@@ -8,6 +8,7 @@ pub const MAX_SYNC_BLOCK_BYTES: usize = 4 * 1024 * 1024;
 pub const MAX_SYNC_BLOCKS_PER_DOCUMENT: usize = 4096;
 pub const MAX_SYNC_DOCUMENTS_PER_REQUEST: usize = 32;
 pub const MAX_SYNC_ROOTS_PER_DOCUMENT: usize = 16;
+pub const MAX_SYNC_RELATIONSHIPS_PER_DOCUMENT: usize = 16;
 pub const MAX_SYNC_PULL_DOC_IDS: usize = 64;
 pub const DEFAULT_SYNC_PAGE_SIZE: usize = 32;
 pub const MAX_SYNC_PAGE_SIZE: usize = 64;
@@ -19,12 +20,31 @@ pub struct BrowserSyncBlock {
     pub data: String,
 }
 
+/// One access grant to apply to the document it arrives with.
+///
+/// `target` is an actor DID or the all-actors wildcard `*`. The relationship
+/// endpoint's wider subject language — cross-object edges, usersets — is
+/// deliberately out of reach from a push.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BrowserSyncRelationship {
+    pub relation: String,
+    pub target: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BrowserSyncDocument {
     pub doc_id: String,
     pub collection_id: String,
     pub roots: Vec<String>,
     pub blocks: Vec<BrowserSyncBlock>,
+    /// Grants applied while the document is registered, so a document under a
+    /// policy becomes registered and readable in one step. Pushing and then
+    /// granting cannot: the merge announces the document between the two, and
+    /// a peer pulling on that announcement may not read it yet.
+    ///
+    /// Absent on the wire means empty.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub relationships: Vec<BrowserSyncRelationship>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -51,4 +71,35 @@ pub struct BrowserSyncResponse {
     pub documents: Vec<BrowserSyncDocument>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub next_cursor: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A client built before `relationships` existed must still be read, and
+    /// must still see the bytes it has always seen.
+    #[test]
+    fn a_document_without_relationships_round_trips_unchanged() {
+        let legacy = r#"{"doc_id":"d","collection_id":"c","roots":["r"],"blocks":[]}"#;
+        let document: BrowserSyncDocument = serde_json::from_str(legacy).unwrap();
+        assert!(document.relationships.is_empty());
+        assert_eq!(serde_json::to_string(&document).unwrap(), legacy);
+    }
+
+    #[test]
+    fn relationships_are_carried_when_present() {
+        let document: BrowserSyncDocument = serde_json::from_str(
+            r#"{"doc_id":"d","collection_id":"c","roots":["r"],"blocks":[],
+                "relationships":[{"relation":"reader","target":"*"}]}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            document.relationships,
+            vec![BrowserSyncRelationship {
+                relation: "reader".into(),
+                target: "*".into(),
+            }]
+        );
+    }
 }

--- a/crates/wasm/src/sync/session.rs
+++ b/crates/wasm/src/sync/session.rs
@@ -342,12 +342,14 @@ mod tests {
                     cid: "block-one".into(),
                     data: "data-one".into(),
                 }],
+                relationships: Vec::new(),
             },
             BrowserSyncDocument {
                 doc_id: "doc-two".into(),
                 collection_id: "collection".into(),
                 roots: vec![],
                 blocks: vec![],
+                relationships: Vec::new(),
             },
         ];
         let incremental_size = documents.iter().enumerate().fold(


### PR DESCRIPTION
**TL;DR** — Creating a document from an authoring client takes two steps: create
it, then add the ACL. The node announces the document on the first, so peers are
pushed a document they are not yet allowed to read. Nothing retries, and an empty
pull is indistinguishable from a document that does not exist.

Measured downstream, one writer and one browser holding a synced node: a document
written with a policy **never arrived** — checked at 10 s intervals to 100 s, with
no warning. The same document with no policy on the collection: under 3 s. It
stopped a design.

## The change

`BrowserSyncDocument` gains an optional `relationships` list, applied between
`register_doc_if_needed` and `apply_validated_document` — so registered, granted
and announced are one step. Absent on the wire means empty, so an older client
pushes exactly what it pushed before.

## Authority is unchanged

Grants apply as the authenticated caller of the push, not as the owner the push
registers. `add_actor_relationship` still decides, so a push can do what that
caller could have done with a second call to the relationship endpoint and no
more — a relay forwarding somebody else's DAG still gets `NotOwner`.

## Not covered

- A manager who is not the owner cannot grant this way (`managing_relations` is
  empty), and the relation name is not checked against the policy, so an
  unmatched relation can only ever grant less. Both need the policy store the
  adapter does not hold, and both remain the relationship endpoint's job.
- The browser client sends an empty list: it exports no `sign_*`, so it cannot
  sign a genesis, own a document, or have anything to grant. This is the
  server-side writer's path.

## Testing

Four new adapter tests: grants on the push make a protected document readable at
once; grants cannot be attached to a foreign-signed document; grants require an
authenticated caller; the owner relation and an unbounded list are refused.

`cargo test -p cli --lib` 76 passed, `defra-core` 95 passed, clippy and fmt clean.

Downstream re-measured with the instrument that found the fault: a push carrying
its grant lands in **0.06 s**, where push-then-grant never lands.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
