### PR TITLE
perf(wasm): answer a burst of updates in one sync exchange

### DIFF
--- a/crates/cli/src/browser_sync_adapter_tests.rs
+++ b/crates/cli/src/browser_sync_adapter_tests.rs
@@ -538,6 +538,69 @@ async fn concurrent_changes_converge_through_push_pull_exchange() {
     }
 }
 
+/// A pull naming several documents can be cut short by the page limit, and its
+/// cursor has to resume *within the named set* — resuming across the whole
+/// store would lose whatever fell off the first page.
+#[tokio::test]
+async fn a_pull_naming_several_documents_resumes_across_its_cursor() {
+    let database = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
+    database
+        .create_collection(users_schema(false))
+        .await
+        .unwrap();
+
+    let mut named = Vec::new();
+    for name in ["Alice", "Bob", "Carol"] {
+        named.push(create_document(&database, name).await.doc_id);
+    }
+    // In the store, not in the pull: a cursor over the whole store serves it.
+    let unnamed = create_document(&database, "Mallory").await.doc_id;
+
+    let acp = Arc::new(LocalDocumentACP::new(Arc::new(MemoryAcpStore::new())));
+    let adapter = BrowserSyncAdapter::new_arc(database, acp);
+
+    let mut cursor = None;
+    let mut seen: Vec<String> = Vec::new();
+    for _ in 0..8 {
+        let page = adapter
+            .sync(
+                BrowserSyncRequest {
+                    documents: Vec::new(),
+                    pull: Some(BrowserSyncPull {
+                        doc_ids: named.clone(),
+                        cursor: cursor.clone(),
+                        // Below the number named, so the pull must paginate.
+                        limit: Some(2),
+                    }),
+                },
+                None,
+                false,
+            )
+            .await
+            .expect("a pull naming several documents must be served");
+        seen.extend(page.documents.iter().map(|doc| doc.doc_id.clone()));
+        match page.next_cursor {
+            Some(next) => {
+                assert_ne!(Some(&next), cursor.as_ref(), "cursor must advance");
+                cursor = Some(next);
+            }
+            None => break,
+        }
+    }
+
+    seen.sort();
+    let mut expected = named.clone();
+    expected.sort();
+    assert_eq!(
+        seen, expected,
+        "every named document must be served across the pages"
+    );
+    assert!(
+        !seen.contains(&unnamed),
+        "a document the pull did not name must not be served"
+    );
+}
+
 /// #1188 skips the oversized document, but the property that matters is that
 /// pagination still reaches documents ordered *after* it. Doc IDs are
 /// content-derived, so this fixture asserts the oversized document actually

--- a/crates/wasm/src/sync/session.rs
+++ b/crates/wasm/src/sync/session.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use defra_core::browser_sync::{
     BrowserSyncDocument, BrowserSyncPull, BrowserSyncRequest, BrowserSyncResponse,
-    MAX_SYNC_BODY_BYTES, MAX_SYNC_DOCUMENTS_PER_REQUEST, MAX_SYNC_PAGE_SIZE,
+    MAX_SYNC_BODY_BYTES, MAX_SYNC_DOCUMENTS_PER_REQUEST, MAX_SYNC_PAGE_SIZE, MAX_SYNC_PULL_DOC_IDS,
 };
 use events::Bus;
 use futures::channel::oneshot;
@@ -21,6 +21,12 @@ use super::sse::SseStream;
 const INITIAL_RECONNECT_DELAY_MS: u32 = 1_000;
 const MAX_RECONNECT_DELAY_MS: u32 = 30_000;
 const EMPTY_PUSH_REQUEST_BYTES: usize = b"{\"documents\":[]}".len();
+
+/// What an exchange costs before a document or a pull ID is in it.
+/// `incremental_sync_size_matches_serialized_request` holds it against a real
+/// serialization.
+const EMPTY_SYNC_REQUEST_BYTES: usize =
+    b"{\"documents\":[],\"pull\":{\"doc_ids\":[],\"limit\":64}}".len();
 
 pub(crate) struct SyncTask {
     abort: AbortHandle,
@@ -185,38 +191,96 @@ impl SyncSession {
         }
     }
 
-    async fn sync_document(&self, doc_id: &str) -> Result<()> {
-        let mut documents = Vec::new();
-        if let Some(document_ref) = self
+    /// Push what is local and pull what is not, in as few exchanges as the wire
+    /// limits allow. A burst of writes raises one update event per document and
+    /// they arrive together, so one exchange each would cost a round trip per
+    /// document.
+    async fn sync_documents(&self, doc_ids: &[String]) -> Result<()> {
+        let mut batch = SyncBatch::default();
+        for doc_id in doc_ids {
+            let id_bytes = serde_json::to_vec(doc_id)?.len();
+            let mut document = self.load_push_document(doc_id).await?;
+            let mut document_bytes = match document.as_ref() {
+                Some(document) => Some(serde_json::to_vec(document)?.len()),
+                None => None,
+            };
+
+            // Over the limit alone, so no request can carry it. Drop it from
+            // the push; the pull still names it.
+            if !SyncBatch::default().fits(id_bytes, document_bytes) {
+                warn(&format!(
+                    "browser sync skipped document {doc_id} because it exceeds the sync request limit"
+                ));
+                document = None;
+                document_bytes = None;
+            }
+
+            if !batch.is_empty() && !batch.fits(id_bytes, document_bytes) {
+                self.exchange_batch(batch.take()).await?;
+            }
+            batch.accept(doc_id.clone(), document, id_bytes, document_bytes);
+        }
+        if !batch.is_empty() {
+            self.exchange_batch(batch.take()).await?;
+        }
+        Ok(())
+    }
+
+    /// The push payload for a document, or `None` when there is nothing local
+    /// to push: it is not held here, or it is too large to represent. Failing
+    /// instead would force a full sync on every update touching it.
+    async fn load_push_document(&self, doc_id: &str) -> Result<Option<BrowserSyncDocument>> {
+        let Some(document_ref) = self
             .engine
             .document_ref(doc_id)
             .await
             .map_err(engine_error)?
-        {
-            // Nothing to push for an over-large document, but the pull below
-            // still applies. Failing here would fall back to a full sync on
-            // every single update touching this document.
-            match self.engine.load_document(&document_ref).await {
-                Ok(Some(document)) => documents.push(document),
-                Ok(None) => {}
-                Err(error @ db::merge::browser_sync::BrowserSyncError::TooLarge(_)) => {
-                    warn(&format!(
-                        "browser sync skipped document {doc_id} because it cannot be represented as a sync payload: {error}"
-                    ));
+        else {
+            return Ok(None);
+        };
+        match self.engine.load_document(&document_ref).await {
+            Ok(document) => Ok(document),
+            Err(error @ db::merge::browser_sync::BrowserSyncError::TooLarge(_)) => {
+                warn(&format!(
+                    "browser sync skipped document {doc_id} because it cannot be represented as a sync payload: {error}"
+                ));
+                Ok(None)
+            }
+            Err(error) => Err(engine_error(error)),
+        }
+    }
+
+    /// One batch: its documents pushed once, then its pull followed to the end.
+    /// A pull naming many documents can be cut short by the page limit, where a
+    /// pull naming one never could, so later requests carry no documents.
+    async fn exchange_batch(&self, batch: SyncBatch) -> Result<()> {
+        let SyncBatch {
+            mut documents,
+            doc_ids,
+            ..
+        } = batch;
+        let mut cursor = None;
+        loop {
+            let response = self
+                .exchange(BrowserSyncRequest {
+                    documents: std::mem::take(&mut documents),
+                    pull: Some(BrowserSyncPull {
+                        doc_ids: doc_ids.clone(),
+                        cursor: cursor.clone(),
+                        limit: Some(MAX_SYNC_PAGE_SIZE as u16),
+                    }),
+                })
+                .await?;
+            match response.next_cursor {
+                Some(next) if cursor.as_deref() != Some(next.as_str()) => cursor = Some(next),
+                Some(_) => {
+                    return Err(WasmError::Sync(
+                        "server returned a non-advancing sync cursor".into(),
+                    ))
                 }
-                Err(error) => return Err(engine_error(error)),
+                None => return Ok(()),
             }
         }
-        self.exchange(BrowserSyncRequest {
-            documents,
-            pull: Some(BrowserSyncPull {
-                doc_ids: vec![doc_id.to_string()],
-                cursor: None,
-                limit: Some(1),
-            }),
-        })
-        .await?;
-        Ok(())
     }
 
     async fn exchange(&self, request: BrowserSyncRequest) -> Result<BrowserSyncResponse> {
@@ -246,12 +310,13 @@ impl SyncSession {
             while let Ok(message) = subscription.try_recv() {
                 collect_local_update(&message, &mut doc_ids);
             }
-            for doc_id in doc_ids {
-                if let Err(error) = self.sync_document(&doc_id).await {
-                    self.recover_full_sync(&format!("syncing local document {doc_id}"), error)
-                        .await;
-                    break;
-                }
+            let doc_ids = Vec::from_iter(doc_ids);
+            if let Err(error) = self.sync_documents(&doc_ids).await {
+                self.recover_full_sync(
+                    &format!("syncing {} local document(s)", doc_ids.len()),
+                    error,
+                )
+                .await;
             }
         }
     }
@@ -261,9 +326,15 @@ impl SyncSession {
             loop {
                 match events.next_document_id().await {
                     Ok(Some(doc_id)) => {
-                        if let Err(error) = self.sync_document(&doc_id).await {
+                        // A burst arrives as one stream chunk, so what was
+                        // decoded alongside this ID belongs in the same
+                        // exchange.
+                        let mut doc_ids = BTreeSet::from([doc_id]);
+                        doc_ids.extend(events.take_decoded_document_ids());
+                        let doc_ids = Vec::from_iter(doc_ids);
+                        if let Err(error) = self.sync_documents(&doc_ids).await {
                             self.recover_full_sync(
-                                &format!("syncing remote document {doc_id}"),
+                                &format!("syncing {} remote document(s)", doc_ids.len()),
                                 error,
                             )
                             .await;
@@ -309,6 +380,68 @@ impl SyncSession {
     }
 }
 
+/// One exchange's worth of work, packed while documents are loaded one at a
+/// time. The limits are the server's, and packing is kept apart from loading so
+/// the rules can be checked without a node or a network.
+struct SyncBatch {
+    documents: Vec<BrowserSyncDocument>,
+    doc_ids: Vec<String>,
+    bytes: usize,
+}
+
+impl Default for SyncBatch {
+    fn default() -> Self {
+        Self {
+            documents: Vec::new(),
+            doc_ids: Vec::new(),
+            bytes: EMPTY_SYNC_REQUEST_BYTES,
+        }
+    }
+}
+
+impl SyncBatch {
+    fn is_empty(&self) -> bool {
+        self.doc_ids.is_empty()
+    }
+
+    /// Whether a document and its pull ID can still join this batch. An ID with
+    /// no document of its own still takes a place in the pull.
+    fn fits(&self, id_bytes: usize, document_bytes: Option<usize>) -> bool {
+        if self.doc_ids.len() == MAX_SYNC_PULL_DOC_IDS {
+            return false;
+        }
+        if document_bytes.is_some() && self.documents.len() == MAX_SYNC_DOCUMENTS_PER_REQUEST {
+            return false;
+        }
+        self.bytes + self.added_bytes(id_bytes, document_bytes) <= MAX_SYNC_BODY_BYTES
+    }
+
+    fn added_bytes(&self, id_bytes: usize, document_bytes: Option<usize>) -> usize {
+        let id = id_bytes + usize::from(!self.doc_ids.is_empty());
+        let document =
+            document_bytes.map_or(0, |bytes| bytes + usize::from(!self.documents.is_empty()));
+        id + document
+    }
+
+    fn accept(
+        &mut self,
+        doc_id: String,
+        document: Option<BrowserSyncDocument>,
+        id_bytes: usize,
+        document_bytes: Option<usize>,
+    ) {
+        self.bytes += self.added_bytes(id_bytes, document_bytes);
+        if let Some(document) = document {
+            self.documents.push(document);
+        }
+        self.doc_ids.push(doc_id);
+    }
+
+    fn take(&mut self) -> Self {
+        std::mem::take(self)
+    }
+}
+
 fn collect_local_update(message: &events::Message, doc_ids: &mut BTreeSet<String>) {
     if let Some(update) = message.as_update() {
         if !update.is_relay && !update.doc_id.is_empty() {
@@ -327,11 +460,46 @@ fn warn(message: &str) {
 
 #[cfg(test)]
 mod tests {
-    use defra_core::browser_sync::{BrowserSyncBlock, BrowserSyncDocument, BrowserSyncRequest};
+    use defra_core::browser_sync::{
+        BrowserSyncBlock, BrowserSyncDocument, BrowserSyncPull, BrowserSyncRequest,
+        MAX_SYNC_BODY_BYTES, MAX_SYNC_DOCUMENTS_PER_REQUEST, MAX_SYNC_PAGE_SIZE,
+        MAX_SYNC_PULL_DOC_IDS,
+    };
 
-    use super::EMPTY_PUSH_REQUEST_BYTES;
+    use wasm_bindgen_test::wasm_bindgen_test;
 
-    #[test]
+    use super::{SyncBatch, EMPTY_PUSH_REQUEST_BYTES};
+
+    fn document(doc_id: &str, data: &str) -> BrowserSyncDocument {
+        BrowserSyncDocument {
+            doc_id: doc_id.into(),
+            collection_id: "collection".into(),
+            roots: vec!["root".into()],
+            blocks: vec![BrowserSyncBlock {
+                cid: "block".into(),
+                data: data.into(),
+            }],
+            relationships: Vec::new(),
+        }
+    }
+
+    /// Offer a document the way `sync_documents` does, returning the batch its
+    /// arrival flushed.
+    fn offer(batch: &mut SyncBatch, document: BrowserSyncDocument) -> Option<SyncBatch> {
+        let id_bytes = serde_json::to_vec(&document.doc_id).unwrap().len();
+        let document_bytes = serde_json::to_vec(&document).unwrap().len();
+        let flushed = (!batch.is_empty() && !batch.fits(id_bytes, Some(document_bytes)))
+            .then(|| batch.take());
+        batch.accept(
+            document.doc_id.clone(),
+            Some(document),
+            id_bytes,
+            Some(document_bytes),
+        );
+        flushed
+    }
+
+    #[wasm_bindgen_test]
     fn incremental_push_size_matches_serialized_request() {
         let documents = vec![
             BrowserSyncDocument {
@@ -367,5 +535,82 @@ mod tests {
             incremental_size,
             serde_json::to_vec(&request).unwrap().len()
         );
+    }
+    #[wasm_bindgen_test]
+    fn incremental_sync_size_matches_serialized_request() {
+        let mut batch = SyncBatch::default();
+        for index in 0..3 {
+            offer(&mut batch, document(&format!("doc-{index}"), "data"));
+        }
+        // The pull names every document in the batch and always asks for a
+        // full page.
+        let request = BrowserSyncRequest {
+            documents: batch.documents.clone(),
+            pull: Some(BrowserSyncPull {
+                doc_ids: batch.doc_ids.clone(),
+                cursor: None,
+                limit: Some(MAX_SYNC_PAGE_SIZE as u16),
+            }),
+        };
+        assert_eq!(batch.bytes, serde_json::to_vec(&request).unwrap().len());
+    }
+
+    #[wasm_bindgen_test]
+    fn a_pull_id_without_a_document_costs_only_its_id() {
+        let mut batch = SyncBatch::default();
+        let doc_id = "doc-remote".to_string();
+        let id_bytes = serde_json::to_vec(&doc_id).unwrap().len();
+        batch.accept(doc_id.clone(), None, id_bytes, None);
+
+        let request = BrowserSyncRequest {
+            documents: Vec::new(),
+            pull: Some(BrowserSyncPull {
+                doc_ids: vec![doc_id],
+                cursor: None,
+                limit: Some(MAX_SYNC_PAGE_SIZE as u16),
+            }),
+        };
+        assert_eq!(batch.bytes, serde_json::to_vec(&request).unwrap().len());
+    }
+
+    #[wasm_bindgen_test]
+    fn a_batch_ends_at_the_document_limit() {
+        let mut batch = SyncBatch::default();
+        for index in 0..MAX_SYNC_DOCUMENTS_PER_REQUEST {
+            assert!(offer(&mut batch, document(&format!("doc-{index}"), "data")).is_none());
+        }
+        let flushed = offer(&mut batch, document("doc-over", "data")).expect("batch is full");
+        assert_eq!(flushed.documents.len(), MAX_SYNC_DOCUMENTS_PER_REQUEST);
+        assert_eq!(batch.documents.len(), 1);
+    }
+
+    /// A document held only by the server has no push payload, so the pull
+    /// limit binds before the document limit.
+    #[wasm_bindgen_test]
+    fn a_batch_ends_at_the_pull_id_limit() {
+        let mut batch = SyncBatch::default();
+        for index in 0..MAX_SYNC_PULL_DOC_IDS {
+            let doc_id = format!("doc-{index}");
+            let id_bytes = serde_json::to_vec(&doc_id).unwrap().len();
+            assert!(batch.fits(id_bytes, None));
+            batch.accept(doc_id, None, id_bytes, None);
+        }
+        assert!(!batch.fits(serde_json::to_vec("doc-over").unwrap().len(), None));
+    }
+
+    #[wasm_bindgen_test]
+    fn a_batch_ends_at_the_body_limit() {
+        let heavy = "x".repeat(MAX_SYNC_BODY_BYTES / 4);
+        let mut batch = SyncBatch::default();
+        for index in 0..3 {
+            assert!(
+                offer(&mut batch, document(&format!("doc-{index}"), &heavy)).is_none(),
+                "three quarters of the body still fits"
+            );
+        }
+        let flushed = offer(&mut batch, document("doc-over", &heavy)).expect("body is full");
+        assert!(flushed.bytes <= MAX_SYNC_BODY_BYTES);
+        assert_eq!(flushed.documents.len(), 3);
+        assert_eq!(batch.documents.len(), 1);
     }
 }

--- a/crates/wasm/src/sync/sse.rs
+++ b/crates/wasm/src/sync/sse.rs
@@ -23,6 +23,13 @@ impl SseStream {
         }
     }
 
+    /// Every document ID already decoded, taken without reading the stream
+    /// again. A burst arrives as one chunk, so these are the rest of it and can
+    /// be answered in one exchange.
+    pub(super) fn take_decoded_document_ids(&mut self) -> Vec<String> {
+        self.pending_doc_ids.drain(..).collect()
+    }
+
     pub(super) async fn next_document_id(&mut self) -> Result<Option<String>> {
         loop {
             if let Some(doc_id) = self.pending_doc_ids.pop_front() {


### PR DESCRIPTION
Stacked on #1718 — review that first; this branch contains it.

**TL;DR** — A burst of writes cost one HTTP round trip per document. A burst is
now one exchange, up to the server's limits.

Measured downstream, browser node to a reader watching the server node: a single
write is 3.0 ms median, already good enough; a burst of 20 is 24.7 ms median and
**51.5 ms** at worst. The tail is arithmetic, not congestion — twenty documents
was twenty round trips, because `run_local` called `sync_document` once per ID
and `run_remote` did the same per announced document. Nothing on the wire
required it: a request already carries a list of documents and a pull already
takes a list of IDs.

## The change

`sync_documents` packs a set of IDs into as few exchanges as the server allows —
`MAX_SYNC_DOCUMENTS_PER_REQUEST` documents, `MAX_SYNC_PULL_DOC_IDS` pull IDs, a
body under `MAX_SYNC_BODY_BYTES`.

- Packing lives in `SyncBatch`, apart from the loading, so the rules are testable
  without a node or a network.
- A document too large to push is still named by the pull, as before.
- A pull naming many documents can be cut short by the page limit where a pull
  naming one never could, so a batch follows its cursor to the end.
- The remote side batches from the buffer the SSE decoder already fills: a burst
  arrives as one chunk, and `take_decoded_document_ids` takes the rest of it into
  the same exchange.

## Testing

Five unit tests on the packing: the byte estimate matches a real serialization,
with and without a document behind a pull ID; a batch ends at the document limit,
at the pull-ID limit, and at the body limit. One adapter test on the server side:
a pull naming several documents resumes across its cursor within the named set,
and never serves a document it did not name — the adapter did this already,
nothing pinned it, and the batched client now depends on it.

`just test-wasm` 59 passed in headless Firefox, `cargo test -p cli --lib` 77
passed, `just lint-wasm` and fmt clean.

**Worth flagging:** the unit tests in this module ran nowhere — plain `#[test]`
in a crate that only compiles for wasm32, which `wasm-bindgen-test-runner` does
not collect. They are `#[wasm_bindgen_test]` now, the pre-existing size test
included.

## Not measured here

The round-trip count follows from the request shape and the packing is pinned by
tests, but the wall clock wants the downstream harness that produced the table
above. Worth re-running there before this is called a measured win.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
