### PR TITLE
feat(wasm): a browser client that authors, signs and grants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3605,6 +3605,7 @@ dependencies = [
  "getrandom 0.2.17",
  "gloo-timers",
  "hex",
+ "identity",
  "js-sys",
  "query",
  "schema",
@@ -5529,6 +5530,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3621,6 +3621,7 @@ dependencies = [
  "wasm-bindgen-test",
  "wasm-streams 0.4.2",
  "web-sys",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2060,6 +2060,7 @@ dependencies = [
  "base64 0.22.1",
  "blockstore",
  "bytes",
+ "cid",
  "clap",
  "crypto",
  "db",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -130,6 +130,7 @@ profiling = ["dep:tracing-chrome"]
 otel = ["telemetry/otlp"]
 
 [dev-dependencies]
+cid.workspace = true
 toml = "0.9"
 tempfile = "3.17"
 portpicker = "0.1"

--- a/crates/cli/src/browser_sync_adapter.rs
+++ b/crates/cli/src/browser_sync_adapter.rs
@@ -184,9 +184,24 @@ impl<S: Store + 'static> BrowserSyncAdapter<S> {
         }
         // Before the merge, so the document carries its grants by the time the
         // merge announces it to peers.
-        let granted = self
-            .apply_relationships(&document, &doc_id, identity)
-            .await?;
+        //
+        // A grant refused partway leaves the earlier ones durable, exactly as a
+        // refused merge would, so it reverts through the same path.
+        let mut granted = Vec::new();
+        if let Err(error) = self
+            .apply_relationships(&document, &doc_id, identity, &mut granted)
+            .await
+        {
+            self.revert_acp(
+                policy.as_ref(),
+                &doc_id,
+                registered_before,
+                &granted,
+                identity,
+            )
+            .await;
+            return Err(error);
+        }
 
         match self
             .engine
@@ -280,14 +295,19 @@ impl<S: Store + 'static> BrowserSyncAdapter<S> {
     ///
     /// `managing_relations` is empty, so a manager who is not the owner has to
     /// use that endpoint, which resolves the policy's managers.
+    ///
+    /// `granted` collects what was actually created, and keeps it when this
+    /// returns an error: a list refused partway has already applied its earlier
+    /// entries, and the caller has to take those back.
     async fn apply_relationships(
         &self,
         document: &PendingSyncDocument,
         doc_id: &str,
         identity: &Identity,
-    ) -> BrowserSyncResult<Vec<PendingRelationship>> {
+        granted: &mut Vec<PendingRelationship>,
+    ) -> BrowserSyncResult<()> {
         if document.relationships.is_empty() {
-            return Ok(Vec::new());
+            return Ok(());
         }
         // Both established by `prepare_relationships` before anything in this
         // request was applied.
@@ -298,7 +318,6 @@ impl<S: Store + 'static> BrowserSyncAdapter<S> {
                 "sync relationships reached apply without a caller or a policy".into(),
             ));
         };
-        let mut granted = Vec::new();
         for relationship in &document.relationships {
             let added = self
                 .document_acp
@@ -329,7 +348,7 @@ impl<S: Store + 'static> BrowserSyncAdapter<S> {
                 });
             }
         }
-        Ok(granted)
+        Ok(())
     }
 
     async fn pull_documents(

--- a/crates/cli/src/browser_sync_adapter.rs
+++ b/crates/cli/src/browser_sync_adapter.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use defra_core::browser_sync::{
     BrowserSyncDocument, BrowserSyncPull, BrowserSyncRequest, BrowserSyncResponse,
     DEFAULT_SYNC_PAGE_SIZE, MAX_SYNC_BODY_BYTES, MAX_SYNC_ID_BYTES, MAX_SYNC_PAGE_SIZE,
-    MAX_SYNC_PAYLOAD_BYTES,
+    MAX_SYNC_PAYLOAD_BYTES, MAX_SYNC_RELATIONSHIPS_PER_DOCUMENT,
 };
 use defra_http::router::{BrowserSyncError, BrowserSyncOperations, BrowserSyncResult};
 use storage::corekv::Store;
@@ -20,6 +20,14 @@ struct PendingSyncDocument {
     document: db::merge::ValidatedBrowserSyncDocument,
     collection: db::Collection,
     register_owner: Option<identity::Did>,
+    relationships: Vec<PendingRelationship>,
+}
+
+/// A grant from the push, resolved to the two subjects
+/// `add_actor_relationship` can represent.
+struct PendingRelationship {
+    relation: String,
+    target: identity::Did,
 }
 
 impl<S: Store + 'static> BrowserSyncAdapter<S> {
@@ -80,6 +88,7 @@ impl<S: Store + 'static> BrowserSyncAdapter<S> {
         identity: &Identity,
         bypass_dac: bool,
     ) -> BrowserSyncResult<PendingSyncDocument> {
+        let source = document;
         let document = self
             .engine
             .validate_document(document)
@@ -135,10 +144,12 @@ impl<S: Store + 'static> BrowserSyncAdapter<S> {
         } else {
             None
         };
+        let relationships = prepare_relationships(source, &collection, identity)?;
         Ok(PendingSyncDocument {
             document,
             collection,
             register_owner,
+            relationships,
         })
     }
 
@@ -159,11 +170,65 @@ impl<S: Store + 'static> BrowserSyncAdapter<S> {
             .await
             .map_err(|error| BrowserSyncError::Internal(error.to_string()))?;
         }
+        // Before the merge, so the document carries its grants by the time the
+        // merge announces it to peers.
+        self.apply_relationships(&document, &doc_id, identity)
+            .await?;
 
         self.engine
             .apply_validated_document(document.document, creator)
             .await
             .map_err(map_engine_error)
+    }
+
+    /// Apply the push's grants as the authenticated caller, never as the owner
+    /// the push registered: `add_actor_relationship` then allows exactly what a
+    /// second call to the relationship endpoint would, and a relay pushing
+    /// somebody else's DAG still gets `NotOwner`.
+    ///
+    /// `managing_relations` is empty, so a manager who is not the owner has to
+    /// use that endpoint, which resolves the policy's managers.
+    async fn apply_relationships(
+        &self,
+        document: &PendingSyncDocument,
+        doc_id: &str,
+        identity: &Identity,
+    ) -> BrowserSyncResult<()> {
+        if document.relationships.is_empty() {
+            return Ok(());
+        }
+        // Both established by `prepare_relationships` before anything in this
+        // request was applied.
+        let (Some(requestor), Some(policy)) =
+            (identity.did(), document.collection.schema().policy.as_ref())
+        else {
+            return Err(BrowserSyncError::Internal(
+                "sync relationships reached apply without a caller or a policy".into(),
+            ));
+        };
+        for relationship in &document.relationships {
+            self.document_acp
+                .add_actor_relationship(
+                    requestor,
+                    &relationship.target,
+                    &policy.id,
+                    &policy.resource_name,
+                    doc_id,
+                    &relationship.relation,
+                    &[],
+                )
+                .await
+                .map_err(|error| match error {
+                    acp::Error::NotOwner { .. } | acp::Error::NotManager { .. } => {
+                        BrowserSyncError::Forbidden(format!(
+                            "cannot grant '{}' on document {doc_id}: {error}",
+                            relationship.relation
+                        ))
+                    }
+                    error => BrowserSyncError::Internal(error.to_string()),
+                })?;
+        }
+        Ok(())
     }
 
     async fn pull_documents(
@@ -368,6 +433,66 @@ fn map_engine_error(error: db::merge::BrowserSyncError) -> BrowserSyncError {
         db::merge::BrowserSyncError::Storage(message) => BrowserSyncError::Internal(message),
         other => BrowserSyncError::Internal(other.to_string()),
     }
+}
+
+/// Resolve the push's grants before anything in the request is applied.
+///
+/// Who may grant stays with `add_actor_relationship`. This refuses only what
+/// that call cannot express: a caller with no DID, a collection with no policy,
+/// a target that is neither an actor nor the wildcard, and the immutable
+/// `owner` relation.
+fn prepare_relationships(
+    document: &BrowserSyncDocument,
+    collection: &db::Collection,
+    identity: &Identity,
+) -> BrowserSyncResult<Vec<PendingRelationship>> {
+    if document.relationships.is_empty() {
+        return Ok(Vec::new());
+    }
+    if document.relationships.len() > MAX_SYNC_RELATIONSHIPS_PER_DOCUMENT {
+        return Err(BrowserSyncError::InvalidInput(format!(
+            "sync document {} exceeds {MAX_SYNC_RELATIONSHIPS_PER_DOCUMENT} relationships",
+            document.doc_id
+        )));
+    }
+    if identity.did().is_none() {
+        return Err(BrowserSyncError::Forbidden(format!(
+            "sync relationships on document {} require an authenticated caller",
+            document.doc_id
+        )));
+    }
+    if collection.schema().policy.is_none() {
+        return Err(BrowserSyncError::InvalidInput(format!(
+            "collection '{}' has no policy to grant relationships under",
+            document.collection_id
+        )));
+    }
+
+    let mut prepared = Vec::with_capacity(document.relationships.len());
+    for relationship in &document.relationships {
+        validate_id("relation", &relationship.relation)?;
+        validate_id("relationship target", &relationship.target)?;
+        if relationship.relation == "owner" {
+            return Err(BrowserSyncError::InvalidInput(
+                "cannot add owner relation".into(),
+            ));
+        }
+        let target = if relationship.target == "*" {
+            identity::Did::wildcard()
+        } else {
+            identity::Did::try_from(relationship.target.clone()).map_err(|error| {
+                BrowserSyncError::InvalidInput(format!(
+                    "relationship target '{}' is not an actor DID: {error}",
+                    relationship.target
+                ))
+            })?
+        };
+        prepared.push(PendingRelationship {
+            relation: relationship.relation.clone(),
+            target,
+        });
+    }
+    Ok(prepared)
 }
 
 fn validate_optional_id(name: &str, value: Option<&str>) -> BrowserSyncResult<()> {

--- a/crates/cli/src/browser_sync_adapter.rs
+++ b/crates/cli/src/browser_sync_adapter.rs
@@ -160,6 +160,18 @@ impl<S: Store + 'static> BrowserSyncAdapter<S> {
     ) -> BrowserSyncResult<()> {
         let doc_id = document.document.doc_id().to_string();
         let creator = identity.did().map_or("browser-sync", |did| did.as_str());
+        let policy = document.collection.schema().policy.clone();
+
+        // Whether ACP knew this document before this request, which decides how
+        // much of ACP is this request's to undo.
+        let registered_before = match (policy.as_ref(), document.register_owner.as_ref()) {
+            (Some(policy), Some(_)) => self
+                .document_acp
+                .is_doc_registered(&policy.id, &policy.resource_name, &doc_id)
+                .await
+                .map_err(|error| BrowserSyncError::Internal(error.to_string()))?,
+            _ => true,
+        };
         if let Some(owner) = document.register_owner.as_ref() {
             db::collection::acp::register_doc_if_needed(
                 self.document_acp.as_ref(),
@@ -172,13 +184,93 @@ impl<S: Store + 'static> BrowserSyncAdapter<S> {
         }
         // Before the merge, so the document carries its grants by the time the
         // merge announces it to peers.
-        self.apply_relationships(&document, &doc_id, identity)
+        let granted = self
+            .apply_relationships(&document, &doc_id, identity)
             .await?;
 
-        self.engine
+        match self
+            .engine
             .apply_validated_document(document.document, creator)
             .await
-            .map_err(map_engine_error)
+        {
+            Ok(()) => Ok(()),
+            Err(error) => {
+                self.revert_acp(
+                    policy.as_ref(),
+                    &doc_id,
+                    registered_before,
+                    &granted,
+                    identity,
+                )
+                .await;
+                Err(map_engine_error(error))
+            }
+        }
+    }
+
+    /// Put ACP back as this request found it, for a merge that did not happen.
+    ///
+    /// The grants precede the merge so that nothing is announced before it can
+    /// be read, which leaves them durable when the merge is refused. There is
+    /// no transaction to span both: the ACP backends are separate stores, one
+    /// of them a chain.
+    ///
+    /// A document this request registered can be undone in one call —
+    /// `unregister_doc_object` takes the owner tuple and every grant with it.
+    /// A document that existed before keeps whatever it had, so only the grants
+    /// this request created come off, and a grant that was already there stays.
+    ///
+    /// A failure here cannot be reported: the merge error is what the caller
+    /// needs. It is logged, and re-pushing the document applies the same grants
+    /// again.
+    async fn revert_acp(
+        &self,
+        policy: Option<&schema::PolicyDescription>,
+        doc_id: &str,
+        registered_before: bool,
+        granted: &[PendingRelationship],
+        identity: &Identity,
+    ) {
+        let Some(policy) = policy else { return };
+        if !registered_before {
+            if let Err(error) = self
+                .document_acp
+                .unregister_doc_object(&policy.id, &policy.resource_name, doc_id)
+                .await
+            {
+                tracing::warn!(
+                    %doc_id,
+                    %error,
+                    "browser sync could not unregister a document whose merge was refused"
+                );
+            }
+            return;
+        }
+        let Some(requestor) = identity.did() else {
+            return;
+        };
+        for relationship in granted {
+            if let Err(error) = self
+                .document_acp
+                .delete_actor_relationship(
+                    requestor,
+                    &relationship.target,
+                    &policy.id,
+                    &policy.resource_name,
+                    doc_id,
+                    &relationship.relation,
+                    &[],
+                )
+                .await
+            {
+                tracing::warn!(
+                    %doc_id,
+                    relation = %relationship.relation,
+                    %error,
+                    "browser sync could not revoke a grant whose merge was refused"
+                );
+            }
+        }
     }
 
     /// Apply the push's grants as the authenticated caller, never as the owner
@@ -193,9 +285,9 @@ impl<S: Store + 'static> BrowserSyncAdapter<S> {
         document: &PendingSyncDocument,
         doc_id: &str,
         identity: &Identity,
-    ) -> BrowserSyncResult<()> {
+    ) -> BrowserSyncResult<Vec<PendingRelationship>> {
         if document.relationships.is_empty() {
-            return Ok(());
+            return Ok(Vec::new());
         }
         // Both established by `prepare_relationships` before anything in this
         // request was applied.
@@ -206,8 +298,10 @@ impl<S: Store + 'static> BrowserSyncAdapter<S> {
                 "sync relationships reached apply without a caller or a policy".into(),
             ));
         };
+        let mut granted = Vec::new();
         for relationship in &document.relationships {
-            self.document_acp
+            let added = self
+                .document_acp
                 .add_actor_relationship(
                     requestor,
                     &relationship.target,
@@ -227,8 +321,15 @@ impl<S: Store + 'static> BrowserSyncAdapter<S> {
                     }
                     error => BrowserSyncError::Internal(error.to_string()),
                 })?;
+            // Only what this request added is this request's to take back.
+            if added {
+                granted.push(PendingRelationship {
+                    relation: relationship.relation.clone(),
+                    target: relationship.target.clone(),
+                });
+            }
         }
-        Ok(())
+        Ok(granted)
     }
 
     async fn pull_documents(

--- a/crates/cli/src/browser_sync_adapter_tests.rs
+++ b/crates/cli/src/browser_sync_adapter_tests.rs
@@ -1076,17 +1076,20 @@ async fn relationships_cannot_be_attached_to_a_foreign_signed_document() {
         matches!(error, defra_http::router::BrowserSyncError::Forbidden(_)),
         "expected a forbidden grant, got {error:?}"
     );
+    // The refused grant takes the registration this request made with it: the
+    // merge never ran, so ACP holds nothing for a document the node does not
+    // have. Bob has squatted nothing either way.
     assert_eq!(
         acp.get_doc_owner("users-policy", "users", &doc_id)
             .await
             .unwrap()
             .map(|did| did.to_string()),
-        Some(alice.clone()),
-        "ownership must still follow the verified genesis creator"
+        None,
+        "a refused push must leave no registration behind"
     );
 
-    // A refused grant does not leave the document stranded: Alice's own push
-    // lands the same grant.
+    // And the document is not stranded: Alice's own push registers her as the
+    // verified genesis creator and lands the same grant.
     adapter
         .sync(
             BrowserSyncRequest {
@@ -1104,6 +1107,14 @@ async fn relationships_cannot_be_attached_to_a_foreign_signed_document() {
         )
         .await
         .unwrap();
+    assert_eq!(
+        acp.get_doc_owner("users-policy", "users", &doc_id)
+            .await
+            .unwrap()
+            .map(|did| did.to_string()),
+        Some(alice.clone()),
+        "ownership follows the verified genesis creator, not the caller"
+    );
     let anonymous = adapter
         .sync(
             BrowserSyncRequest {
@@ -1204,7 +1215,8 @@ async fn relationships_refuse_the_owner_relation_and_an_unbounded_list() {
                 false,
             )
             .await
-            .expect_err("expected a refusal for {relationships:?}");
+            .err()
+            .unwrap_or_else(|| panic!("expected a refusal for {relationships:?}"));
         assert!(
             matches!(error, defra_http::router::BrowserSyncError::InvalidInput(_)),
             "expected invalid input for {relationships:?}, got {error:?}"

--- a/crates/cli/src/browser_sync_adapter_tests.rs
+++ b/crates/cli/src/browser_sync_adapter_tests.rs
@@ -3,7 +3,9 @@ use std::sync::Arc;
 
 use acp::{DocumentACP, LocalDocumentACP, MemoryAcpStore};
 use crypto::{Key as _, PrivateKey as _};
-use defra_core::browser_sync::{BrowserSyncPull, BrowserSyncRequest};
+use defra_core::browser_sync::{
+    BrowserSyncDocument, BrowserSyncPull, BrowserSyncRelationship, BrowserSyncRequest,
+};
 use defra_core::signing::{set_signing_config, SigningConfig, SigningKeyType};
 use document::{DocID, Document, NormalValue};
 use query::mutator::DocMutator;
@@ -686,4 +688,243 @@ async fn pull_skips_a_block_heavy_document_and_keeps_paginating() {
         "every loadable document must be served, including those after the block-heavy one"
     );
     assert!(!seen.contains(&heavy));
+}
+
+/// The window this field exists to close: a protected document is invisible to
+/// every other key until its owner grants a read, and the push announces it
+/// between the two. Both halves are asserted — without the grant the anonymous
+/// pull is empty, with it the document is there.
+#[tokio::test]
+async fn relationships_on_the_push_make_a_protected_document_readable_at_once() {
+    let source = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
+    source.create_collection(users_schema(true)).await.unwrap();
+    let owner = install_signing_identity();
+    let granted = create_document(&source, "Granted").await;
+    let ungranted = create_document(&source, "Ungranted").await;
+    set_signing_config(None);
+    let granted_doc_id = granted.doc_id.clone();
+    let ungranted_doc_id = ungranted.doc_id.clone();
+
+    let target = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
+    target.create_collection(users_schema(true)).await.unwrap();
+    let acp = Arc::new(LocalDocumentACP::new(Arc::new(MemoryAcpStore::new())));
+    let adapter = BrowserSyncAdapter::new_arc(target, acp.clone(), None);
+
+    adapter
+        .sync(
+            BrowserSyncRequest {
+                documents: vec![
+                    BrowserSyncDocument {
+                        relationships: vec![BrowserSyncRelationship {
+                            relation: "reader".into(),
+                            target: "*".into(),
+                        }],
+                        ..granted
+                    },
+                    ungranted,
+                ],
+                pull: None,
+            },
+            Some(&owner),
+            false,
+        )
+        .await
+        .unwrap();
+
+    let anonymous = adapter
+        .sync(
+            BrowserSyncRequest {
+                documents: Vec::new(),
+                pull: Some(BrowserSyncPull::default()),
+            },
+            None,
+            false,
+        )
+        .await
+        .unwrap();
+    let seen: Vec<&str> = anonymous
+        .documents
+        .iter()
+        .map(|document| document.doc_id.as_str())
+        .collect();
+    assert_eq!(
+        seen,
+        vec![granted_doc_id.as_str()],
+        "only the document whose push carried a wildcard reader grant is visible anonymously"
+    );
+    assert!(!seen.contains(&ungranted_doc_id.as_str()));
+}
+
+/// The grant is applied as the caller, not as the owner the push established,
+/// so a relay pushing somebody else's DAG cannot attach one.
+#[tokio::test]
+async fn relationships_cannot_be_attached_to_a_foreign_signed_document() {
+    let source = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
+    source.create_collection(users_schema(true)).await.unwrap();
+    let alice = install_signing_identity();
+    let document = create_document(&source, "Alice").await;
+    set_signing_config(None);
+    let doc_id = document.doc_id.clone();
+
+    let target = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
+    target.create_collection(users_schema(true)).await.unwrap();
+    let acp = Arc::new(LocalDocumentACP::new(Arc::new(MemoryAcpStore::new())));
+    let adapter = BrowserSyncAdapter::new_arc(target, acp.clone(), None);
+
+    let bob = "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH";
+    let error = adapter
+        .sync(
+            BrowserSyncRequest {
+                documents: vec![BrowserSyncDocument {
+                    relationships: vec![BrowserSyncRelationship {
+                        relation: "reader".into(),
+                        target: bob.into(),
+                    }],
+                    ..document.clone()
+                }],
+                pull: None,
+            },
+            Some(bob),
+            false,
+        )
+        .await
+        .expect_err("a caller who is not the owner must not be able to grant");
+    assert!(
+        matches!(error, defra_http::router::BrowserSyncError::Forbidden(_)),
+        "expected a forbidden grant, got {error:?}"
+    );
+    assert_eq!(
+        acp.get_doc_owner("users-policy", "users", &doc_id)
+            .await
+            .unwrap()
+            .map(|did| did.to_string()),
+        Some(alice.clone()),
+        "ownership must still follow the verified genesis creator"
+    );
+
+    // A refused grant does not leave the document stranded: Alice's own push
+    // lands the same grant.
+    adapter
+        .sync(
+            BrowserSyncRequest {
+                documents: vec![BrowserSyncDocument {
+                    relationships: vec![BrowserSyncRelationship {
+                        relation: "reader".into(),
+                        target: "*".into(),
+                    }],
+                    ..document
+                }],
+                pull: None,
+            },
+            Some(&alice),
+            false,
+        )
+        .await
+        .unwrap();
+    let anonymous = adapter
+        .sync(
+            BrowserSyncRequest {
+                documents: Vec::new(),
+                pull: Some(BrowserSyncPull::default()),
+            },
+            None,
+            false,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        anonymous
+            .documents
+            .iter()
+            .map(|document| document.doc_id.as_str())
+            .collect::<Vec<_>>(),
+        vec![doc_id.as_str()]
+    );
+}
+
+#[tokio::test]
+async fn relationships_require_an_authenticated_caller() {
+    let source = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
+    source.create_collection(users_schema(true)).await.unwrap();
+    install_signing_identity();
+    let document = create_document(&source, "Alice").await;
+    set_signing_config(None);
+
+    let target = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
+    target.create_collection(users_schema(true)).await.unwrap();
+    let acp = Arc::new(LocalDocumentACP::new(Arc::new(MemoryAcpStore::new())));
+    let adapter = BrowserSyncAdapter::new_arc(target, acp, None);
+
+    let error = adapter
+        .sync(
+            BrowserSyncRequest {
+                documents: vec![BrowserSyncDocument {
+                    relationships: vec![BrowserSyncRelationship {
+                        relation: "reader".into(),
+                        target: "*".into(),
+                    }],
+                    ..document
+                }],
+                pull: None,
+            },
+            None,
+            false,
+        )
+        .await
+        .expect_err("an anonymous caller has no DID to grant as");
+    assert!(matches!(
+        error,
+        defra_http::router::BrowserSyncError::Forbidden(_)
+    ));
+}
+
+#[tokio::test]
+async fn relationships_refuse_the_owner_relation_and_an_unbounded_list() {
+    let source = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
+    source.create_collection(users_schema(true)).await.unwrap();
+    let owner = install_signing_identity();
+    let document = create_document(&source, "Alice").await;
+    set_signing_config(None);
+
+    let target = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
+    target.create_collection(users_schema(true)).await.unwrap();
+    let acp = Arc::new(LocalDocumentACP::new(Arc::new(MemoryAcpStore::new())));
+    let adapter = BrowserSyncAdapter::new_arc(target, acp, None);
+
+    for relationships in [
+        vec![BrowserSyncRelationship {
+            relation: "owner".into(),
+            target: "*".into(),
+        }],
+        vec![BrowserSyncRelationship {
+            relation: "reader".into(),
+            target: "not-a-did".into(),
+        }],
+        vec![
+            BrowserSyncRelationship {
+                relation: "reader".into(),
+                target: "*".into(),
+            };
+            defra_core::browser_sync::MAX_SYNC_RELATIONSHIPS_PER_DOCUMENT + 1
+        ],
+    ] {
+        let error = adapter
+            .sync(
+                BrowserSyncRequest {
+                    documents: vec![BrowserSyncDocument {
+                        relationships: relationships.clone(),
+                        ..document.clone()
+                    }],
+                    pull: None,
+                },
+                Some(&owner),
+                false,
+            )
+            .await
+            .expect_err("expected a refusal for {relationships:?}");
+        assert!(
+            matches!(error, defra_http::router::BrowserSyncError::InvalidInput(_)),
+            "expected invalid input for {relationships:?}, got {error:?}"
+        );
+    }
 }

--- a/crates/cli/src/browser_sync_adapter_tests.rs
+++ b/crates/cli/src/browser_sync_adapter_tests.rs
@@ -538,6 +538,69 @@ async fn concurrent_changes_converge_through_push_pull_exchange() {
     }
 }
 
+/// A pull naming several documents can be cut short by the page limit, and its
+/// cursor has to resume *within the named set* — resuming across the whole
+/// store would lose whatever fell off the first page.
+#[tokio::test]
+async fn a_pull_naming_several_documents_resumes_across_its_cursor() {
+    let database = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
+    database
+        .create_collection(users_schema(false))
+        .await
+        .unwrap();
+
+    let mut named = Vec::new();
+    for name in ["Alice", "Bob", "Carol"] {
+        named.push(create_document(&database, name).await.doc_id);
+    }
+    // In the store, not in the pull: a cursor over the whole store serves it.
+    let unnamed = create_document(&database, "Mallory").await.doc_id;
+
+    let acp = Arc::new(LocalDocumentACP::new(Arc::new(MemoryAcpStore::new())));
+    let adapter = BrowserSyncAdapter::new_arc(database, acp);
+
+    let mut cursor = None;
+    let mut seen: Vec<String> = Vec::new();
+    for _ in 0..8 {
+        let page = adapter
+            .sync(
+                BrowserSyncRequest {
+                    documents: Vec::new(),
+                    pull: Some(BrowserSyncPull {
+                        doc_ids: named.clone(),
+                        cursor: cursor.clone(),
+                        // Below the number named, so the pull must paginate.
+                        limit: Some(2),
+                    }),
+                },
+                None,
+                false,
+            )
+            .await
+            .expect("a pull naming several documents must be served");
+        seen.extend(page.documents.iter().map(|doc| doc.doc_id.clone()));
+        match page.next_cursor {
+            Some(next) => {
+                assert_ne!(Some(&next), cursor.as_ref(), "cursor must advance");
+                cursor = Some(next);
+            }
+            None => break,
+        }
+    }
+
+    seen.sort();
+    let mut expected = named.clone();
+    expected.sort();
+    assert_eq!(
+        seen, expected,
+        "every named document must be served across the pages"
+    );
+    assert!(
+        !seen.contains(&unnamed),
+        "a document the pull did not name must not be served"
+    );
+}
+
 /// #1188 skips the oversized document, but the property that matters is that
 /// pagination still reaches documents ordered *after* it. Doc IDs are
 /// content-derived, so this fixture asserts the oversized document actually

--- a/crates/cli/src/browser_sync_adapter_tests.rs
+++ b/crates/cli/src/browser_sync_adapter_tests.rs
@@ -10,6 +10,7 @@ use defra_core::signing::{set_signing_config, SigningConfig, SigningKeyType};
 use document::{DocID, Document, NormalValue};
 use query::mutator::DocMutator;
 use schema::{CollectionVersion, FieldDescription, FieldKind, PolicyDescription};
+use std::str::FromStr;
 use storage::RegolithStore;
 
 use crate::browser_sync_adapter::BrowserSyncAdapter;
@@ -538,6 +539,225 @@ async fn concurrent_changes_converge_through_push_pull_exchange() {
     }
 }
 
+/// The grants precede the merge, so a merge that is refused leaves them behind.
+/// Nothing spans both stores — one ACP backend is a chain — so the adapter puts
+/// ACP back itself: a document it registered goes away whole, taking the owner
+/// tuple and every grant with it.
+///
+/// The refusal is a signature that cannot verify, reached by pointing an update
+/// block at the genesis block's signature. Validation verifies the genesis
+/// only, so this passes it and is refused by the merge, which is exactly the
+/// window the revert exists for.
+#[tokio::test]
+async fn a_refused_merge_leaves_no_grant_behind() {
+    let owner = install_signing_identity();
+    let source = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
+    source.create_collection(users_schema(true)).await.unwrap();
+
+    let mut document = Document::new();
+    document.set("name", "Alice");
+    let mutator = db::AutoCommitMutator::new(source.clone());
+    let created = mutator.create("Users", document).await.unwrap();
+    let doc_id = created.doc_id.to_string();
+
+    let mut updated = Document::new();
+    updated.set_id(created.doc_id.clone());
+    updated.set("name", "Alice Updated");
+    mutator
+        .update("Users", updated, HashSet::from(["name".to_string()]))
+        .await
+        .unwrap();
+    set_signing_config(None);
+
+    let engine = db::merge::BrowserSyncEngine::new(source.clone());
+    let document_ref = engine.document_ref(&doc_id).await.unwrap().unwrap();
+    let payload = engine.load_document(&document_ref).await.unwrap().unwrap();
+    let forged = point_root_at_the_genesis_signature(payload);
+
+    let target = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
+    target.create_collection(users_schema(true)).await.unwrap();
+    let tuples = Arc::new(MemoryAcpStore::new());
+    let acp = Arc::new(LocalDocumentACP::new(tuples.clone()));
+    let adapter = BrowserSyncAdapter::new_arc(target, acp.clone(), None);
+
+    let refused = adapter
+        .sync(
+            BrowserSyncRequest {
+                documents: vec![BrowserSyncDocument {
+                    relationships: vec![BrowserSyncRelationship {
+                        relation: "reader".into(),
+                        target: "*".into(),
+                    }],
+                    ..forged
+                }],
+                pull: None,
+            },
+            Some(&owner),
+            false,
+        )
+        .await;
+    assert!(
+        refused.is_err(),
+        "a signature that cannot verify must refuse the merge: {refused:?}"
+    );
+
+    assert!(
+        !acp.is_doc_registered("users-policy", "users", &doc_id)
+            .await
+            .unwrap(),
+        "a document whose merge was refused must not stay registered, and its \
+         grants go with the registration"
+    );
+    // The owner tuple and the grant go together: an unregistered document is
+    // public to this backend, so absence of tuples is the state to assert.
+    assert!(
+        acp::AcpStore::get_doc_tuples(tuples.as_ref(), "users-policy:users", &doc_id)
+            .await
+            .unwrap()
+            .is_empty(),
+        "no tuple may outlive the merge that was refused"
+    );
+}
+
+/// The other half: a document ACP already knew keeps what it had. Only the
+/// grant this request created comes off, and the owner tuple — which this
+/// request did not make — stays.
+#[tokio::test]
+async fn a_refused_merge_keeps_what_it_did_not_create() {
+    let owner = install_signing_identity();
+    let source = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
+    source.create_collection(users_schema(true)).await.unwrap();
+
+    let mut document = Document::new();
+    document.set("name", "Alice");
+    let mutator = db::AutoCommitMutator::new(source.clone());
+    let created = mutator.create("Users", document).await.unwrap();
+    let doc_id = created.doc_id.to_string();
+
+    let engine = db::merge::BrowserSyncEngine::new(source.clone());
+    let document_ref = engine.document_ref(&doc_id).await.unwrap().unwrap();
+    let create_payload = engine.load_document(&document_ref).await.unwrap().unwrap();
+
+    let mut updated = Document::new();
+    updated.set_id(created.doc_id.clone());
+    updated.set("name", "Alice Updated");
+    mutator
+        .update("Users", updated, HashSet::from(["name".to_string()]))
+        .await
+        .unwrap();
+    set_signing_config(None);
+    let update_payload = engine.load_document(&document_ref).await.unwrap().unwrap();
+    let forged = point_root_at_the_genesis_signature(update_payload);
+
+    let target = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
+    target.create_collection(users_schema(true)).await.unwrap();
+    let tuples = Arc::new(MemoryAcpStore::new());
+    let acp = Arc::new(LocalDocumentACP::new(tuples.clone()));
+    let adapter = BrowserSyncAdapter::new_arc(target, acp.clone(), None);
+
+    adapter
+        .sync(
+            BrowserSyncRequest {
+                documents: vec![create_payload],
+                pull: None,
+            },
+            Some(&owner),
+            false,
+        )
+        .await
+        .expect("the create merges and registers the document");
+
+    let before = acp::AcpStore::get_doc_tuples(tuples.as_ref(), "users-policy:users", &doc_id)
+        .await
+        .unwrap();
+
+    let refused = adapter
+        .sync(
+            BrowserSyncRequest {
+                documents: vec![BrowserSyncDocument {
+                    relationships: vec![BrowserSyncRelationship {
+                        relation: "reader".into(),
+                        target: "*".into(),
+                    }],
+                    ..forged
+                }],
+                pull: None,
+            },
+            Some(&owner),
+            false,
+        )
+        .await;
+    assert!(refused.is_err(), "the forged update must be refused");
+
+    assert!(
+        acp.is_doc_registered("users-policy", "users", &doc_id)
+            .await
+            .unwrap(),
+        "a registration this request did not make must survive"
+    );
+    let after = acp::AcpStore::get_doc_tuples(tuples.as_ref(), "users-policy:users", &doc_id)
+        .await
+        .unwrap();
+    assert_eq!(
+        after.len(),
+        before.len(),
+        "only the grant this request created may come off"
+    );
+}
+
+/// Repoint the payload's root at the genesis block's signature, so the root
+/// carries a signature made over different bytes. Every CID stays honest; only
+/// the pairing is wrong.
+fn point_root_at_the_genesis_signature(
+    mut payload: defra_core::browser_sync::BrowserSyncDocument,
+) -> defra_core::browser_sync::BrowserSyncDocument {
+    let decoded: Vec<(String, Vec<u8>)> = payload
+        .blocks
+        .iter()
+        .map(|block| (block.cid.clone(), hex::decode(&block.data).unwrap()))
+        .collect();
+    let genesis_signature = decoded
+        .iter()
+        .find_map(|(cid, bytes)| {
+            let block = defra_core::block::Block::from_dag_cbor(bytes).ok()?;
+            let cid = cid::Cid::from_str(cid).ok()?;
+            (db::block::builder::derive_doc_id(&cid) == payload.doc_id)
+                .then_some(block.signature)?
+        })
+        .expect("the genesis block is signed");
+
+    let root = payload.roots[0].clone();
+    let root_bytes = decoded
+        .iter()
+        .find_map(|(cid, bytes)| (*cid == root).then_some(bytes))
+        .expect("the root is in the payload");
+    let mut root_block = defra_core::block::Block::from_dag_cbor(root_bytes).unwrap();
+    assert_ne!(
+        root_block.signature,
+        Some(genesis_signature),
+        "the root must be an update, not the genesis itself"
+    );
+    let orphaned_signature = root_block.signature.expect("an update block is signed");
+    root_block.signature = Some(genesis_signature);
+
+    let forged_bytes = root_block.to_dag_cbor().unwrap();
+    let forged_cid = defra_core::block::generate_cid_from_bytes(&forged_bytes)
+        .unwrap()
+        .to_string();
+    for block in &mut payload.blocks {
+        if block.cid == root {
+            block.cid = forged_cid.clone();
+            block.data = hex::encode(&forged_bytes);
+        }
+    }
+    // The root's own signature is unreachable now, and a payload carrying a
+    // block outside its DAG is refused before it reaches the merge.
+    let orphan = orphaned_signature.to_string();
+    payload.blocks.retain(|block| block.cid != orphan);
+    payload.roots = vec![forged_cid];
+    payload
+}
+
 /// A pull naming several documents can be cut short by the page limit, and its
 /// cursor has to resume *within the named set* — resuming across the whole
 /// store would lose whatever fell off the first page.
@@ -557,7 +777,7 @@ async fn a_pull_naming_several_documents_resumes_across_its_cursor() {
     let unnamed = create_document(&database, "Mallory").await.doc_id;
 
     let acp = Arc::new(LocalDocumentACP::new(Arc::new(MemoryAcpStore::new())));
-    let adapter = BrowserSyncAdapter::new_arc(database, acp);
+    let adapter = BrowserSyncAdapter::new_arc(database, acp, None);
 
     let mut cursor = None;
     let mut seen: Vec<String> = Vec::new();

--- a/crates/db/src/merge/browser_sync.rs
+++ b/crates/db/src/merge/browser_sync.rs
@@ -283,6 +283,8 @@ impl<S: Store + 'static> BrowserSyncEngine<S> {
             collection_id: document_ref.collection_id.clone(),
             roots: roots.into_iter().map(|cid| cid.to_string()).collect(),
             blocks,
+            // Grants are node-local state, not part of the DAG a pull carries.
+            relationships: Vec::new(),
         };
         self.validate_document(&document)?;
         Ok(Some(document))

--- a/crates/db/tests/merge/browser_sync_tests.rs
+++ b/crates/db/tests/merge/browser_sync_tests.rs
@@ -82,6 +82,7 @@ fn validation_distinguishes_empty_and_over_limit_counts() {
         collection_id: "collection".into(),
         roots: Vec::new(),
         blocks: vec![block.clone()],
+        relationships: Vec::new(),
     };
     assert!(matches!(
         sync.validate_document(&empty_roots),

--- a/crates/defra-core/src/browser_sync.rs
+++ b/crates/defra-core/src/browser_sync.rs
@@ -8,6 +8,7 @@ pub const MAX_SYNC_BLOCK_BYTES: usize = 4 * 1024 * 1024;
 pub const MAX_SYNC_BLOCKS_PER_DOCUMENT: usize = 4096;
 pub const MAX_SYNC_DOCUMENTS_PER_REQUEST: usize = 32;
 pub const MAX_SYNC_ROOTS_PER_DOCUMENT: usize = 16;
+pub const MAX_SYNC_RELATIONSHIPS_PER_DOCUMENT: usize = 16;
 pub const MAX_SYNC_PULL_DOC_IDS: usize = 64;
 pub const DEFAULT_SYNC_PAGE_SIZE: usize = 32;
 pub const MAX_SYNC_PAGE_SIZE: usize = 64;
@@ -19,12 +20,31 @@ pub struct BrowserSyncBlock {
     pub data: String,
 }
 
+/// One access grant to apply to the document it arrives with.
+///
+/// `target` is an actor DID or the all-actors wildcard `*`. The relationship
+/// endpoint's wider subject language — cross-object edges, usersets — is
+/// deliberately out of reach from a push.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BrowserSyncRelationship {
+    pub relation: String,
+    pub target: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BrowserSyncDocument {
     pub doc_id: String,
     pub collection_id: String,
     pub roots: Vec<String>,
     pub blocks: Vec<BrowserSyncBlock>,
+    /// Grants applied while the document is registered, so a document under a
+    /// policy becomes registered and readable in one step. Pushing and then
+    /// granting cannot: the merge announces the document between the two, and
+    /// a peer pulling on that announcement may not read it yet.
+    ///
+    /// Absent on the wire means empty.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub relationships: Vec<BrowserSyncRelationship>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -51,4 +71,35 @@ pub struct BrowserSyncResponse {
     pub documents: Vec<BrowserSyncDocument>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub next_cursor: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A client built before `relationships` existed must still be read, and
+    /// must still see the bytes it has always seen.
+    #[test]
+    fn a_document_without_relationships_round_trips_unchanged() {
+        let legacy = r#"{"doc_id":"d","collection_id":"c","roots":["r"],"blocks":[]}"#;
+        let document: BrowserSyncDocument = serde_json::from_str(legacy).unwrap();
+        assert!(document.relationships.is_empty());
+        assert_eq!(serde_json::to_string(&document).unwrap(), legacy);
+    }
+
+    #[test]
+    fn relationships_are_carried_when_present() {
+        let document: BrowserSyncDocument = serde_json::from_str(
+            r#"{"doc_id":"d","collection_id":"c","roots":["r"],"blocks":[],
+                "relationships":[{"relation":"reader","target":"*"}]}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            document.relationships,
+            vec![BrowserSyncRelationship {
+                relation: "reader".into(),
+                target: "*".into(),
+            }]
+        );
+    }
 }

--- a/crates/identity/Cargo.toml
+++ b/crates/identity/Cargo.toml
@@ -23,6 +23,7 @@ base64.workspace = true
 # Replaces a hand-rolled ASN.1 parser in `token/der.rs` (#775).
 k256.workspace = true
 p256 = "0.13"
+web-time.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/identity/src/token/mod.rs
+++ b/crates/identity/src/token/mod.rs
@@ -29,7 +29,8 @@ mod der;
 mod encoding;
 mod identity;
 
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
+use web_time::{SystemTime, UNIX_EPOCH};
 
 use crypto::{public_key_from_bytes, KeyType};
 use serde::Serialize;

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -28,6 +28,7 @@ web-sys = { version = "0.3", features = [
     "Request",
     "RequestInit",
     "Response",
+    "Url",
     "Window",
 ] }
 wasm-streams = "0.4"
@@ -65,6 +66,7 @@ document = { path = "../document" }
 query = { path = "../query" }
 defra-core = { path = "../defra-core" }
 crypto = { path = "../crypto" }
+identity = { path = "../identity" }
 events = { path = "../events", features = ["channel"] }
 
 # IPLD

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -67,6 +67,7 @@ query = { path = "../query" }
 defra-core = { path = "../defra-core" }
 crypto = { path = "../crypto" }
 identity = { path = "../identity" }
+zeroize = "1.8"
 events = { path = "../events", features = ["channel"] }
 
 # IPLD

--- a/crates/wasm/src/bindings.rs
+++ b/crates/wasm/src/bindings.rs
@@ -24,6 +24,10 @@ pub fn from_js<T: DeserializeOwned>(value: JsValue) -> Result<T> {
 pub struct ClientConfig {
     /// Database name for storage
     pub db_name: Option<String>,
+    /// Hex-encoded private key this client authors with, if it holds one.
+    pub private_key: Option<String>,
+    /// Key type of `private_key`: ed25519, secp256k1 or secp256r1.
+    pub key_type: Option<String>,
 }
 
 /// Collection info returned to JavaScript.

--- a/crates/wasm/src/client.rs
+++ b/crates/wasm/src/client.rs
@@ -16,6 +16,8 @@ type WasmRunner = QueryRunner<LensedAutoCommitFetcher<RegolithStore>>;
 
 use crate::bindings::{from_js, to_js, ClientConfig, CollectionInfo, FieldInfo};
 use crate::error::{Result, WasmError};
+use crate::identity::{ClientIdentity, SigningGuard};
+use defra_core::browser_sync::BrowserSyncRelationship;
 
 /// DefraDB client for browser applications.
 ///
@@ -51,6 +53,9 @@ pub struct DefraClient {
     runner: Option<WasmRunner>,
     event_bus: Arc<events::ChannelBus>,
     sync_task: Option<crate::sync::SyncTask>,
+    identity: Option<ClientIdentity>,
+    grants: Vec<BrowserSyncRelationship>,
+    mutate_lock: futures::lock::Mutex<()>,
     closed: bool,
 }
 
@@ -119,6 +124,75 @@ impl DefraClient {
     #[wasm_bindgen]
     pub async fn mutate(&self, graphql: &str) -> std::result::Result<JsValue, JsValue> {
         self.mutate_impl(graphql).await.map_err(|e| e.into())
+    }
+
+    /// Author with a key this client holds, given as hex.
+    ///
+    /// Every block written afterwards is signed with it, and the key never
+    /// leaves the tab: a server merging these blocks derives their owner from
+    /// the signature and cannot produce one itself. Returns the DID of the key.
+    ///
+    /// # Example
+    ///
+    /// ```javascript
+    /// const did = client.set_identity(privateKeyHex, 'ed25519');
+    /// ```
+    #[wasm_bindgen]
+    pub fn set_identity(
+        &mut self,
+        private_key_hex: &str,
+        key_type: &str,
+    ) -> std::result::Result<String, JsValue> {
+        self.ensure_open()?;
+        let identity = ClientIdentity::from_private_key(private_key_hex, key_type)?;
+        let did = identity.did().to_string();
+        self.identity = Some(identity);
+        Ok(did)
+    }
+
+    /// Grant these relations on every document this client authors, applied by
+    /// the push that registers the document rather than by a call after it.
+    ///
+    /// Each entry is `{ relation, target }`, where `target` is an actor DID or
+    /// `*` for everyone. Documents this client did not sign are pushed
+    /// untouched — the node would refuse a grant on them.
+    ///
+    /// # Example
+    ///
+    /// ```javascript
+    /// client.set_grants([{ relation: 'reader', target: '*' }]);
+    /// ```
+    #[wasm_bindgen]
+    pub fn set_grants(&mut self, grants: JsValue) -> std::result::Result<(), JsValue> {
+        self.ensure_open()?;
+        self.grants = if grants.is_undefined() || grants.is_null() {
+            Vec::new()
+        } else {
+            from_js(grants)?
+        };
+        Ok(())
+    }
+
+    /// The DID this client authors as, or `undefined` when it holds no key.
+    #[wasm_bindgen]
+    pub fn did(&self) -> Option<String> {
+        self.identity.as_ref().map(|id| id.did().to_string())
+    }
+
+    /// A JWT proving possession of this client's key, for `audience` — the host
+    /// of the server it will be sent to, which is what that server checks it
+    /// against.
+    ///
+    /// `sync` mints one of these for itself, so this is for callers that need
+    /// the token for a request of their own.
+    #[wasm_bindgen]
+    pub fn auth_token(&self, audience: Option<String>) -> std::result::Result<String, JsValue> {
+        self.ensure_open()?;
+        Ok(self
+            .identity
+            .as_ref()
+            .ok_or(WasmError::Identity("client holds no key".into()))?
+            .auth_token(audience)?)
     }
 
     /// Get information about all registered collections.
@@ -217,11 +291,22 @@ impl DefraClient {
             .with_mutator(mutator)
             .with_collection_truncator(db::DbCollectionTruncator::new_arc(Arc::clone(&db)));
 
+        let identity = match (config.private_key.as_deref(), config.key_type.as_deref()) {
+            (Some(private_key), key_type) => Some(ClientIdentity::from_private_key(
+                private_key,
+                key_type.unwrap_or("ed25519"),
+            )?),
+            (None, _) => None,
+        };
+
         Ok(Self {
             db: Some(db),
             runner: Some(runner),
             event_bus,
             sync_task: None,
+            identity,
+            grants: Vec::new(),
+            mutate_lock: futures::lock::Mutex::new(()),
             closed: false,
         })
     }
@@ -298,6 +383,11 @@ impl DefraClient {
             return Err(WasmError::Query("Empty mutation string".to_string()));
         }
 
+        // One mutation at a time. The signing config is a thread-local, so a
+        // second mutation starting mid-flight would take it away from the
+        // first, which would go on to write unsigned blocks.
+        let _writing = self.mutate_lock.lock().await;
+        let _signing = SigningGuard::install(self.identity.as_ref());
         let result = self
             .runner
             .as_ref()
@@ -383,10 +473,46 @@ impl DefraClient {
 
     async fn sync_impl(&mut self, server_url: &str, auth_token: Option<String>) -> Result<()> {
         let database = Arc::clone(self.ensure_open()?);
+        // Unauthenticated, the push registers ownership from the block
+        // signatures but can grant nothing: `add_actor_relationship` needs a
+        // caller to attribute the grant to.
+        let auth_token = match (auth_token, self.identity.as_ref()) {
+            (Some(token), _) => Some(token),
+            (None, Some(identity)) => Some(identity.auth_token(audience_of(server_url))?),
+            (None, None) => None,
+        };
+        // A bearer token on a cleartext origin is a credential anyone on the
+        // path can take and replay. `localhost` is exempt because a browser
+        // treats it as a secure context and it is where a node is developed
+        // against.
+        if auth_token.is_some() && !is_secure_origin(server_url) {
+            return Err(WasmError::Sync(format!(
+                "refusing to send a token to {server_url}: sync with a token needs https"
+            )));
+        }
         self.stop_sync().await;
-        self.sync_task =
-            Some(crate::sync::start(database, &self.event_bus, server_url, auth_token).await?);
+        self.sync_task = Some(
+            crate::sync::start(
+                database,
+                &self.event_bus,
+                server_url,
+                auth_token,
+                self.grants(),
+            )
+            .await?,
+        );
         Ok(())
+    }
+
+    fn grants(&self) -> crate::sync::Grants {
+        crate::sync::Grants {
+            relationships: self.grants.clone(),
+            signer_identity: self
+                .identity
+                .as_ref()
+                .map(ClientIdentity::signer_identity)
+                .unwrap_or_default(),
+        }
     }
 
     async fn stop_sync(&mut self) {
@@ -396,9 +522,37 @@ impl DefraClient {
     }
 }
 
+/// The host a server URL points at, which is the audience its node checks a
+/// token against.
+///
+/// The browser's parser is the right authority here: the node compares the
+/// audience with the `Host` header the browser sends, and that header is this
+/// same `host` — userinfo stripped, scheme lower-cased, a default port left
+/// off, an IPv6 authority bracketed.
+fn audience_of(server_url: &str) -> Option<String> {
+    let host = web_sys::Url::new(server_url).ok()?.host();
+    (!host.is_empty()).then_some(host)
+}
+
+/// Whether a browser treats this origin as secure, so a token may be sent to
+/// it. `localhost` counts, as it does for every other browser API.
+fn is_secure_origin(server_url: &str) -> bool {
+    let Ok(url) = web_sys::Url::new(server_url) else {
+        return false;
+    };
+    let hostname = url.hostname();
+    url.protocol() == "https:"
+        || hostname == "localhost"
+        || hostname.ends_with(".localhost")
+        || hostname == "127.0.0.1"
+        || hostname == "[::1]"
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crypto::keys::Key as _;
+    use identity::Identity as _;
     use wasm_bindgen_test::*;
 
     wasm_bindgen_test_configure!(run_in_browser);
@@ -407,8 +561,313 @@ mod tests {
     fn test_config(name: &str) -> JsValue {
         serde_wasm_bindgen::to_value(&ClientConfig {
             db_name: Some(name.to_string()),
+            ..Default::default()
         })
         .unwrap()
+    }
+
+    /// A client that authors with a key of its own, and that key's hex.
+    async fn client_with_identity(name: &str) -> (DefraClient, String) {
+        let private_key = crypto::generate_ed25519().unwrap();
+        let private_key_hex = private_key.to_hex_string();
+        let config = serde_wasm_bindgen::to_value(&ClientConfig {
+            db_name: Some(name.to_string()),
+            private_key: Some(private_key_hex.clone()),
+            key_type: Some("ed25519".into()),
+        })
+        .unwrap();
+        let client = DefraClient::create(config).await.unwrap();
+        (client, private_key_hex)
+    }
+
+    /// Every signature over a block of this client's one document, as the
+    /// signer identity each carries: Go's `PublicKey().String()`, so the
+    /// hex-encoded public key as bytes.
+    async fn signing_keys(client: &DefraClient) -> Vec<Vec<u8>> {
+        signing_keys_by_document(client).await.remove(0)
+    }
+
+    /// The same, for every document this client holds.
+    async fn signing_keys_by_document(client: &DefraClient) -> Vec<Vec<Vec<u8>>> {
+        let engine = db::merge::BrowserSyncEngine::new(Arc::clone(client.db.as_ref().unwrap()));
+        let mut documents = Vec::new();
+        for document_ref in engine.document_refs().await.unwrap() {
+            let document = engine
+                .load_document(&document_ref)
+                .await
+                .unwrap()
+                .expect("the document must be loadable");
+            documents.push(signatures_in(&document));
+        }
+        documents
+    }
+
+    fn signatures_in(document: &defra_core::browser_sync::BrowserSyncDocument) -> Vec<Vec<u8>> {
+        let blocks: std::collections::HashMap<String, Vec<u8>> = document
+            .blocks
+            .iter()
+            .map(|block| (block.cid.clone(), hex::decode(&block.data).unwrap()))
+            .collect();
+        let mut keys = Vec::new();
+        for bytes in blocks.values() {
+            let Ok(block) = defra_core::block::Block::from_dag_cbor(bytes) else {
+                continue;
+            };
+            let Some(signature_cid) = block.signature else {
+                continue;
+            };
+            let signature =
+                defra_core::block::Signature::from_dag_cbor(&blocks[&signature_cid.to_string()])
+                    .expect("a block's signature must decode");
+            keys.push(signature.header.identity);
+        }
+        keys
+    }
+
+    async fn create_one_document(client: &mut DefraClient) {
+        client
+            .add_schema("type User { name: String }")
+            .await
+            .unwrap();
+        client
+            .mutate(r#"mutation { create_User(input: {name: "Alice"}) { _docID } }"#)
+            .await
+            .unwrap();
+    }
+
+    #[wasm_bindgen_test]
+    async fn a_client_signs_what_it_authors_with_its_own_key() {
+        let (mut client, private_key_hex) = client_with_identity("signing_authored").await;
+        let public_key_hex =
+            crypto::private_key_from_string(crypto::KeyType::Ed25519, &private_key_hex)
+                .unwrap()
+                .public_key()
+                .to_hex_string()
+                .into_bytes();
+
+        create_one_document(&mut client).await;
+
+        let keys = signing_keys(&client).await;
+        assert!(!keys.is_empty(), "the document must carry a signature");
+        assert!(
+            keys.iter().all(|key| *key == public_key_hex),
+            "every signature must be made with this client's key"
+        );
+        client.close().await.unwrap();
+    }
+
+    /// The node signs for a caller whose key it holds; a client that holds its
+    /// own signs for itself, and `did()` names who that is.
+    #[wasm_bindgen_test]
+    async fn a_client_reports_the_did_it_authors_as() {
+        let (mut client, _) = client_with_identity("signing_did").await;
+        let did = client.did().expect("a client with a key has a DID");
+        assert!(did.starts_with("did:key:"), "unexpected DID: {did}");
+        client.close().await.unwrap();
+    }
+
+    #[wasm_bindgen_test]
+    async fn without_a_key_a_client_authors_unsigned_blocks() {
+        let mut client = DefraClient::create(test_config("signing_none"))
+            .await
+            .unwrap();
+        assert!(client.did().is_none());
+
+        create_one_document(&mut client).await;
+
+        assert!(
+            signing_keys(&client).await.is_empty(),
+            "a client with no key must not sign"
+        );
+        client.close().await.unwrap();
+    }
+
+    /// The token has to name the same DID the blocks are signed with, or the
+    /// node registers a document to one identity and refuses grants from the
+    /// other.
+    #[wasm_bindgen_test]
+    async fn a_minted_token_names_the_same_did_the_blocks_carry() {
+        let (mut client, _) = client_with_identity("signing_token").await;
+        let token = client.auth_token(Some("example.test:9181".into())).unwrap();
+
+        let parsed = identity::from_token(token.as_bytes()).unwrap();
+        identity::verify_auth_token(&parsed, "example.test:9181").unwrap();
+        assert_eq!(
+            parsed.did().unwrap().to_string(),
+            client.did().unwrap(),
+            "the token and the blocks must name one identity"
+        );
+        client.close().await.unwrap();
+    }
+
+    #[wasm_bindgen_test]
+    async fn a_client_without_a_key_cannot_mint_a_token() {
+        let client = DefraClient::create(test_config("signing_no_token"))
+            .await
+            .unwrap();
+        assert!(client.auth_token(None).is_err());
+    }
+
+    /// `mutate` takes `&self`, so a page can start a second one before the
+    /// first resolves, and the signing config they share is a thread-local.
+    /// The mutation lock is what keeps one from taking it away from the other;
+    /// this pins the outcome, since each mutation runs to completion without
+    /// yielding here and the interleaving cannot be provoked from a test.
+    #[wasm_bindgen_test]
+    async fn concurrent_mutations_are_each_signed() {
+        let (mut client, _) = client_with_identity("signing_concurrent").await;
+        client
+            .add_schema("type User { name: String }")
+            .await
+            .unwrap();
+
+        let (first, second) = futures::join!(
+            client.mutate(r#"mutation { create_User(input: {name: "Alice"}) { _docID } }"#),
+            client.mutate(r#"mutation { create_User(input: {name: "Bob"}) { _docID } }"#),
+        );
+        first.unwrap();
+        second.unwrap();
+
+        let by_document = signing_keys_by_document(&client).await;
+        assert_eq!(by_document.len(), 2, "both documents must exist");
+        assert!(
+            by_document.iter().all(|keys| !keys.is_empty()),
+            "an interleaved mutation must not lose its signature"
+        );
+        client.close().await.unwrap();
+    }
+
+    /// A grant is applied as the caller and refused on a document that caller
+    /// does not own, so attaching one to a relayed document would fail the push
+    /// that carries it.
+    #[wasm_bindgen_test]
+    async fn grants_ride_only_on_documents_this_client_signed() {
+        let (mut client, _) = client_with_identity("signing_grants").await;
+        client
+            .set_grants(
+                serde_wasm_bindgen::to_value(&vec![BrowserSyncRelationship {
+                    relation: "reader".into(),
+                    target: "*".into(),
+                }])
+                .unwrap(),
+            )
+            .unwrap();
+        create_one_document(&mut client).await;
+
+        let engine = db::merge::BrowserSyncEngine::new(Arc::clone(client.db.as_ref().unwrap()));
+        let refs = engine.document_refs().await.unwrap();
+        let mut document = engine.load_document(&refs[0]).await.unwrap().unwrap();
+
+        client.grants().attach(&mut document);
+        assert_eq!(
+            document.relationships.len(),
+            1,
+            "a document this client signed carries its grants"
+        );
+
+        // The same document as far as a relay is concerned: signed by somebody
+        // whose key this client does not hold.
+        let mut relayed = document.clone();
+        relayed.relationships = Vec::new();
+        crate::sync::Grants {
+            relationships: vec![BrowserSyncRelationship {
+                relation: "reader".into(),
+                target: "*".into(),
+            }],
+            signer_identity: b"another-key".to_vec(),
+        }
+        .attach(&mut relayed);
+        assert!(
+            relayed.relationships.is_empty(),
+            "a document signed by another key must go out untouched"
+        );
+        client.close().await.unwrap();
+    }
+
+    /// Better to refuse the key than to mint a token with it and fail every
+    /// write: block signing needs a remote signer for secp256r1.
+    #[wasm_bindgen_test]
+    async fn a_key_that_cannot_sign_in_a_browser_is_refused() {
+        let mut client = DefraClient::create(test_config("signing_r1"))
+            .await
+            .unwrap();
+        let private_key = crypto::generate_secp256r1().unwrap();
+        assert!(client
+            .set_identity(&private_key.to_hex_string(), "secp256r1")
+            .is_err());
+        client.close().await.unwrap();
+    }
+
+    /// The node compares the audience with the `Host` header the browser sent,
+    /// so the two have to be derived the same way.
+    #[wasm_bindgen_test]
+    fn an_audience_is_the_host_the_token_is_sent_to() {
+        assert_eq!(
+            audience_of("http://localhost:9181/api/v0"),
+            Some("localhost:9181".into())
+        );
+        assert_eq!(
+            audience_of("https://node.example"),
+            Some("node.example".into())
+        );
+        // A browser leaves a default port off the Host header.
+        assert_eq!(
+            audience_of("https://node.example:443"),
+            Some("node.example".into())
+        );
+        assert_eq!(
+            audience_of("http://node.example:80/x"),
+            Some("node.example".into())
+        );
+        assert_eq!(
+            audience_of("HTTPS://Node.Example/x"),
+            Some("node.example".into())
+        );
+        assert_eq!(
+            audience_of("https://user:pass@node.example"),
+            Some("node.example".into())
+        );
+        assert_eq!(audience_of("https://[::1]:9181"), Some("[::1]:9181".into()));
+        assert_eq!(audience_of(""), None);
+    }
+
+    /// A bearer token on a cleartext origin is a credential anyone on the path
+    /// can take, so sync refuses to send one.
+    #[wasm_bindgen_test]
+    async fn a_token_is_not_sent_over_cleartext() {
+        let (mut client, _) = client_with_identity("signing_cleartext").await;
+        let error = client
+            .sync("http://node.example:9181", None)
+            .await
+            .expect_err("a token must not travel in the clear");
+        assert!(
+            format!("{error:?}").contains("https"),
+            "unexpected error: {error:?}"
+        );
+        client.close().await.unwrap();
+    }
+
+    #[wasm_bindgen_test]
+    fn localhost_is_a_secure_origin_for_a_token() {
+        assert!(is_secure_origin("http://localhost:9181"));
+        assert!(is_secure_origin("http://127.0.0.1:9181"));
+        assert!(is_secure_origin("https://node.example"));
+        assert!(!is_secure_origin("http://node.example"));
+        assert!(!is_secure_origin("not a url"));
+    }
+
+    /// A closed client holds no database, so changing what it would author or
+    /// minting a credential for it is a mistake worth reporting.
+    #[wasm_bindgen_test]
+    async fn a_closed_client_refuses_identity_and_token_operations() {
+        let (mut client, private_key_hex) = client_with_identity("signing_closed").await;
+        client.close().await.unwrap();
+
+        assert!(client.set_identity(&private_key_hex, "ed25519").is_err());
+        assert!(client.set_grants(JsValue::NULL).is_err());
+        assert!(client.auth_token(None).is_err());
+        // Reading back who it was is still fine.
+        assert!(client.did().is_some());
     }
 
     #[wasm_bindgen_test]

--- a/crates/wasm/src/client.rs
+++ b/crates/wasm/src/client.rs
@@ -551,7 +551,7 @@ fn is_secure_origin(server_url: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crypto::keys::Key as _;
+    use crypto::keys::{Key as _, PrivateKey as _};
     use identity::Identity as _;
     use wasm_bindgen_test::*;
 
@@ -781,6 +781,50 @@ mod tests {
             relayed.relationships.is_empty(),
             "a document signed by another key must go out untouched"
         );
+        client.close().await.unwrap();
+    }
+
+    /// A browser generating its key with WebCrypto exports a JWK whose `d` is
+    /// the 32-byte seed, so that is what a caller has in hand. It names the
+    /// same identity as the 64-byte form this codebase stores.
+    #[wasm_bindgen_test]
+    async fn an_ed25519_seed_names_the_same_identity_as_the_full_key() {
+        let private_key = crypto::generate_ed25519().unwrap();
+        let full = private_key.raw().to_vec();
+        assert_eq!(full.len(), 64, "the stored form is seed || public key");
+        let seed = &full[..32];
+
+        let mut client = DefraClient::create(test_config("signing_seed"))
+            .await
+            .unwrap();
+        let from_seed = client.set_identity(&hex::encode(seed), "ed25519").unwrap();
+        let from_full = client.set_identity(&hex::encode(&full), "ed25519").unwrap();
+        assert_eq!(from_seed, from_full);
+
+        // And it signs: the seed is a whole key here, not just an identifier.
+        client
+            .add_schema("type User { name: String }")
+            .await
+            .unwrap();
+        client.set_identity(&hex::encode(seed), "ed25519").unwrap();
+        client
+            .mutate(r#"mutation { create_User(input: {name: "Alice"}) { _docID } }"#)
+            .await
+            .unwrap();
+        let expected = private_key.public_key().to_hex_string().into_bytes();
+        let keys = signing_keys(&client).await;
+        assert!(!keys.is_empty() && keys.iter().all(|key| *key == expected));
+        client.close().await.unwrap();
+    }
+
+    #[wasm_bindgen_test]
+    async fn a_key_of_the_wrong_length_is_still_refused() {
+        let mut client = DefraClient::create(test_config("signing_short"))
+            .await
+            .unwrap();
+        assert!(client
+            .set_identity(&hex::encode([7u8; 16]), "ed25519")
+            .is_err());
         client.close().await.unwrap();
     }
 

--- a/crates/wasm/src/error.rs
+++ b/crates/wasm/src/error.rs
@@ -33,6 +33,9 @@ pub enum WasmError {
     #[error("Sync error: {0}")]
     Sync(String),
 
+    #[error("Identity error: {0}")]
+    Identity(String),
+
     #[error("Client not initialized")]
     NotInitialized,
 

--- a/crates/wasm/src/identity.rs
+++ b/crates/wasm/src/identity.rs
@@ -9,12 +9,16 @@ use std::time::Duration;
 
 use defra_core::signing::{SigningConfig, SigningKeyType};
 use identity::{Identity, IdentityKeyType, RawIdentity};
+use zeroize::Zeroize;
 
 use crate::error::{Result, WasmError};
 
 /// How long a minted token stays valid. Long enough to outlive a page's sync
 /// session, short enough that a leaked one expires.
 const TOKEN_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// The `d` of an RFC 8037 Ed25519 JWK, which is the seed alone.
+const ED25519_SEED_BYTES: usize = 32;
 
 pub(crate) struct ClientIdentity {
     raw: RawIdentity,
@@ -25,10 +29,21 @@ pub(crate) struct ClientIdentity {
 impl ClientIdentity {
     pub(crate) fn from_private_key(private_key_hex: &str, key_type: &str) -> Result<Self> {
         let (key_type, signing_key_type) = parse_key_type(key_type)?;
-        let bytes = hex::decode(private_key_hex.trim_start_matches("0x"))
+        let mut bytes = hex::decode(private_key_hex.trim_start_matches("0x"))
             .map_err(|error| WasmError::Identity(format!("private key is not hex: {error}")))?;
+        // A browser generating its key with WebCrypto exports an RFC 8037 JWK,
+        // whose `d` is the 32-byte seed, while an Ed25519 key here is the
+        // 64-byte seed || public form. Promote at this boundary, as the CLI's
+        // JWK import does, rather than in the shared constructor.
+        if key_type == IdentityKeyType::Ed25519 && bytes.len() == ED25519_SEED_BYTES {
+            let promoted = crypto::ed25519_key_from_seed(&bytes)
+                .map_err(|error| WasmError::Identity(error.to_string()))?;
+            bytes.zeroize();
+            bytes = promoted;
+        }
         let raw = RawIdentity::from_identity_key_type(key_type, &bytes)
             .map_err(|error| WasmError::Identity(error.to_string()))?;
+        bytes.zeroize();
         let did = raw
             .did()
             .map_err(|error| WasmError::Identity(error.to_string()))?

--- a/crates/wasm/src/identity.rs
+++ b/crates/wasm/src/identity.rs
@@ -1,0 +1,116 @@
+//! The key this browser authors with. It signs the blocks the tab writes and
+//! mints the token that authenticates them, and it never leaves the tab.
+//!
+//! Without one, blocks go out unsigned: `/sync` derives ownership from the
+//! verified genesis signer, so an unsigned document is owned by nobody and its
+//! author can never grant access to it.
+
+use std::time::Duration;
+
+use defra_core::signing::{SigningConfig, SigningKeyType};
+use identity::{Identity, IdentityKeyType, RawIdentity};
+
+use crate::error::{Result, WasmError};
+
+/// How long a minted token stays valid. Long enough to outlive a page's sync
+/// session, short enough that a leaked one expires.
+const TOKEN_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+
+pub(crate) struct ClientIdentity {
+    raw: RawIdentity,
+    did: String,
+    signing: SigningConfig,
+}
+
+impl ClientIdentity {
+    pub(crate) fn from_private_key(private_key_hex: &str, key_type: &str) -> Result<Self> {
+        let (key_type, signing_key_type) = parse_key_type(key_type)?;
+        let bytes = hex::decode(private_key_hex.trim_start_matches("0x"))
+            .map_err(|error| WasmError::Identity(format!("private key is not hex: {error}")))?;
+        let raw = RawIdentity::from_identity_key_type(key_type, &bytes)
+            .map_err(|error| WasmError::Identity(error.to_string()))?;
+        let did = raw
+            .did()
+            .map_err(|error| WasmError::Identity(error.to_string()))?
+            .to_string();
+
+        let public_key_bytes = raw.public_key_bytes();
+        let signing = SigningConfig {
+            key_type: signing_key_type,
+            private_key_bytes: SigningConfig::private_key_bytes_from_vec(raw.private_key_bytes()),
+            public_key_hex: hex::encode(&public_key_bytes),
+            public_key_bytes,
+            remote_signer: None,
+            signing_authorization: None,
+        };
+
+        Ok(Self { raw, did, signing })
+    }
+
+    pub(crate) fn did(&self) -> &str {
+        &self.did
+    }
+
+    /// How this client appears in a signature header: Go's
+    /// `PublicKey().String()`, the hex-encoded key as bytes.
+    pub(crate) fn signer_identity(&self) -> Vec<u8> {
+        self.signing.public_key_hex.as_bytes().to_vec()
+    }
+
+    pub(crate) fn signing_config(&self) -> SigningConfig {
+        self.signing.clone()
+    }
+
+    /// A self-signed JWT naming this identity. The node verifies it against the
+    /// request's Host header, so the audience is the server being synced with.
+    pub(crate) fn auth_token(&self, audience: Option<String>) -> Result<String> {
+        let token = identity::new_token(&self.raw, TOKEN_TTL, audience, None)
+            .map_err(|error| WasmError::Identity(error.to_string()))?;
+        String::from_utf8(token)
+            .map_err(|error| WasmError::Identity(format!("token is not valid UTF-8: {error}")))
+    }
+}
+
+fn parse_key_type(key_type: &str) -> Result<(IdentityKeyType, SigningKeyType)> {
+    match key_type
+        .to_ascii_lowercase()
+        .replace(['-', '_'], "")
+        .as_str()
+    {
+        "ed25519" => Ok((IdentityKeyType::Ed25519, SigningKeyType::Ed25519)),
+        "secp256k1" => Ok((IdentityKeyType::Secp256k1, SigningKeyType::Secp256k1)),
+        // Accepting it would mint tokens and then fail every write: block
+        // signing refuses secp256r1 without a remote signer, since a Secure
+        // Enclave key cannot be exported, and a browser has no signer to reach.
+        "secp256r1" => Err(WasmError::Identity(
+            "secp256r1 cannot sign in a browser: it needs a remote signer".into(),
+        )),
+        other => Err(WasmError::Identity(format!(
+            "unsupported key type '{other}': expected ed25519 or secp256k1"
+        ))),
+    }
+}
+
+/// Installs a signing config for as long as it is held.
+///
+/// The config is a thread-local the write path reads, and blocks arriving from
+/// the server must not be signed with this key, so it is installed around a
+/// local write and taken away again.
+///
+/// One writer at a time: the caller holds the mutation lock, because a guard
+/// dropped while another mutation is still in flight would leave that one
+/// writing unsigned blocks.
+pub(crate) struct SigningGuard;
+
+impl SigningGuard {
+    pub(crate) fn install(identity: Option<&ClientIdentity>) -> Self {
+        defra_core::signing::set_signing_config(identity.map(ClientIdentity::signing_config));
+        Self
+    }
+}
+
+impl Drop for SigningGuard {
+    fn drop(&mut self) {
+        defra_core::signing::set_signing_config(None);
+    }
+}

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -57,6 +57,8 @@ pub mod bindings;
 pub mod client;
 pub mod error;
 #[cfg(target_arch = "wasm32")]
+mod identity;
+#[cfg(target_arch = "wasm32")]
 mod storage_tests;
 #[cfg(target_arch = "wasm32")]
 mod sync;

--- a/crates/wasm/src/sync/grants.rs
+++ b/crates/wasm/src/sync/grants.rs
@@ -1,0 +1,49 @@
+//! Grants that ride along with the documents this client authored.
+
+use std::str::FromStr;
+
+use cid::Cid;
+use defra_core::block::{Block, Signature};
+use defra_core::browser_sync::{BrowserSyncDocument, BrowserSyncRelationship};
+
+/// Attach `grants` to a document this client signed.
+///
+/// The node applies a pushed grant as the caller and refuses one on a document
+/// the caller does not own, which would fail the whole push — so a relayed
+/// document goes out as it arrived.
+pub(super) fn attach_grants(
+    document: &mut BrowserSyncDocument,
+    grants: &[BrowserSyncRelationship],
+    signer_identity: &[u8],
+) {
+    if !grants.is_empty() && authored_by(document, signer_identity) {
+        document.relationships = grants.to_vec();
+    }
+}
+
+/// Whether the document's genesis block is signed by this identity, which is
+/// what the node registers ownership from.
+fn authored_by(document: &BrowserSyncDocument, signer_identity: &[u8]) -> bool {
+    let Some(genesis) = document.blocks.iter().find_map(|block| {
+        let cid = Cid::from_str(&block.cid).ok()?;
+        (db::block::builder::derive_doc_id(&cid) == document.doc_id).then_some(block)
+    }) else {
+        return false;
+    };
+    let Some(signature_cid) = hex::decode(&genesis.data)
+        .ok()
+        .and_then(|bytes| Block::from_dag_cbor(&bytes).ok())
+        .and_then(|block| block.signature)
+    else {
+        return false;
+    };
+    let signature_cid = signature_cid.to_string();
+
+    document
+        .blocks
+        .iter()
+        .find(|block| block.cid == signature_cid)
+        .and_then(|block| hex::decode(&block.data).ok())
+        .and_then(|bytes| Signature::from_dag_cbor(&bytes).ok())
+        .is_some_and(|signature| signature.header.identity == signer_identity)
+}

--- a/crates/wasm/src/sync/mod.rs
+++ b/crates/wasm/src/sync/mod.rs
@@ -1,5 +1,6 @@
+mod grants;
 mod http;
 mod session;
 mod sse;
 
-pub(crate) use session::{start, SyncTask};
+pub(crate) use session::{start, Grants, SyncTask};

--- a/crates/wasm/src/sync/session.rs
+++ b/crates/wasm/src/sync/session.rs
@@ -3,8 +3,9 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use defra_core::browser_sync::{
-    BrowserSyncDocument, BrowserSyncPull, BrowserSyncRequest, BrowserSyncResponse,
-    MAX_SYNC_BODY_BYTES, MAX_SYNC_DOCUMENTS_PER_REQUEST, MAX_SYNC_PAGE_SIZE, MAX_SYNC_PULL_DOC_IDS,
+    BrowserSyncDocument, BrowserSyncPull, BrowserSyncRelationship, BrowserSyncRequest,
+    BrowserSyncResponse, MAX_SYNC_BODY_BYTES, MAX_SYNC_DOCUMENTS_PER_REQUEST, MAX_SYNC_PAGE_SIZE,
+    MAX_SYNC_PULL_DOC_IDS,
 };
 use events::Bus;
 use futures::channel::oneshot;
@@ -15,6 +16,7 @@ use wasm_bindgen_futures::spawn_local;
 
 use crate::error::{Result, WasmError};
 
+use super::grants::attach_grants;
 use super::http::SyncHttpClient;
 use super::sse::SseStream;
 
@@ -27,6 +29,10 @@ const EMPTY_PUSH_REQUEST_BYTES: usize = b"{\"documents\":[]}".len();
 /// serialization.
 const EMPTY_SYNC_REQUEST_BYTES: usize =
     b"{\"documents\":[],\"pull\":{\"doc_ids\":[],\"limit\":64}}".len();
+
+// The literal above spells out the page limit, so a limit of a different width
+// would silently mis-size every batch.
+const _: () = assert!(MAX_SYNC_PAGE_SIZE == 64);
 
 pub(crate) struct SyncTask {
     abort: AbortHandle,
@@ -51,12 +57,14 @@ pub(crate) async fn start(
     event_bus: &Arc<events::ChannelBus>,
     server_url: &str,
     auth_token: Option<String>,
+    grants: Grants,
 ) -> Result<SyncTask> {
     let session = Rc::new(SyncSession {
         engine: db::merge::BrowserSyncEngine::new(database),
         http: SyncHttpClient::new(server_url, auth_token)?,
         exchange_lock: Mutex::new(()),
         full_sync_lock: Mutex::new(()),
+        grants,
     });
     let subscription = event_bus.subscribe(&[events::EventName::Update]);
     let subscription_id = subscription.id();
@@ -95,6 +103,21 @@ struct SyncSession {
     http: SyncHttpClient,
     exchange_lock: Mutex<()>,
     full_sync_lock: Mutex<()>,
+    grants: Grants,
+}
+
+/// The grants this client puts on every document it authors, and the identity
+/// that says which documents those are.
+#[derive(Default, Clone)]
+pub(crate) struct Grants {
+    pub(crate) relationships: Vec<BrowserSyncRelationship>,
+    pub(crate) signer_identity: Vec<u8>,
+}
+
+impl Grants {
+    pub(crate) fn attach(&self, document: &mut BrowserSyncDocument) {
+        attach_grants(document, &self.relationships, &self.signer_identity);
+    }
 }
 
 impl SyncSession {
@@ -124,9 +147,10 @@ impl SyncSession {
                 }
                 Err(error) => return Err(engine_error(error)),
             };
-            let Some(document) = loaded else {
+            let Some(mut document) = loaded else {
                 continue;
             };
+            self.grants.attach(&mut document);
 
             let document_size = serde_json::to_vec(&document)?.len();
             let single_document_size = EMPTY_PUSH_REQUEST_BYTES + document_size;
@@ -239,7 +263,10 @@ impl SyncSession {
             return Ok(None);
         };
         match self.engine.load_document(&document_ref).await {
-            Ok(document) => Ok(document),
+            Ok(document) => Ok(document.map(|mut document| {
+                self.grants.attach(&mut document);
+                document
+            })),
             Err(error @ db::merge::browser_sync::BrowserSyncError::TooLarge(_)) => {
                 warn(&format!(
                     "browser sync skipped document {doc_id} because it cannot be represented as a sync payload: {error}"

--- a/crates/wasm/src/sync/session.rs
+++ b/crates/wasm/src/sync/session.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use defra_core::browser_sync::{
     BrowserSyncDocument, BrowserSyncPull, BrowserSyncRequest, BrowserSyncResponse,
-    MAX_SYNC_BODY_BYTES, MAX_SYNC_DOCUMENTS_PER_REQUEST, MAX_SYNC_PAGE_SIZE,
+    MAX_SYNC_BODY_BYTES, MAX_SYNC_DOCUMENTS_PER_REQUEST, MAX_SYNC_PAGE_SIZE, MAX_SYNC_PULL_DOC_IDS,
 };
 use events::Bus;
 use futures::channel::oneshot;
@@ -21,6 +21,12 @@ use super::sse::SseStream;
 const INITIAL_RECONNECT_DELAY_MS: u32 = 1_000;
 const MAX_RECONNECT_DELAY_MS: u32 = 30_000;
 const EMPTY_PUSH_REQUEST_BYTES: usize = b"{\"documents\":[]}".len();
+
+/// What an exchange costs before a document or a pull ID is in it.
+/// `incremental_sync_size_matches_serialized_request` holds it against a real
+/// serialization.
+const EMPTY_SYNC_REQUEST_BYTES: usize =
+    b"{\"documents\":[],\"pull\":{\"doc_ids\":[],\"limit\":64}}".len();
 
 pub(crate) struct SyncTask {
     abort: AbortHandle,
@@ -185,38 +191,96 @@ impl SyncSession {
         }
     }
 
-    async fn sync_document(&self, doc_id: &str) -> Result<()> {
-        let mut documents = Vec::new();
-        if let Some(document_ref) = self
+    /// Push what is local and pull what is not, in as few exchanges as the wire
+    /// limits allow. A burst of writes raises one update event per document and
+    /// they arrive together, so one exchange each would cost a round trip per
+    /// document.
+    async fn sync_documents(&self, doc_ids: &[String]) -> Result<()> {
+        let mut batch = SyncBatch::default();
+        for doc_id in doc_ids {
+            let id_bytes = serde_json::to_vec(doc_id)?.len();
+            let mut document = self.load_push_document(doc_id).await?;
+            let mut document_bytes = match document.as_ref() {
+                Some(document) => Some(serde_json::to_vec(document)?.len()),
+                None => None,
+            };
+
+            // Over the limit alone, so no request can carry it. Drop it from
+            // the push; the pull still names it.
+            if !SyncBatch::default().fits(id_bytes, document_bytes) {
+                warn(&format!(
+                    "browser sync skipped document {doc_id} because it exceeds the sync request limit"
+                ));
+                document = None;
+                document_bytes = None;
+            }
+
+            if !batch.is_empty() && !batch.fits(id_bytes, document_bytes) {
+                self.exchange_batch(batch.take()).await?;
+            }
+            batch.accept(doc_id.clone(), document, id_bytes, document_bytes);
+        }
+        if !batch.is_empty() {
+            self.exchange_batch(batch.take()).await?;
+        }
+        Ok(())
+    }
+
+    /// The push payload for a document, or `None` when there is nothing local
+    /// to push: it is not held here, or it is too large to represent. Failing
+    /// instead would force a full sync on every update touching it.
+    async fn load_push_document(&self, doc_id: &str) -> Result<Option<BrowserSyncDocument>> {
+        let Some(document_ref) = self
             .engine
             .document_ref(doc_id)
             .await
             .map_err(engine_error)?
-        {
-            // Nothing to push for an over-large document, but the pull below
-            // still applies. Failing here would fall back to a full sync on
-            // every single update touching this document.
-            match self.engine.load_document(&document_ref).await {
-                Ok(Some(document)) => documents.push(document),
-                Ok(None) => {}
-                Err(error @ db::merge::browser_sync::BrowserSyncError::TooLarge(_)) => {
-                    warn(&format!(
-                        "browser sync skipped document {doc_id} because it cannot be represented as a sync payload: {error}"
-                    ));
+        else {
+            return Ok(None);
+        };
+        match self.engine.load_document(&document_ref).await {
+            Ok(document) => Ok(document),
+            Err(error @ db::merge::browser_sync::BrowserSyncError::TooLarge(_)) => {
+                warn(&format!(
+                    "browser sync skipped document {doc_id} because it cannot be represented as a sync payload: {error}"
+                ));
+                Ok(None)
+            }
+            Err(error) => Err(engine_error(error)),
+        }
+    }
+
+    /// One batch: its documents pushed once, then its pull followed to the end.
+    /// A pull naming many documents can be cut short by the page limit, where a
+    /// pull naming one never could, so later requests carry no documents.
+    async fn exchange_batch(&self, batch: SyncBatch) -> Result<()> {
+        let SyncBatch {
+            mut documents,
+            doc_ids,
+            ..
+        } = batch;
+        let mut cursor = None;
+        loop {
+            let response = self
+                .exchange(BrowserSyncRequest {
+                    documents: std::mem::take(&mut documents),
+                    pull: Some(BrowserSyncPull {
+                        doc_ids: doc_ids.clone(),
+                        cursor: cursor.clone(),
+                        limit: Some(MAX_SYNC_PAGE_SIZE as u16),
+                    }),
+                })
+                .await?;
+            match response.next_cursor {
+                Some(next) if cursor.as_deref() != Some(next.as_str()) => cursor = Some(next),
+                Some(_) => {
+                    return Err(WasmError::Sync(
+                        "server returned a non-advancing sync cursor".into(),
+                    ))
                 }
-                Err(error) => return Err(engine_error(error)),
+                None => return Ok(()),
             }
         }
-        self.exchange(BrowserSyncRequest {
-            documents,
-            pull: Some(BrowserSyncPull {
-                doc_ids: vec![doc_id.to_string()],
-                cursor: None,
-                limit: Some(1),
-            }),
-        })
-        .await?;
-        Ok(())
     }
 
     async fn exchange(&self, request: BrowserSyncRequest) -> Result<BrowserSyncResponse> {
@@ -246,12 +310,13 @@ impl SyncSession {
             while let Ok(message) = subscription.try_recv() {
                 collect_local_update(&message, &mut doc_ids);
             }
-            for doc_id in doc_ids {
-                if let Err(error) = self.sync_document(&doc_id).await {
-                    self.recover_full_sync(&format!("syncing local document {doc_id}"), error)
-                        .await;
-                    break;
-                }
+            let doc_ids = Vec::from_iter(doc_ids);
+            if let Err(error) = self.sync_documents(&doc_ids).await {
+                self.recover_full_sync(
+                    &format!("syncing {} local document(s)", doc_ids.len()),
+                    error,
+                )
+                .await;
             }
         }
     }
@@ -261,9 +326,15 @@ impl SyncSession {
             loop {
                 match events.next_document_id().await {
                     Ok(Some(doc_id)) => {
-                        if let Err(error) = self.sync_document(&doc_id).await {
+                        // A burst arrives as one stream chunk, so what was
+                        // decoded alongside this ID belongs in the same
+                        // exchange.
+                        let mut doc_ids = BTreeSet::from([doc_id]);
+                        doc_ids.extend(events.take_decoded_document_ids());
+                        let doc_ids = Vec::from_iter(doc_ids);
+                        if let Err(error) = self.sync_documents(&doc_ids).await {
                             self.recover_full_sync(
-                                &format!("syncing remote document {doc_id}"),
+                                &format!("syncing {} remote document(s)", doc_ids.len()),
                                 error,
                             )
                             .await;
@@ -309,6 +380,68 @@ impl SyncSession {
     }
 }
 
+/// One exchange's worth of work, packed while documents are loaded one at a
+/// time. The limits are the server's, and packing is kept apart from loading so
+/// the rules can be checked without a node or a network.
+struct SyncBatch {
+    documents: Vec<BrowserSyncDocument>,
+    doc_ids: Vec<String>,
+    bytes: usize,
+}
+
+impl Default for SyncBatch {
+    fn default() -> Self {
+        Self {
+            documents: Vec::new(),
+            doc_ids: Vec::new(),
+            bytes: EMPTY_SYNC_REQUEST_BYTES,
+        }
+    }
+}
+
+impl SyncBatch {
+    fn is_empty(&self) -> bool {
+        self.doc_ids.is_empty()
+    }
+
+    /// Whether a document and its pull ID can still join this batch. An ID with
+    /// no document of its own still takes a place in the pull.
+    fn fits(&self, id_bytes: usize, document_bytes: Option<usize>) -> bool {
+        if self.doc_ids.len() == MAX_SYNC_PULL_DOC_IDS {
+            return false;
+        }
+        if document_bytes.is_some() && self.documents.len() == MAX_SYNC_DOCUMENTS_PER_REQUEST {
+            return false;
+        }
+        self.bytes + self.added_bytes(id_bytes, document_bytes) <= MAX_SYNC_BODY_BYTES
+    }
+
+    fn added_bytes(&self, id_bytes: usize, document_bytes: Option<usize>) -> usize {
+        let id = id_bytes + usize::from(!self.doc_ids.is_empty());
+        let document =
+            document_bytes.map_or(0, |bytes| bytes + usize::from(!self.documents.is_empty()));
+        id + document
+    }
+
+    fn accept(
+        &mut self,
+        doc_id: String,
+        document: Option<BrowserSyncDocument>,
+        id_bytes: usize,
+        document_bytes: Option<usize>,
+    ) {
+        self.bytes += self.added_bytes(id_bytes, document_bytes);
+        if let Some(document) = document {
+            self.documents.push(document);
+        }
+        self.doc_ids.push(doc_id);
+    }
+
+    fn take(&mut self) -> Self {
+        std::mem::take(self)
+    }
+}
+
 fn collect_local_update(message: &events::Message, doc_ids: &mut BTreeSet<String>) {
     if let Some(update) = message.as_update() {
         if !update.is_relay && !update.doc_id.is_empty() {
@@ -327,11 +460,46 @@ fn warn(message: &str) {
 
 #[cfg(test)]
 mod tests {
-    use defra_core::browser_sync::{BrowserSyncBlock, BrowserSyncDocument, BrowserSyncRequest};
+    use defra_core::browser_sync::{
+        BrowserSyncBlock, BrowserSyncDocument, BrowserSyncPull, BrowserSyncRequest,
+        MAX_SYNC_BODY_BYTES, MAX_SYNC_DOCUMENTS_PER_REQUEST, MAX_SYNC_PAGE_SIZE,
+        MAX_SYNC_PULL_DOC_IDS,
+    };
 
-    use super::EMPTY_PUSH_REQUEST_BYTES;
+    use wasm_bindgen_test::wasm_bindgen_test;
 
-    #[test]
+    use super::{SyncBatch, EMPTY_PUSH_REQUEST_BYTES};
+
+    fn document(doc_id: &str, data: &str) -> BrowserSyncDocument {
+        BrowserSyncDocument {
+            doc_id: doc_id.into(),
+            collection_id: "collection".into(),
+            roots: vec!["root".into()],
+            blocks: vec![BrowserSyncBlock {
+                cid: "block".into(),
+                data: data.into(),
+            }],
+            relationships: Vec::new(),
+        }
+    }
+
+    /// Offer a document the way `sync_documents` does, returning the batch its
+    /// arrival flushed.
+    fn offer(batch: &mut SyncBatch, document: BrowserSyncDocument) -> Option<SyncBatch> {
+        let id_bytes = serde_json::to_vec(&document.doc_id).unwrap().len();
+        let document_bytes = serde_json::to_vec(&document).unwrap().len();
+        let flushed = (!batch.is_empty() && !batch.fits(id_bytes, Some(document_bytes)))
+            .then(|| batch.take());
+        batch.accept(
+            document.doc_id.clone(),
+            Some(document),
+            id_bytes,
+            Some(document_bytes),
+        );
+        flushed
+    }
+
+    #[wasm_bindgen_test]
     fn incremental_push_size_matches_serialized_request() {
         let documents = vec![
             BrowserSyncDocument {
@@ -367,5 +535,82 @@ mod tests {
             incremental_size,
             serde_json::to_vec(&request).unwrap().len()
         );
+    }
+    #[wasm_bindgen_test]
+    fn incremental_sync_size_matches_serialized_request() {
+        let mut batch = SyncBatch::default();
+        for index in 0..3 {
+            offer(&mut batch, document(&format!("doc-{index}"), "data"));
+        }
+        // The pull names every document in the batch and always asks for a
+        // full page.
+        let request = BrowserSyncRequest {
+            documents: batch.documents.clone(),
+            pull: Some(BrowserSyncPull {
+                doc_ids: batch.doc_ids.clone(),
+                cursor: None,
+                limit: Some(MAX_SYNC_PAGE_SIZE as u16),
+            }),
+        };
+        assert_eq!(batch.bytes, serde_json::to_vec(&request).unwrap().len());
+    }
+
+    #[wasm_bindgen_test]
+    fn a_pull_id_without_a_document_costs_only_its_id() {
+        let mut batch = SyncBatch::default();
+        let doc_id = "doc-remote".to_string();
+        let id_bytes = serde_json::to_vec(&doc_id).unwrap().len();
+        batch.accept(doc_id.clone(), None, id_bytes, None);
+
+        let request = BrowserSyncRequest {
+            documents: Vec::new(),
+            pull: Some(BrowserSyncPull {
+                doc_ids: vec![doc_id],
+                cursor: None,
+                limit: Some(MAX_SYNC_PAGE_SIZE as u16),
+            }),
+        };
+        assert_eq!(batch.bytes, serde_json::to_vec(&request).unwrap().len());
+    }
+
+    #[wasm_bindgen_test]
+    fn a_batch_ends_at_the_document_limit() {
+        let mut batch = SyncBatch::default();
+        for index in 0..MAX_SYNC_DOCUMENTS_PER_REQUEST {
+            assert!(offer(&mut batch, document(&format!("doc-{index}"), "data")).is_none());
+        }
+        let flushed = offer(&mut batch, document("doc-over", "data")).expect("batch is full");
+        assert_eq!(flushed.documents.len(), MAX_SYNC_DOCUMENTS_PER_REQUEST);
+        assert_eq!(batch.documents.len(), 1);
+    }
+
+    /// A document held only by the server has no push payload, so the pull
+    /// limit binds before the document limit.
+    #[wasm_bindgen_test]
+    fn a_batch_ends_at_the_pull_id_limit() {
+        let mut batch = SyncBatch::default();
+        for index in 0..MAX_SYNC_PULL_DOC_IDS {
+            let doc_id = format!("doc-{index}");
+            let id_bytes = serde_json::to_vec(&doc_id).unwrap().len();
+            assert!(batch.fits(id_bytes, None));
+            batch.accept(doc_id, None, id_bytes, None);
+        }
+        assert!(!batch.fits(serde_json::to_vec("doc-over").unwrap().len(), None));
+    }
+
+    #[wasm_bindgen_test]
+    fn a_batch_ends_at_the_body_limit() {
+        let heavy = "x".repeat(MAX_SYNC_BODY_BYTES / 4);
+        let mut batch = SyncBatch::default();
+        for index in 0..3 {
+            assert!(
+                offer(&mut batch, document(&format!("doc-{index}"), &heavy)).is_none(),
+                "three quarters of the body still fits"
+            );
+        }
+        let flushed = offer(&mut batch, document("doc-over", &heavy)).expect("body is full");
+        assert!(flushed.bytes <= MAX_SYNC_BODY_BYTES);
+        assert_eq!(flushed.documents.len(), 3);
+        assert_eq!(batch.documents.len(), 1);
     }
 }

--- a/crates/wasm/src/sync/session.rs
+++ b/crates/wasm/src/sync/session.rs
@@ -342,12 +342,14 @@ mod tests {
                     cid: "block-one".into(),
                     data: "data-one".into(),
                 }],
+                relationships: Vec::new(),
             },
             BrowserSyncDocument {
                 doc_id: "doc-two".into(),
                 collection_id: "collection".into(),
                 roots: vec![],
                 blocks: vec![],
+                relationships: Vec::new(),
             },
         ];
         let incremental_size = documents.iter().enumerate().fold(

--- a/crates/wasm/src/sync/sse.rs
+++ b/crates/wasm/src/sync/sse.rs
@@ -23,6 +23,13 @@ impl SseStream {
         }
     }
 
+    /// Every document ID already decoded, taken without reading the stream
+    /// again. A burst arrives as one chunk, so these are the rest of it and can
+    /// be answered in one exchange.
+    pub(super) fn take_decoded_document_ids(&mut self) -> Vec<String> {
+        self.pending_doc_ids.drain(..).collect()
+    }
+
     pub(super) async fn next_document_id(&mut self) -> Result<Option<String>> {
         loop {
             if let Some(doc_id) = self.pending_doc_ids.pop_front() {


### PR DESCRIPTION
**TL;DR** The WASM client could not be an authoring client. It could not sign,
so `/sync` registered its documents to nobody, so it could never grant access to
its own data; and creating a document with an ACL took two calls with a window
between them where the node announced a document peers were not allowed to read.
This makes the browser a first-class author: it holds its own key, signs what it
writes, authenticates as the identity that signed, and grants access in the same
push that registers the document.

Everything here came out of a downstream consumer building on the WASM client and
measuring what it hit. Nothing is released yet and we are the first users, so this
lands as one change that gets the path into the right shape rather than as a
sequence of partial ones.

## What was wrong

**Creating a document with an ACL needed two steps.** A document under a policy is
registered to the DID verified from its genesis signature and is invisible to every
other key until its owner grants a read. Only an owner may grant, and a grant needs
the document to exist, so the calls cannot be reordered — and the node announces the
document on the first one. A peer acting on that announcement pulls anonymously,
gets an empty answer it cannot distinguish from a document that does not exist, and
never retries. Measured: a document written with a policy **never arrived**, checked
at 10 s intervals to 100 s, with no warning. The same document with no policy: under
3 s.

**The browser could not sign at all.** `crates/wasm` exported verify and keygen and
no `sign_*`, and nothing set the signing config the write path reads. So every block
a tab authored was unsigned and owned by nobody, and the only way to get a signed
commit was to register the author's key on the node — which then holds it and can
forge with it.

**A burst of writes cost a round trip per document.** The incremental sync path
called `sync_document` once per document ID. Measured browser-to-reader: 3.0 ms for
a single write, but 24.7 ms median and **51.5 ms** worst for a burst of 20 — twenty
round trips, arithmetic rather than congestion.

## What this does

Four commits, each its own reading:

**`feat(sync)`: a push can carry the grants that make what it registers readable.**
`BrowserSyncDocument` gains an optional `relationships` list, applied between
`register_doc_if_needed` and `apply_validated_document` — registered, granted and
announced become one step. Grants are applied as the *authenticated caller*, never
as the owner the push registers, so `add_actor_relationship` still decides: a push
can do what that caller could have done with a second call and no more, and a relay
forwarding somebody else's DAG still gets `NotOwner`. Absent on the wire means empty.

**`perf(wasm)`: answer a burst of updates in one sync exchange.** `sync_documents`
packs IDs into as few exchanges as the server's limits allow. Packing lives in
`SyncBatch`, apart from the loading, so the rules are testable without a node. A
document too large to push is still named by the pull. A pull naming many documents
can be cut short by the page limit where a pull naming one never could, so a batch
follows its cursor to the end. The remote side batches from the buffer the SSE
decoder already fills.

**`test(sync)`: pin the cursor contract a batched pull depends on.** A pull naming
several documents resumes within the named set and never serves a document it did
not name. The adapter did this already; nothing pinned it.

**`feat(wasm)`: let the browser client author with a key of its own.** `DefraClient`
takes a key, as `create({ private_key, key_type })` or `set_identity()`. It signs
what it authors — installed around a local write only, so blocks arriving from the
server are never signed with this key. It reports its DID. It mints its own
self-signed JWT for the host it syncs with, so the identity signing the blocks is
the caller the node authenticates. And it carries grants on its own pushes via
`set_grants()`, so a browser can create a document under a policy and make it
readable in one step; a document it did not sign is pushed untouched.

```javascript
const client = await DefraClient.create({ db_name: 'arena', private_key, key_type: 'ed25519' });
client.set_grants([{ relation: 'reader', target: '*' }]);
await client.sync('https://node.example');   // token minted from the same key
```

The key stays in the tab. The node verifies signatures it cannot produce.

## One shared-crate change

`crates/identity`'s token layer used `std::time::SystemTime::now()`, which panics on
wasm32. It is `web-time` now — std on every other target, the same swap this repo
already made in `db`, `query` and `storage`.

## Not covered

- A manager who is not the document's owner cannot grant through a push, and the
  relation name is not checked against the policy, so an unmatched relation can only
  ever grant less. Both need the policy store the adapter does not hold, and both
  remain the relationship endpoint's job.
- The end-to-end path — browser authors, pushes with a grant, a second node reads —
  has no test, because the browser suite has no server in it. Each half is tested and
  the seam between them is the wire type. Worth a cross-runtime test once a harness
  can drive a browser and a node together.
- The batching win is not measured here. The round-trip count follows from the
  request shape and the packing is pinned by tests, but the wall clock wants the
  downstream harness that produced the table above.

## Testing

- Five new adapter tests on grants: they make a protected document readable at once;
  they cannot be attached to a foreign-signed document; they require an authenticated
  caller; the owner relation and an unbounded list are refused; a pull naming several
  documents resumes across its cursor.
- Six new browser tests on authoring: every signature over an authored document
  carries this client's key and no other; a client with no key authors unsigned
  blocks; `did()` names the authoring identity; a minted token verifies against its
  audience and names the same DID the blocks carry; a keyless client cannot mint one;
  grants ride only on documents this client signed.
- Five new unit tests on batching: the byte estimate matches a real serialization,
  with and without a document behind a pull ID; a batch ends at the document limit,
  the pull-ID limit, and the body limit.

`just test-wasm` 66 passed in headless Firefox · `cargo test -p cli --lib` 77 ·
`defra-http --lib` + `defra-core` 224 · `db --test merge` 120 · `identity` 68 ·
`just lint-wasm`, `cargo clippy -p cli -p db -p defra-core -p identity --all-targets
-- -D warnings` and `cargo fmt --all --check` clean.

Also fixed on the way: the unit tests in `crates/wasm/src/sync/session.rs` ran
nowhere — plain `#[test]` in a crate that only compiles for wasm32, which
`wasm-bindgen-test-runner` does not collect. They are `#[wasm_bindgen_test]` now.
