### PR TITLE
fix(perf): publish the dashboard, and stop dropping every emitted family

### DIFF
--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -2,7 +2,7 @@ name: Performance (pull request)
 
 # Its own workflow, and that is the whole reason it exists separately.
 #
-# The full matrix is forty jobs across three platforms. Keeping it in the
+# The full sweep is forty jobs across three platforms. Keeping it in the
 # workflow a pull request triggers meant every PR carried forty skipped checks,
 # and GitHub renders a skipped matrix job without expanding its matrix: the
 # check list filled up with literal `${{ matrix.family }}` rows. A pull request
@@ -26,39 +26,50 @@ env:
   CARGO_INCREMENTAL: '0'
 
 jobs:
-  # Every pull request, no ceremony. Four families on Linux,
-  # measured against this PR's own merge base on this same runner with this
-  # same profile, and posted back as a comment.
+  # Every pull request, no ceremony. A few families on Linux, measured against
+  # this PR's own merge base, and posted back as a comment.
   #
-  # Two decisions keep it quick without making it dishonest.
+  # Three decisions keep it quick without making it dishonest.
   #
-  # `release-fast` rather than the `bench` profile: thin LTO and sixteen
-  # codegen units build in a fraction of the time fat LTO takes. It produces
-  # different absolute numbers, which is exactly why this path never publishes
-  # to the dashboard and never compares against it. Both sides of this
-  # comparison are built the same way, so the delta between them is real even
-  # though neither figure is the one a release would post.
+  # `release-fast` rather than the `bench` profile: thin LTO and sixteen codegen
+  # units build in a fraction of the time fat LTO takes. It produces different
+  # absolute numbers, which is exactly why this path never publishes to the
+  # dashboard and never compares against it.
   #
-  # And the base measurement is cached by its commit. A base is measured once
-  # and then reused by every later pull request that shares it, so only the
-  # first one after a merge to `main` pays for the second build.
+  # Both sides are built and measured in this one job, on this one runner. A
+  # cached baseline measured on some other runner days ago is not a baseline for
+  # anything: the machines differ by more than the code does.
+  #
+  # And the passes are interleaved: head, base, base, head. A runner is cold and
+  # idle at the start of a job and hot and contended by the end, which is a
+  # drift in one direction rather than noise that averages out. Measured
+  # sequentially, one pass each, that drift showed up as sixteen double-digit
+  # "improvements" on a pull request that changed only YAML. Interleaving puts
+  # both sides at both ends of the job, and each side's recorded range spans its
+  # passes, so a separation between the two ranges means the code moved.
   quick:
     name: Quick benchmark
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 60
     permissions:
       contents: read
       pull-requests: write
     env:
       DEFRA_BENCH_CRITERION_ARGS: --warm-up-time 0.5 --measurement-time 1.5 --sample-size 10
       PERF_PROFILE: release-fast
+      PERF_THRESHOLD: '5'
       # The write path, the allocation counts that catch a stray clone before
       # the clock does, cold start, and the storage transaction seam.
       QUICK_FAMILIES: document_write allocs startup transaction
+      CARGO_TARGET_DIR: ${{ github.workspace }}/head/target
     steps:
       - uses: actions/checkout@v4
         with:
           path: head
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
       - uses: extractions/setup-just@v2
       # Its own interpreter rather than the system one: a PEP 668 image refuses
       # to let pip touch the system environment, and this gate must not be the
@@ -83,129 +94,89 @@ jobs:
       - name: Record how quiet the host is
         run: python3 head/tools/perf-site/loadguard.py --out loadguard.json
 
-      - name: Measure this pull request
-        working-directory: head
-        env:
-          DEFRA_BENCH_OUT: ${{ github.workspace }}/head.jsonl
+      # Both builds first, so no compile sits between two measurement passes and
+      # adds its own heat to whichever side follows it.
+      - name: Build both sides
         run: |
           set -euo pipefail
-          for family in $QUICK_FAMILIES; do
-            echo "::group::$family"
-            rm -rf target/criterion
-            cargo bench --profile "$PERF_PROFILE" -p benches --bench "$family" \
-              -- $DEFRA_BENCH_CRITERION_ARGS
-            mkdir -p "$GITHUB_WORKSPACE/criterion-head/$family"
-            [ -d target/criterion ] && cp -R target/criterion/. "$GITHUB_WORKSPACE/criterion-head/$family/"
+          for side in head base; do
+            echo "::group::build $side"
+            ( cd "$side"
+              # A family this pull request introduces does not exist on the
+              # base. That is a new measurement, not a failure.
+              for family in $QUICK_FAMILIES; do
+                cargo bench --profile "$PERF_PROFILE" -p benches --bench "$family" --no-run \
+                  || echo "::notice::$family does not build on $side; it will show as new"
+              done )
             echo "::endgroup::"
           done
-          touch "$DEFRA_BENCH_OUT"
 
-      - name: Assemble this pull request's document
-        working-directory: head
-        env:
-          DEFRA_BENCH_OUT: ${{ github.workspace }}/head.jsonl
-          PERF_COMMIT: ${{ github.event.pull_request.head.sha }}
-          PERF_LABEL: pr-${{ github.event.pull_request.number }}
+      - name: Measure, interleaved
         run: |
           set -euo pipefail
-          cargo run --profile "$PERF_PROFILE" -p defra-perf --bin collect -- \
-            --criterion-root "$GITHUB_WORKSPACE/criterion-head" \
-            --out "$GITHUB_WORKSPACE/platform-head.json" \
-            --commit "$PERF_COMMIT" \
-            --label "$PERF_LABEL" \
-            --target x86_64-unknown-linux-gnu \
-            --loadguard "$GITHUB_WORKSPACE/loadguard.json"
-
-      # A base is the same commit for every PR branched off it, so measuring it
-      # once and reusing the document is the difference between paying for two
-      # builds on every pull request and paying for them once per merge.
-      - name: Restore the baseline measured for this base commit
-        id: basecache
-        uses: actions/cache@v4
-        with:
-          path: platform-base.json
-          key: perf-quick-base-${{ github.event.pull_request.base.sha }}-v1
-
-      - uses: actions/checkout@v4
-        if: steps.basecache.outputs.cache-hit != 'true'
-        with:
-          ref: ${{ github.event.pull_request.base.sha }}
-          path: base
-
-      - name: Measure the merge base
-        if: steps.basecache.outputs.cache-hit != 'true'
-        working-directory: base
-        env:
-          DEFRA_BENCH_OUT: ${{ github.workspace }}/base.jsonl
-          # The same target directory as the head build, so the second build
-          # reuses every dependency artifact the first one produced.
-          CARGO_TARGET_DIR: ${{ github.workspace }}/head/target
-        run: |
-          set -euo pipefail
-          for family in $QUICK_FAMILIES; do
-            # A family this pull request introduces does not exist on the base,
-            # and that is a new measurement rather than a failure. The
-            # comparison reports it as measured on one side only.
-            echo "::group::$family"
-            rm -rf "$CARGO_TARGET_DIR/criterion"
-            cargo bench --profile "$PERF_PROFILE" -p benches --bench "$family" \
-              -- $DEFRA_BENCH_CRITERION_ARGS \
-              || echo "::notice::$family did not run on the base commit; it will show as new"
-            mkdir -p "$GITHUB_WORKSPACE/criterion-base/$family"
-            [ -d "$CARGO_TARGET_DIR/criterion" ] && \
-              cp -R "$CARGO_TARGET_DIR/criterion/." "$GITHUB_WORKSPACE/criterion-base/$family/"
+          pass() {
+            local side="$1" tag="$2"
+            echo "::group::measure $tag ($side)"
+            mkdir -p "$GITHUB_WORKSPACE/crit-$tag"
+            ( cd "$side"
+              for family in $QUICK_FAMILIES; do
+                rm -rf "$CARGO_TARGET_DIR/criterion"
+                DEFRA_BENCH_OUT="$GITHUB_WORKSPACE/$tag.jsonl" \
+                  cargo bench --profile "$PERF_PROFILE" -p benches --bench "$family" \
+                  -- $DEFRA_BENCH_CRITERION_ARGS || true
+                if [ -d "$CARGO_TARGET_DIR/criterion" ]; then
+                  mkdir -p "$GITHUB_WORKSPACE/crit-$tag/$family"
+                  cp -R "$CARGO_TARGET_DIR/criterion/." "$GITHUB_WORKSPACE/crit-$tag/$family/"
+                fi
+              done )
+            touch "$GITHUB_WORKSPACE/$tag.jsonl"
             echo "::endgroup::"
-          done
-          touch "$DEFRA_BENCH_OUT"
+          }
+          # head, base, base, head: both sides see the cold start and the hot
+          # end of the job, so a monotonic drift cancels instead of landing on
+          # whichever side happened to go last.
+          pass head head1
+          pass base base1
+          pass base base2
+          pass head head2
 
-      - name: Assemble the merge base's document
-        if: steps.basecache.outputs.cache-hit != 'true'
-        working-directory: base
+      - name: Assemble the four documents
         env:
-          DEFRA_BENCH_OUT: ${{ github.workspace }}/base.jsonl
-          CARGO_TARGET_DIR: ${{ github.workspace }}/head/target
-          PERF_BASE_COMMIT: ${{ github.event.pull_request.base.sha }}
+          PERF_HEAD: ${{ github.event.pull_request.head.sha }}
+          PERF_BASE: ${{ github.event.pull_request.base.sha }}
+          PERF_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          # Built from the base checkout when it has the collector, and from
-          # this PR's when the PR is what introduces it.
-          manifest=Cargo.toml
-          if ! grep -q '"tools/perf"' Cargo.toml; then
-            manifest="$GITHUB_WORKSPACE/head/Cargo.toml"
-          fi
-          cargo run --manifest-path "$manifest" --profile "$PERF_PROFILE" \
-            -p defra-perf --bin collect -- \
-            --criterion-root "$GITHUB_WORKSPACE/criterion-base" \
-            --out "$GITHUB_WORKSPACE/platform-base.json" \
-            --commit "$PERF_BASE_COMMIT" \
-            --label "base" \
-            --target x86_64-unknown-linux-gnu \
-            --loadguard "$GITHUB_WORKSPACE/loadguard.json"
+          # Built from head's checkout in every case: the base may predate the
+          # collector, and a document is only comparable when both sides were
+          # assembled by the same version of it.
+          for tag in head1 head2 base1 base2; do
+            case "$tag" in head*) commit="$PERF_HEAD"; label="pr-$PERF_NUMBER";;
+                           base*) commit="$PERF_BASE"; label="base";; esac
+            DEFRA_BENCH_OUT="$GITHUB_WORKSPACE/$tag.jsonl" \
+              cargo run --manifest-path head/Cargo.toml --profile "$PERF_PROFILE" \
+                -p defra-perf --bin collect -- \
+                --criterion-root "$GITHUB_WORKSPACE/crit-$tag" \
+                --out "$GITHUB_WORKSPACE/platform-$tag.json" \
+                --commit "$commit" --label "$label" \
+                --target x86_64-unknown-linux-gnu \
+                --loadguard "$GITHUB_WORKSPACE/loadguard.json"
+          done
 
       - name: Compare
-        id: compare
-        env:
-          PERF_THRESHOLD: '5'
         run: |
           set -euo pipefail
-          mkdir -p head-site base-site
-          python3 head/tools/perf-site/publish.py --site head-site platform-head.json
-          if [ ! -f platform-base.json ]; then
-            {
-              echo "## Performance"
-              echo ""
-              echo "The merge base could not be measured, so there is nothing to compare"
-              echo "against. This pull request's own numbers are attached to the workflow run."
-            } > report.md
-          else
-            python3 head/tools/perf-site/publish.py --site base-site platform-base.json
-            python3 head/tools/perf-site/compare.py \
-              --baseline "$(ls base-site/runs/*.json | grep -v index.json | head -1)" \
-              --current  "$(ls head-site/runs/*.json | grep -v index.json | head -1)" \
-              --threshold "$PERF_THRESHOLD" \
-              --markdown report.md \
-              --note "Quick check: \`$QUICK_FAMILIES\` on \`x86_64-unknown-linux-gnu\`, built with the \`$PERF_PROFILE\` profile against this PR's own merge base on this runner. Both sides were built and measured identically, so the deltas are real; the absolute figures are not the release-profile ones the dashboard publishes. The full matrix across Linux, macOS and the browser runs on a push to \`main\`, or on demand from the Performance workflow."
-          fi
+          mkdir -p site-head1 site-head2 site-base1 site-base2
+          for tag in head1 head2 base1 base2; do
+            python3 head/tools/perf-site/publish.py --site "site-$tag" "platform-$tag.json" >/dev/null
+          done
+          run_doc() { ls "site-$1"/runs/*.json | grep -v index.json | head -1; }
+          python3 head/tools/perf-site/compare.py \
+            --baseline "$(run_doc base1)" --baseline "$(run_doc base2)" \
+            --current  "$(run_doc head1)" --current  "$(run_doc head2)" \
+            --threshold "$PERF_THRESHOLD" \
+            --markdown report.md \
+            --note "Quick check: \`$QUICK_FAMILIES\` on \`x86_64-unknown-linux-gnu\`, built with the \`$PERF_PROFILE\` profile. Both sides were built and measured in this job on this runner, so the deltas are real; the absolute figures are not the release-profile ones the dashboard publishes. The full matrix across Linux, macOS and the browser runs on a push to \`main\`, or on demand from the Performance workflow."
           cat report.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Comment on the pull request
@@ -231,7 +202,9 @@ jobs:
           name: perf-quick
           path: |
             report.md
-            platform-head.json
-            platform-base.json
+            platform-head1.json
+            platform-head2.json
+            platform-base1.json
+            platform-base2.json
           if-no-files-found: warn
           retention-days: 30

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -260,6 +260,49 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  # What the shipped artifacts weigh. Its own job because it is the only thing
+  # here that needs a release build rather than a benchmark, and because a size
+  # is read off an artifact instead of measured by running one.
+  size:
+    name: artifact size
+    needs: scope
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - run: .github/scripts/install-linux-ci-deps.sh
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: perf-size
+      - name: Build the shipped artifacts
+        run: |
+          set -euo pipefail
+          cargo build --release -p cli
+          command -v wasm-pack >/dev/null 2>&1 || cargo install wasm-pack --locked
+          CARGO_PROFILE_RELEASE_OPT_LEVEL=z RUSTFLAGS="-C target-feature=+simd128" \
+            wasm-pack build crates/wasm --release --target web --out-dir ../../pkg/wasm
+      - name: Weigh them
+        run: |
+          set -euo pipefail
+          python3 -m pip install --quiet --break-system-packages brotli || \
+            echo "::notice::brotli is unavailable; the bundle is reported gzip-only"
+          python3 tools/perf-site/artifact_sizes.py --out bench-size.jsonl \
+            "defra=target/release/defra" \
+            "defra-wasm=pkg/wasm/defra_wasm_bg.wasm"
+      - name: Record how quiet the host is
+        run: python3 tools/perf-site/loadguard.py --out loadguard.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: perf-x86_64-unknown-linux-gnu-size
+          path: |
+            bench-size.jsonl
+            loadguard.json
+          if-no-files-found: error
+          retention-days: 7
+
   # Fold one platform's families into one platform document. Cheap: `collect`
   # depends on the reporting contract and nothing else, so this does not build
   # the database on every platform in the matrix.
@@ -269,7 +312,7 @@ jobs:
     # is rendered by GitHub without expanding its matrix, so the job list would
     # show a literal `${{ matrix.target }}`. Whether scope actually produced
     # anything is checked below, where it can fail with a reason.
-    needs: [scope, bench, bench-wasm]
+    needs: [scope, bench, bench-wasm, size]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -303,6 +346,11 @@ jobs:
         env:
           PERF_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
           PERF_LABEL: ${{ needs.scope.outputs.label }}
+          # Where `collect` reads the families from. Without it the collector
+          # falls back to ./bench-out/, which does not exist in this job, and
+          # every family a bench emitted is dropped while the criterion harvest
+          # survives and hides the loss.
+          DEFRA_BENCH_OUT: ${{ github.workspace }}/families.jsonl
         run: |
           set -euo pipefail
           if [ ! -d artifacts ] || [ -z "$(ls -A artifacts 2>/dev/null)" ]; then
@@ -311,8 +359,9 @@ jobs:
           fi
           # One JSON Lines stream out of every family this platform recorded,
           # and one criterion tree out of every runner's estimates.
-          : > families.jsonl
-          find artifacts -name '*.jsonl' -exec cat {} + >> families.jsonl || true
+          : > "$DEFRA_BENCH_OUT"
+          find artifacts -name '*.jsonl' -exec cat {} + >> "$DEFRA_BENCH_OUT" || true
+          echo "collect: $(wc -l < "$DEFRA_BENCH_OUT") family record(s) for ${{ matrix.target }}"
           mkdir -p criterion-merged
           for d in artifacts/*/criterion-out; do
             [ -d "$d" ] && cp -R "$d/." criterion-merged/ || true
@@ -333,6 +382,31 @@ jobs:
               --label "$PERF_LABEL" \
               --target "${{ matrix.target }}" \
               ${guard:+--loadguard "$guard"}
+      # A family that reached this job and not the document is a silent loss,
+      # and it stays silent until the dashboard is short a section three jobs
+      # later. Fail here, where the cause is.
+      - name: Refuse to drop a family that was collected
+        run: |
+          set -euo pipefail
+          python3 - "$DEFRA_BENCH_OUT" "platform-${{ matrix.target }}.json" <<'PY'
+          import json, sys
+          records, document = sys.argv[1], sys.argv[2]
+          emitted = set()
+          with open(records) as f:
+              for line in f:
+                  if line.strip():
+                      emitted.add(json.loads(line)["family"])
+          families = set(json.load(open(document))["families"])
+          lost = sorted(emitted - families)
+          if lost:
+              print(f"::error::{len(lost)} family record(s) reached the collector and "
+                    f"not the document: {', '.join(lost)}", file=sys.stderr)
+              sys.exit(1)
+          print(f"{len(emitted)} emitted famil(ies) all present, "
+                f"{len(families) - len(emitted)} harvested from criterion")
+          PY
+        env:
+          DEFRA_BENCH_OUT: ${{ github.workspace }}/families.jsonl
       - uses: actions/upload-artifact@v4
         with:
           name: perf-platform-${{ matrix.target }}

--- a/tools/perf-site/compare.py
+++ b/tools/perf-site/compare.py
@@ -18,7 +18,9 @@ Three rules keep a verdict honest:
   test, which is correct for a deterministic count and is why a bench that
   repeats a timing should always report one.
 * **A floor on top of that.** Non-overlapping ranges can still be a fraction of
-  a percent apart. A change under ``--threshold`` is noise regardless.
+  a percent apart. A change within plus or minus ``--threshold`` percent is
+  acceptable and reported as noise regardless, so at the default only a move of
+  more than 5% either way is called a regression or an improvement.
 
 Comparisons are per platform. A metric measured on Linux is not a baseline for
 the same metric measured in a browser, and pretending otherwise would produce a
@@ -80,8 +82,8 @@ def classify(before, after, threshold):
     if before["lower"]:
         pct = -pct
 
-    if abs(pct) < threshold:
-        return NOISE, pct, f"within the {threshold:g}% threshold"
+    if abs(pct) <= threshold:
+        return NOISE, pct, f"within the {threshold:g}% band, which is acceptable"
 
     have_ranges = all(
         isinstance(side[k], (int, float)) for side in (before, after) for k in ("min", "max")
@@ -167,8 +169,9 @@ def markdown(deltas, platforms, only_cur, base, cur, threshold, note=""):
     out = ["## Performance", ""]
     out.append(
         f"`{(cur.get('commit') or '')[:12]}` ({cur.get('label') or 'this run'}) "
-        f"against `{(base.get('commit') or '')[:12]}` ({base.get('label') or 'baseline'}), "
-        f"threshold {threshold:g}%."
+        f"against `{(base.get('commit') or '')[:12]}` ({base.get('label') or 'baseline'}). "
+        f"Anything within plus or minus {threshold:g}% is acceptable; only a move past that "
+        f"is reported, and only when the two runs' measured ranges do not overlap."
     )
     if note:
         out.append("")
@@ -234,7 +237,7 @@ def main():
         "--threshold",
         type=float,
         default=5.0,
-        help="percent change below which a delta is noise (default 5)",
+        help="a change within plus or minus this percent is acceptable (default 5)",
     )
     ap.add_argument("--markdown", help="write the report here as well as to stdout")
     ap.add_argument(

--- a/tools/perf-site/compare.py
+++ b/tools/perf-site/compare.py
@@ -22,6 +22,15 @@ Three rules keep a verdict honest:
   acceptable and reported as noise regardless, so at the default only a move of
   more than 5% either way is called a regression or an improvement.
 
+Each side may be given more than once, and should be. A benchmark's own
+confidence interval describes the spread *within* one measurement, which on a
+shared runner is a fraction of the spread *between* two of them: the first
+measurement in a job runs on a cold, idle machine and the last runs on a hot,
+contended one, which is a systematic drift in one direction rather than noise
+that averages out. Repeating each side and interleaving the passes is what makes
+the recorded range mean "what this metric does on this runner", and only then
+does a separation between two ranges mean the code changed.
+
 Comparisons are per platform. A metric measured on Linux is not a baseline for
 the same metric measured in a browser, and pretending otherwise would produce a
 regression report on every run.
@@ -69,6 +78,40 @@ def rows_of(doc, platform):
     return out
 
 
+def fold(docs, platform):
+    """One row set from repeated measurements of the same commit.
+
+    The point estimate is the median across passes, and the range spans every
+    pass: both the spread between them and each pass's own interval. Wider is
+    the honest direction here, because every percent of range that is left out
+    becomes a delta reported as real.
+    """
+    passes = [rows_of(doc, platform) for doc in docs]
+    keys = set().union(*(set(p) for p in passes)) if passes else set()
+    out = {}
+    for key in keys:
+        seen = [p[key] for p in passes if key in p]
+        if not seen:
+            continue
+        values = sorted(r["value"] for r in seen)
+        mid = len(values) // 2
+        median = values[mid] if len(values) % 2 else (values[mid - 1] + values[mid]) / 2
+        lows = [r["min"] if isinstance(r["min"], (int, float)) else r["value"] for r in seen]
+        highs = [r["max"] if isinstance(r["max"], (int, float)) else r["value"] for r in seen]
+        worst = max((r["trust"] for r in seen), key=lambda t: {"clean": 0}.get(t, 1))
+        out[key] = {
+            "value": median,
+            "min": min(lows + values),
+            "max": max(highs + values),
+            "unit": seen[0]["unit"],
+            "lower": seen[0]["lower"],
+            "trust": worst,
+            "family": seen[0]["family"],
+            "passes": len(seen),
+        }
+    return out
+
+
 def classify(before, after, threshold):
     """Verdict, percentage and reason for one pair of measurements."""
     if before["trust"] != TRUSTED:
@@ -98,14 +141,19 @@ def classify(before, after, threshold):
     return (REGRESSED if pct < 0 else IMPROVED), pct, ""
 
 
-def compare(base, cur, threshold):
-    platforms = sorted(
-        set((base.get("platforms") or {})) & set((cur.get("platforms") or {}))
-    )
-    only_cur = sorted(set(cur.get("platforms") or {}) - set(base.get("platforms") or {}))
+def platforms_of(docs):
+    seen = set()
+    for d in docs:
+        seen |= set(d.get("platforms") or {})
+    return seen
+
+
+def compare(bases, curs, threshold):
+    platforms = sorted(platforms_of(bases) & platforms_of(curs))
+    only_cur = sorted(platforms_of(curs) - platforms_of(bases))
     deltas = []
     for platform in platforms:
-        b, c = rows_of(base, platform), rows_of(cur, platform)
+        b, c = fold(bases, platform), fold(curs, platform)
         for key in sorted(set(b) | set(c)):
             if key not in b or key not in c:
                 deltas.append(
@@ -160,7 +208,7 @@ def fmt(v, unit):
     return f"{v:.4g}"
 
 
-def markdown(deltas, platforms, only_cur, base, cur, threshold, note=""):
+def markdown(deltas, platforms, only_cur, base, cur, threshold, note="", passes=(1, 1)):
     regressed = [d for d in deltas if d["verdict"] == REGRESSED]
     improved = [d for d in deltas if d["verdict"] == IMPROVED]
     unverified = [d for d in deltas if d["verdict"] == UNVERIFIED]
@@ -171,8 +219,15 @@ def markdown(deltas, platforms, only_cur, base, cur, threshold, note=""):
         f"`{(cur.get('commit') or '')[:12]}` ({cur.get('label') or 'this run'}) "
         f"against `{(base.get('commit') or '')[:12]}` ({base.get('label') or 'baseline'}). "
         f"Anything within plus or minus {threshold:g}% is acceptable; only a move past that "
-        f"is reported, and only when the two runs' measured ranges do not overlap."
+        f"is reported, and only when the two sides' measured ranges do not overlap."
     )
+    if max(passes) > 1:
+        out.append("")
+        out.append(
+            f"Measured over {passes[1]} pass(es) of this run and {passes[0]} of the baseline, "
+            "interleaved so that a runner getting slower as the job proceeds cannot read as a "
+            "change in the code. Each side's range spans its passes."
+        )
     if note:
         out.append("")
         out.append(note)
@@ -231,8 +286,18 @@ def markdown(deltas, platforms, only_cur, base, cur, threshold, note=""):
 
 def main():
     ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("--baseline", required=True)
-    ap.add_argument("--current", required=True)
+    ap.add_argument(
+        "--baseline",
+        required=True,
+        action="append",
+        help="a run document for the baseline; repeat it once per measurement pass",
+    )
+    ap.add_argument(
+        "--current",
+        required=True,
+        action="append",
+        help="a run document for this run; repeat it once per measurement pass",
+    )
     ap.add_argument(
         "--threshold",
         type=float,
@@ -248,10 +313,13 @@ def main():
     ap.add_argument("--fail-on-regression", action="store_true")
     args = ap.parse_args()
 
-    base = json.loads(pathlib.Path(args.baseline).read_text())
-    cur = json.loads(pathlib.Path(args.current).read_text())
-    deltas, platforms, only_cur = compare(base, cur, args.threshold)
-    report = markdown(deltas, platforms, only_cur, base, cur, args.threshold, args.note)
+    bases = [json.loads(pathlib.Path(p).read_text()) for p in args.baseline]
+    curs = [json.loads(pathlib.Path(p).read_text()) for p in args.current]
+    deltas, platforms, only_cur = compare(bases, curs, args.threshold)
+    report = markdown(
+        deltas, platforms, only_cur, bases[0], curs[0], args.threshold, args.note,
+        passes=(len(bases), len(curs)),
+    )
     print(report)
     if args.markdown:
         pathlib.Path(args.markdown).write_text(report + "\n")

--- a/tools/perf-site/render_check.mjs
+++ b/tools/perf-site/render_check.mjs
@@ -206,7 +206,9 @@ if (!drewHeading("Overview")) failures.push(`${platform}: the overview section i
 if (Object.keys(newest.platforms ?? {}).length > 1 && !drewHeading("Across platforms")) {
   failures.push(`${platform}: the run has more than one platform but the cross-platform section is missing`);
 }
-if (index.runs.length && !drewHeading("Trend across every recorded run")) {
+// Only when this platform has something to plot: the trend reads scalars, so a
+// platform that drew no family has no series and correctly renders nothing.
+if (drawn && index.runs.length && !drewHeading("Trend across every recorded run")) {
   failures.push(`${platform}: the trend section is missing`);
 }
 if (out.length < 2000) {


### PR DESCRIPTION
The first `main` run after #1692 merged did not publish. `Publish` failed at the
render check, which refused to put a dashboard on `gh-pages` that was missing
data. The guard was right; two bugs behind it were mine.

## The collector was pointed at nothing

`collect` reads its family records from `$DEFRA_BENCH_OUT`. The `collect` job
carefully assembled every runner's records into `families.jsonl` and then never
set that variable, so the collector fell back to `./bench-out/`, which does not
exist in that job, and read nothing.

Every family a bench emitted was dropped on every platform: `allocs`, `memory`,
`startup`, `disk_footprint`, `document_ops`, `browser_storage`. The Linux
document came back with 29 families, all 29 harvested from criterion and not one
emitted. That is what hid it: criterion filled the page on Linux and macOS, and
only the browser, which produces no criterion output at all, came back empty
enough to trip the guard.

Reproduced from the failed run's own artifacts. Without the variable the browser
platform holds `criterion: absent` and nothing else, which is exactly the
document CI produced; with it, `document_ops` and `browser_storage` arrive with
their rows. The collector had been printing `no family records found in
$DEFRA_BENCH_OUT (unset)` in the log the whole time.

A new step now fails the collect job when a family reaches it and not the
document, naming the families that went missing, so this class of loss cannot
be silent again. Verified both ways: it passes on a good document and fails on
the broken one with `2 family record(s) reached the collector and not the
document: browser_storage, document_ops`.

## Nothing ever weighed the artifacts

`tools/perf-site/artifact_sizes.py` shipped in #1692 and no workflow called it,
so the `artifact_size` family could never exist. It gets a job: it builds the
release CLI and the wasm bundle and weighs them, raw and compressed.

## The check demanded a trend from a platform with no data

The trend plots scalars, so a platform that recorded none correctly draws
nothing, and the check called that a failure. It is now required only from a
platform that drew at least one family.

## The threshold band is inclusive

A change within plus or minus the threshold is acceptable. At the default that
means exactly -5% and exactly +5% are both fine, and only a move past either is
reported. The pull-request comment says so in its own text rather than leaving
the reader to infer it.

Boundary tested: -5.0% and +5.0% both report no regression, -6.0% reports a
regression.

## Verification

The exact failing scenario, rebuilt from the failed run's Linux, macOS and
browser artifacts, now publishes: `3 of 3 platform(s) verified, 133 cards
across them`, exit 0.
