### PR TITLE
feat(iroh): multiplex every protocol over one QUIC connection

### DIFF
--- a/crates/p2p/src/iroh/README.md
+++ b/crates/p2p/src/iroh/README.md
@@ -3,20 +3,36 @@
 DefraDB's Iroh transport uses the same `P2PTransport` surface as libp2p, but the
 wire mechanics are intentionally different where Iroh has different primitives.
 
-## Direct streams instead of `pubsub_rpc`
+## One connection per peer
 
-DocSync and BranchableSync use Iroh QUIC bidirectional streams rather than the
-`pubsub_rpc` layer introduced for libp2p in #828. The `pubsub_rpc` topic model is
-tied to libp2p peer IDs and gossipsub topic meshes. Iroh peers are addressed by
-`EndpointId`, so reusing the libp2p response-topic convention would require a
-peer-id translation layer that does not exist on the Go-compatible wire path.
+Every Defra protocol shares a single QUIC connection, negotiated on the mux
+ALPN `/defra-iroh/mux/0.1`. A stream names its protocol in-band: the first
+frame it writes is a one-byte length followed by a tag such as
+`/defra-iroh/docsync/0.1`, and `endpoint_streams::dispatch_stream` routes on
+that tag. `protocols.rs` holds the ALPN, the tags, and the frame helpers.
 
-Iroh therefore maps request/response traffic onto dedicated ALPNs:
+The discriminator has to be in-band because ALPN is negotiated once per TLS
+handshake. Naming each protocol with its own ALPN — as this transport did until
+the tags were introduced — costs a separate connection, congestion controller,
+path MTU probe, hole-punch, and keepalive timer per protocol against the same
+peer. An embedded client touching identity, replication, doc sync, branchable
+sync, and CAR fetch paid five of each.
 
-- `/defra-iroh/docsync/0.1` and `/defra-iroh/docsync/0.1/resp`
-- `/defra-iroh/branchable/0.1` and `/defra-iroh/branchable/0.1/resp`
-- `/defra-iroh/se/0.1`
-- `/defra-iroh/se-query/0.1/req` and `/defra-iroh/se-query/0.1/resp`
+Two consequences worth knowing:
+
+- The outbound connection cache in `endpoint_rpc.rs` is keyed by `EndpointId`
+  alone, and an explicit dial adopts its connection into that cache. A stream
+  failure therefore must not evict it — `evict_if_closed` drops a cached entry
+  only once QUIC itself reports the connection closed, since every other
+  protocol is still using it.
+- `iroh-gossip` keeps its own ALPN. It owns that handshake and takes whole
+  connections, so a gossiping node holds two connections to a peer, not one.
+
+DocSync and BranchableSync ride these streams rather than the `pubsub_rpc` layer
+introduced for libp2p in #828. The `pubsub_rpc` topic model is tied to libp2p
+peer IDs and gossipsub topic meshes. Iroh peers are addressed by `EndpointId`,
+so reusing the libp2p response-topic convention would require a peer-id
+translation layer that does not exist on the Go-compatible wire path.
 
 The CBOR message structs stay shared with libp2p; only the transport envelope is
 Iroh-specific. Iroh SE push and SE query messages are signed with the sending

--- a/crates/p2p/src/iroh/endpoint.rs
+++ b/crates/p2p/src/iroh/endpoint.rs
@@ -128,8 +128,12 @@ pub async fn spawn_endpoint(
     Arc<ReplicatorRegistry>,
     JoinHandle<()>,
 )> {
-    let mut alpns: Vec<Vec<u8>> = protocols::ALL_ALPNS.iter().map(|a| a.to_vec()).collect();
-    alpns.push(iroh_gossip::net::GOSSIP_ALPN.to_vec());
+    // Every Defra protocol is multiplexed over one ALPN. Gossip keeps its own:
+    // iroh-gossip owns that handshake and takes whole connections.
+    let alpns: Vec<Vec<u8>> = vec![
+        protocols::ALPN_MUX.to_vec(),
+        iroh_gossip::net::GOSSIP_ALPN.to_vec(),
+    ];
 
     let relay_mode = relay_mode_from_config(&config.relay_mode)?;
     let node_identity = config.node_identity.clone();

--- a/crates/p2p/src/iroh/endpoint_commands.rs
+++ b/crates/p2p/src/iroh/endpoint_commands.rs
@@ -23,7 +23,8 @@ use super::endpoint::{
 };
 use super::endpoint_rpc::{
     close_peer_connections, handle_block_sync, handle_car_request_response, handle_fire_and_forget,
-    handle_request_response, handle_send_only, handle_two_stream_request, BlockSyncResources,
+    handle_request_response, handle_send_only, handle_two_stream_request, remember_connection,
+    BlockSyncResources,
 };
 use super::endpoint_streams::ConnectionStreamContext;
 use super::gossip_heal;
@@ -171,7 +172,7 @@ pub(super) async fn handle_command(
                 let result = handle_request_response(
                     &endpoint,
                     &peer_id,
-                    protocols::ALPN_IDENTITY,
+                    protocols::STREAM_IDENTITY,
                     &request,
                     direct_addr,
                     &connection_cache,
@@ -289,8 +290,8 @@ pub(super) async fn handle_command(
             reply_msg,
             reply,
         } => {
-            // Retained for mixed-version peers whose request did not advertise
-            // same-stream reply support.
+            // The reply path for a request that did not advertise same-stream
+            // reply support.
             let direct_addr = peer_direct_addr(peer_map, &peer_id);
             let endpoint = endpoint.clone();
             let connection_cache = Arc::clone(connection_cache);
@@ -298,7 +299,7 @@ pub(super) async fn handle_command(
                 let result = handle_send_only(
                     &endpoint,
                     &peer_id,
-                    protocols::ALPN_TWOSTREAM_RESP,
+                    protocols::STREAM_TWOSTREAM_RESP,
                     &reply_msg,
                     direct_addr,
                     &connection_cache,
@@ -322,7 +323,7 @@ pub(super) async fn handle_command(
                     handle_request_response(
                         &endpoint,
                         &peer_id,
-                        protocols::ALPN_DOCSYNC,
+                        protocols::STREAM_DOCSYNC,
                         &request,
                         direct_addr,
                         &connection_cache,
@@ -359,7 +360,7 @@ pub(super) async fn handle_command(
                     handle_request_response(
                         &endpoint,
                         &peer_id,
-                        protocols::ALPN_BRANCHABLE,
+                        protocols::STREAM_BRANCHABLE,
                         &request,
                         direct_addr,
                         &connection_cache,
@@ -394,7 +395,7 @@ pub(super) async fn handle_command(
                 let result = handle_fire_and_forget(
                     &endpoint,
                     &peer_id,
-                    protocols::ALPN_DOCSYNC_RESP,
+                    protocols::STREAM_DOCSYNC_RESP,
                     &reply_msg,
                     direct_addr,
                     &connection_cache,
@@ -416,7 +417,7 @@ pub(super) async fn handle_command(
                 let result = handle_fire_and_forget(
                     &endpoint,
                     &peer_id,
-                    protocols::ALPN_BRANCHABLE_RESP,
+                    protocols::STREAM_BRANCHABLE_RESP,
                     &reply_msg,
                     direct_addr,
                     &connection_cache,
@@ -497,7 +498,7 @@ pub(super) async fn handle_command(
                 let result = handle_fire_and_forget(
                     &endpoint,
                     &peer_id,
-                    protocols::ALPN_CAR_RESP,
+                    protocols::STREAM_CAR_RESP,
                     &car_data,
                     direct_addr,
                     &connection_cache,
@@ -519,7 +520,7 @@ pub(super) async fn handle_command(
                 let result = handle_fire_and_forget(
                     &endpoint,
                     &peer_id,
-                    protocols::ALPN_SE,
+                    protocols::STREAM_SE,
                     &request,
                     direct_addr,
                     &connection_cache,
@@ -541,7 +542,7 @@ pub(super) async fn handle_command(
                 let result = handle_fire_and_forget(
                     &endpoint,
                     &peer_id,
-                    protocols::ALPN_SE_QUERY_REQ,
+                    protocols::STREAM_SE_QUERY_REQ,
                     &request,
                     direct_addr,
                     &connection_cache,
@@ -563,7 +564,7 @@ pub(super) async fn handle_command(
                 let result = handle_fire_and_forget(
                     &endpoint,
                     &peer_id,
-                    protocols::ALPN_SE_QUERY_RESP,
+                    protocols::STREAM_SE_QUERY_RESP,
                     &reply_msg,
                     direct_addr,
                     &connection_cache,
@@ -585,7 +586,7 @@ pub(super) async fn handle_command(
                 let result = handle_fire_and_forget(
                     &endpoint,
                     &peer_id,
-                    protocols::ALPN_MANAGE_REQ,
+                    protocols::STREAM_MANAGE_REQ,
                     &request,
                     direct_addr,
                     &connection_cache,
@@ -607,7 +608,7 @@ pub(super) async fn handle_command(
                 let result = handle_fire_and_forget(
                     &endpoint,
                     &peer_id,
-                    protocols::ALPN_MANAGE_RESP,
+                    protocols::STREAM_MANAGE_RESP,
                     &reply_msg,
                     direct_addr,
                     &connection_cache,
@@ -629,7 +630,7 @@ pub(super) async fn handle_command(
                 let result = handle_fire_and_forget(
                     &endpoint,
                     &peer_id,
-                    protocols::ALPN_MANAGE_QUERY_REQ,
+                    protocols::STREAM_MANAGE_QUERY_REQ,
                     &request,
                     direct_addr,
                     &connection_cache,
@@ -651,7 +652,7 @@ pub(super) async fn handle_command(
                 let result = handle_fire_and_forget(
                     &endpoint,
                     &peer_id,
-                    protocols::ALPN_MANAGE_QUERY_RESP,
+                    protocols::STREAM_MANAGE_QUERY_RESP,
                     &reply_msg,
                     direct_addr,
                     &connection_cache,
@@ -779,11 +780,13 @@ async fn handle_dial(
     let connection = ctx
         .resources
         .endpoint
-        .connect(endpoint_addr, protocols::ALPN_PUSHLOG)
+        .connect(endpoint_addr, protocols::ALPN_MUX)
         .await
         .map_err(|e| crate::error::Error::Dial(e.to_string()))?;
 
-    let conn_alpn = connection.alpn().to_vec();
+    // Send over the connection we just opened instead of dialling a second one
+    // on the first message.
+    remember_connection(&ctx.resources.connection_cache, peer_id, &connection)?;
 
     let is_new = ctx.resources.peer_map.lock().increment_connections(
         endpoint_id,
@@ -816,13 +819,8 @@ async fn handle_dial(
         ctx.event_tx.clone(),
     );
     let task = tokio::spawn(async move {
-        super::endpoint_streams::handle_connection_streams(
-            connection,
-            endpoint_id,
-            conn_alpn,
-            stream_context,
-        )
-        .await;
+        super::endpoint_streams::handle_connection_streams(connection, endpoint_id, stream_context)
+            .await;
     });
     track_task(&ctx.resources.spawned_tasks, task);
 

--- a/crates/p2p/src/iroh/endpoint_rpc.rs
+++ b/crates/p2p/src/iroh/endpoint_rpc.rs
@@ -14,11 +14,8 @@ use crate::QueryId;
 use super::peer_map::{parse_endpoint_id, PeerMap};
 use super::protocols;
 
-/// One shared connection per peer, keyed by endpoint alone.
-///
-/// Every protocol is multiplexed over [`protocols::ALPN_MUX`], so the peer's
-/// identity is the whole key: the first caller to dial establishes the
-/// connection and every other protocol opens a stream on it.
+/// One shared connection per peer, keyed by endpoint alone: every protocol is
+/// multiplexed over [`protocols::ALPN_MUX`], so identity is the whole key.
 #[derive(Default)]
 pub(super) struct ConnectionCacheState {
     connections: parking_lot::Mutex<HashMap<iroh::EndpointId, iroh::endpoint::Connection>>,
@@ -182,11 +179,8 @@ async fn open_tagged_stream(
     Ok((send, recv))
 }
 
-/// The peer's shared connection, if one is cached and still open.
-///
-/// A closed entry is dropped rather than handed out: with every protocol on one
-/// connection, serving a dead handle would fail every protocol at once instead
-/// of redialling.
+/// The peer's shared connection, if one is cached and still open. A closed
+/// entry is dropped rather than handed out, so the caller redials.
 fn cached_connection(
     cache: &ConnectionCache,
     peer_id: &PeerId,
@@ -203,11 +197,8 @@ fn cached_connection(
     }
 }
 
-/// Adopt `connection` as the peer's shared connection.
-///
-/// An explicit dial calls this so the connection it just established is the one
-/// every protocol then sends over, rather than leaving the first send to open a
-/// second connection to a peer we are already talking to.
+/// Adopt `connection` as the peer's shared connection, so an explicit dial does
+/// not leave the first send to open a second one.
 pub(super) fn remember_connection(
     cache: &ConnectionCache,
     peer_id: &PeerId,
@@ -221,13 +212,9 @@ pub(super) fn remember_connection(
     Ok(())
 }
 
-/// Drop a peer's shared connection, but only once QUIC has actually closed it.
-///
-/// One connection now carries every protocol, so a stream-level failure — a
-/// malformed frame, a timeout on one slow request — must not evict the
-/// transport that replication and sync are still using. A live connection is
-/// left in the cache; only a closed one is removed, and only if it is still the
-/// entry a concurrent dial has not already replaced.
+/// Drop a peer's shared connection, but only once QUIC has actually closed it:
+/// a stream-level failure must not evict the transport every other protocol is
+/// still using. The `stable_id` check avoids racing a concurrent dial.
 fn evict_if_closed(
     cache: &ConnectionCache,
     peer_id: &PeerId,
@@ -306,9 +293,8 @@ async fn connect_with_cache(
     let guard = dial_guard(cache, parse_endpoint_id(peer_id)?);
     let _dial_guard = guard.lock().await;
 
-    // Another protocol may have established the shared QUIC connection while
-    // this request waited. Only the dial owner may create it; requests remain
-    // concurrent as independent streams after this point.
+    // Another protocol may have established the shared connection while this
+    // request waited on the dial guard.
     if let Some(connection) = cached_connection(cache, peer_id)? {
         return Ok(connection);
     }
@@ -323,9 +309,8 @@ async fn connect_with_cache(
 /// Dial `alpn`, preferring a known direct address before falling back to
 /// discovery.
 ///
-/// Defra traffic always passes [`protocols::ALPN_MUX`]; gossip healing is the
-/// one caller that dials a different ALPN, because iroh-gossip owns its own
-/// handshake.
+/// Gossip healing is the one caller that passes an ALPN other than
+/// [`protocols::ALPN_MUX`], because iroh-gossip owns its own handshake.
 pub(super) async fn connect_with_direct_addr_fallback(
     endpoint: &Endpoint,
     peer_id: &PeerId,

--- a/crates/p2p/src/iroh/endpoint_rpc.rs
+++ b/crates/p2p/src/iroh/endpoint_rpc.rs
@@ -14,16 +14,15 @@ use crate::QueryId;
 use super::peer_map::{parse_endpoint_id, PeerMap};
 use super::protocols;
 
-#[derive(Clone, Eq, Hash, PartialEq)]
-pub(super) struct ConnectionCacheKey {
-    endpoint_id: iroh::EndpointId,
-    alpn: Vec<u8>,
-}
-
+/// One shared connection per peer, keyed by endpoint alone.
+///
+/// Every protocol is multiplexed over [`protocols::ALPN_MUX`], so the peer's
+/// identity is the whole key: the first caller to dial establishes the
+/// connection and every other protocol opens a stream on it.
 #[derive(Default)]
 pub(super) struct ConnectionCacheState {
-    connections: parking_lot::Mutex<HashMap<ConnectionCacheKey, iroh::endpoint::Connection>>,
-    dial_guards: parking_lot::Mutex<HashMap<ConnectionCacheKey, Arc<tokio::sync::Mutex<()>>>>,
+    connections: parking_lot::Mutex<HashMap<iroh::EndpointId, iroh::endpoint::Connection>>,
+    dial_guards: parking_lot::Mutex<HashMap<iroh::EndpointId, Arc<tokio::sync::Mutex<()>>>>,
 }
 
 pub(super) type ConnectionCache = Arc<ConnectionCacheState>;
@@ -160,63 +159,104 @@ async fn connect_once(
     .map_err(|e| crate::error::Error::Dial(e.to_string()))
 }
 
-async fn open_bi_with_timeout(
+/// Open a stream for `tag` on the peer's shared connection and announce which
+/// protocol it carries.
+async fn open_tagged_stream(
     connection: &iroh::endpoint::Connection,
     peer_id: &PeerId,
-    alpn: &[u8],
+    tag: &[u8],
 ) -> crate::error::Result<(iroh::endpoint::SendStream, iroh::endpoint::RecvStream)> {
-    tokio::time::timeout(OPEN_STREAM_TIMEOUT, connection.open_bi())
+    let (mut send, recv) = tokio::time::timeout(OPEN_STREAM_TIMEOUT, connection.open_bi())
         .await
         .map_err(|_| {
             crate::error::Error::Transport(format!(
                 "timed out opening {} stream to {} after {}s",
-                String::from_utf8_lossy(alpn),
+                String::from_utf8_lossy(tag),
                 peer_id,
                 OPEN_STREAM_TIMEOUT.as_secs()
             ))
         })?
-        .map_err(|e| crate::error::Error::Transport(e.to_string()))
+        .map_err(|e| crate::error::Error::Transport(e.to_string()))?;
+
+    protocols::write_stream_tag(&mut send, tag).await?;
+    Ok((send, recv))
 }
 
-fn connection_cache_key(peer_id: &PeerId, alpn: &[u8]) -> crate::error::Result<ConnectionCacheKey> {
-    Ok(ConnectionCacheKey {
-        endpoint_id: parse_endpoint_id(peer_id)?,
-        alpn: alpn.to_vec(),
-    })
-}
-
+/// The peer's shared connection, if one is cached and still open.
+///
+/// A closed entry is dropped rather than handed out: with every protocol on one
+/// connection, serving a dead handle would fail every protocol at once instead
+/// of redialling.
 fn cached_connection(
     cache: &ConnectionCache,
     peer_id: &PeerId,
-    alpn: &[u8],
 ) -> crate::error::Result<Option<iroh::endpoint::Connection>> {
-    let key = connection_cache_key(peer_id, alpn)?;
-    Ok(cache.connections.lock().get(&key).cloned())
-}
-
-fn remember_connection(
-    cache: &ConnectionCache,
-    peer_id: &PeerId,
-    alpn: &[u8],
-    connection: &iroh::endpoint::Connection,
-) -> crate::error::Result<()> {
-    let key = connection_cache_key(peer_id, alpn)?;
-    cache.connections.lock().insert(key, connection.clone());
-    Ok(())
-}
-
-fn evict_connection(cache: &ConnectionCache, peer_id: &PeerId, alpn: &[u8]) {
-    if let Ok(key) = connection_cache_key(peer_id, alpn) {
-        cache.connections.lock().remove(&key);
+    let endpoint_id = parse_endpoint_id(peer_id)?;
+    let mut guard = cache.connections.lock();
+    match guard.get(&endpoint_id) {
+        Some(connection) if connection.close_reason().is_none() => Ok(Some(connection.clone())),
+        Some(_) => {
+            guard.remove(&endpoint_id);
+            Ok(None)
+        }
+        None => Ok(None),
     }
 }
 
-fn dial_guard(cache: &ConnectionCache, key: ConnectionCacheKey) -> Arc<tokio::sync::Mutex<()>> {
+/// Adopt `connection` as the peer's shared connection.
+///
+/// An explicit dial calls this so the connection it just established is the one
+/// every protocol then sends over, rather than leaving the first send to open a
+/// second connection to a peer we are already talking to.
+pub(super) fn remember_connection(
+    cache: &ConnectionCache,
+    peer_id: &PeerId,
+    connection: &iroh::endpoint::Connection,
+) -> crate::error::Result<()> {
+    let endpoint_id = parse_endpoint_id(peer_id)?;
+    cache
+        .connections
+        .lock()
+        .insert(endpoint_id, connection.clone());
+    Ok(())
+}
+
+/// Drop a peer's shared connection, but only once QUIC has actually closed it.
+///
+/// One connection now carries every protocol, so a stream-level failure — a
+/// malformed frame, a timeout on one slow request — must not evict the
+/// transport that replication and sync are still using. A live connection is
+/// left in the cache; only a closed one is removed, and only if it is still the
+/// entry a concurrent dial has not already replaced.
+fn evict_if_closed(
+    cache: &ConnectionCache,
+    peer_id: &PeerId,
+    connection: &iroh::endpoint::Connection,
+) {
+    if connection.close_reason().is_none() {
+        return;
+    }
+    let Ok(endpoint_id) = parse_endpoint_id(peer_id) else {
+        return;
+    };
+    let mut guard = cache.connections.lock();
+    if guard
+        .get(&endpoint_id)
+        .is_some_and(|cached| cached.stable_id() == connection.stable_id())
+    {
+        guard.remove(&endpoint_id);
+    }
+}
+
+fn dial_guard(
+    cache: &ConnectionCache,
+    endpoint_id: iroh::EndpointId,
+) -> Arc<tokio::sync::Mutex<()>> {
     let mut guards = cache.dial_guards.lock();
     guards.retain(|_, guard| Arc::strong_count(guard) > 1);
     Arc::clone(
         guards
-            .entry(key)
+            .entry(endpoint_id)
             .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(()))),
     )
 }
@@ -225,29 +265,21 @@ fn dial_guard(cache: &ConnectionCache, key: ConnectionCacheKey) -> Arc<tokio::sy
 /// response to a `disconnect` request.
 const DISCONNECT_ERROR_CODE: u32 = 0;
 
-/// Close and remove every cached connection to `endpoint_id`.
+/// Close and remove the cached connection to `endpoint_id`.
 ///
 /// Used by `disconnect` to tear down the outbound-send connection cache for a
-/// peer. Closing is idempotent — a peer with no cached connections is a no-op.
+/// peer. Closing is idempotent — a peer with no cached connection is a no-op.
 pub(super) fn close_cached_connections(cache: &ConnectionCache, endpoint_id: &iroh::EndpointId) {
-    let mut guard = cache.connections.lock();
-    let keys: Vec<ConnectionCacheKey> = guard
-        .keys()
-        .filter(|key| &key.endpoint_id == endpoint_id)
-        .cloned()
-        .collect();
-    for key in keys {
-        if let Some(connection) = guard.remove(&key) {
-            connection.close(DISCONNECT_ERROR_CODE.into(), b"disconnect");
-        }
+    if let Some(connection) = cache.connections.lock().remove(endpoint_id) {
+        connection.close(DISCONNECT_ERROR_CODE.into(), b"disconnect");
     }
 }
 
 /// Hang up every connection we hold to a peer: all handles retained in
-/// `peer_map` (covering dial- and accept-initiated connections across every
-/// ALPN) and any cached outbound-send connections. Each stream task then
-/// observes the `accept_bi` error and decrements the count until it reaches
-/// zero and `PeerDisconnected` is emitted. Idempotent.
+/// `peer_map` (the inbound connection the peer dialled, plus our own outbound
+/// one) and the cached outbound-send connection. Each stream task then observes
+/// the `accept_bi` error and decrements the count until it reaches zero and
+/// `PeerDisconnected` is emitted. Idempotent.
 pub(super) fn close_peer_connections(
     peer_map: &Arc<parking_lot::Mutex<PeerMap>>,
     cache: &ConnectionCache,
@@ -259,34 +291,41 @@ pub(super) fn close_peer_connections(
     close_cached_connections(cache, endpoint_id);
 }
 
+/// The peer's shared connection, dialling it if this is the first protocol to
+/// need it.
 async fn connect_with_cache(
     endpoint: &Endpoint,
     peer_id: &PeerId,
-    alpn: &[u8],
     direct_addr: Option<std::net::SocketAddr>,
     cache: &ConnectionCache,
 ) -> crate::error::Result<iroh::endpoint::Connection> {
-    if let Some(connection) = cached_connection(cache, peer_id, alpn)? {
+    if let Some(connection) = cached_connection(cache, peer_id)? {
         return Ok(connection);
     }
 
-    let key = connection_cache_key(peer_id, alpn)?;
-    let guard = dial_guard(cache, key);
+    let guard = dial_guard(cache, parse_endpoint_id(peer_id)?);
     let _dial_guard = guard.lock().await;
 
-    // Another request may have established the shared QUIC connection while
-    // this request waited. Only the keyed dial owner may create it; requests
-    // remain concurrent as independent streams after this point.
-    if let Some(connection) = cached_connection(cache, peer_id, alpn)? {
+    // Another protocol may have established the shared QUIC connection while
+    // this request waited. Only the dial owner may create it; requests remain
+    // concurrent as independent streams after this point.
+    if let Some(connection) = cached_connection(cache, peer_id)? {
         return Ok(connection);
     }
 
     let connection =
-        connect_with_direct_addr_fallback(endpoint, peer_id, alpn, direct_addr).await?;
-    remember_connection(cache, peer_id, alpn, &connection)?;
+        connect_with_direct_addr_fallback(endpoint, peer_id, protocols::ALPN_MUX, direct_addr)
+            .await?;
+    remember_connection(cache, peer_id, &connection)?;
     Ok(connection)
 }
 
+/// Dial `alpn`, preferring a known direct address before falling back to
+/// discovery.
+///
+/// Defra traffic always passes [`protocols::ALPN_MUX`]; gossip healing is the
+/// one caller that dials a different ALPN, because iroh-gossip owns its own
+/// handshake.
 pub(super) async fn connect_with_direct_addr_fallback(
     endpoint: &Endpoint,
     peer_id: &PeerId,
@@ -320,7 +359,7 @@ pub(super) async fn connect_with_direct_addr_fallback(
 pub(super) async fn handle_request_response<Req, Resp>(
     endpoint: &Endpoint,
     peer_id: &PeerId,
-    alpn: &[u8],
+    tag: &[u8],
     request: &Req,
     direct_addr: Option<std::net::SocketAddr>,
     cache: &ConnectionCache,
@@ -329,25 +368,25 @@ where
     Req: serde::Serialize,
     Resp: serde::de::DeserializeOwned,
 {
-    let connection = connect_with_cache(endpoint, peer_id, alpn, direct_addr, cache).await?;
+    let connection = connect_with_cache(endpoint, peer_id, direct_addr, cache).await?;
 
-    let (mut send, mut recv) = match open_bi_with_timeout(&connection, peer_id, alpn).await {
+    let (mut send, mut recv) = match open_tagged_stream(&connection, peer_id, tag).await {
         Ok(streams) => streams,
         Err(error) => {
-            evict_connection(cache, peer_id, alpn);
+            evict_if_closed(cache, peer_id, &connection);
             return Err(error);
         }
     };
 
     if let Err(error) = protocols::write_message(&mut send, request).await {
-        evict_connection(cache, peer_id, alpn);
+        evict_if_closed(cache, peer_id, &connection);
         return Err(error);
     }
     if let Err(error) = send
         .finish()
         .map_err(|e| crate::error::Error::Transport(e.to_string()))
     {
-        evict_connection(cache, peer_id, alpn);
+        evict_if_closed(cache, peer_id, &connection);
         return Err(error);
     }
 
@@ -357,28 +396,28 @@ where
     )
     .await
     .map_err(|_| {
-        let alpn_str = String::from_utf8_lossy(alpn);
         warn!(
             peer_id = %peer_id,
-            alpn = %alpn_str,
+            stream_tag = %String::from_utf8_lossy(tag),
             timeout_secs = REQUEST_RESPONSE_TIMEOUT.as_secs(),
             "request-response timed out waiting for peer"
         );
-        evict_connection(cache, peer_id, alpn);
+        evict_if_closed(cache, peer_id, &connection);
         crate::error::Error::ResponseTimeout
     })?
     .inspect_err(|_| {
-        evict_connection(cache, peer_id, alpn);
+        evict_if_closed(cache, peer_id, &connection);
     })?;
     Ok(response)
 }
 
 /// Send a two-stream PushLog request and accept either response shape.
 ///
-/// Current peers reply on this request's receive stream. During a rolling
-/// upgrade, older peers may still reverse-dial `ALPN_TWOSTREAM_RESP`, which is
-/// delivered through `legacy_reply`. A failure on either path is therefore not
-/// terminal while the other path can still produce the ACK.
+/// A peer normally replies on this request's receive stream. One that does not
+/// advertise same-stream reply support answers on a separate
+/// `STREAM_TWOSTREAM_RESP` stream instead, delivered through `legacy_reply`. A
+/// failure on either path is therefore not terminal while the other path can
+/// still produce the ACK.
 pub(super) async fn handle_two_stream_request(
     endpoint: &Endpoint,
     peer_id: &PeerId,
@@ -387,26 +426,26 @@ pub(super) async fn handle_two_stream_request(
     cache: &ConnectionCache,
     legacy_reply: oneshot::Receiver<PushLogReply>,
 ) -> crate::error::Result<PushLogReply> {
-    let alpn = protocols::ALPN_TWOSTREAM;
-    let connection = connect_with_cache(endpoint, peer_id, alpn, direct_addr, cache).await?;
+    let connection = connect_with_cache(endpoint, peer_id, direct_addr, cache).await?;
 
-    let (mut send, mut recv) = match open_bi_with_timeout(&connection, peer_id, alpn).await {
-        Ok(streams) => streams,
-        Err(error) => {
-            evict_connection(cache, peer_id, alpn);
-            return Err(error);
-        }
-    };
+    let (mut send, mut recv) =
+        match open_tagged_stream(&connection, peer_id, protocols::STREAM_TWOSTREAM).await {
+            Ok(streams) => streams,
+            Err(error) => {
+                evict_if_closed(cache, peer_id, &connection);
+                return Err(error);
+            }
+        };
 
     if let Err(error) = protocols::write_message(&mut send, request).await {
-        evict_connection(cache, peer_id, alpn);
+        evict_if_closed(cache, peer_id, &connection);
         return Err(error);
     }
     if let Err(error) = send
         .finish()
         .map_err(|e| crate::error::Error::Transport(e.to_string()))
     {
-        evict_connection(cache, peer_id, alpn);
+        evict_if_closed(cache, peer_id, &connection);
         return Err(error);
     }
 
@@ -438,41 +477,41 @@ pub(super) async fn handle_two_stream_request(
                 timeout_secs = REQUEST_RESPONSE_TIMEOUT.as_secs(),
                 "two-stream request timed out waiting for same-stream or legacy reply"
             );
-            evict_connection(cache, peer_id, alpn);
+            evict_if_closed(cache, peer_id, &connection);
             crate::error::Error::ResponseTimeout
         })?
         .inspect_err(|_| {
-            evict_connection(cache, peer_id, alpn);
+            evict_if_closed(cache, peer_id, &connection);
         })
 }
 
 async fn send_one_way_message<T: serde::Serialize>(
     endpoint: &Endpoint,
     peer_id: &PeerId,
-    alpn: &[u8],
+    tag: &[u8],
     msg: &T,
     direct_addr: Option<std::net::SocketAddr>,
     cache: &ConnectionCache,
 ) -> crate::error::Result<()> {
-    let connection = connect_with_cache(endpoint, peer_id, alpn, direct_addr, cache).await?;
+    let connection = connect_with_cache(endpoint, peer_id, direct_addr, cache).await?;
 
-    let (mut send, mut recv) = match open_bi_with_timeout(&connection, peer_id, alpn).await {
+    let (mut send, mut recv) = match open_tagged_stream(&connection, peer_id, tag).await {
         Ok(streams) => streams,
         Err(error) => {
-            evict_connection(cache, peer_id, alpn);
+            evict_if_closed(cache, peer_id, &connection);
             return Err(error);
         }
     };
 
     if let Err(error) = protocols::write_message(&mut send, msg).await {
-        evict_connection(cache, peer_id, alpn);
+        evict_if_closed(cache, peer_id, &connection);
         return Err(error);
     }
     if let Err(error) = send
         .finish()
         .map_err(|e| crate::error::Error::Transport(e.to_string()))
     {
-        evict_connection(cache, peer_id, alpn);
+        evict_if_closed(cache, peer_id, &connection);
         return Err(error);
     }
 
@@ -491,12 +530,12 @@ async fn send_one_way_message<T: serde::Serialize>(
 pub(super) async fn handle_fire_and_forget<T: serde::Serialize>(
     endpoint: &Endpoint,
     peer_id: &PeerId,
-    alpn: &[u8],
+    tag: &[u8],
     msg: &T,
     direct_addr: Option<std::net::SocketAddr>,
     cache: &ConnectionCache,
 ) -> crate::error::Result<()> {
-    send_one_way_message(endpoint, peer_id, alpn, msg, direct_addr, cache).await
+    send_one_way_message(endpoint, peer_id, tag, msg, direct_addr, cache).await
 }
 
 /// Send a one-way message, then keep the bidirectional stream alive briefly so
@@ -509,12 +548,12 @@ pub(super) async fn handle_fire_and_forget<T: serde::Serialize>(
 pub(super) async fn handle_send_only<T: serde::Serialize>(
     endpoint: &Endpoint,
     peer_id: &PeerId,
-    alpn: &[u8],
+    tag: &[u8],
     msg: &T,
     direct_addr: Option<std::net::SocketAddr>,
     cache: &ConnectionCache,
 ) -> crate::error::Result<()> {
-    send_one_way_message(endpoint, peer_id, alpn, msg, direct_addr, cache).await
+    send_one_way_message(endpoint, peer_id, tag, msg, direct_addr, cache).await
 }
 
 /// Send a CAR request and emit the response as a transport event.
@@ -531,28 +570,27 @@ pub(super) async fn handle_car_request_response(
     cache: &ConnectionCache,
     event_tx: &mpsc::Sender<TransportEvent<iroh::endpoint::SendStream>>,
 ) -> crate::error::Result<()> {
-    let connection =
-        connect_with_cache(endpoint, peer_id, protocols::ALPN_CAR, direct_addr, cache).await?;
+    let connection = connect_with_cache(endpoint, peer_id, direct_addr, cache).await?;
 
     let (mut send, mut recv) =
-        match open_bi_with_timeout(&connection, peer_id, protocols::ALPN_CAR).await {
+        match open_tagged_stream(&connection, peer_id, protocols::STREAM_CAR).await {
             Ok(streams) => streams,
             Err(error) => {
-                evict_connection(cache, peer_id, protocols::ALPN_CAR);
+                evict_if_closed(cache, peer_id, &connection);
                 return Err(error);
             }
         };
 
     let request = CarFetchRequest::full_dag(root_cid);
     if let Err(error) = protocols::write_message(&mut send, &request).await {
-        evict_connection(cache, peer_id, protocols::ALPN_CAR);
+        evict_if_closed(cache, peer_id, &connection);
         return Err(error);
     }
     if let Err(error) = send
         .finish()
         .map_err(|e| crate::error::Error::Transport(e.to_string()))
     {
-        evict_connection(cache, peer_id, protocols::ALPN_CAR);
+        evict_if_closed(cache, peer_id, &connection);
         return Err(error);
     }
 
@@ -562,11 +600,11 @@ pub(super) async fn handle_car_request_response(
     )
     .await
     .map_err(|_| {
-        evict_connection(cache, peer_id, protocols::ALPN_CAR);
+        evict_if_closed(cache, peer_id, &connection);
         crate::error::Error::ResponseTimeout
     })?
     .map_err(|e| {
-        evict_connection(cache, peer_id, protocols::ALPN_CAR);
+        evict_if_closed(cache, peer_id, &connection);
         crate::error::Error::Transport(e.to_string())
     })?;
 
@@ -612,31 +650,29 @@ async fn try_fetch_from_provider(
         };
     }
 
-    let connection =
-        match connect_with_cache(endpoint, provider, protocols::ALPN_CAR, direct_addr, cache).await
-        {
-            Ok(conn) => conn,
-            Err(e) => {
-                debug!(
-                    provider = %provider,
-                    root = %request.root_cid,
-                    recursive = request.recursive,
-                    requested_count = request.wanted_cids.len(),
-                    error = %e,
-                    "CAR fetch: connection failed"
-                );
-                return CarFetchAttempt {
-                    provider: provider.clone(),
-                    outcome: CarFetchOutcome::ConnectFailed(e.to_string()),
-                };
-            }
-        };
+    let connection = match connect_with_cache(endpoint, provider, direct_addr, cache).await {
+        Ok(conn) => conn,
+        Err(e) => {
+            debug!(
+                provider = %provider,
+                root = %request.root_cid,
+                recursive = request.recursive,
+                requested_count = request.wanted_cids.len(),
+                error = %e,
+                "CAR fetch: connection failed"
+            );
+            return CarFetchAttempt {
+                provider: provider.clone(),
+                outcome: CarFetchOutcome::ConnectFailed(e.to_string()),
+            };
+        }
+    };
 
     let (mut send, mut recv) =
-        match open_bi_with_timeout(&connection, provider, protocols::ALPN_CAR).await {
+        match open_tagged_stream(&connection, provider, protocols::STREAM_CAR).await {
             Ok(streams) => streams,
             Err(e) => {
-                evict_connection(cache, provider, protocols::ALPN_CAR);
+                evict_if_closed(cache, provider, &connection);
                 debug!(
                     provider = %provider,
                     root = %request.root_cid,
@@ -651,7 +687,7 @@ async fn try_fetch_from_provider(
         };
 
     if let Err(e) = protocols::write_message(&mut send, &request).await {
-        evict_connection(cache, provider, protocols::ALPN_CAR);
+        evict_if_closed(cache, provider, &connection);
         debug!(
             provider = %provider,
             root = %request.root_cid,
@@ -664,7 +700,7 @@ async fn try_fetch_from_provider(
         };
     }
     if let Err(e) = send.finish() {
-        evict_connection(cache, provider, protocols::ALPN_CAR);
+        evict_if_closed(cache, provider, &connection);
         debug!(
             provider = %provider,
             root = %request.root_cid,
@@ -691,7 +727,7 @@ async fn try_fetch_from_provider(
         {
             Ok(Ok(data)) => data,
             Ok(Err(e)) => {
-                evict_connection(cache, provider, protocols::ALPN_CAR);
+                evict_if_closed(cache, provider, &connection);
                 debug!(
                     provider = %provider,
                     root = %request.root_cid,
@@ -704,7 +740,7 @@ async fn try_fetch_from_provider(
                 };
             }
             Err(_) => {
-                evict_connection(cache, provider, protocols::ALPN_CAR);
+                evict_if_closed(cache, provider, &connection);
                 debug!(
                     provider = %provider,
                     root = %request.root_cid,
@@ -996,11 +1032,11 @@ mod tests {
             .expect("bind endpoint")
     }
 
-    /// Regression (#1092 review): a peer can hold several live connections
-    /// (one per ALPN, dial + accept). Hanging up must close every retained
-    /// handle — closing only the most recent one leaves the others alive, the
-    /// connection count never reaches zero, and `PeerDisconnected` never
-    /// fires.
+    /// Regression (#1092 review): a peer can hold several live connections —
+    /// the one it dialled and the one it accepted. Hanging up must close every
+    /// retained handle — closing only the most recent one leaves the others
+    /// alive, the connection count never reaches zero, and `PeerDisconnected`
+    /// never fires.
     #[tokio::test]
     async fn close_peer_connections_closes_every_retained_handle() {
         let accept_ep = localhost_endpoint(vec![b"test/a".to_vec(), b"test/b".to_vec()]).await;
@@ -1051,10 +1087,9 @@ mod tests {
 
     #[tokio::test]
     async fn concurrent_requests_share_one_connection_dial() {
-        const ALPN: &[u8] = b"test/shared-dial";
         const CALLERS: usize = 16;
 
-        let accept_ep = localhost_endpoint(vec![ALPN.to_vec()]).await;
+        let accept_ep = localhost_endpoint(vec![protocols::ALPN_MUX.to_vec()]).await;
         let dial_ep = localhost_endpoint(vec![]).await;
         let direct_addr = accept_ep
             .addr()
@@ -1088,7 +1123,7 @@ mod tests {
             let barrier = Arc::clone(&barrier);
             callers.spawn(async move {
                 barrier.wait().await;
-                connect_with_cache(&endpoint, &peer_id, ALPN, Some(direct_addr), &cache)
+                connect_with_cache(&endpoint, &peer_id, Some(direct_addr), &cache)
                     .await
                     .expect("shared connection")
             });

--- a/crates/p2p/src/iroh/endpoint_streams.rs
+++ b/crates/p2p/src/iroh/endpoint_streams.rs
@@ -132,9 +132,8 @@ impl ConnectionStreamContext {
 
 /// Process streams on an accepted connection, dispatching by stream tag.
 ///
-/// Every protocol shares this one connection, so the tag is read inside the
-/// spawned task rather than in the accept loop — a peer that opens a stream and
-/// stalls before writing its tag must not hold up the other protocols.
+/// The tag is read inside the spawned task, not the accept loop, so a peer that
+/// stalls before writing one cannot hold up the other protocols.
 ///
 /// Emits `PeerDisconnected` only when the last connection for this peer closes.
 pub(super) async fn handle_connection_streams(
@@ -264,8 +263,7 @@ async fn dispatch_stream(
         }
         x if x == protocols::STREAM_TWOSTREAM_RESP => {
             // The reverse-stream ACK, for a request that did not advertise
-            // same-stream reply support. Now one more stream on the shared
-            // connection rather than a connection of its own.
+            // same-stream reply support.
             let reply: PushLogReply =
                 protocols::read_message(recv, protocols::MAX_MESSAGE_SIZE).await?;
             let (sender, pending_len_after_remove) = {

--- a/crates/p2p/src/iroh/endpoint_streams.rs
+++ b/crates/p2p/src/iroh/endpoint_streams.rs
@@ -99,7 +99,7 @@ pub(super) async fn handle_incoming(
         event_tx.clone(),
     );
     let task = tokio::spawn(async move {
-        handle_connection_streams(connection, remote_id, conn_alpn, context).await;
+        handle_connection_streams(connection, remote_id, context).await;
     });
     track_task(&resources.spawned_tasks, task);
 }
@@ -130,13 +130,16 @@ impl ConnectionStreamContext {
     }
 }
 
-/// Process streams on an accepted connection, dispatching by ALPN.
+/// Process streams on an accepted connection, dispatching by stream tag.
+///
+/// Every protocol shares this one connection, so the tag is read inside the
+/// spawned task rather than in the accept loop — a peer that opens a stream and
+/// stalls before writing its tag must not hold up the other protocols.
 ///
 /// Emits `PeerDisconnected` only when the last connection for this peer closes.
 pub(super) async fn handle_connection_streams(
     connection: Connection,
     remote_id: EndpointId,
-    alpn: Vec<u8>,
     context: ConnectionStreamContext,
 ) {
     let peer_id = endpoint_id_to_peer_id(&remote_id);
@@ -144,12 +147,18 @@ pub(super) async fn handle_connection_streams(
     while let Ok((send, mut recv)) = connection.accept_bi().await {
         let peer_id = peer_id.clone();
         let event_tx = context.event_tx.clone();
-        let alpn = alpn.clone();
         let pending_pushlog_replies = context.pending_pushlog_replies.clone();
         let node_identity = context.node_identity.clone();
         let task = tokio::spawn(async move {
+            let tag = match protocols::read_stream_tag(&mut recv).await {
+                Ok(tag) => tag,
+                Err(e) => {
+                    debug!(peer_id = %peer_id, error = %e, "Unreadable stream tag");
+                    return;
+                }
+            };
             if let Err(e) = dispatch_stream(
-                &alpn,
+                &tag,
                 &peer_id,
                 send,
                 &mut recv,
@@ -179,9 +188,9 @@ pub(super) async fn handle_connection_streams(
     }
 }
 
-/// Dispatch a stream based on the connection ALPN.
+/// Dispatch a stream based on the tag its opener wrote.
 async fn dispatch_stream(
-    alpn: &[u8],
+    tag: &[u8],
     peer_id: &PeerId,
     send: iroh::endpoint::SendStream,
     recv: &mut iroh::endpoint::RecvStream,
@@ -189,8 +198,8 @@ async fn dispatch_stream(
     pending_pushlog_replies: &PendingPushLogReplies,
     node_identity: Option<&identity::RawIdentity>,
 ) -> crate::error::Result<()> {
-    match alpn {
-        x if x == protocols::ALPN_IDENTITY => {
+    match tag {
+        x if x == protocols::STREAM_IDENTITY => {
             let request: crate::message::IdentityRequest =
                 protocols::read_message(recv, protocols::MAX_MESSAGE_SIZE).await?;
             let mut send = send;
@@ -221,7 +230,7 @@ async fn dispatch_stream(
             send.finish()
                 .map_err(|error| Error::Transport(error.to_string()))?;
         }
-        x if x == protocols::ALPN_PUSHLOG => {
+        x if x == protocols::STREAM_PUSHLOG => {
             let request: crate::message::PushLogRequest =
                 protocols::read_message(recv, protocols::MAX_MESSAGE_SIZE).await?;
             if event_tx
@@ -236,7 +245,7 @@ async fn dispatch_stream(
                 warn!("Event channel closed, cannot emit PushLogRequest");
             }
         }
-        x if x == protocols::ALPN_TWOSTREAM => {
+        x if x == protocols::STREAM_TWOSTREAM => {
             let request: crate::message::PushLogRequest =
                 protocols::read_message(recv, protocols::MAX_MESSAGE_SIZE).await?;
             if event_tx
@@ -253,9 +262,10 @@ async fn dispatch_stream(
                 warn!("Event channel closed, cannot emit TwoStreamRequest");
             }
         }
-        x if x == protocols::ALPN_TWOSTREAM_RESP => {
-            // Retained so upgraded senders can receive reverse-stream ACKs
-            // from older receivers during a rolling deployment.
+        x if x == protocols::STREAM_TWOSTREAM_RESP => {
+            // The reverse-stream ACK, for a request that did not advertise
+            // same-stream reply support. Now one more stream on the shared
+            // connection rather than a connection of its own.
             let reply: PushLogReply =
                 protocols::read_message(recv, protocols::MAX_MESSAGE_SIZE).await?;
             let (sender, pending_len_after_remove) = {
@@ -274,7 +284,7 @@ async fn dispatch_stream(
                 );
             }
         }
-        x if x == protocols::ALPN_DOCSYNC => {
+        x if x == protocols::STREAM_DOCSYNC => {
             let request: crate::message::DocSyncRequest =
                 protocols::read_message(recv, protocols::MAX_MESSAGE_SIZE).await?;
             if event_tx
@@ -289,7 +299,7 @@ async fn dispatch_stream(
                 warn!("Event channel closed, cannot emit DocSyncRequest");
             }
         }
-        x if x == protocols::ALPN_BRANCHABLE => {
+        x if x == protocols::STREAM_BRANCHABLE => {
             let request: crate::message::BranchableSyncRequest =
                 protocols::read_message(recv, protocols::MAX_MESSAGE_SIZE).await?;
             if event_tx
@@ -304,7 +314,7 @@ async fn dispatch_stream(
                 warn!("Event channel closed, cannot emit BranchableSyncRequest");
             }
         }
-        x if x == protocols::ALPN_CAR => {
+        x if x == protocols::STREAM_CAR => {
             debug!(peer_id = %peer_id, "CAR dispatch: reading request");
             let request: crate::message::CarFetchRequest =
                 protocols::read_message(recv, protocols::MAX_MESSAGE_SIZE).await?;
@@ -327,7 +337,7 @@ async fn dispatch_stream(
                 warn!("Event channel closed, cannot emit CarFetchRequest");
             }
         }
-        x if x == protocols::ALPN_CAR_RESP => {
+        x if x == protocols::STREAM_CAR_RESP => {
             let car_data: Vec<u8> = protocols::read_message(recv, protocols::MAX_CAR_SIZE).await?;
             // Extract the root CID from the CAR headers for event correlation.
             let root_cid = match crate::sync::car::decode_car(&car_data) {
@@ -352,7 +362,7 @@ async fn dispatch_stream(
                 }
             }
         }
-        x if x == protocols::ALPN_DOCSYNC_RESP => {
+        x if x == protocols::STREAM_DOCSYNC_RESP => {
             let reply: crate::message::DocSyncReply =
                 protocols::read_message(recv, protocols::MAX_MESSAGE_SIZE).await?;
             debug!(peer_id = %peer_id, "Received doc sync response via fire-and-forget");
@@ -367,7 +377,7 @@ async fn dispatch_stream(
                 warn!("Event channel closed, cannot emit DocSyncReply");
             }
         }
-        x if x == protocols::ALPN_BRANCHABLE_RESP => {
+        x if x == protocols::STREAM_BRANCHABLE_RESP => {
             let reply: crate::message::BranchableSyncReply =
                 protocols::read_message(recv, protocols::MAX_MESSAGE_SIZE).await?;
             debug!(peer_id = %peer_id, "Received branchable sync response via fire-and-forget");
@@ -382,7 +392,7 @@ async fn dispatch_stream(
                 warn!("Event channel closed, cannot emit BranchableSyncReply");
             }
         }
-        x if x == protocols::ALPN_SE => {
+        x if x == protocols::STREAM_SE => {
             let request: crate::message::PushSEArtifactsRequest =
                 protocols::read_message(recv, protocols::MAX_MESSAGE_SIZE).await?;
             verify_iroh_message(&request)?;
@@ -406,7 +416,7 @@ async fn dispatch_stream(
                 warn!("Event channel closed, cannot emit SEArtifactsReceived");
             }
         }
-        x if x == protocols::ALPN_SE_QUERY_REQ => {
+        x if x == protocols::STREAM_SE_QUERY_REQ => {
             let request: crate::message::QuerySEArtifactsRequest =
                 protocols::read_message(recv, protocols::MAX_MESSAGE_SIZE).await?;
             verify_iroh_message(&request)?;
@@ -429,7 +439,7 @@ async fn dispatch_stream(
                 warn!("Event channel closed, cannot emit SEQueryRequest");
             }
         }
-        x if x == protocols::ALPN_SE_QUERY_RESP => {
+        x if x == protocols::STREAM_SE_QUERY_RESP => {
             let reply: crate::message::QuerySEArtifactsReply =
                 protocols::read_message(recv, protocols::MAX_MESSAGE_SIZE).await?;
             verify_iroh_message(&reply)?;
@@ -451,7 +461,7 @@ async fn dispatch_stream(
                 warn!("Event channel closed, cannot emit SEQueryReply");
             }
         }
-        x if x == protocols::ALPN_MANAGE_REQ => {
+        x if x == protocols::STREAM_MANAGE_REQ => {
             let request: crate::message::ManageRequest =
                 protocols::read_message(recv, protocols::MAX_MANAGE_MSG_SIZE).await?;
             verify_iroh_message(&request)?;
@@ -472,7 +482,7 @@ async fn dispatch_stream(
                 warn!("Event channel closed, cannot emit ManageRequest");
             }
         }
-        x if x == protocols::ALPN_MANAGE_RESP => {
+        x if x == protocols::STREAM_MANAGE_RESP => {
             let reply: crate::message::ManageReply =
                 protocols::read_message(recv, protocols::MAX_MANAGE_MSG_SIZE).await?;
             verify_iroh_message(&reply)?;
@@ -493,7 +503,7 @@ async fn dispatch_stream(
                 warn!("Event channel closed, cannot emit ManageReply");
             }
         }
-        x if x == protocols::ALPN_MANAGE_QUERY_REQ => {
+        x if x == protocols::STREAM_MANAGE_QUERY_REQ => {
             let request: crate::message::ManageQueryRequest =
                 protocols::read_message(recv, protocols::MAX_MANAGE_MSG_SIZE).await?;
             verify_iroh_message(&request)?;
@@ -514,7 +524,7 @@ async fn dispatch_stream(
                 warn!("Event channel closed, cannot emit ManageQueryRequest");
             }
         }
-        x if x == protocols::ALPN_MANAGE_QUERY_RESP => {
+        x if x == protocols::STREAM_MANAGE_QUERY_RESP => {
             let reply: crate::message::ManageQueryReply =
                 protocols::read_message(recv, protocols::MAX_MANAGE_MSG_SIZE).await?;
             verify_iroh_message(&reply)?;
@@ -536,7 +546,7 @@ async fn dispatch_stream(
             }
         }
         _ => {
-            debug!("Unknown ALPN: {:?}", String::from_utf8_lossy(alpn));
+            debug!("Unknown stream tag: {:?}", String::from_utf8_lossy(tag));
         }
     }
     Ok(())

--- a/crates/p2p/src/iroh/mod.rs
+++ b/crates/p2p/src/iroh/mod.rs
@@ -18,6 +18,8 @@ mod endpoint_config;
 mod endpoint_rpc;
 mod endpoint_streams;
 mod gossip_heal;
+#[cfg(test)]
+mod mux_tests;
 mod peer_map;
 mod protocols;
 mod secret_key;

--- a/crates/p2p/src/iroh/mux_tests.rs
+++ b/crates/p2p/src/iroh/mux_tests.rs
@@ -1,8 +1,7 @@
 //! Every Defra protocol shares one QUIC connection per peer.
 //!
-//! The peer here is a bare iroh endpoint rather than a second transport, so the
-//! assertions are about what a real `IrohTransport` puts on the wire: how many
-//! connections it opens, and which protocol tags it multiplexes over them.
+//! The peer is a bare iroh endpoint, so the assertions are about what a real
+//! `IrohTransport` puts on the wire: connections opened, and tags muxed.
 
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
@@ -169,10 +168,6 @@ async fn drive_six_protocols(transport: &IrohTransport, peer: &PeerId) {
 }
 
 /// The point of the mux ALPN: six protocols, one connection.
-///
-/// Before multiplexing each protocol negotiated its own ALPN, so this exchange
-/// cost six QUIC handshakes — six congestion controllers, six hole-punches, six
-/// keepalive timers — against a single peer.
 #[tokio::test]
 async fn six_protocols_share_one_connection() {
     let peer = spawn_bare_peer().await;
@@ -236,8 +231,7 @@ async fn repeated_sends_do_not_redial() {
 }
 
 /// A stream-level failure must not evict the connection every other protocol is
-/// using. An unknown tag is dispatched as a no-op by the peer; the sends around
-/// it keep flowing on the same connection.
+/// using.
 #[tokio::test]
 async fn a_failed_stream_does_not_tear_down_the_connection() {
     let peer = spawn_bare_peer().await;

--- a/crates/p2p/src/iroh/mux_tests.rs
+++ b/crates/p2p/src/iroh/mux_tests.rs
@@ -1,0 +1,283 @@
+//! Every Defra protocol shares one QUIC connection per peer.
+//!
+//! The peer here is a bare iroh endpoint rather than a second transport, so the
+//! assertions are about what a real `IrohTransport` puts on the wire: how many
+//! connections it opens, and which protocol tags it multiplexes over them.
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+use std::time::Duration;
+
+use iroh::SecretKey;
+use parking_lot::Mutex;
+use tokio::task::JoinHandle;
+
+use super::protocols;
+use super::{spawn_endpoint, IrohDiscoveryConfig, IrohEndpointConfig, IrohTransport};
+use crate::message::{
+    BranchableSyncReply, DocSyncReply, ManageMutateOp, ManageQueryOp, ManageQueryRequest,
+    ManageRequest, PushSEArtifactsRequest,
+};
+use crate::transport::{P2PTransport, PeerAddr, PeerId};
+
+/// What the bare peer saw: how many QUIC connections were opened to it, and the
+/// protocol tag of every stream that arrived.
+#[derive(Default, Clone)]
+struct Observed {
+    connections: usize,
+    tags: Vec<Vec<u8>>,
+}
+
+impl Observed {
+    fn distinct_tags(&self) -> Vec<String> {
+        let mut tags: Vec<String> = self
+            .tags
+            .iter()
+            .map(|tag| String::from_utf8_lossy(tag).into_owned())
+            .collect();
+        tags.sort();
+        tags.dedup();
+        tags
+    }
+}
+
+struct BarePeer {
+    peer_id: PeerId,
+    addr: SocketAddr,
+    observed: Arc<Mutex<Observed>>,
+    accept_task: JoinHandle<()>,
+}
+
+impl BarePeer {
+    fn observed(&self) -> Observed {
+        self.observed.lock().clone()
+    }
+}
+
+/// A peer that speaks nothing but the mux ALPN: it accepts connections, reads
+/// each stream's tag, and closes its side so one-way senders do not block.
+async fn spawn_bare_peer() -> BarePeer {
+    let endpoint = iroh::Endpoint::builder(iroh::endpoint::presets::Minimal)
+        .relay_mode(iroh::RelayMode::Disabled)
+        .alpns(vec![protocols::ALPN_MUX.to_vec()])
+        .bind_addr("127.0.0.1:0".parse::<SocketAddr>().unwrap())
+        .expect("bind addr")
+        .bind()
+        .await
+        .expect("bind endpoint");
+
+    let peer_id = PeerId::new(endpoint.id().to_string());
+    let addr = endpoint
+        .addr()
+        .ip_addrs()
+        .next()
+        .copied()
+        .expect("listener direct address");
+
+    let observed = Arc::new(Mutex::new(Observed::default()));
+    let accept_task = tokio::spawn({
+        let endpoint = endpoint.clone();
+        let observed = Arc::clone(&observed);
+        async move {
+            // The endpoint must outlive the accept loop, so hold it here.
+            let _endpoint = endpoint.clone();
+            while let Some(incoming) = endpoint.accept().await {
+                let Ok(connection) = incoming.await else {
+                    continue;
+                };
+                observed.lock().connections += 1;
+                let observed = Arc::clone(&observed);
+                tokio::spawn(async move {
+                    while let Ok((mut send, mut recv)) = connection.accept_bi().await {
+                        match protocols::read_stream_tag(&mut recv).await {
+                            Ok(tag) => observed.lock().tags.push(tag),
+                            Err(_) => break,
+                        }
+                        let _ = send.finish();
+                    }
+                });
+            }
+        }
+    });
+
+    BarePeer {
+        peer_id,
+        addr,
+        observed,
+        accept_task,
+    }
+}
+
+async fn spawn_transport() -> (IrohTransport, JoinHandle<()>) {
+    let secret_key = SecretKey::generate();
+    let config = IrohEndpointConfig {
+        secret_key: secret_key.clone(),
+        node_identity: None,
+        relay_mode: super::IrohRelayModeConfig::Disabled,
+        discovery: IrohDiscoveryConfig::Disabled,
+        bind_port: None,
+        bind_addr: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+        max_concurrent_multipath_paths: None,
+        gossip_heal: Default::default(),
+    };
+    let (command_tx, _events, _replicators, task) = spawn_endpoint(config).await.unwrap();
+    (IrohTransport::new(command_tx, secret_key), task)
+}
+
+/// Drive six protocols that a client uses to interact with a node's DAG, each
+/// on a different stream tag.
+async fn drive_six_protocols(transport: &IrohTransport, peer: &PeerId) {
+    transport
+        .send_doc_sync_response(peer, DocSyncReply::success("doc-sync", Vec::new()))
+        .await
+        .expect("doc sync response");
+    transport
+        .send_branchable_sync_response(
+            peer,
+            BranchableSyncReply::success("branchable", "collection1", Vec::new()),
+        )
+        .await
+        .expect("branchable sync response");
+    transport
+        .send_car_response(peer, vec![1, 2, 3])
+        .await
+        .expect("car response");
+    transport
+        .send_se_artifacts(peer, PushSEArtifactsRequest::new("collection1", Vec::new()))
+        .await
+        .expect("se artifacts");
+    transport
+        .send_manage_request(
+            peer,
+            ManageRequest::new(
+                ManageMutateOp::ReplicatorDelete {
+                    addresses: Vec::new(),
+                    collection_ids: Vec::new(),
+                },
+                Vec::new(),
+            ),
+        )
+        .await
+        .expect("manage request");
+    transport
+        .send_manage_query_request(
+            peer,
+            ManageQueryRequest::new(ManageQueryOp::ReplicatorList, Vec::new()),
+        )
+        .await
+        .expect("manage query request");
+}
+
+/// The point of the mux ALPN: six protocols, one connection.
+///
+/// Before multiplexing each protocol negotiated its own ALPN, so this exchange
+/// cost six QUIC handshakes — six congestion controllers, six hole-punches, six
+/// keepalive timers — against a single peer.
+#[tokio::test]
+async fn six_protocols_share_one_connection() {
+    let peer = spawn_bare_peer().await;
+    let (transport, endpoint_task) = spawn_transport().await;
+
+    transport
+        .dial(&peer.peer_id, vec![PeerAddr::new(peer.addr.to_string())])
+        .await
+        .expect("dial bare peer");
+
+    drive_six_protocols(&transport, &peer.peer_id).await;
+
+    let observed = peer.observed();
+    assert_eq!(
+        observed.distinct_tags().len(),
+        6,
+        "expected six protocols, saw {:?}",
+        observed.distinct_tags()
+    );
+    assert_eq!(
+        observed.connections,
+        1,
+        "six protocols must share one connection, saw {} (tags: {:?})",
+        observed.connections,
+        observed.distinct_tags()
+    );
+
+    peer.accept_task.abort();
+    transport.shutdown().await.unwrap();
+    endpoint_task.await.unwrap();
+}
+
+/// Repeating a protocol reuses the connection rather than redialling.
+#[tokio::test]
+async fn repeated_sends_do_not_redial() {
+    let peer = spawn_bare_peer().await;
+    let (transport, endpoint_task) = spawn_transport().await;
+
+    transport
+        .dial(&peer.peer_id, vec![PeerAddr::new(peer.addr.to_string())])
+        .await
+        .expect("dial bare peer");
+
+    for _ in 0..5 {
+        transport
+            .send_car_response(&peer.peer_id, vec![7])
+            .await
+            .expect("car response");
+    }
+
+    let observed = peer.observed();
+    assert_eq!(observed.tags.len(), 5, "every send must reach the peer");
+    assert_eq!(
+        observed.connections, 1,
+        "repeated sends must reuse the dialled connection"
+    );
+
+    peer.accept_task.abort();
+    transport.shutdown().await.unwrap();
+    endpoint_task.await.unwrap();
+}
+
+/// A stream-level failure must not evict the connection every other protocol is
+/// using. An unknown tag is dispatched as a no-op by the peer; the sends around
+/// it keep flowing on the same connection.
+#[tokio::test]
+async fn a_failed_stream_does_not_tear_down_the_connection() {
+    let peer = spawn_bare_peer().await;
+    let (transport, endpoint_task) = spawn_transport().await;
+
+    transport
+        .dial(&peer.peer_id, vec![PeerAddr::new(peer.addr.to_string())])
+        .await
+        .expect("dial bare peer");
+
+    transport
+        .send_car_response(&peer.peer_id, vec![1])
+        .await
+        .expect("car response before");
+
+    // A CAR *request* expects bytes back; the bare peer never sends any, so this
+    // stream fails on read. The connection itself stays healthy.
+    let _ = tokio::time::timeout(
+        Duration::from_secs(2),
+        transport.send_car_request(&peer.peer_id, cid_for_test()),
+    )
+    .await;
+
+    transport
+        .send_car_response(&peer.peer_id, vec![2])
+        .await
+        .expect("car response after");
+
+    let observed = peer.observed();
+    assert_eq!(
+        observed.connections, 1,
+        "a failed stream must not force a redial"
+    );
+
+    peer.accept_task.abort();
+    transport.shutdown().await.unwrap();
+    endpoint_task.await.unwrap();
+}
+
+fn cid_for_test() -> cid::Cid {
+    use multihash_codetable::{Code, MultihashDigest};
+    cid::Cid::new_v1(0x71, Code::Sha2_256.digest(b"mux-test"))
+}

--- a/crates/p2p/src/iroh/protocols.rs
+++ b/crates/p2p/src/iroh/protocols.rs
@@ -1,78 +1,96 @@
-//! ALPN protocol constants and wire format helpers for iroh transport.
+//! The mux ALPN, its stream tags, and wire format helpers for iroh transport.
+//!
+//! Every Defra protocol shares one QUIC connection per peer. The connection is
+//! negotiated on [`ALPN_MUX`]; the protocol a stream carries is named by a tag
+//! written as that stream's first frame. Putting the discriminator in-band
+//! rather than in the ALPN is what lets one connection serve all of them — ALPN
+//! is negotiated once per TLS handshake, so an ALPN-per-protocol design costs a
+//! connection, a congestion controller, and a hole-punch per protocol.
 
 use iroh::endpoint::{RecvStream, SendStream};
 
-/// ALPN for PushLog request-response.
-pub const ALPN_PUSHLOG: &[u8] = b"/defra-iroh/pushlog/0.1";
+/// The single ALPN every Defra protocol is multiplexed over.
+pub const ALPN_MUX: &[u8] = b"/defra-iroh/mux/0.1";
 
-/// ALPN for document sync request.
-pub const ALPN_DOCSYNC: &[u8] = b"/defra-iroh/docsync/0.1";
+/// Stream tag for PushLog request-response.
+pub const STREAM_PUSHLOG: &[u8] = b"/defra-iroh/pushlog/0.1";
 
-/// ALPN for document sync response (separate from request to avoid ambiguous decoding).
-pub const ALPN_DOCSYNC_RESP: &[u8] = b"/defra-iroh/docsync/0.1/resp";
+/// Stream tag for document sync request.
+pub const STREAM_DOCSYNC: &[u8] = b"/defra-iroh/docsync/0.1";
 
-/// ALPN for branchable sync request.
-pub const ALPN_BRANCHABLE: &[u8] = b"/defra-iroh/branchable/0.1";
+/// Stream tag for document sync response (separate from request to avoid ambiguous decoding).
+pub const STREAM_DOCSYNC_RESP: &[u8] = b"/defra-iroh/docsync/0.1/resp";
 
-/// ALPN for branchable sync response.
-pub const ALPN_BRANCHABLE_RESP: &[u8] = b"/defra-iroh/branchable/0.1/resp";
+/// Stream tag for branchable sync request.
+pub const STREAM_BRANCHABLE: &[u8] = b"/defra-iroh/branchable/0.1";
 
-/// ALPN for CAR block transfer request.
-pub const ALPN_CAR: &[u8] = b"/defra-iroh/car/0.1";
+/// Stream tag for branchable sync response.
+pub const STREAM_BRANCHABLE_RESP: &[u8] = b"/defra-iroh/branchable/0.1/resp";
 
-/// ALPN for CAR block transfer response.
-pub const ALPN_CAR_RESP: &[u8] = b"/defra-iroh/car/0.1/resp";
+/// Stream tag for CAR block transfer request.
+pub const STREAM_CAR: &[u8] = b"/defra-iroh/car/0.1";
 
-/// ALPN for audience-bound Defra peer identity resolution.
-pub const ALPN_IDENTITY: &[u8] = b"/defra-iroh/identity/0.1";
+/// Stream tag for CAR block transfer response.
+pub const STREAM_CAR_RESP: &[u8] = b"/defra-iroh/car/0.1/resp";
 
-/// ALPN for searchable encryption artifacts.
-pub const ALPN_SE: &[u8] = b"/defra-iroh/se/0.1";
+/// Stream tag for audience-bound Defra peer identity resolution.
+pub const STREAM_IDENTITY: &[u8] = b"/defra-iroh/identity/0.1";
 
-/// ALPN for searchable encryption artifact query requests.
-pub const ALPN_SE_QUERY_REQ: &[u8] = b"/defra-iroh/se-query/0.1/req";
+/// Stream tag for searchable encryption artifacts.
+pub const STREAM_SE: &[u8] = b"/defra-iroh/se/0.1";
 
-/// ALPN for searchable encryption artifact query responses.
-pub const ALPN_SE_QUERY_RESP: &[u8] = b"/defra-iroh/se-query/0.1/resp";
+/// Stream tag for searchable encryption artifact query requests.
+pub const STREAM_SE_QUERY_REQ: &[u8] = b"/defra-iroh/se-query/0.1/req";
 
-/// ALPN for management mutate requests.
-pub const ALPN_MANAGE_REQ: &[u8] = b"/defra-iroh/manage/0.1/req";
+/// Stream tag for searchable encryption artifact query responses.
+pub const STREAM_SE_QUERY_RESP: &[u8] = b"/defra-iroh/se-query/0.1/resp";
 
-/// ALPN for management mutate responses.
-pub const ALPN_MANAGE_RESP: &[u8] = b"/defra-iroh/manage/0.1/resp";
+/// Stream tag for management mutate requests.
+pub const STREAM_MANAGE_REQ: &[u8] = b"/defra-iroh/manage/0.1/req";
 
-/// ALPN for management query requests.
-pub const ALPN_MANAGE_QUERY_REQ: &[u8] = b"/defra-iroh/manage-query/0.1/req";
+/// Stream tag for management mutate responses.
+pub const STREAM_MANAGE_RESP: &[u8] = b"/defra-iroh/manage/0.1/resp";
 
-/// ALPN for management query responses.
-pub const ALPN_MANAGE_QUERY_RESP: &[u8] = b"/defra-iroh/manage-query/0.1/resp";
+/// Stream tag for management query requests.
+pub const STREAM_MANAGE_QUERY_REQ: &[u8] = b"/defra-iroh/manage-query/0.1/req";
 
-/// ALPN for two-stream push protocol.
-pub const ALPN_TWOSTREAM: &[u8] = b"/defra-iroh/twostream/0.1";
+/// Stream tag for management query responses.
+pub const STREAM_MANAGE_QUERY_RESP: &[u8] = b"/defra-iroh/manage-query/0.1/resp";
 
-/// ALPN for two-stream push replies.
-pub const ALPN_TWOSTREAM_RESP: &[u8] = b"/defra-iroh/twostream/0.1/resp";
+/// Stream tag for the two-stream push protocol.
+pub const STREAM_TWOSTREAM: &[u8] = b"/defra-iroh/twostream/0.1";
 
-/// All ALPNs this node should accept.
-pub const ALL_ALPNS: &[&[u8]] = &[
-    ALPN_PUSHLOG,
-    ALPN_DOCSYNC,
-    ALPN_DOCSYNC_RESP,
-    ALPN_BRANCHABLE,
-    ALPN_BRANCHABLE_RESP,
-    ALPN_CAR,
-    ALPN_CAR_RESP,
-    ALPN_IDENTITY,
-    ALPN_SE,
-    ALPN_SE_QUERY_REQ,
-    ALPN_SE_QUERY_RESP,
-    ALPN_TWOSTREAM,
-    ALPN_TWOSTREAM_RESP,
-    ALPN_MANAGE_REQ,
-    ALPN_MANAGE_RESP,
-    ALPN_MANAGE_QUERY_REQ,
-    ALPN_MANAGE_QUERY_RESP,
+/// Stream tag for two-stream push replies.
+pub const STREAM_TWOSTREAM_RESP: &[u8] = b"/defra-iroh/twostream/0.1/resp";
+
+/// Every stream tag this node dispatches, for the invariants asserted below.
+///
+/// Dispatch matches tags individually, so this list exists to prove the set is
+/// distinct, framable, and disjoint from the ALPN it travels on.
+#[cfg(test)]
+pub const ALL_STREAM_TAGS: &[&[u8]] = &[
+    STREAM_PUSHLOG,
+    STREAM_DOCSYNC,
+    STREAM_DOCSYNC_RESP,
+    STREAM_BRANCHABLE,
+    STREAM_BRANCHABLE_RESP,
+    STREAM_CAR,
+    STREAM_CAR_RESP,
+    STREAM_IDENTITY,
+    STREAM_SE,
+    STREAM_SE_QUERY_REQ,
+    STREAM_SE_QUERY_RESP,
+    STREAM_TWOSTREAM,
+    STREAM_TWOSTREAM_RESP,
+    STREAM_MANAGE_REQ,
+    STREAM_MANAGE_RESP,
+    STREAM_MANAGE_QUERY_REQ,
+    STREAM_MANAGE_QUERY_RESP,
 ];
+
+/// Upper bound on a stream tag, enforced on read so a peer cannot make us
+/// allocate on a length it never intends to fill.
+pub const MAX_STREAM_TAG_LEN: usize = 64;
 
 /// Maximum size for general messages (matches libp2p default).
 pub const MAX_MESSAGE_SIZE: usize = 16 * 1024 * 1024; // 16 MiB
@@ -82,6 +100,50 @@ pub const MAX_CAR_SIZE: usize = 64 * 1024 * 1024; // 64 MiB
 
 /// Maximum size for management messages.
 pub const MAX_MANAGE_MSG_SIZE: usize = 4 * 1024 * 1024; // 4 MiB
+
+/// Write the tag naming the protocol this stream carries.
+///
+/// Every stream opened on [`ALPN_MUX`] begins with this frame, before any
+/// protocol payload. The one-byte length distinguishes it from the four-byte
+/// message length prefix that follows.
+pub async fn write_stream_tag(send: &mut SendStream, tag: &[u8]) -> crate::error::Result<()> {
+    if tag.is_empty() || tag.len() > MAX_STREAM_TAG_LEN {
+        return Err(crate::error::Error::Codec(format!(
+            "stream tag of {} bytes does not fit a tag frame",
+            tag.len()
+        )));
+    }
+
+    send.write_all(&[tag.len() as u8])
+        .await
+        .map_err(|e| crate::error::Error::Codec(format!("failed to write tag length: {}", e)))?;
+    send.write_all(tag)
+        .await
+        .map_err(|e| crate::error::Error::Codec(format!("failed to write tag: {}", e)))?;
+    Ok(())
+}
+
+/// Read the tag a peer wrote as the first frame of a mux stream.
+pub async fn read_stream_tag(recv: &mut RecvStream) -> crate::error::Result<Vec<u8>> {
+    let mut len_buf = [0u8; 1];
+    recv.read_exact(&mut len_buf)
+        .await
+        .map_err(|e| crate::error::Error::Codec(format!("failed to read tag length: {}", e)))?;
+
+    let len = len_buf[0] as usize;
+    if len == 0 || len > MAX_STREAM_TAG_LEN {
+        return Err(crate::error::Error::Codec(format!(
+            "invalid stream tag length: {}",
+            len
+        )));
+    }
+
+    let mut tag = vec![0u8; len];
+    recv.read_exact(&mut tag)
+        .await
+        .map_err(|e| crate::error::Error::Codec(format!("failed to read tag: {}", e)))?;
+    Ok(tag)
+}
 
 /// Read a length-prefixed CBOR message from a QUIC recv stream.
 ///
@@ -144,14 +206,42 @@ mod tests {
     use super::*;
 
     #[test]
-    fn manage_alpns_registered() {
-        for a in [
-            ALPN_MANAGE_REQ,
-            ALPN_MANAGE_RESP,
-            ALPN_MANAGE_QUERY_REQ,
-            ALPN_MANAGE_QUERY_RESP,
+    fn manage_tags_registered() {
+        for tag in [
+            STREAM_MANAGE_REQ,
+            STREAM_MANAGE_RESP,
+            STREAM_MANAGE_QUERY_REQ,
+            STREAM_MANAGE_QUERY_RESP,
         ] {
-            assert!(ALL_ALPNS.contains(&a));
+            assert!(ALL_STREAM_TAGS.contains(&tag));
         }
+    }
+
+    #[test]
+    fn every_tag_fits_a_stream_tag_frame() {
+        for tag in ALL_STREAM_TAGS {
+            assert!(
+                !tag.is_empty() && tag.len() <= MAX_STREAM_TAG_LEN,
+                "tag {:?} does not fit a stream tag frame",
+                String::from_utf8_lossy(tag)
+            );
+        }
+    }
+
+    #[test]
+    fn tags_are_distinct() {
+        let mut seen = std::collections::HashSet::new();
+        for tag in ALL_STREAM_TAGS {
+            assert!(
+                seen.insert(*tag),
+                "duplicate stream tag {:?}",
+                String::from_utf8_lossy(tag)
+            );
+        }
+    }
+
+    #[test]
+    fn no_tag_collides_with_the_mux_alpn() {
+        assert!(!ALL_STREAM_TAGS.contains(&ALPN_MUX));
     }
 }

--- a/crates/p2p/src/iroh/protocols.rs
+++ b/crates/p2p/src/iroh/protocols.rs
@@ -1,11 +1,7 @@
 //! The mux ALPN, its stream tags, and wire format helpers for iroh transport.
 //!
-//! Every Defra protocol shares one QUIC connection per peer. The connection is
-//! negotiated on [`ALPN_MUX`]; the protocol a stream carries is named by a tag
-//! written as that stream's first frame. Putting the discriminator in-band
-//! rather than in the ALPN is what lets one connection serve all of them — ALPN
-//! is negotiated once per TLS handshake, so an ALPN-per-protocol design costs a
-//! connection, a congestion controller, and a hole-punch per protocol.
+//! The discriminator is in-band — a tag in the stream's first frame — because
+//! ALPN is negotiated once per TLS handshake and so cannot vary per stream.
 
 use iroh::endpoint::{RecvStream, SendStream};
 
@@ -63,10 +59,8 @@ pub const STREAM_TWOSTREAM: &[u8] = b"/defra-iroh/twostream/0.1";
 /// Stream tag for two-stream push replies.
 pub const STREAM_TWOSTREAM_RESP: &[u8] = b"/defra-iroh/twostream/0.1/resp";
 
-/// Every stream tag this node dispatches, for the invariants asserted below.
-///
-/// Dispatch matches tags individually, so this list exists to prove the set is
-/// distinct, framable, and disjoint from the ALPN it travels on.
+/// Every stream tag this node dispatches. Dispatch matches tags individually;
+/// this list exists so the tests can assert the set is distinct and framable.
 #[cfg(test)]
 pub const ALL_STREAM_TAGS: &[&[u8]] = &[
     STREAM_PUSHLOG,
@@ -103,9 +97,8 @@ pub const MAX_MANAGE_MSG_SIZE: usize = 4 * 1024 * 1024; // 4 MiB
 
 /// Write the tag naming the protocol this stream carries.
 ///
-/// Every stream opened on [`ALPN_MUX`] begins with this frame, before any
-/// protocol payload. The one-byte length distinguishes it from the four-byte
-/// message length prefix that follows.
+/// The length is one byte to distinguish it from the four-byte message length
+/// prefix that follows.
 pub async fn write_stream_tag(send: &mut SendStream, tag: &[u8]) -> crate::error::Result<()> {
     if tag.is_empty() || tag.len() > MAX_STREAM_TAG_LEN {
         return Err(crate::error::Error::Codec(format!(


### PR DESCRIPTION
Every Defra protocol now shares one QUIC connection per peer.

This is a breaking protocol change!

I discovered whilst trying to make a light client we currently use ALPN for protocol discrimination. This forces a client to use a connection for each protocol. This is a mild perf concern in most contexts but a complete blocker on embedded platforms such as stm32h7 and esp32 where only a few MB of RAM is available.

The current pattern looks somewhat odd as one of the core purposes of QUIC (which Iroh is a layer on top of) is having multiple streams coexist in a single connection.

This also helps to clear ground for future work to make defra-wasm talk iroh directly.

---

The protocol discriminator lived in the QUIC ALPN, which is negotiated once per
TLS handshake and so is connection-scoped. Seventeen protocols therefore meant
up to seventeen connections to the same peer, each with its own congestion
controller, path MTU probe, hole-punch and keepalive timer. An embedded client
touching identity, replication, doc sync, branchable sync and CAR fetch paid
five of each.

## What changes

The discriminator moves in-band. One ALPN, `/defra-iroh/mux/0.1`, carries every
protocol; a stream names itself in its first frame with a length-prefixed tag,
and `dispatch_stream` routes on that tag instead of on `connection.alpn()`. The
tag is read inside the per-stream task rather than in the accept loop, so a peer
that opens a stream and stalls before writing one cannot hold up the other
protocols.

The outbound connection cache is keyed by `EndpointId` alone, and an explicit
dial adopts its connection into that cache rather than leaving the first send to
open a second one. Because one connection carries everything, eviction has to be
narrower: `evict_if_closed` drops a cached entry only once QUIC reports the
connection closed, so a stream timeout no longer tears down the transport
replication is still using. It compares `stable_id` before removing, so it
cannot evict a connection a concurrent dial has already replaced.

iroh-gossip keeps its own ALPN — it owns that handshake and takes whole
connections — so a gossiping node holds two connections to a peer.

## This is a breaking wire change

There is one implementation of this wire, so this is a clean break rather than a
migration: pre-mux peers cannot complete a handshake. Deployed iroh nodes need a
coordinated upgrade. Comments that described the old ALPN split as a
rolling-upgrade bridge are corrected accordingly.

## Tests

`mux_tests` covers the three properties that matter, against a bare iroh
endpoint standing in for a peer so the assertions are about what the transport
actually puts on the wire: six protocols share one connection, a repeated
protocol reuses it rather than redialling, and a stream-level failure does not
evict the connection the other protocols are using.

Locally green: `cargo fmt`, `cargo clippy -p p2p --features iroh-transport
--all-targets`, the 383 `p2p` unit tests, and both iroh gates CI runs —
`--test p2p_iroh connection::` (27 passed) and the two `peer::create` sync
ownership fences.

## Open for review

`read_stream_tag` has no deadline. A peer can open a bidirectional stream, never
write a tag, and pin the spawned task until the connection closes. QUIC's
concurrent-stream limit bounds it, so it is not unbounded, but it is new surface
and a timeout may be worth adding before this leaves draft.
