### PR TITLE
fix(sync): a browser cannot sync against a store it has already pulled from

### DIFF
--- a/crates/cli/src/browser_sync_adapter.rs
+++ b/crates/cli/src/browser_sync_adapter.rs
@@ -95,14 +95,14 @@ impl<S: Store + 'static> BrowserSyncAdapter<S> {
             .map_err(map_engine_error)?;
         let collection = self.collection(document.collection_id())?;
         // The delta before the permission, because what changes nothing is not
-        // an update. A peer that offers back a document it was given holds no
-        // block this node lacks, and refusing that costs the exchange it rode
-        // in on — the pull included. A payload that does carry a block is an
-        // update and is checked as one, so this narrows what needs permission
-        // without widening what may be written.
+        // an update. A peer that offers back a document it was given carries no
+        // block this node has not already merged, and refusing that costs the
+        // exchange it rode in on — the pull included. A payload that would
+        // still apply is an update and is checked as one, so this narrows what
+        // needs permission without widening what may be written.
         if !self
             .engine
-            .holds_every_block(&document)
+            .has_merged_every_block(&document)
             .await
             .map_err(map_engine_error)?
             && !self

--- a/crates/cli/src/browser_sync_adapter.rs
+++ b/crates/cli/src/browser_sync_adapter.rs
@@ -4,9 +4,9 @@ use std::sync::Arc;
 use acp::{DocumentPermission, Identity};
 use async_trait::async_trait;
 use defra_core::browser_sync::{
-    BrowserSyncDocument, BrowserSyncPull, BrowserSyncRequest, BrowserSyncResponse,
-    DEFAULT_SYNC_PAGE_SIZE, MAX_SYNC_BODY_BYTES, MAX_SYNC_ID_BYTES, MAX_SYNC_PAGE_SIZE,
-    MAX_SYNC_PAYLOAD_BYTES, MAX_SYNC_RELATIONSHIPS_PER_DOCUMENT,
+    BrowserSyncDocument, BrowserSyncPull, BrowserSyncRefusal, BrowserSyncRequest,
+    BrowserSyncResponse, DEFAULT_SYNC_PAGE_SIZE, MAX_SYNC_BODY_BYTES, MAX_SYNC_ID_BYTES,
+    MAX_SYNC_PAGE_SIZE, MAX_SYNC_PAYLOAD_BYTES, MAX_SYNC_RELATIONSHIPS_PER_DOCUMENT,
 };
 use defra_http::router::{BrowserSyncError, BrowserSyncOperations, BrowserSyncResult};
 use storage::corekv::Store;
@@ -94,15 +94,26 @@ impl<S: Store + 'static> BrowserSyncAdapter<S> {
             .validate_document(document)
             .map_err(map_engine_error)?;
         let collection = self.collection(document.collection_id())?;
+        // The delta before the permission, because what changes nothing is not
+        // an update. A peer that offers back a document it was given holds no
+        // block this node lacks, and refusing that costs the exchange it rode
+        // in on — the pull included. A payload that does carry a block is an
+        // update and is checked as one, so this narrows what needs permission
+        // without widening what may be written.
         if !self
-            .can_access(
-                identity,
-                DocumentPermission::Update,
-                &collection,
-                document.doc_id(),
-                bypass_dac,
-            )
-            .await?
+            .engine
+            .holds_every_block(&document)
+            .await
+            .map_err(map_engine_error)?
+            && !self
+                .can_access(
+                    identity,
+                    DocumentPermission::Update,
+                    &collection,
+                    document.doc_id(),
+                    bypass_dac,
+                )
+                .await?
         {
             return Err(BrowserSyncError::Forbidden(format!(
                 "update access denied for document {}",
@@ -489,6 +500,7 @@ impl<S: Store + 'static> BrowserSyncAdapter<S> {
         Ok(BrowserSyncResponse {
             documents,
             next_cursor: has_more.then_some(resume_cursor).flatten(),
+            refused: Vec::new(),
         })
     }
 }
@@ -524,24 +536,51 @@ impl<S: Store + 'static> BrowserSyncOperations for BrowserSyncAdapter<S> {
             .map(|document| (document.doc_id.clone(), document.roots.clone()))
             .collect();
 
+        // A refusal is scoped to its document; every other failure is a fact
+        // about the request and still fails all of it. That is what keeps the
+        // batch atomic where atomicity means something — an invalid or
+        // duplicated document is rejected before anything is written — while
+        // one document nobody may write no longer costs the other documents,
+        // the pull, and the session that was driving them.
+        let mut refused = Vec::new();
         let mut pending = Vec::with_capacity(request.documents.len());
         for document in &request.documents {
-            pending.push(
-                self.prepare_document(document, &identity, bypass_dac)
-                    .await?,
-            );
+            match self.prepare_document(document, &identity, bypass_dac).await {
+                Ok(prepared) => pending.push(prepared),
+                Err(BrowserSyncError::Forbidden(reason)) => {
+                    refused.push(refusal(&document.doc_id, reason))
+                }
+                Err(error) => return Err(error),
+            }
         }
         for document in pending {
-            self.apply_document(document, &identity).await?;
+            let doc_id = document.document.doc_id().to_string();
+            match self.apply_document(document, &identity).await {
+                Ok(()) => {}
+                Err(BrowserSyncError::Forbidden(reason)) => refused.push(refusal(&doc_id, reason)),
+                Err(error) => return Err(error),
+            }
         }
 
-        match request.pull {
+        let mut response = match request.pull {
             Some(pull) => {
                 self.pull_documents(pull, &identity, &known_roots, bypass_dac)
-                    .await
+                    .await?
             }
-            None => Ok(BrowserSyncResponse::default()),
-        }
+            None => BrowserSyncResponse::default(),
+        };
+        response.refused = refused;
+        Ok(response)
+    }
+}
+
+/// Report a refused document, and say so in the log as well: a refusal the
+/// caller decides to ignore must still be visible to whoever runs the node.
+fn refusal(doc_id: &str, reason: String) -> BrowserSyncRefusal {
+    tracing::warn!(%doc_id, %reason, "browser sync refused a pushed document");
+    BrowserSyncRefusal {
+        doc_id: doc_id.to_string(),
+        reason,
     }
 }
 

--- a/crates/cli/src/browser_sync_adapter_tests.rs
+++ b/crates/cli/src/browser_sync_adapter_tests.rs
@@ -5,6 +5,7 @@ use acp::{DocumentACP, LocalDocumentACP, MemoryAcpStore};
 use crypto::{Key as _, PrivateKey as _};
 use defra_core::browser_sync::{
     BrowserSyncDocument, BrowserSyncPull, BrowserSyncRelationship, BrowserSyncRequest,
+    BrowserSyncResponse,
 };
 use defra_core::signing::{set_signing_config, SigningConfig, SigningKeyType};
 use document::{DocID, Document, NormalValue};
@@ -63,6 +64,18 @@ async fn update_document(
         .update("Users", document, HashSet::from([field.to_string()]))
         .await
         .unwrap();
+}
+
+/// The one refusal a response carries for a document, which is where a push
+/// the node will not apply is reported now that it no longer fails the
+/// exchange it arrived in.
+fn refusal_for<'a>(response: &'a BrowserSyncResponse, doc_id: &str) -> &'a str {
+    let refusal = response
+        .refused
+        .iter()
+        .find(|refusal| refusal.doc_id == doc_id)
+        .unwrap_or_else(|| panic!("expected {doc_id} to be refused, got {response:?}"));
+    &refusal.reason
 }
 
 async fn read_document(database: &Arc<db::DB<RegolithStore>>, doc_id: &str) -> Document {
@@ -413,8 +426,91 @@ async fn duplicate_document_batch_is_rejected_before_merge() {
         .is_none());
 }
 
+/// A push that carries a block is an update, and an update to somebody else's
+/// document is refused however the caller dresses it up.
+///
+/// The change matters: an identical re-push carries no block and is not an
+/// update at all — `an_unchanged_push_is_not_an_update` is the other half, and
+/// the two together are the whole of what the delta check moved.
 #[tokio::test]
 async fn protected_document_rejects_updates_from_another_identity() {
+    let source = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
+    let target = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
+    source.create_collection(users_schema(true)).await.unwrap();
+    target.create_collection(users_schema(true)).await.unwrap();
+    let owner = install_signing_identity();
+    let document = create_document(&source, "Protected").await;
+    let doc_id = document.doc_id.clone();
+    set_signing_config(None);
+
+    let acp = Arc::new(LocalDocumentACP::new(Arc::new(MemoryAcpStore::new())));
+    let adapter = BrowserSyncAdapter::new_arc(target.clone(), acp, None);
+    adapter
+        .sync(
+            BrowserSyncRequest {
+                documents: vec![document.clone()],
+                pull: None,
+            },
+            Some(&owner),
+            false,
+        )
+        .await
+        .unwrap();
+
+    update_document(&source, &doc_id, "email", "protected@example.com").await;
+    let source_engine = db::merge::BrowserSyncEngine::new(source.clone());
+    let source_ref = source_engine.document_ref(&doc_id).await.unwrap().unwrap();
+    let changed = source_engine
+        .load_document(&source_ref)
+        .await
+        .unwrap()
+        .unwrap();
+
+    let other = "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH";
+    let response = adapter
+        .sync(
+            BrowserSyncRequest {
+                documents: vec![changed.clone()],
+                pull: None,
+            },
+            Some(other),
+            false,
+        )
+        .await
+        .unwrap();
+    assert!(refusal_for(&response, &doc_id).contains("update access denied"));
+    assert_eq!(
+        read_document(&target, &doc_id).await.get("email"),
+        None,
+        "a refused update must not reach the document"
+    );
+
+    adapter
+        .sync(
+            BrowserSyncRequest {
+                documents: vec![changed],
+                pull: None,
+            },
+            Some(other),
+            true,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        read_document(&target, &doc_id).await.get("email"),
+        Some(&NormalValue::String("protected@example.com".into()))
+    );
+}
+
+/// A payload whose blocks this node already holds changes nothing, so it is
+/// not an update and needs no permission to update.
+///
+/// This is the shape a synced browser used to arrive in: it pulled a document
+/// it does not own, and its next exchange offered the same document back. The
+/// 403 that answered cost the whole exchange, the pull inside it, and — once
+/// `recover_full_sync` met the same document again — the session.
+#[tokio::test]
+async fn an_unchanged_push_is_not_an_update() {
     let source = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
     let target = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
     source.create_collection(users_schema(true)).await.unwrap();
@@ -437,34 +533,106 @@ async fn protected_document_rejects_updates_from_another_identity() {
         .await
         .unwrap();
 
-    let other = "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH";
-    let error = adapter
-        .sync(
-            BrowserSyncRequest {
-                documents: vec![document.clone()],
-                pull: None,
-            },
-            Some(other),
-            false,
-        )
-        .await
-        .unwrap_err();
-    assert!(matches!(
-        error,
-        defra_http::router::BrowserSyncError::Forbidden(_)
-    ));
+    let stranger = "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH";
+    for caller in [Some(stranger), None] {
+        let response = adapter
+            .sync(
+                BrowserSyncRequest {
+                    documents: vec![document.clone()],
+                    pull: Some(BrowserSyncPull::default()),
+                },
+                caller,
+                false,
+            )
+            .await
+            .expect("an unchanged document is not an update");
+        assert!(
+            response.refused.is_empty(),
+            "nothing to refuse: {response:?}"
+        );
+    }
+}
 
+/// One document nobody may write is one document's problem. Before this, the
+/// refusal was the whole request's answer: the other documents never landed,
+/// the pull riding along never ran, and the browser driving it took the
+/// failure as a reason to start over and meet the same document again.
+#[tokio::test]
+async fn a_refused_document_does_not_cost_the_rest_of_the_exchange() {
+    let source = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
+    let target = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
+    source.create_collection(users_schema(true)).await.unwrap();
+    target.create_collection(users_schema(true)).await.unwrap();
+    let owner = install_signing_identity();
+    let protected = create_document(&source, "Protected").await;
+    let protected_id = protected.doc_id.clone();
+
+    let acp = Arc::new(LocalDocumentACP::new(Arc::new(MemoryAcpStore::new())));
+    let adapter = BrowserSyncAdapter::new_arc(target.clone(), acp, None);
     adapter
         .sync(
             BrowserSyncRequest {
-                documents: vec![document],
+                documents: vec![protected],
                 pull: None,
             },
-            Some(other),
-            true,
+            Some(&owner),
+            false,
         )
         .await
         .unwrap();
+    set_signing_config(None);
+
+    update_document(&source, &protected_id, "email", "protected@example.com").await;
+    let source_engine = db::merge::BrowserSyncEngine::new(source.clone());
+    let protected_ref = source_engine
+        .document_ref(&protected_id)
+        .await
+        .unwrap()
+        .unwrap();
+    let refused_document = source_engine
+        .load_document(&protected_ref)
+        .await
+        .unwrap()
+        .unwrap();
+    let mine = create_document(&source, "Mine").await;
+    let mine_id = mine.doc_id.clone();
+    // Held only by the node, so the pull has something of its own to answer
+    // with: the documents of the push are covered by the roots it carried.
+    let server_only_id = create_document(&target, "Server").await.doc_id;
+
+    let stranger = "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH";
+    let response = adapter
+        .sync(
+            BrowserSyncRequest {
+                documents: vec![refused_document, mine],
+                pull: Some(BrowserSyncPull::default()),
+            },
+            Some(stranger),
+            false,
+        )
+        .await
+        .expect("one refused document must not fail the exchange");
+
+    assert!(refusal_for(&response, &protected_id).contains("update access denied"));
+    assert_eq!(
+        read_document(&target, &protected_id).await.get("email"),
+        None,
+        "a refused update must not reach the document"
+    );
+    assert_eq!(
+        read_document(&target, &mine_id).await.get("name"),
+        Some(&NormalValue::String("Mine".into())),
+        "the documents that were not refused still land"
+    );
+    assert_eq!(
+        response
+            .documents
+            .iter()
+            .map(|document| document.doc_id.as_str())
+            .collect::<Vec<_>>(),
+        vec![server_only_id.as_str()],
+        "the pull still answers"
+    );
 }
 
 #[tokio::test]
@@ -1055,7 +1223,7 @@ async fn relationships_cannot_be_attached_to_a_foreign_signed_document() {
     let adapter = BrowserSyncAdapter::new_arc(target, acp.clone(), None);
 
     let bob = "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH";
-    let error = adapter
+    let response = adapter
         .sync(
             BrowserSyncRequest {
                 documents: vec![BrowserSyncDocument {
@@ -1071,10 +1239,10 @@ async fn relationships_cannot_be_attached_to_a_foreign_signed_document() {
             false,
         )
         .await
-        .expect_err("a caller who is not the owner must not be able to grant");
+        .unwrap();
     assert!(
-        matches!(error, defra_http::router::BrowserSyncError::Forbidden(_)),
-        "expected a forbidden grant, got {error:?}"
+        refusal_for(&response, &doc_id).contains("cannot grant 'reader'"),
+        "a caller who is not the owner must not be able to grant"
     );
     // The refused grant takes the registration this request made with it: the
     // merge never ran, so ACP holds nothing for a document the node does not
@@ -1149,7 +1317,8 @@ async fn relationships_require_an_authenticated_caller() {
     let acp = Arc::new(LocalDocumentACP::new(Arc::new(MemoryAcpStore::new())));
     let adapter = BrowserSyncAdapter::new_arc(target, acp, None);
 
-    let error = adapter
+    let doc_id = document.doc_id.clone();
+    let response = adapter
         .sync(
             BrowserSyncRequest {
                 documents: vec![BrowserSyncDocument {
@@ -1165,11 +1334,11 @@ async fn relationships_require_an_authenticated_caller() {
             false,
         )
         .await
-        .expect_err("an anonymous caller has no DID to grant as");
-    assert!(matches!(
-        error,
-        defra_http::router::BrowserSyncError::Forbidden(_)
-    ));
+        .unwrap();
+    assert!(
+        refusal_for(&response, &doc_id).contains("require an authenticated caller"),
+        "an anonymous caller has no DID to grant as"
+    );
 }
 
 #[tokio::test]

--- a/crates/db/src/merge/browser_sync.rs
+++ b/crates/db/src/merge/browser_sync.rs
@@ -221,6 +221,29 @@ impl<S: Store + 'static> BrowserSyncEngine<S> {
         Ok(None)
     }
 
+    /// Whether every block in a validated payload is already held here, in
+    /// which case merging it cannot change anything.
+    ///
+    /// The blocks are content-addressed, so holding the CID is holding the
+    /// block: a payload this answers `true` for has nothing in it this node
+    /// has not already seen.
+    pub async fn holds_every_block(
+        &self,
+        document: &ValidatedBrowserSyncDocument,
+    ) -> Result<bool, BrowserSyncError> {
+        for (cid, _) in &document.blocks {
+            if !self
+                .blockstore
+                .has(cid)
+                .await
+                .map_err(|error| BrowserSyncError::Storage(error.to_string()))?
+            {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+
     pub async fn load_document(
         &self,
         document_ref: &BrowserSyncDocumentRef,

--- a/crates/db/src/merge/browser_sync.rs
+++ b/crates/db/src/merge/browser_sync.rs
@@ -6,7 +6,8 @@ use blockstore::{Blockstore, DefraBlockstore};
 use cid::Cid;
 use defra_core::browser_sync::{BrowserSyncBlock, BrowserSyncDocument, MAX_SYNC_PAYLOAD_BYTES};
 use defra_core::merge::{BlockMetadata, MergeHandler, MergeOutcome};
-use storage::corekv::{IterOptions, Store};
+use storage::corekv::{IterOptions, Key as _, Store};
+use storage::keys::BrowserSyncHeadKey;
 
 use crate::event::emission::{TxnBroadcastEvent, TxnBroadcaster};
 use crate::merge::merge_handler::DbMergeHandler;
@@ -219,6 +220,123 @@ impl<S: Store + 'static> BrowserSyncEngine<S> {
         }
 
         Ok(None)
+    }
+
+    /// The document's current composite heads, without loading its DAG.
+    ///
+    /// This is what a push would offer, and it is read on its own so that
+    /// deciding not to push costs a headstore lookup rather than the whole
+    /// history.
+    pub async fn document_roots(
+        &self,
+        document_ref: &BrowserSyncDocumentRef,
+    ) -> Result<Vec<String>, BrowserSyncError> {
+        let txn = self
+            .db
+            .new_txn(true)
+            .await
+            .map_err(|error| BrowserSyncError::Storage(error.to_string()))?;
+        head_roots(&txn, document_ref).await
+    }
+
+    /// Whether `peer` still needs what this node holds for the document.
+    ///
+    /// A push can only ever deliver a block the peer has not got. When the
+    /// peer's last recorded heads are this node's current heads, there is no
+    /// such block, and offering the document anyway is somebody else's
+    /// document coming back unchanged — which the receiver has every right to
+    /// refuse, and which used to end the exchange it rode in on.
+    ///
+    /// Absent a record the answer is yes: a node that has never exchanged this
+    /// document with the peer must assume the peer lacks it.
+    ///
+    /// One transaction, because a full sync asks this of every document it
+    /// holds before it loads any of them.
+    pub async fn peer_needs_document(
+        &self,
+        peer: &str,
+        document_ref: &BrowserSyncDocumentRef,
+    ) -> Result<bool, BrowserSyncError> {
+        let txn = self
+            .db
+            .new_txn(true)
+            .await
+            .map_err(|error| BrowserSyncError::Storage(error.to_string()))?;
+        let recorded = read_peer_roots(
+            &txn.peerstore()
+                .map_err(|error| BrowserSyncError::Storage(error.to_string()))?,
+            peer,
+            &document_ref.doc_id,
+        )
+        .await?;
+        let Some(recorded) = recorded else {
+            return Ok(true);
+        };
+        Ok(recorded != head_roots(&txn, document_ref).await?)
+    }
+
+    /// The heads `peer` was last known to hold for a document.
+    pub async fn peer_roots(
+        &self,
+        peer: &str,
+        doc_id: &str,
+    ) -> Result<Option<Vec<String>>, BrowserSyncError> {
+        let txn = self
+            .db
+            .new_txn(true)
+            .await
+            .map_err(|error| BrowserSyncError::Storage(error.to_string()))?;
+        read_peer_roots(
+            &txn.peerstore()
+                .map_err(|error| BrowserSyncError::Storage(error.to_string()))?,
+            peer,
+            doc_id,
+        )
+        .await
+    }
+
+    /// Record the heads `peer` holds: the roots it handed over, or the roots
+    /// it accepted.
+    ///
+    /// Durable, because the question it answers outlives a session. A second
+    /// `sync()`, a reconnect and a reopened store all start by asking what the
+    /// peer needs, and a record that died with the session would answer
+    /// "everything" every time.
+    ///
+    /// A whole exchange in one transaction: a pull page carries up to
+    /// sixty-four documents and an initial pull is every document there is.
+    pub async fn record_peer_roots(
+        &self,
+        peer: &str,
+        documents: &[(String, Vec<String>)],
+    ) -> Result<(), BrowserSyncError> {
+        if documents.is_empty() {
+            return Ok(());
+        }
+        let txn = self
+            .db
+            .new_txn(false)
+            .await
+            .map_err(|error| BrowserSyncError::Storage(error.to_string()))?;
+        {
+            // The view borrows the transaction, and a transaction with a
+            // reference outstanding will not commit.
+            let peerstore = txn
+                .peerstore()
+                .map_err(|error| BrowserSyncError::Storage(error.to_string()))?;
+            for (doc_id, roots) in documents {
+                peerstore
+                    .set(
+                        &BrowserSyncHeadKey::new(peer, doc_id).bytes(),
+                        sorted_roots(roots.iter().cloned()).join("\n").as_bytes(),
+                    )
+                    .await
+                    .map_err(|error| BrowserSyncError::Storage(error.to_string()))?;
+            }
+        }
+        txn.commit()
+            .await
+            .map_err(|error| BrowserSyncError::Storage(error.to_string()))
     }
 
     /// Whether every block in a validated payload is already held here, in
@@ -463,4 +581,56 @@ impl<S: Store + 'static> BrowserSyncEngine<S> {
             document.to_map().ok()?.into_iter().collect(),
         ))
     }
+}
+
+/// A document's composite heads, in the canonical order.
+async fn head_roots<S: Store + 'static>(
+    txn: &crate::txn::DbTxn<S>,
+    document_ref: &BrowserSyncDocumentRef,
+) -> Result<Vec<String>, BrowserSyncError> {
+    let headstore = txn
+        .headstore()
+        .map_err(|error| BrowserSyncError::Storage(error.to_string()))?;
+    let blockstore = txn
+        .blockstore()
+        .map_err(|error| BrowserSyncError::Storage(error.to_string()))?;
+    Ok(sorted_roots(
+        load_latest_composite_head_cids(&headstore, &blockstore, document_ref.doc_short_id)
+            .await
+            .into_iter()
+            .map(|cid| cid.to_string()),
+    ))
+}
+
+/// What a peer was last recorded as holding, or `None` where nothing was.
+async fn read_peer_roots(
+    peerstore: &datastore::NamespaceView,
+    peer: &str,
+    doc_id: &str,
+) -> Result<Option<Vec<String>>, BrowserSyncError> {
+    let Some(stored) = peerstore
+        .get(&BrowserSyncHeadKey::new(peer, doc_id).bytes())
+        .await
+        .map_err(|error| BrowserSyncError::Storage(error.to_string()))?
+    else {
+        return Ok(None);
+    };
+    let stored = std::str::from_utf8(&stored)
+        .map_err(|error| BrowserSyncError::Storage(error.to_string()))?;
+    // A document with no heads is not one a push can carry, so the empty
+    // record is the empty set rather than a set holding an empty root.
+    Ok(Some(if stored.is_empty() {
+        Vec::new()
+    } else {
+        stored.split('\n').map(ToString::to_string).collect()
+    }))
+}
+
+/// Root CIDs in a canonical order, so that two head sets compare equal exactly
+/// when they hold the same roots.
+fn sorted_roots(roots: impl IntoIterator<Item = String>) -> Vec<String> {
+    let mut roots: Vec<String> = roots.into_iter().collect();
+    roots.sort();
+    roots.dedup();
+    roots
 }

--- a/crates/db/src/merge/browser_sync.rs
+++ b/crates/db/src/merge/browser_sync.rs
@@ -339,20 +339,24 @@ impl<S: Store + 'static> BrowserSyncEngine<S> {
             .map_err(|error| BrowserSyncError::Storage(error.to_string()))
     }
 
-    /// Whether every block in a validated payload is already held here, in
-    /// which case merging it cannot change anything.
+    /// Whether every block in a validated payload has already been merged
+    /// here, in which case merging it again cannot change anything.
     ///
-    /// The blocks are content-addressed, so holding the CID is holding the
-    /// block: a payload this answers `true` for has nothing in it this node
-    /// has not already seen.
-    pub async fn holds_every_block(
+    /// Merged, not merely held: the two come apart, and only the first is a
+    /// promise that the payload is inert. `apply_validated_document` stores
+    /// blocks before it merges them, so a merge that fails leaves them held
+    /// and unapplied, and the P2P stack holds the blocks of a pending or
+    /// quarantined DAG it has fetched but not merged. A payload of those
+    /// blocks would still change the document, so answering on presence alone
+    /// would let a caller who may not update it force the merge.
+    pub async fn has_merged_every_block(
         &self,
         document: &ValidatedBrowserSyncDocument,
     ) -> Result<bool, BrowserSyncError> {
         for (cid, _) in &document.blocks {
             if !self
                 .blockstore
-                .has(cid)
+                .is_merged(cid)
                 .await
                 .map_err(|error| BrowserSyncError::Storage(error.to_string()))?
             {
@@ -455,6 +459,7 @@ impl<S: Store + 'static> BrowserSyncEngine<S> {
             .await
             .map_err(|error| BrowserSyncError::Storage(error.to_string()))?;
 
+        let mut merged = false;
         for root in &document.roots {
             let data = document
                 .blocks
@@ -477,12 +482,23 @@ impl<S: Store + 'static> BrowserSyncEngine<S> {
                 .await
                 .map_err(|error| BrowserSyncError::Merge(error.to_string()))?
             {
-                MergeOutcome::Merged | MergeOutcome::Skipped { terminal: true, .. } => {}
+                MergeOutcome::Merged => merged = true,
+                MergeOutcome::Skipped { terminal: true, .. } => {}
                 MergeOutcome::Skipped { reason, .. } | MergeOutcome::Rejected { reason } => {
                     return Err(BrowserSyncError::Merge(reason));
                 }
                 _ => return Err(BrowserSyncError::Merge("unsupported merge outcome".into())),
             }
+        }
+
+        // A push that merged nothing has nothing to mark and nothing to tell
+        // the network. Validation rejects a payload holding a block its roots
+        // do not reach, so roots that were every one of them already merged
+        // means every block here was. Announcing anyway puts blocks the
+        // network already has back on the wire once per document, which is
+        // the whole store of a browser that has not been updated.
+        if !merged {
+            return Ok(());
         }
 
         let cids: Vec<_> = document.blocks.iter().map(|(cid, _)| *cid).collect();

--- a/crates/db/tests/merge/browser_sync_tests.rs
+++ b/crates/db/tests/merge/browser_sync_tests.rs
@@ -270,9 +270,9 @@ async fn what_the_peer_holds_outlives_the_engine_that_recorded_it() {
 }
 
 /// What decides whether a pushed payload is an update at all: a payload whose
-/// blocks are already held cannot change anything, whoever sent it.
+/// blocks this node has already merged cannot change anything, whoever sent it.
 #[tokio::test]
-async fn a_payload_of_blocks_already_held_carries_nothing() {
+async fn a_payload_of_blocks_already_merged_carries_nothing() {
     let source = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
     let target = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
     source.create_collection(users_schema()).await.unwrap();
@@ -296,14 +296,14 @@ async fn a_payload_of_blocks_already_held_carries_nothing() {
     let target_sync = BrowserSyncEngine::new(target);
     assert!(
         !target_sync
-            .holds_every_block(&target_sync.validate_document(&first).unwrap())
+            .has_merged_every_block(&target_sync.validate_document(&first).unwrap())
             .await
             .unwrap(),
         "a document this node has never seen is all new"
     );
     target_sync.apply_document(&first, "browser").await.unwrap();
     assert!(target_sync
-        .holds_every_block(&target_sync.validate_document(&first).unwrap())
+        .has_merged_every_block(&target_sync.validate_document(&first).unwrap())
         .await
         .unwrap());
 
@@ -325,7 +325,7 @@ async fn a_payload_of_blocks_already_held_carries_nothing() {
         .unwrap();
     assert!(
         !target_sync
-            .holds_every_block(&target_sync.validate_document(&second).unwrap())
+            .has_merged_every_block(&target_sync.validate_document(&second).unwrap())
             .await
             .unwrap(),
         "the update block is one this node does not hold"
@@ -684,5 +684,110 @@ async fn an_unsigned_fragment_is_announced_without_a_creator_claim() {
     assert_eq!(
         events[0].creator_did, None,
         "with no signature there is no owner to claim on the receiving node"
+    );
+}
+
+/// Held is not merged, and only merged makes a payload inert.
+///
+/// `apply_validated_document` stores a payload's blocks before it merges them,
+/// so a merge that fails leaves them held and unapplied — as does a pending or
+/// quarantined DAG the P2P stack has fetched but not merged. Answering on
+/// presence alone would call such a payload an update that changes nothing, and
+/// wave it past the permission check that stands in front of the merge.
+#[tokio::test]
+async fn blocks_held_without_being_merged_are_not_already_applied() {
+    use blockstore::Blockstore as _;
+
+    let source = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
+    let target = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
+    source.create_collection(users_schema()).await.unwrap();
+    target.create_collection(users_schema()).await.unwrap();
+    let (wire_document, _) = pushable_document(source, false).await;
+
+    // What a failed merge or a pending DAG leaves behind: the blocks, stored
+    // and unapplied. The `true` is the merge tracking every server-side
+    // blockstore is built with.
+    let held = blockstore::DefraBlockstore::new(target.store().clone(), true);
+    let decoded: Vec<(Cid, Vec<u8>)> = wire_document
+        .blocks
+        .iter()
+        .map(|block| {
+            (
+                Cid::try_from(block.cid.as_str()).unwrap(),
+                hex::decode(&block.data).unwrap(),
+            )
+        })
+        .collect();
+    held.put_many(
+        &decoded
+            .iter()
+            .map(|(cid, data)| (cid, data.as_slice()))
+            .collect::<Vec<_>>(),
+    )
+    .await
+    .unwrap();
+
+    let target_sync = BrowserSyncEngine::new(target);
+    assert!(
+        !target_sync
+            .has_merged_every_block(&target_sync.validate_document(&wire_document).unwrap())
+            .await
+            .unwrap(),
+        "the blocks are here and nothing has applied them, so this payload would still change the document"
+    );
+
+    target_sync
+        .apply_document(&wire_document, "browser")
+        .await
+        .unwrap();
+    assert!(
+        target_sync
+            .has_merged_every_block(&target_sync.validate_document(&wire_document).unwrap())
+            .await
+            .unwrap(),
+        "merged now, so the same payload would change nothing"
+    );
+}
+
+/// A push that merges nothing announces nothing.
+///
+/// A browser that has not been updated offers its whole store back, and every
+/// document of it reaches the merge only to be terminally skipped. Announcing
+/// those would put blocks the network already holds back on the wire once per
+/// document, at every boot, for every such browser — which is exactly the
+/// traffic a node fixed on its own has to absorb.
+#[tokio::test]
+async fn a_push_that_merges_nothing_is_not_announced() {
+    let source = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
+    let target = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
+    source.create_collection(users_schema()).await.unwrap();
+    target.create_collection(users_schema()).await.unwrap();
+    let (wire_document, _) = pushable_document(source, true).await;
+
+    let events = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let broadcaster: Arc<dyn db::event::emission::TxnBroadcaster> =
+        Arc::new(CapturingBroadcaster {
+            events: events.clone(),
+        });
+    let target_sync = BrowserSyncEngine::with_broadcaster(target, broadcaster);
+
+    target_sync
+        .apply_document(&wire_document, "the-pusher")
+        .await
+        .unwrap();
+    assert_eq!(
+        events.lock().unwrap().len(),
+        1,
+        "the merge that landed is announced"
+    );
+
+    target_sync
+        .apply_document(&wire_document, "the-pusher")
+        .await
+        .unwrap();
+    assert_eq!(
+        events.lock().unwrap().len(),
+        1,
+        "the same document again merged nothing, so there is nothing to tell peers"
     );
 }

--- a/crates/db/tests/merge/browser_sync_tests.rs
+++ b/crates/db/tests/merge/browser_sync_tests.rs
@@ -155,6 +155,69 @@ async fn document_round_trip_uses_crdt_blocks() {
     );
 }
 
+/// What decides whether a pushed payload is an update at all: a payload whose
+/// blocks are already held cannot change anything, whoever sent it.
+#[tokio::test]
+async fn a_payload_of_blocks_already_held_carries_nothing() {
+    let source = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
+    let target = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
+    source.create_collection(users_schema()).await.unwrap();
+    target.create_collection(users_schema()).await.unwrap();
+
+    let mut document = Document::new();
+    document.set("name", "Alice");
+    let created = db::AutoCommitMutator::new(source.clone())
+        .create("Users", document)
+        .await
+        .unwrap();
+    let doc_id = created.doc_id.to_string();
+    let source_sync = BrowserSyncEngine::new(source.clone());
+    let source_ref = source_sync.document_ref(&doc_id).await.unwrap().unwrap();
+    let first = source_sync
+        .load_document(&source_ref)
+        .await
+        .unwrap()
+        .unwrap();
+
+    let target_sync = BrowserSyncEngine::new(target);
+    assert!(
+        !target_sync
+            .holds_every_block(&target_sync.validate_document(&first).unwrap())
+            .await
+            .unwrap(),
+        "a document this node has never seen is all new"
+    );
+    target_sync.apply_document(&first, "browser").await.unwrap();
+    assert!(target_sync
+        .holds_every_block(&target_sync.validate_document(&first).unwrap())
+        .await
+        .unwrap());
+
+    let mut update = Document::new();
+    update.set_id(DocID::from_string(&doc_id).unwrap());
+    update.set("name", "Alice again");
+    db::AutoCommitMutator::new(source)
+        .update(
+            "Users",
+            update,
+            std::collections::HashSet::from(["name".to_string()]),
+        )
+        .await
+        .unwrap();
+    let second = source_sync
+        .load_document(&source_ref)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(
+        !target_sync
+            .holds_every_block(&target_sync.validate_document(&second).unwrap())
+            .await
+            .unwrap(),
+        "the update block is one this node does not hold"
+    );
+}
+
 #[tokio::test]
 async fn rejects_forged_document_id_before_merge() {
     let source = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());

--- a/crates/db/tests/merge/browser_sync_tests.rs
+++ b/crates/db/tests/merge/browser_sync_tests.rs
@@ -155,6 +155,120 @@ async fn document_round_trip_uses_crdt_blocks() {
     );
 }
 
+/// A node that pulled a document and wrote down what its peer holds has
+/// nothing to offer that peer back.
+///
+/// This is the push half of the browser-sync failure: a synced browser
+/// answered every announcement by loading its own copy of the named document
+/// and putting it in the same exchange as the pull, whether or not it held a
+/// block the server lacked. For a document it did not author, that was
+/// somebody else's document going back where it came from, and the `403` that
+/// answered cost the exchange, the pull inside it, and — through
+/// `recover_full_sync`, which meets the same document again — the session.
+#[tokio::test]
+async fn a_document_the_peer_supplied_is_not_offered_back() {
+    let server = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
+    let browser = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
+    server.create_collection(users_schema()).await.unwrap();
+    browser.create_collection(users_schema()).await.unwrap();
+
+    let mut document = Document::new();
+    document.set("name", "Alice");
+    let created = db::AutoCommitMutator::new(server.clone())
+        .create("Users", document)
+        .await
+        .unwrap();
+    let doc_id = created.doc_id.to_string();
+
+    let server_sync = BrowserSyncEngine::new(server);
+    let server_ref = server_sync.document_ref(&doc_id).await.unwrap().unwrap();
+    let pulled = server_sync
+        .load_document(&server_ref)
+        .await
+        .unwrap()
+        .unwrap();
+
+    let browser_sync = BrowserSyncEngine::new(browser.clone());
+    let peer = "https://node.example";
+    browser_sync
+        .apply_document(&pulled, "server")
+        .await
+        .unwrap();
+    browser_sync
+        .record_peer_roots(peer, &[(doc_id.clone(), pulled.roots.clone())])
+        .await
+        .unwrap();
+
+    let browser_ref = browser_sync.document_ref(&doc_id).await.unwrap().unwrap();
+    assert!(
+        !browser_sync
+            .peer_needs_document(peer, &browser_ref)
+            .await
+            .unwrap(),
+        "the peer handed this over; it cannot need it back"
+    );
+    // The record is the peer's, not the document's: a node pointed at a second
+    // server still owes that server everything it holds.
+    assert!(browser_sync
+        .peer_needs_document("https://other.example", &browser_ref)
+        .await
+        .unwrap());
+
+    // A write here is a block the peer has not got, and the offer comes back.
+    let mut update = Document::new();
+    update.set_id(DocID::from_string(&doc_id).unwrap());
+    update.set("name", "Alice in the browser");
+    db::AutoCommitMutator::new(browser)
+        .update(
+            "Users",
+            update,
+            std::collections::HashSet::from(["name".to_string()]),
+        )
+        .await
+        .unwrap();
+    assert!(
+        browser_sync
+            .peer_needs_document(peer, &browser_ref)
+            .await
+            .unwrap(),
+        "a local write is exactly what a push is for"
+    );
+}
+
+/// The record survives the engine that wrote it, because the question it
+/// answers outlives a session: a second `sync()` on the same store used to
+/// start by offering the server everything it had just been given.
+#[tokio::test]
+async fn what_the_peer_holds_outlives_the_engine_that_recorded_it() {
+    let database = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
+    database.create_collection(users_schema()).await.unwrap();
+    let mut document = Document::new();
+    document.set("name", "Alice");
+    let created = db::AutoCommitMutator::new(database.clone())
+        .create("Users", document)
+        .await
+        .unwrap();
+    let doc_id = created.doc_id.to_string();
+
+    let session = BrowserSyncEngine::new(database.clone());
+    let document_ref = session.document_ref(&doc_id).await.unwrap().unwrap();
+    let roots = session.document_roots(&document_ref).await.unwrap();
+    assert!(session
+        .peer_needs_document("https://node.example", &document_ref)
+        .await
+        .unwrap());
+    session
+        .record_peer_roots("https://node.example", &[(doc_id, roots)])
+        .await
+        .unwrap();
+
+    let next_session = BrowserSyncEngine::new(database);
+    assert!(!next_session
+        .peer_needs_document("https://node.example", &document_ref)
+        .await
+        .unwrap());
+}
+
 /// What decides whether a pushed payload is an update at all: a payload whose
 /// blocks are already held cannot change anything, whoever sent it.
 #[tokio::test]

--- a/crates/defra-core/src/browser_sync.rs
+++ b/crates/defra-core/src/browser_sync.rs
@@ -65,12 +65,29 @@ pub struct BrowserSyncRequest {
     pub pull: Option<BrowserSyncPull>,
 }
 
+/// One document of a push that was not applied, and why.
+///
+/// A refusal is a fact about a document, not about the exchange it arrived in:
+/// the rest of the push still applies and the pull still answers. Reporting it
+/// rather than failing the request is what keeps a session alive through a
+/// document it may not write — and naming it is what keeps that from being a
+/// silent drop.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BrowserSyncRefusal {
+    pub doc_id: String,
+    pub reason: String,
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BrowserSyncResponse {
     #[serde(default)]
     pub documents: Vec<BrowserSyncDocument>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub next_cursor: Option<String>,
+    /// Documents of the request's push that were refused. Absent on the wire
+    /// means none, so a client built before this existed reads unchanged.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub refused: Vec<BrowserSyncRefusal>,
 }
 
 #[cfg(test)]
@@ -85,6 +102,17 @@ mod tests {
         let document: BrowserSyncDocument = serde_json::from_str(legacy).unwrap();
         assert!(document.relationships.is_empty());
         assert_eq!(serde_json::to_string(&document).unwrap(), legacy);
+    }
+
+    /// The response gained `refused` after clients existed. An old client must
+    /// still read a new server's answer, and a new client must still read an
+    /// old server's.
+    #[test]
+    fn a_response_without_refusals_round_trips_unchanged() {
+        let legacy = r#"{"documents":[]}"#;
+        let response: BrowserSyncResponse = serde_json::from_str(legacy).unwrap();
+        assert!(response.refused.is_empty());
+        assert_eq!(serde_json::to_string(&response).unwrap(), legacy);
     }
 
     #[test]

--- a/crates/http/src/handlers/browser_sync_tests.rs
+++ b/crates/http/src/handlers/browser_sync_tests.rs
@@ -35,6 +35,7 @@ impl BrowserSyncOperations for RecordingSync {
         Ok(BrowserSyncResponse {
             documents: request.documents,
             next_cursor: None,
+            refused: Vec::new(),
         })
     }
 }

--- a/crates/storage/src/keys/mod.rs
+++ b/crates/storage/src/keys/mod.rs
@@ -68,7 +68,8 @@ pub use headstore::{
     HeadstorePriorityKey,
 };
 pub use peerstore::{
-    PeerstoreSERetry, ReplicatorKey, ReplicatorRetryDocIDKey, ReplicatorRetryIDKey,
+    BrowserSyncHeadKey, PeerstoreSERetry, ReplicatorKey, ReplicatorRetryDocIDKey,
+    ReplicatorRetryIDKey,
 };
 pub use systemstore::{
     CollectionID, CollectionIDSequenceKey, CollectionKey, CollectionNameKey, CollectionVersionKey,

--- a/crates/storage/src/keys/peerstore.rs
+++ b/crates/storage/src/keys/peerstore.rs
@@ -256,6 +256,45 @@ impl Key for PeerstoreSERetry {
     }
 }
 
+/// BrowserSyncHeadKey: What a browser-sync peer is known to hold for a document
+///
+/// Structure: /bsync/head/[Peer]/[DocID]
+/// Example: /bsync/head/https://node.example/bae123456789abcdef0123456789abcdef012345
+///
+/// The value is the peer's composite head CIDs, sorted and newline-joined. A
+/// node writes it when the peer hands it a document and when the peer accepts
+/// one, which is what lets the next push offer only what the peer has not got.
+///
+/// `peer` is the sync endpoint the record is about, verbatim, so it may contain
+/// separators; the key is only ever addressed exactly, never scanned by prefix.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserSyncHeadKey {
+    /// The sync endpoint this record is about.
+    pub peer: String,
+    /// Document identifier.
+    pub doc_id: String,
+}
+
+impl BrowserSyncHeadKey {
+    /// Create a new BrowserSyncHeadKey
+    pub fn new(peer: impl Into<String>, doc_id: impl Into<String>) -> Self {
+        Self {
+            peer: peer.into(),
+            doc_id: doc_id.into(),
+        }
+    }
+}
+
+impl Key for BrowserSyncHeadKey {
+    fn bytes(&self) -> Vec<u8> {
+        format!("/bsync/head/{}/{}", self.peer, self.doc_id).into_bytes()
+    }
+
+    fn to_string(&self) -> String {
+        format!("/bsync/head/{}/{}", self.peer, self.doc_id)
+    }
+}
+
 #[cfg(test)]
 #[path = "peerstore_tests.rs"]
 mod tests;

--- a/crates/storage/src/keys/peerstore_tests.rs
+++ b/crates/storage/src/keys/peerstore_tests.rs
@@ -127,3 +127,16 @@ fn test_peerstore_se_retry() {
         format!("/se-retry/{}/{}/", peer_id, collection_id).as_bytes()
     );
 }
+
+#[test]
+fn test_browser_sync_head_key() {
+    let key = BrowserSyncHeadKey::new(
+        "https://node.example",
+        "bae123456789abcdef0123456789abcdef012345",
+    );
+    assert_eq!(
+        key.to_string(),
+        "/bsync/head/https://node.example/bae123456789abcdef0123456789abcdef012345"
+    );
+    assert_eq!(key.bytes(), key.to_string().as_bytes());
+}

--- a/crates/wasm/src/sync/http.rs
+++ b/crates/wasm/src/sync/http.rs
@@ -34,6 +34,12 @@ impl SyncHttpClient {
         })
     }
 
+    /// The endpoint this client syncs against, which is the peer that
+    /// document-head records are about.
+    pub(super) fn peer(&self) -> &str {
+        &self.base_url
+    }
+
     pub(super) async fn sync(&self, request: &BrowserSyncRequest) -> Result<BrowserSyncResponse> {
         let body = serde_json::to_string(request)?;
         let response = self

--- a/crates/wasm/src/sync/session.rs
+++ b/crates/wasm/src/sync/session.rs
@@ -59,9 +59,11 @@ pub(crate) async fn start(
     auth_token: Option<String>,
     grants: Grants,
 ) -> Result<SyncTask> {
+    let http = SyncHttpClient::new(server_url, auth_token)?;
     let session = Rc::new(SyncSession {
         engine: db::merge::BrowserSyncEngine::new(database),
-        http: SyncHttpClient::new(server_url, auth_token)?,
+        peer: http.peer().to_string(),
+        http,
         exchange_lock: Mutex::new(()),
         full_sync_lock: Mutex::new(()),
         grants,
@@ -100,6 +102,9 @@ pub(crate) async fn start(
 
 struct SyncSession {
     engine: db::merge::BrowserSyncEngine<RegolithStore>,
+    /// The server these head records are about, so a node pointed at a second
+    /// one still offers it everything.
+    peer: String,
     http: SyncHttpClient,
     exchange_lock: Mutex<()>,
     full_sync_lock: Mutex<()>,
@@ -132,6 +137,9 @@ impl SyncSession {
         let mut documents = Vec::new();
         let mut serialized_size = EMPTY_PUSH_REQUEST_BYTES;
         for document_ref in refs {
+            if !self.peer_needs_document(&document_ref).await? {
+                continue;
+            }
             let loaded = match self.engine.load_document(&document_ref).await {
                 Ok(loaded) => loaded,
                 // Cannot be represented as a sync payload — too large, or too
@@ -250,9 +258,10 @@ impl SyncSession {
         Ok(())
     }
 
-    /// The push payload for a document, or `None` when there is nothing local
-    /// to push: it is not held here, or it is too large to represent. Failing
-    /// instead would force a full sync on every update touching it.
+    /// The push payload for a document, or `None` when there is nothing to
+    /// push: it is not held here, the server already has what is held, or it
+    /// is too large to represent. Failing instead would force a full sync on
+    /// every update touching it.
     async fn load_push_document(&self, doc_id: &str) -> Result<Option<BrowserSyncDocument>> {
         let Some(document_ref) = self
             .engine
@@ -262,6 +271,9 @@ impl SyncSession {
         else {
             return Ok(None);
         };
+        if !self.peer_needs_document(&document_ref).await? {
+            return Ok(None);
+        }
         match self.engine.load_document(&document_ref).await {
             Ok(document) => Ok(document.map(|mut document| {
                 self.grants.attach(&mut document);
@@ -322,13 +334,52 @@ impl SyncSession {
                 refusal.doc_id, refusal.reason
             ));
         }
+        // What the server holds now, written down once for the whole
+        // exchange: what it took, and what it handed over.
+        let mut held = Vec::with_capacity(request.documents.len() + response.documents.len());
+        for document in &request.documents {
+            if response
+                .refused
+                .iter()
+                .any(|refusal| refusal.doc_id == document.doc_id)
+            {
+                continue;
+            }
+            held.push((document.doc_id.clone(), document.roots.clone()));
+        }
         for document in &response.documents {
             self.engine
                 .apply_document(document, "server")
                 .await
                 .map_err(engine_error)?;
+            held.push((document.doc_id.clone(), document.roots.clone()));
         }
+        self.record_peer_roots(&held).await;
         Ok(response)
+    }
+
+    /// Whether the server still lacks something this node holds for a
+    /// document. A push that is not the answer to that question is somebody
+    /// else's document going back where it came from.
+    async fn peer_needs_document(
+        &self,
+        document_ref: &db::merge::browser_sync::BrowserSyncDocumentRef,
+    ) -> Result<bool> {
+        self.engine
+            .peer_needs_document(&self.peer, document_ref)
+            .await
+            .map_err(engine_error)
+    }
+
+    /// Write down what the server now holds. A failure here costs a redundant
+    /// push later; failing the exchange over bookkeeping would cost the
+    /// session, which is the fault this record exists to prevent.
+    async fn record_peer_roots(&self, held: &[(String, Vec<String>)]) {
+        if let Err(error) = self.engine.record_peer_roots(&self.peer, held).await {
+            warn(&format!(
+                "browser sync could not record what the server holds: {error}"
+            ));
+        }
     }
 
     async fn run_local(self: Rc<Self>, mut subscription: events::Subscription) {
@@ -496,15 +547,22 @@ fn warn(message: &str) {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use defra_core::browser_sync::{
         BrowserSyncBlock, BrowserSyncDocument, BrowserSyncPull, BrowserSyncRequest,
         MAX_SYNC_BODY_BYTES, MAX_SYNC_DOCUMENTS_PER_REQUEST, MAX_SYNC_PAGE_SIZE,
         MAX_SYNC_PULL_DOC_IDS,
     };
+    use futures::lock::Mutex;
+    use query::mutator::DocMutator;
+    use storage::RegolithStore;
 
-    use wasm_bindgen_test::wasm_bindgen_test;
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
 
-    use super::{SyncBatch, EMPTY_PUSH_REQUEST_BYTES};
+    use super::{Grants, SyncBatch, SyncHttpClient, SyncSession, EMPTY_PUSH_REQUEST_BYTES};
+
+    wasm_bindgen_test_configure!(run_in_browser);
 
     fn document(doc_id: &str, data: &str) -> BrowserSyncDocument {
         BrowserSyncDocument {
@@ -648,5 +706,68 @@ mod tests {
         assert!(flushed.bytes <= MAX_SYNC_BODY_BYTES);
         assert_eq!(flushed.documents.len(), 3);
         assert_eq!(batch.documents.len(), 1);
+    }
+
+    const PEER: &str = "https://node.example";
+
+    fn session(database: Arc<db::DB<RegolithStore>>) -> SyncSession {
+        SyncSession {
+            engine: db::merge::BrowserSyncEngine::new(database),
+            peer: PEER.into(),
+            http: SyncHttpClient::new(PEER, None).unwrap(),
+            exchange_lock: Mutex::new(()),
+            full_sync_lock: Mutex::new(()),
+            grants: Grants::default(),
+        }
+    }
+
+    /// The push half of the browser-sync failure, at the seam that decides it.
+    ///
+    /// Answering an announcement used to mean loading this node's copy of the
+    /// named document and putting it in the same exchange as the pull, whether
+    /// or not this node held a block the server lacked. A document pulled from
+    /// the server and not written to since is exactly that case, and offering
+    /// it back is what a node that does not own it is refused for.
+    // As `DefraClient::new_impl`: the browser has no threads to send it across.
+    #[allow(clippy::arc_with_non_send_sync)]
+    #[wasm_bindgen_test]
+    async fn a_document_the_server_supplied_is_not_offered_back() {
+        let database = Arc::new(db::DB::new(RegolithStore::in_memory().unwrap()).unwrap());
+        database
+            .create_collection(schema::CollectionVersion::new(
+                "Users",
+                "users-version",
+                "users-collection",
+                vec![
+                    schema::FieldDescription::new("1", "_docID", schema::FieldKind::doc_id()),
+                    schema::FieldDescription::new("2", "name", schema::FieldKind::string()),
+                ],
+            ))
+            .await
+            .unwrap();
+        let mut document = document::Document::new();
+        document.set("name", "Alice");
+        let doc_id = db::AutoCommitMutator::new(database.clone())
+            .create("Users", document)
+            .await
+            .unwrap()
+            .doc_id
+            .to_string();
+
+        let session = session(database);
+        let pushed = session
+            .load_push_document(&doc_id)
+            .await
+            .unwrap()
+            .expect("a document the server has never seen is offered");
+
+        // What `exchange` writes down once the server has it.
+        session
+            .record_peer_roots(&[(doc_id.clone(), pushed.roots.clone())])
+            .await;
+        assert!(
+            session.load_push_document(&doc_id).await.unwrap().is_none(),
+            "the server holds this; there is nothing to offer"
+        );
     }
 }

--- a/crates/wasm/src/sync/session.rs
+++ b/crates/wasm/src/sync/session.rs
@@ -313,6 +313,15 @@ impl SyncSession {
     async fn exchange(&self, request: BrowserSyncRequest) -> Result<BrowserSyncResponse> {
         let _guard = self.exchange_lock.lock().await;
         let response = self.http.sync(&request).await?;
+        // A document the server would not take is one document's problem. It
+        // is said out loud rather than counted, because the alternative to a
+        // dead session must not be a quiet one.
+        for refusal in &response.refused {
+            warn(&format!(
+                "browser sync could not push document {}: {}",
+                refusal.doc_id, refusal.reason
+            ));
+        }
         for document in &response.documents {
             self.engine
                 .apply_document(document, "server")


### PR DESCRIPTION
## The bug

A browser syncing against a server sent documents **back** to the server that it had just downloaded from it. The server answered `403 update access denied`, and that one refusal killed the whole exchange — including the download riding along with it. The browser then retried the identical request forever and never recovered.

Above ~4,096 documents it failed on **every boot**: the initial download overflowed an internal event queue, and the dropped event forced a full resync, which sent everything back and hit the bug immediately.

## Why

Two independent causes, one on each side:

- **Browser** — its rule for what to send was "everything I hold that isn't too big". It never asked whether the server already had it.
- **Server** — it checked permission *before* checking whether the push carried anything new. Handing back an identical copy changes nothing, but was still treated as an attempted edit. So someone who could read a document but not edit it got refused for returning it unchanged.

## The fix

1. **The browser offers a document only when it holds a block the server lacks** — remembered per peer in the peerstore, so a reconnect doesn't re-offer what it was just given.
2. **The server asks "would this change anything?" before asking "may you change it?"**
3. **A refusal is scoped to its document** — reported and skipped, instead of failing the whole exchange.

Either 1 or 2 closes the bug on its own; a fixed server rescues browsers already in the wild.

## ⚠️ One behaviour change

A push the server will not apply now returns **`200` with the document named in a `refused` list**, where it previously returned `403` and discarded the exchange.

`refused` is omitted from the wire when empty, so old and new clients interoperate in both directions. **Permissions did not change** — nothing can be written now that could not be written before.

## Scope

Confined to browser sync. `/sync` is Rust-only and separate from the Go-compatible `/documents/sync`. Every non-test caller of the changed code is either the `/sync` adapter or the browser client. `crates/p2p/`, the CRDT merge handler, and `crates/blockstore/` are untouched.

## Testing

1937 unit tests, 74 browser tests, and the ACP integration suite are green. Ten tests added, each confirmed failing when its own fix is reverted in isolation.

Measured against one store of 5,256 documents, none written by the browser:

|  | unfixed server | fixed server |
|---|---|---|
| **shipped browser** | refused in 79 ms | completes in 15.9 s |
| **fixed browser** | completes | completes |

<details>
<summary><b>Implementation detail</b></summary>

**"Changes anything" means already merged, not merely held.** The delta check asks `is_merged`, not `has`. The two come apart: `apply_validated_document` stores a payload's blocks before merging them, so a failed merge leaves them held and unapplied, and the P2P stack holds the blocks of a pending or quarantined DAG for the same reason. Answering on presence alone would let a caller who may not update a document force the merge of blocks that are present but unapplied.

This stays a narrowing rather than a widening: a document written locally goes through `txn.blockstore()`, which writes no merge marker, so a node's own documents are merged by this measure; browser-sync applies mark their batch, and P2P marks on merge.

**A push that merges nothing is not announced.** Validation rejects a payload holding a block its roots do not reach, so roots that were all already merged means the whole payload was. Announcing anyway put those blocks back on the wire once per document — for a browser that has not been updated, that is its entire store, at every boot.

**Access control is unchanged.** `protected_document_rejects_updates_from_another_identity` now has the stranger push a document carrying a real new block — still refused, with an assertion the field never reached the document. Validation already binds a payload to its claimed document (exactly one genesis, `derive_doc_id(genesis) == doc_id`, per-block CID verification, genesis signature verification), so block substitution is not possible.

**Every `Forbidden` is demoted to a per-document refusal**, not only the no-op-push case — `relationships require an authenticated caller` and `cannot grant '<relation>'` included. `revert_acp` still undoes partial ACP work for those.

**Known and accepted.** The head record treats a `200` as "the peer now holds these roots", so a node restored from an older backup would not be re-offered documents it lost until they change; the records are written and never invalidated. Separately, skipping a push drops the document from the server's `known_roots`, so the pull answers with a DAG the browser already holds — a redundant push traded for a redundant pull. It does not loop, because merges publish no `Update` event. Both are interim costs of `/sync` lacking the have/want negotiation the P2P path has; follow-up tracked separately.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
