### PR TITLE
Add bounded coalesced document-state subscriptions

### DIFF
--- a/crates/db/src/merge/merge_handler/batch.rs
+++ b/crates/db/src/merge/merge_handler/batch.rs
@@ -268,9 +268,7 @@ impl<S: Store + 'static, B: blockstore::Blockstore + 'static> DbMergeHandler<S, 
         // Emit all collected events
         if let Some(bus) = self.db.event_bus() {
             let events = pending_events.into_inner().unwrap();
-            for event in events {
-                bus.publish(event.message);
-            }
+            bus.publish_batch(events.into_iter().map(|event| event.message).collect());
         }
 
         Ok(results)

--- a/crates/db/tests/merge/single_root_batch.rs
+++ b/crates/db/tests/merge/single_root_batch.rs
@@ -5,11 +5,12 @@ use blockstore::Blockstore;
 use defra_core::merge::{MergeBlock, MergeHandler, MergeOutcome};
 use defra_core::{Block, CompositeDeltaPayload, CrdtDelta, DAGLink, LwwDeltaPayload};
 use document::{Document, NormalValue};
+use events::{Bus, EventName};
 use storage::corekv::Store;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn single_root_history_uses_bounded_commits_not_one_per_revision() {
-    let (handler, blockstore, _bus) = make_handler_with_schema_and_bus().await;
+    let (handler, blockstore, bus) = make_handler_with_schema_and_bus().await;
     let collection = handler
         .db()
         .find_collection_by_id("col-users")
@@ -57,6 +58,14 @@ async fn single_root_history_uses_bounded_commits_not_one_per_revision() {
         composite_heads = vec![cid];
     }
     let (cid, data) = latest.unwrap();
+    let mut raw = bus.subscribe(&[EventName::Update]);
+    let mut changes = bus.subscribe_document_changes();
+    let observation = tokio::spawn(async move {
+        tokio::time::timeout(std::time::Duration::from_secs(5), changes.recv())
+            .await
+            .unwrap()
+            .unwrap()
+    });
     let stats = handler.db().store().transaction_stats_handle().unwrap();
     let before = stats.snapshot().commits;
     let results = handler
@@ -81,6 +90,23 @@ async fn single_root_history_uses_bounded_commits_not_one_per_revision() {
         commits, 2,
         "one document transaction plus one field-marker transaction"
     );
+    let batch = observation.await.unwrap();
+    assert_eq!(batch.changes.len(), 1);
+    assert_eq!(batch.changes[0].doc_id, doc_id.to_string());
+    assert_eq!(
+        batch.updates, 257,
+        "one state notification for the entire committed history"
+    );
+    assert!(!batch.resync_required);
+    let mut raw_count = 0;
+    while raw.try_recv().is_ok() {
+        raw_count += 1;
+    }
+    assert_eq!(
+        raw_count, 257,
+        "revision subscribers still receive every update"
+    );
+    assert_eq!(raw.dropped_count(), 0);
     let txn = handler.db().new_txn(true).await.unwrap();
     let stored = collection
         .get_by_doc_id(

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -470,6 +470,12 @@ impl EmbeddedNode {
         self.event_bus.subscribe(event_names)
     }
 
+    /// Subscribe to bounded current-state invalidations without retaining every
+    /// historical revision. Subscribe before the initial query to avoid gaps.
+    pub fn subscribe_document_changes(&self) -> events::DocumentChangeSubscription {
+        self.event_bus.subscribe_document_changes()
+    }
+
     /// Begin a manually finalized transaction. Dropping its handle does not
     /// roll it back; use [`Self::begin_transaction_guard`] for scope ownership.
     pub async fn begin_transaction(

--- a/crates/events/src/bus.rs
+++ b/crates/events/src/bus.rs
@@ -14,6 +14,14 @@ pub trait Bus: Send + Sync {
     /// whose event filter matches the message's event name.
     fn publish(&self, msg: Message);
 
+    /// Publish one committed batch. Raw subscribers retain every event; state
+    /// observers may receive one invalidation per affected document.
+    fn publish_batch(&self, messages: Vec<Message>) {
+        for message in messages {
+            self.publish(message);
+        }
+    }
+
     /// Subscribe to events matching the given event names.
     ///
     /// Returns a `Subscription` that can be used to receive events.

--- a/crates/events/src/bus.rs
+++ b/crates/events/src/bus.rs
@@ -22,6 +22,11 @@ pub trait Bus: Send + Sync {
     /// Use `EventName::WildCard` to receive all events.
     fn subscribe(&self, events: &[EventName]) -> Subscription;
 
+    /// Observe current document state with bounded, coalesced invalidations.
+    /// Revision-sensitive consumers must keep using `subscribe` instead.
+    #[cfg(feature = "channel")]
+    fn subscribe_document_changes(&self) -> crate::DocumentChangeSubscription;
+
     /// Unsubscribe by subscription ID.
     ///
     /// After unsubscribing, the subscription will no longer receive events

--- a/crates/events/src/channel_bus.rs
+++ b/crates/events/src/channel_bus.rs
@@ -127,6 +127,64 @@ impl Bus for ChannelBus {
             });
         }
 
+        self.publish_raw(msg);
+    }
+
+    fn publish_batch(&self, messages: Vec<Message>) {
+        if self.closed.load(Ordering::Acquire) {
+            return;
+        }
+        {
+            let mut observers = self.document_observers.write();
+            observers.retain(|_, observer| {
+                if observer.is_closed() {
+                    return false;
+                }
+                observer.publish_batch(messages.iter().filter_map(Message::as_update));
+                true
+            });
+        }
+        for message in messages {
+            self.publish_raw(message);
+        }
+    }
+
+    fn subscribe(&self, events: &[EventName]) -> Subscription {
+        self.subscribe_raw(events)
+    }
+
+    fn unsubscribe(&self, sub_id: u64) {
+        self.document_observers.write().remove(&sub_id);
+        self.subscribers.write().remove(&sub_id);
+    }
+
+    fn close(&self) {
+        if self.closed.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        self.subscribers.write().clear();
+        self.document_observers.write().clear();
+    }
+
+    fn is_closed(&self) -> bool {
+        self.closed.load(Ordering::Acquire)
+    }
+
+    fn subscribe_document_changes(&self) -> DocumentChangeSubscription {
+        let mut observers = self.document_observers.write();
+        if self.closed.load(Ordering::Acquire) {
+            return DocumentChangeSubscription::closed();
+        }
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let (publisher, subscription) =
+            DocumentChangeSubscription::new(id, self.config.event_buffer_size);
+        observers.insert(id, publisher);
+        subscription
+    }
+}
+
+impl ChannelBus {
+    fn publish_raw(&self, msg: Message) {
         // Collect dead subscriber IDs for lazy cleanup
         let mut dead_subs: Vec<u64> = Vec::new();
 
@@ -202,7 +260,7 @@ impl Bus for ChannelBus {
         }
     }
 
-    fn subscribe(&self, events: &[EventName]) -> Subscription {
+    fn subscribe_raw(&self, events: &[EventName]) -> Subscription {
         if self.closed.load(Ordering::Acquire) {
             // Return a subscription with a closed channel
             let (_tx, rx) = async_channel::bounded(1);
@@ -231,46 +289,5 @@ impl Bus for ChannelBus {
         );
 
         Subscription::with_dropped_counter(id, rx, dropped_count)
-    }
-
-    fn unsubscribe(&self, sub_id: u64) {
-        self.document_observers.write().remove(&sub_id);
-        if let Some(subscriber) = self.subscribers.write().remove(&sub_id) {
-            // Drop the sender to close the receiver
-            drop(subscriber);
-            tracing::debug!(sub_id = sub_id, "Unsubscribed");
-        }
-    }
-
-    fn close(&self) {
-        if self.closed.swap(true, Ordering::AcqRel) {
-            // Already closed
-            return;
-        }
-
-        // Clear all subscribers (this will close all channels)
-        let mut subscribers = self.subscribers.write();
-        let count = subscribers.len();
-        subscribers.clear();
-        self.document_observers.write().clear();
-
-        tracing::info!(subscribers_closed = count, "Event bus closed");
-    }
-
-    fn is_closed(&self) -> bool {
-        self.closed.load(Ordering::Acquire)
-    }
-
-    fn subscribe_document_changes(&self) -> DocumentChangeSubscription {
-        // Serialize registration with close, including the closed-state check.
-        let mut observers = self.document_observers.write();
-        if self.closed.load(Ordering::Acquire) {
-            return DocumentChangeSubscription::closed();
-        }
-        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
-        let (publisher, subscription) =
-            DocumentChangeSubscription::new(id, self.config.event_buffer_size);
-        observers.insert(id, publisher);
-        subscription
     }
 }

--- a/crates/events/src/channel_bus.rs
+++ b/crates/events/src/channel_bus.rs
@@ -7,15 +7,17 @@ use async_channel::{Sender, TrySendError};
 use parking_lot::RwLock;
 
 use crate::bus::Bus;
+use crate::document_changes::{ChangePublisher, DocumentChangeSubscription};
 use crate::event::{EventName, Message};
 use crate::subscription::Subscription;
 
 /// Configuration for the channel-based event bus.
 #[derive(Debug, Clone)]
 pub struct ChannelBusConfig {
-    /// Buffer size for subscriber event channels.
+    /// Buffer size for raw event channels, and the maximum number of distinct
+    /// pending documents for current-state observers.
     /// When the buffer is full, new messages are dropped with a warning.
-    /// Default: 100
+    /// Default: 4096
     pub event_buffer_size: usize,
     /// Whether to send a resync signal when messages are dropped due to buffer overflow.
     /// When enabled, a special "resync_needed" flag is tracked per subscriber.
@@ -66,6 +68,7 @@ pub struct ChannelBus {
     next_id: AtomicU64,
     /// Active subscribers indexed by ID.
     subscribers: RwLock<HashMap<u64, Subscriber>>,
+    document_observers: RwLock<HashMap<u64, ChangePublisher>>,
     /// Whether the bus is closed.
     closed: AtomicBool,
     /// Configuration for the bus.
@@ -83,6 +86,7 @@ impl ChannelBus {
         Self {
             next_id: AtomicU64::new(1),
             subscribers: RwLock::new(HashMap::new()),
+            document_observers: RwLock::new(HashMap::new()),
             closed: AtomicBool::new(false),
             config,
         }
@@ -90,7 +94,7 @@ impl ChannelBus {
 
     /// Get the number of active subscribers.
     pub fn subscriber_count(&self) -> usize {
-        self.subscribers.read().len()
+        self.subscribers.read().len() + self.document_observers.read().len()
     }
 
     /// Get the current configuration.
@@ -110,6 +114,17 @@ impl Bus for ChannelBus {
         if self.closed.load(Ordering::Acquire) {
             tracing::debug!(event = %msg.name, "Bus closed, dropping message");
             return;
+        }
+
+        if let Some(update) = msg.as_update() {
+            let mut observers = self.document_observers.write();
+            observers.retain(|_, observer| {
+                if observer.is_closed() {
+                    return false;
+                }
+                observer.publish(update);
+                true
+            });
         }
 
         // Collect dead subscriber IDs for lazy cleanup
@@ -219,6 +234,7 @@ impl Bus for ChannelBus {
     }
 
     fn unsubscribe(&self, sub_id: u64) {
+        self.document_observers.write().remove(&sub_id);
         if let Some(subscriber) = self.subscribers.write().remove(&sub_id) {
             // Drop the sender to close the receiver
             drop(subscriber);
@@ -236,11 +252,25 @@ impl Bus for ChannelBus {
         let mut subscribers = self.subscribers.write();
         let count = subscribers.len();
         subscribers.clear();
+        self.document_observers.write().clear();
 
         tracing::info!(subscribers_closed = count, "Event bus closed");
     }
 
     fn is_closed(&self) -> bool {
         self.closed.load(Ordering::Acquire)
+    }
+
+    fn subscribe_document_changes(&self) -> DocumentChangeSubscription {
+        // Serialize registration with close, including the closed-state check.
+        let mut observers = self.document_observers.write();
+        if self.closed.load(Ordering::Acquire) {
+            return DocumentChangeSubscription::closed();
+        }
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let (publisher, subscription) =
+            DocumentChangeSubscription::new(id, self.config.event_buffer_size);
+        observers.insert(id, publisher);
+        subscription
     }
 }

--- a/crates/events/src/channel_bus.rs
+++ b/crates/events/src/channel_bus.rs
@@ -156,6 +156,7 @@ impl Bus for ChannelBus {
     fn unsubscribe(&self, sub_id: u64) {
         self.document_observers.write().remove(&sub_id);
         self.subscribers.write().remove(&sub_id);
+        tracing::debug!(sub_id, "Unsubscribed");
     }
 
     fn close(&self) {
@@ -164,6 +165,7 @@ impl Bus for ChannelBus {
         }
         self.subscribers.write().clear();
         self.document_observers.write().clear();
+        tracing::info!("Event bus closed");
     }
 
     fn is_closed(&self) -> bool {
@@ -185,6 +187,9 @@ impl Bus for ChannelBus {
 
 impl ChannelBus {
     fn publish_raw(&self, msg: Message) {
+        if self.closed.load(Ordering::Acquire) {
+            return;
+        }
         // Collect dead subscriber IDs for lazy cleanup
         let mut dead_subs: Vec<u64> = Vec::new();
 
@@ -261,6 +266,7 @@ impl ChannelBus {
     }
 
     fn subscribe_raw(&self, events: &[EventName]) -> Subscription {
+        let mut subscribers = self.subscribers.write();
         if self.closed.load(Ordering::Acquire) {
             // Return a subscription with a closed channel
             let (_tx, rx) = async_channel::bounded(1);
@@ -279,7 +285,7 @@ impl ChannelBus {
             dropped_count: dropped_count.clone(),
         };
 
-        self.subscribers.write().insert(id, subscriber);
+        subscribers.insert(id, subscriber);
 
         tracing::debug!(
             sub_id = id,

--- a/crates/events/src/document_changes.rs
+++ b/crates/events/src/document_changes.rs
@@ -43,21 +43,31 @@ pub(crate) struct ChangePublisher {
 
 impl ChangePublisher {
     pub(crate) fn publish(&self, update: &Update) {
+        self.publish_batch(std::iter::once(update));
+    }
+
+    pub(crate) fn publish_batch<'a>(&self, updates: impl Iterator<Item = &'a Update>) {
         let mut pending = self.pending.lock();
-        pending.updates = pending.updates.saturating_add(1);
-        if !pending.resync_required {
-            let key = (update.collection_id.clone(), update.doc_id.clone());
-            if let Some(local) = pending.documents.get_mut(&key) {
-                *local |= !update.is_relay;
-            } else if pending.documents.len() < self.capacity {
-                pending.documents.insert(key, !update.is_relay);
-            } else {
-                pending.documents.clear();
-                pending.resync_required = true;
+        let mut changed = false;
+        for update in updates {
+            changed = true;
+            pending.updates = pending.updates.saturating_add(1);
+            if !pending.resync_required {
+                let key = (update.collection_id.clone(), update.doc_id.clone());
+                if let Some(local) = pending.documents.get_mut(&key) {
+                    *local |= !update.is_relay;
+                } else if pending.documents.len() < self.capacity {
+                    pending.documents.insert(key, !update.is_relay);
+                } else {
+                    pending.documents.clear();
+                    pending.resync_required = true;
+                }
             }
         }
         // One pending wake is sufficient; the state above is authoritative.
-        let _ = self.wake.try_send(());
+        if changed {
+            let _ = self.wake.try_send(());
+        }
     }
 
     pub(crate) fn is_closed(&self) -> bool {

--- a/crates/events/src/document_changes.rs
+++ b/crates/events/src/document_changes.rs
@@ -1,0 +1,141 @@
+//! Lossless invalidation of current document state, not a revision stream.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_channel::{Receiver, Sender};
+use parking_lot::Mutex;
+
+use crate::{TryRecvError, Update};
+
+/// A document whose current state must be read again. No block payload is retained.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocumentChange {
+    pub collection_id: String,
+    pub doc_id: String,
+    /// At least one coalesced update came from a local write.
+    pub has_local_write: bool,
+}
+
+/// Atomically drained invalidations. Updates arriving during the subsequent read
+/// remain pending for the next batch. This is not a snapshot or a durable cursor.
+#[derive(Debug, Default)]
+pub struct DocumentChangeBatch {
+    pub changes: Vec<DocumentChange>,
+    /// Too many distinct documents changed: reload the observer's entire scope.
+    /// Never trust `changes` as a complete delta when this is true.
+    pub resync_required: bool,
+    pub updates: u64,
+}
+
+#[derive(Default)]
+struct Pending {
+    documents: HashMap<(String, String), bool>,
+    resync_required: bool,
+    updates: u64,
+}
+
+pub(crate) struct ChangePublisher {
+    pending: Arc<Mutex<Pending>>,
+    wake: Sender<()>,
+    capacity: usize,
+}
+
+impl ChangePublisher {
+    pub(crate) fn publish(&self, update: &Update) {
+        let mut pending = self.pending.lock();
+        pending.updates = pending.updates.saturating_add(1);
+        if !pending.resync_required {
+            let key = (update.collection_id.clone(), update.doc_id.clone());
+            if let Some(local) = pending.documents.get_mut(&key) {
+                *local |= !update.is_relay;
+            } else if pending.documents.len() < self.capacity {
+                pending.documents.insert(key, !update.is_relay);
+            } else {
+                pending.documents.clear();
+                pending.resync_required = true;
+            }
+        }
+        // One pending wake is sufficient; the state above is authoritative.
+        let _ = self.wake.try_send(());
+    }
+
+    pub(crate) fn is_closed(&self) -> bool {
+        self.wake.is_closed()
+    }
+}
+
+/// Bounded, coalescing subscription for consumers that query current state.
+/// Repeated revisions of one document occupy one entry. Distinct-document
+/// overflow becomes one explicit resync invalidation, never a silent loss.
+/// Raw update/merge subscriptions and their CID/payload semantics are unchanged.
+pub struct DocumentChangeSubscription {
+    id: u64,
+    pending: Arc<Mutex<Pending>>,
+    wake: Receiver<()>,
+}
+
+impl DocumentChangeSubscription {
+    pub(crate) fn new(id: u64, capacity: usize) -> (ChangePublisher, Self) {
+        let pending = Arc::new(Mutex::new(Pending::default()));
+        let (tx, rx) = async_channel::bounded(1);
+        (
+            ChangePublisher {
+                pending: pending.clone(),
+                wake: tx,
+                capacity,
+            },
+            Self {
+                id,
+                pending,
+                wake: rx,
+            },
+        )
+    }
+
+    pub(crate) fn closed() -> Self {
+        let (_, subscription) = Self::new(0, 0);
+        subscription
+    }
+
+    pub fn id(&self) -> u64 {
+        self.id
+    }
+
+    pub async fn recv(&mut self) -> Option<DocumentChangeBatch> {
+        self.wake.recv().await.ok()?;
+        Some(self.take_pending())
+    }
+
+    pub fn try_recv(&mut self) -> Result<DocumentChangeBatch, TryRecvError> {
+        self.wake.try_recv().map_err(|error| match error {
+            async_channel::TryRecvError::Empty => TryRecvError::Empty,
+            async_channel::TryRecvError::Closed => TryRecvError::Disconnected,
+        })?;
+        Ok(self.take_pending())
+    }
+
+    fn take_pending(&self) -> DocumentChangeBatch {
+        let mut pending = self.pending.lock();
+        // A publisher may have filled the wake slot between recv and this lock.
+        // Its changes are included below, so consume that redundant wake too.
+        let _ = self.wake.try_recv();
+        let taken = std::mem::take(&mut *pending);
+        drop(pending);
+        DocumentChangeBatch {
+            changes: taken
+                .documents
+                .into_iter()
+                .map(
+                    |((collection_id, doc_id), has_local_write)| DocumentChange {
+                        collection_id,
+                        doc_id,
+                        has_local_write,
+                    },
+                )
+                .collect(),
+            resync_required: taken.resync_required,
+            updates: taken.updates,
+        }
+    }
+}

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -22,10 +22,17 @@
 //! and records dropped messages per subscription. Consumers that observe a
 //! non-zero dropped count must resync from the database before trusting further
 //! incremental observations.
+//!
+//! Current-state readers can instead use `Bus::subscribe_document_changes`:
+//! repeated revisions coalesce by collection/document without retaining blocks.
+//! Distinct-document overflow produces one explicit resync invalidation. This
+//! opt-in surface does not change raw revision or replication event delivery.
 
 mod bus;
 #[cfg(feature = "channel")]
 mod channel_bus;
+#[cfg(feature = "channel")]
+mod document_changes;
 mod event;
 mod noop_bus;
 mod subscription;
@@ -33,6 +40,8 @@ mod subscription;
 pub use bus::Bus;
 #[cfg(feature = "channel")]
 pub use channel_bus::{ChannelBus, ChannelBusConfig};
+#[cfg(feature = "channel")]
+pub use document_changes::{DocumentChange, DocumentChangeBatch, DocumentChangeSubscription};
 pub use event::{
     AcpCacheInvalidatedData, AcpHeightAdvancedData, EventName, MergeCompleteData, Message,
     PendingDagQuarantinedData, SEArtifactReceivedData, TopicPeerEventData, Update,

--- a/crates/events/src/noop_bus.rs
+++ b/crates/events/src/noop_bus.rs
@@ -39,6 +39,11 @@ impl Bus for NoOpBus {
 
     fn unsubscribe(&self, _sub_id: u64) {}
 
+    #[cfg(feature = "channel")]
+    fn subscribe_document_changes(&self) -> crate::DocumentChangeSubscription {
+        crate::DocumentChangeSubscription::closed()
+    }
+
     fn close(&self) {}
 
     fn is_closed(&self) -> bool {

--- a/crates/events/tests/document_changes.rs
+++ b/crates/events/tests/document_changes.rs
@@ -100,3 +100,44 @@ fn dropped_observers_are_cleaned_up() {
     bus.publish(update("c", "d", true));
     assert_eq!(bus.subscriber_count(), 0);
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn committed_batch_wakes_state_reader_once_and_preserves_raw_order() {
+    let bus = std::sync::Arc::new(ChannelBus::with_config(
+        ChannelBusConfig::new().with_event_buffer_size(12_000),
+    ));
+    let mut changes = bus.subscribe_document_changes();
+    let mut raw = bus.subscribe(&[EventName::Update]);
+    let publisher = bus.clone();
+    let task = tokio::spawn(async move {
+        publisher.publish_batch(
+            (0_u32..12_000)
+                .map(|revision| {
+                    Message::update(Update::new(
+                        "doc".into(),
+                        cid::Cid::default(),
+                        "c".into(),
+                        revision.to_be_bytes().to_vec(),
+                        false,
+                        true,
+                    ))
+                })
+                .collect(),
+        );
+    });
+    let batch = changes.recv().await.unwrap();
+    assert_eq!(batch.updates, 12_000);
+    assert_eq!(batch.changes.len(), 1);
+    assert!(!batch.resync_required);
+    task.await.unwrap();
+    assert!(changes.try_recv().is_err());
+    for revision in 0_u32..12_000 {
+        let message = raw.try_recv().unwrap();
+        assert_eq!(
+            message.as_update().unwrap().block.as_ref(),
+            &revision.to_be_bytes()
+        );
+    }
+    assert!(raw.try_recv().is_err());
+    assert_eq!(raw.dropped_count(), 0);
+}

--- a/crates/events/tests/document_changes.rs
+++ b/crates/events/tests/document_changes.rs
@@ -1,0 +1,102 @@
+use events::{Bus, ChannelBus, ChannelBusConfig, EventName, Message, Update};
+
+fn update(collection: &str, document: &str, relay: bool) -> Message {
+    Message::update(Update::new(
+        document.into(),
+        cid::Cid::default(),
+        collection.into(),
+        vec![7; 100],
+        false,
+        relay,
+    ))
+}
+
+#[tokio::test]
+async fn history_revisions_coalesce_without_changing_raw_events() {
+    let bus = ChannelBus::with_config(ChannelBusConfig::new().with_event_buffer_size(4));
+    let mut changes = bus.subscribe_document_changes();
+    let mut raw = bus.subscribe(&[EventName::Update]);
+    for revision in 0..12_000 {
+        let msg = update("collection", "document", revision != 100);
+        bus.publish(msg);
+        let raw_update = raw.recv().await.unwrap();
+        assert_eq!(raw_update.as_update().unwrap().block.len(), 100);
+    }
+    let batch = changes.recv().await.unwrap();
+    assert_eq!(batch.updates, 12_000);
+    assert_eq!(batch.changes.len(), 1);
+    assert!(batch.changes[0].has_local_write);
+    assert!(!batch.resync_required);
+    assert_eq!(raw.dropped_count(), 0);
+    assert!(changes.try_recv().is_err());
+}
+
+#[tokio::test]
+async fn distinct_document_overflow_is_one_bounded_resync_then_recovers() {
+    let bus = ChannelBus::with_config(ChannelBusConfig::new().with_event_buffer_size(2));
+    let mut changes = bus.subscribe_document_changes();
+    for id in 0..12_000 {
+        bus.publish(update("c", &id.to_string(), true));
+    }
+    let batch = changes.recv().await.unwrap();
+    assert!(batch.resync_required);
+    assert!(batch.changes.is_empty());
+    assert_eq!(batch.updates, 12_000);
+    // Arrival during the consumer's snapshot read must not be cleared by that read.
+    bus.publish(update("c", "after-drain", true));
+    let next = changes.recv().await.unwrap();
+    assert!(!next.resync_required);
+    assert_eq!(next.changes[0].doc_id, "after-drain");
+    assert!(changes.try_recv().is_err());
+}
+
+#[tokio::test]
+async fn collection_identity_close_unsubscribe_and_other_events() {
+    let bus = ChannelBus::new();
+    let mut changes = bus.subscribe_document_changes();
+    bus.publish(Message::merge());
+    assert!(changes.try_recv().is_err());
+    bus.publish(update("first", "same-id", true));
+    bus.publish(update("second", "same-id", true));
+    assert_eq!(changes.recv().await.unwrap().changes.len(), 2);
+    bus.unsubscribe(changes.id());
+    assert!(changes.recv().await.is_none());
+    let mut changes = bus.subscribe_document_changes();
+    bus.close();
+    assert!(changes.recv().await.is_none());
+    assert!(bus.subscribe_document_changes().recv().await.is_none());
+    assert!(events::NoOpBus::new()
+        .subscribe_document_changes()
+        .recv()
+        .await
+        .is_none());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn publishing_races_with_draining_without_losing_a_wake() {
+    let bus = std::sync::Arc::new(ChannelBus::new());
+    let mut changes = bus.subscribe_document_changes();
+    let publisher = bus.clone();
+    let task = tokio::spawn(async move {
+        for _ in 0..10_000 {
+            publisher.publish(update("c", "doc", true));
+            tokio::task::yield_now().await;
+        }
+        publisher.close();
+    });
+    let mut count = 0;
+    while let Some(batch) = changes.recv().await {
+        assert_eq!(batch.changes.len(), 1);
+        count += batch.updates;
+    }
+    task.await.unwrap();
+    assert_eq!(count, 10_000);
+}
+
+#[test]
+fn dropped_observers_are_cleaned_up() {
+    let bus = ChannelBus::new();
+    drop(bus.subscribe_document_changes());
+    bus.publish(update("c", "d", true));
+    assert_eq!(bus.subscriber_count(), 0);
+}

--- a/crates/events/tests/document_changes.rs
+++ b/crates/events/tests/document_changes.rs
@@ -141,3 +141,31 @@ async fn committed_batch_wakes_state_reader_once_and_preserves_raw_order() {
     assert!(raw.try_recv().is_err());
     assert_eq!(raw.dropped_count(), 0);
 }
+
+#[test]
+fn subscription_registration_cannot_escape_close() {
+    for _ in 0..100 {
+        let bus = std::sync::Arc::new(ChannelBus::new());
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+        let registering_bus = bus.clone();
+        let registering_barrier = barrier.clone();
+        let thread = std::thread::spawn(move || {
+            registering_barrier.wait();
+            (
+                registering_bus.subscribe(&[EventName::Update]),
+                registering_bus.subscribe_document_changes(),
+            )
+        });
+        barrier.wait();
+        bus.close();
+        let (mut raw, mut changes) = thread.join().unwrap();
+        assert!(matches!(
+            raw.try_recv(),
+            Err(events::TryRecvError::Disconnected)
+        ));
+        assert!(matches!(
+            changes.try_recv(),
+            Err(events::TryRecvError::Disconnected)
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

Add an opt-in bounded document-state subscription for embedded UI/query consumers. The existing raw Update/MergeComplete event stream is unchanged.

History merge commits currently publish an update per revision synchronously. On the physical Gents iPhone client, this overflowed the UI observer queue (2,235 and 2,790 notifications), forcing repeated snapshot reloads. Increasing the raw queue would not fix the mismatch between revision events and current-state observation.

`Bus::subscribe_document_changes` and `EmbeddedNode::subscribe_document_changes` coalesce pending changes by collection/document, retain no block payloads, and use a single wake slot. `Bus::publish_batch` lets the merge owner publish current-state invalidations once for the entire committed batch, without exposing partial batches to a fast observer. Distinct-document capacity exhaustion becomes an explicit resync invalidation, not silent loss. New updates during a consumer query remain pending for its next read. No wire-protocol, replication fanout, merge acknowledgement, or raw subscription behavior changes.

## Validation

- events: 20 tests pass, including 12,000 revisions coalescing to one entry, unchanged raw delivery/order, overflow/recovery, unsubscribe/close, concurrent registration versus close, and concurrent publish/drain.
- db merge: all 129 tests pass. The real single-root history test proves 257 raw revision updates and one document-state batch, after the existing two bounded commits.
- defra-node: 93 tests pass, 5 existing ignored tests.
- events without default/channel features: check passes.
- clippy for events + db + defra-node, all targets, warnings denied: passes.
- Gents: original observer regression fails with a forced reload; candidate passes with one read, one batch, 11,999 coalesced revisions, zero reloads. Full client suite passes (223 tests).
- Published-pin Gents 2,500-revision enrollment/conversation/reopen test passes with no observer overflow. Local DB-to-observer lag was zero at polling resolution; server-to-client return lag was 0.3-0.5s in that run.
- The committed-batch downstream run passes fresh and 2,500-revision conversation contracts, including the two-second return-lag gate. The 12,000-revision enrollment failure is a distinct confirmed depth-8192 quarantine defect tracked in #1732; its reproduction is retained explicitly. The UI stress case now uses 6,000 revisions (above the old 4,096-event queue, below the separate depth limit), plus concurrent writes. Latency gates remain unchanged. Physical phone acceptance and rollout remain outstanding.

Draft while downstream stress/latency validation finishes.
