### PR TITLE
Align SourceHub ACP with current protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 [[package]]
 name = "acp-light-client"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/backbone.git?rev=9526a4ebfaa1cebf07fc3592de6f0a62d77f9e30#9526a4ebfaa1cebf07fc3592de6f0a62d77f9e30"
+source = "git+https://github.com/sourcenetwork/backbone.git?rev=3d1544ec783b093186422d82b5af326457e63609#3d1544ec783b093186422d82b5af326457e63609"
 dependencies = [
  "alloy-primitives",
  "borsh",
@@ -3466,7 +3466,7 @@ dependencies = [
 [[package]]
 name = "defra-harness"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/backbone.git?rev=9526a4ebfaa1cebf07fc3592de6f0a62d77f9e30#9526a4ebfaa1cebf07fc3592de6f0a62d77f9e30"
+source = "git+https://github.com/sourcenetwork/backbone.git?rev=3d1544ec783b093186422d82b5af326457e63609#3d1544ec783b093186422d82b5af326457e63609"
 dependencies = [
  "eyre",
  "futures",
@@ -5252,7 +5252,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 [[package]]
 name = "hub-harness"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/backbone.git?rev=9526a4ebfaa1cebf07fc3592de6f0a62d77f9e30#9526a4ebfaa1cebf07fc3592de6f0a62d77f9e30"
+source = "git+https://github.com/sourcenetwork/backbone.git?rev=3d1544ec783b093186422d82b5af326457e63609#3d1544ec783b093186422d82b5af326457e63609"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11131,6 +11131,8 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite 0.26.2",
+ "tonic",
+ "tonic-prost",
  "tracing",
  "zanzibar",
 ]
@@ -11138,7 +11140,7 @@ dependencies = [
 [[package]]
 name = "sourcehub-harness"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/backbone.git?rev=9526a4ebfaa1cebf07fc3592de6f0a62d77f9e30#9526a4ebfaa1cebf07fc3592de6f0a62d77f9e30"
+source = "git+https://github.com/sourcenetwork/backbone.git?rev=3d1544ec783b093186422d82b5af326457e63609#3d1544ec783b093186422d82b5af326457e63609"
 dependencies = [
  "cosmrs",
  "eyre",
@@ -11671,7 +11673,7 @@ dependencies = [
 [[package]]
 name = "test-infra"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/backbone.git?rev=9526a4ebfaa1cebf07fc3592de6f0a62d77f9e30#9526a4ebfaa1cebf07fc3592de6f0a62d77f9e30"
+source = "git+https://github.com/sourcenetwork/backbone.git?rev=3d1544ec783b093186422d82b5af326457e63609#3d1544ec783b093186422d82b5af326457e63609"
 dependencies = [
  "eyre",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 [[package]]
 name = "acp-light-client"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/backbone.git?rev=3d1544ec783b093186422d82b5af326457e63609#3d1544ec783b093186422d82b5af326457e63609"
+source = "git+https://github.com/sourcenetwork/backbone.git?rev=e0c42841f212119a385ee6c10465c3afe6fc62d4#e0c42841f212119a385ee6c10465c3afe6fc62d4"
 dependencies = [
  "alloy-primitives",
  "borsh",
@@ -3466,7 +3466,7 @@ dependencies = [
 [[package]]
 name = "defra-harness"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/backbone.git?rev=3d1544ec783b093186422d82b5af326457e63609#3d1544ec783b093186422d82b5af326457e63609"
+source = "git+https://github.com/sourcenetwork/backbone.git?rev=e0c42841f212119a385ee6c10465c3afe6fc62d4#e0c42841f212119a385ee6c10465c3afe6fc62d4"
 dependencies = [
  "eyre",
  "futures",
@@ -5252,7 +5252,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 [[package]]
 name = "hub-harness"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/backbone.git?rev=3d1544ec783b093186422d82b5af326457e63609#3d1544ec783b093186422d82b5af326457e63609"
+source = "git+https://github.com/sourcenetwork/backbone.git?rev=e0c42841f212119a385ee6c10465c3afe6fc62d4#e0c42841f212119a385ee6c10465c3afe6fc62d4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11140,7 +11140,7 @@ dependencies = [
 [[package]]
 name = "sourcehub-harness"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/backbone.git?rev=3d1544ec783b093186422d82b5af326457e63609#3d1544ec783b093186422d82b5af326457e63609"
+source = "git+https://github.com/sourcenetwork/backbone.git?rev=e0c42841f212119a385ee6c10465c3afe6fc62d4#e0c42841f212119a385ee6c10465c3afe6fc62d4"
 dependencies = [
  "cosmrs",
  "eyre",
@@ -11673,7 +11673,7 @@ dependencies = [
 [[package]]
 name = "test-infra"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/backbone.git?rev=3d1544ec783b093186422d82b5af326457e63609#3d1544ec783b093186422d82b5af326457e63609"
+source = "git+https://github.com/sourcenetwork/backbone.git?rev=e0c42841f212119a385ee6c10465c3afe6fc62d4#e0c42841f212119a385ee6c10465c3afe6fc62d4"
 dependencies = [
  "eyre",
  "futures",

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -78,10 +78,15 @@ pub struct Cli {
     #[arg(long, global = true, env = "DEFRA_NO_KEYRING", num_args = 0..=1, require_equals = true, default_missing_value = "true", value_parser = bool_value_parser())]
     pub no_keyring: Option<bool>,
 
-    /// The SourceHub address authorized by the client to make SourceHub transactions
+    /// SourceHub LCD address used for REST queries
     #[cfg(feature = "sourcehub")]
     #[arg(long, global = true, env = "DEFRA_SOURCE_HUB_ADDRESS")]
     pub source_hub_address: Option<String>,
+
+    /// SourceHub gRPC address used for authorization queries
+    #[cfg(feature = "sourcehub")]
+    #[arg(long, global = true, env = "DEFRA_SOURCE_HUB_GRPC_ADDRESS")]
+    pub source_hub_grpc_address: Option<String>,
 
     /// SourceHub CometBFT RPC address for transaction broadcast
     #[cfg(feature = "sourcehub")]

--- a/crates/cli/src/commands/start/server_acp.rs
+++ b/crates/cli/src/commands/start/server_acp.rs
@@ -60,8 +60,13 @@ impl Node {
             );
 
             let provider = Arc::new(
-                sourcehub::CosmosProvider::new(
+                sourcehub::CosmosProvider::new_with_grpc(
                     config.acp.sourcehub_address.clone(),
+                    if config.acp.sourcehub_grpc_address.is_empty() {
+                        config.acp.sourcehub_address.clone()
+                    } else {
+                        config.acp.sourcehub_grpc_address.clone()
+                    },
                     config.acp.sourcehub_comet_address.clone(),
                     signer_key_bytes,
                     &config.acp.sourcehub_chain_id,

--- a/crates/cli/src/commands/start/server_http/node_options.rs
+++ b/crates/cli/src/commands/start/server_http/node_options.rs
@@ -20,7 +20,10 @@ pub(super) fn sanitized_node_options(
     #[cfg(feature = "sourcehub")]
     let (sourcehub_chain_id, sourcehub_grpc_address, sourcehub_comet_address) = (
         redacted_text(!config.acp.sourcehub_chain_id.is_empty()),
-        redacted_text(!config.acp.sourcehub_address.is_empty()),
+        redacted_text(
+            !config.acp.sourcehub_grpc_address.is_empty()
+                || !config.acp.sourcehub_address.is_empty(),
+        ),
         redacted_text(!config.acp.sourcehub_comet_address.is_empty()),
     );
     #[cfg(not(feature = "sourcehub"))]

--- a/crates/cli/src/config/mod.rs
+++ b/crates/cli/src/config/mod.rs
@@ -230,6 +230,10 @@ impl Config {
             self.acp.sourcehub_address = addr.clone();
         }
         #[cfg(feature = "sourcehub")]
+        if let Some(ref addr) = cli.source_hub_grpc_address {
+            self.acp.sourcehub_grpc_address = addr.clone();
+        }
+        #[cfg(feature = "sourcehub")]
         if let Some(ref addr) = cli.source_hub_comet_address {
             self.acp.sourcehub_comet_address = addr.clone();
         }

--- a/crates/cli/src/config/sections.rs
+++ b/crates/cli/src/config/sections.rs
@@ -512,10 +512,15 @@ pub struct AcpConfig {
     /// - `source-hub`: Remote SourceHub access control
     pub document_type: AcpDocumentType,
 
-    /// SourceHub gRPC/LCD endpoint (e.g., "http://localhost:1317")
+    /// SourceHub LCD endpoint (e.g., "http://localhost:1317")
     #[cfg(feature = "sourcehub")]
     #[serde(default)]
     pub sourcehub_address: String,
+
+    /// SourceHub gRPC endpoint (e.g., "http://localhost:9090")
+    #[cfg(feature = "sourcehub")]
+    #[serde(default)]
+    pub sourcehub_grpc_address: String,
 
     /// SourceHub CometBFT RPC endpoint (e.g., "http://localhost:26657")
     #[cfg(feature = "sourcehub")]
@@ -581,6 +586,8 @@ impl Default for AcpConfig {
             document_type: AcpDocumentType::None,
             #[cfg(feature = "sourcehub")]
             sourcehub_address: String::new(),
+            #[cfg(feature = "sourcehub")]
+            sourcehub_grpc_address: String::new(),
             #[cfg(feature = "sourcehub")]
             sourcehub_comet_address: String::new(),
             #[cfg(feature = "sourcehub")]

--- a/crates/cli/tests/config_tests.rs
+++ b/crates/cli/tests/config_tests.rs
@@ -31,6 +31,8 @@ fn cli_with_defaults() -> Cli {
         #[cfg(feature = "sourcehub")]
         source_hub_address: None,
         #[cfg(feature = "sourcehub")]
+        source_hub_grpc_address: None,
+        #[cfg(feature = "sourcehub")]
         source_hub_comet_address: None,
         #[cfg(feature = "sourcehub")]
         source_hub_events_ws: None,
@@ -155,6 +157,7 @@ fn test_apply_cli_flags_valid_values_succeed() {
     #[cfg(feature = "sourcehub")]
     {
         cli.source_hub_address = Some("http://localhost:1317".to_string());
+        cli.source_hub_grpc_address = Some("http://localhost:9090".to_string());
         cli.source_hub_comet_address = Some("http://localhost:26657".to_string());
         cli.source_hub_events_ws = Some("ws://localhost:26657/websocket".to_string());
         cli.source_hub_chain_id = Some("sourcehub-test".to_string());
@@ -183,6 +186,7 @@ fn test_apply_cli_flags_valid_values_succeed() {
     #[cfg(feature = "sourcehub")]
     {
         assert_eq!(config.acp.sourcehub_address, "http://localhost:1317");
+        assert_eq!(config.acp.sourcehub_grpc_address, "http://localhost:9090");
         assert_eq!(config.acp.sourcehub_comet_address, "http://localhost:26657");
         assert_eq!(
             config.acp.sourcehub_events_ws,
@@ -209,6 +213,8 @@ const CONFIG_BACKED_GLOBAL_FLAGS: &[&str] = &[
     "no-keyring",
     #[cfg(feature = "sourcehub")]
     "source-hub-address",
+    #[cfg(feature = "sourcehub")]
+    "source-hub-grpc-address",
     #[cfg(feature = "sourcehub")]
     "source-hub-comet-address",
     #[cfg(feature = "sourcehub")]

--- a/crates/defra-node/src/config.rs
+++ b/crates/defra-node/src/config.rs
@@ -17,6 +17,13 @@ pub enum DocumentAcpConfig {
     /// Requires the `sourcehub` feature (on by default).
     #[cfg(feature = "sourcehub")]
     SourceHub(SourceHubConfig),
+    /// On-chain document ACP via SourceHub with distinct LCD and gRPC
+    /// endpoints.
+    #[cfg(feature = "sourcehub")]
+    SourceHubWithLcd {
+        config: SourceHubConfig,
+        lcd_address: String,
+    },
 }
 
 /// SourceHub document ACP configuration.

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -942,6 +942,20 @@ impl NodeBuilder {
         self
     }
 
+    /// Configure SourceHub ACP when LCD and gRPC use distinct endpoints.
+    #[cfg(feature = "sourcehub")]
+    pub fn with_sourcehub_lcd(
+        mut self,
+        config: SourceHubConfig,
+        lcd_address: impl Into<String>,
+    ) -> Self {
+        self.document_acp = DocumentAcpConfig::SourceHubWithLcd {
+            config,
+            lcd_address: lcd_address.into(),
+        };
+        self
+    }
+
     /// Use an identity already registered in DefraDB's process-local signing registry.
     ///
     /// The caller must register the signer before calling [`NodeBuilder::build`].

--- a/crates/defra-node/src/node_acp.rs
+++ b/crates/defra-node/src/node_acp.rs
@@ -48,6 +48,33 @@ where
                 sourcehub_acp: Some(sh_acp),
             })
         }
+        #[cfg(feature = "sourcehub")]
+        crate::DocumentAcpConfig::SourceHubWithLcd {
+            config: sourcehub_config,
+            lcd_address,
+        } => {
+            let tuning = sourcehub::AcpTuning::default();
+            let provider = Arc::new(
+                sourcehub::CosmosProvider::new_with_grpc(
+                    lcd_address.clone(),
+                    sourcehub_config.grpc_address.clone(),
+                    sourcehub_config.comet_rpc_address.clone(),
+                    &sourcehub_config.signer_key,
+                    &sourcehub_config.chain_id,
+                    &tuning,
+                )
+                .map_err(|error| anyhow!("failed to create SourceHub provider: {error}"))?,
+            );
+            let sourcehub_acp = Arc::new(sourcehub::SourceHubDocumentACP::new(
+                provider,
+                tuning.cache_ttl,
+            ));
+            Ok(DocumentAcpSetup {
+                document_acp: sourcehub_acp.clone(),
+                local_zanzibar_store: None,
+                sourcehub_acp: Some(sourcehub_acp),
+            })
+        }
         crate::DocumentAcpConfig::Local => match persistence {
             Persistence::Persistent => {
                 let zanzibar_store = Arc::new(acp::PersistentZanzibarStore::from_store(store));

--- a/crates/embedded/src/lib.rs
+++ b/crates/embedded/src/lib.rs
@@ -93,6 +93,12 @@ pub enum DocumentAcpConfig {
     Local,
     #[cfg(feature = "sourcehub")]
     SourceHub(SourceHubConfig),
+    /// SourceHub ACP with distinct LCD and gRPC endpoints.
+    #[cfg(feature = "sourcehub")]
+    SourceHubWithLcd {
+        config: SourceHubConfig,
+        lcd_address: String,
+    },
 }
 
 /// SourceHub document ACP configuration.

--- a/crates/embedded/src/node.rs
+++ b/crates/embedded/src/node.rs
@@ -309,6 +309,20 @@ impl NodeBuilder {
         self
     }
 
+    /// Configure SourceHub ACP when LCD and gRPC use distinct endpoints.
+    #[cfg(feature = "sourcehub")]
+    pub fn with_sourcehub_lcd(
+        mut self,
+        config: SourceHubConfig,
+        lcd_address: impl Into<String>,
+    ) -> Self {
+        self.config.document_acp = DocumentAcpConfig::SourceHubWithLcd {
+            config,
+            lcd_address: lcd_address.into(),
+        };
+        self
+    }
+
     pub fn with_query_limits(mut self, limits: query::QueryLimits) -> Self {
         self.config.query_limits = limits;
         self

--- a/crates/embedded/src/node_acp.rs
+++ b/crates/embedded/src/node_acp.rs
@@ -43,6 +43,33 @@ where
                 sourcehub_acp: Some(sh_acp),
             })
         }
+        #[cfg(feature = "sourcehub")]
+        crate::DocumentAcpConfig::SourceHubWithLcd {
+            config: sourcehub_config,
+            lcd_address,
+        } => {
+            let tuning = sourcehub::AcpTuning::default();
+            let provider = Arc::new(
+                sourcehub::CosmosProvider::new_with_grpc(
+                    lcd_address.clone(),
+                    sourcehub_config.grpc_address.clone(),
+                    sourcehub_config.comet_rpc_address.clone(),
+                    &sourcehub_config.signer_key,
+                    &sourcehub_config.chain_id,
+                    &tuning,
+                )
+                .map_err(|error| anyhow!("failed to create SourceHub provider: {error}"))?,
+            );
+            let sourcehub_acp = Arc::new(sourcehub::SourceHubDocumentACP::new(
+                provider,
+                tuning.cache_ttl,
+            ));
+            Ok(DocumentAcpSetup {
+                document_acp: sourcehub_acp.clone(),
+                local_zanzibar_store: None,
+                sourcehub_acp: Some(sourcehub_acp),
+            })
+        }
         crate::DocumentAcpConfig::Local => match persistence {
             Persistence::Persistent => {
                 let zanzibar_store = Arc::new(acp::PersistentZanzibarStore::from_store(store));

--- a/crates/sourcehub/Cargo.toml
+++ b/crates/sourcehub/Cargo.toml
@@ -68,7 +68,7 @@ alloy-rlp.workspace = true
 bs58.workspace = true
 
 # ACP light client (proof-validated cache)
-acp-light-client = { git = "https://github.com/sourcenetwork/backbone.git", rev = "3d1544ec783b093186422d82b5af326457e63609" }
+acp-light-client = { git = "https://github.com/sourcenetwork/backbone.git", rev = "e0c42841f212119a385ee6c10465c3afe6fc62d4" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 futures.workspace = true

--- a/crates/sourcehub/Cargo.toml
+++ b/crates/sourcehub/Cargo.toml
@@ -68,11 +68,13 @@ alloy-rlp.workspace = true
 bs58.workspace = true
 
 # ACP light client (proof-validated cache)
-acp-light-client = { git = "https://github.com/sourcenetwork/backbone.git", rev = "9526a4ebfaa1cebf07fc3592de6f0a62d77f9e30" }
+acp-light-client = { git = "https://github.com/sourcenetwork/backbone.git", rev = "3d1544ec783b093186422d82b5af326457e63609" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 futures.workspace = true
 prost.workspace = true
+tonic.workspace = true
+tonic-prost.workspace = true
 tokio-tungstenite = { version = "0.26.2", features = ["rustls-tls-webpki-roots"] }
 
 [dev-dependencies]

--- a/crates/sourcehub/src/cosmos/client.rs
+++ b/crates/sourcehub/src/cosmos/client.rs
@@ -1,18 +1,72 @@
-/// Client for SourceHub ACP gRPC/REST queries and CometBFT tx broadcast.
-///
-/// Uses the Cosmos LCD REST API for queries (avoids proto compilation)
-/// and CometBFT JSON-RPC for transaction broadcast.
+/// Client for SourceHub ACP queries and CometBFT transaction broadcast.
 pub(crate) struct SourceHubClient {
-    /// LCD/REST base URL derived from gRPC address (same host, port 1317 or LCD port)
-    grpc_address: String,
+    /// LCD/REST base URL.
+    lcd_address: String,
+    /// Reusable gRPC channel. Cloning a channel preserves its connection pool.
+    #[cfg(not(target_arch = "wasm32"))]
+    grpc_channel: tonic::transport::Channel,
+    /// Whole-operation budget for gRPC authorization.
+    #[cfg(not(target_arch = "wasm32"))]
+    request_timeout: std::time::Duration,
     /// CometBFT RPC address for broadcast_tx_sync
     comet_rpc_address: String,
     /// HTTP client for REST queries (configured with per-request timeout)
     http: reqwest::Client,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Clone, PartialEq, prost::Message)]
+struct VerifyAccessRequest {
+    #[prost(string, tag = "1")]
+    policy_id: String,
+    #[prost(message, optional, tag = "2")]
+    access_request: Option<AccessRequest>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Clone, PartialEq, prost::Message)]
+struct AccessRequest {
+    #[prost(message, repeated, tag = "1")]
+    operations: Vec<Operation>,
+    #[prost(message, optional, tag = "2")]
+    actor: Option<Actor>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Clone, PartialEq, prost::Message)]
+struct Operation {
+    #[prost(message, optional, tag = "1")]
+    object: Option<Object>,
+    #[prost(string, tag = "2")]
+    permission: String,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Clone, PartialEq, prost::Message)]
+struct Object {
+    #[prost(string, tag = "1")]
+    resource: String,
+    #[prost(string, tag = "2")]
+    id: String,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Clone, PartialEq, prost::Message)]
+struct Actor {
+    #[prost(string, tag = "1")]
+    id: String,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Clone, PartialEq, prost::Message)]
+struct VerifyAccessResponse {
+    #[prost(bool, tag = "1")]
+    valid: bool,
+}
+
 impl SourceHubClient {
     pub(crate) fn new(
+        lcd_address: String,
         grpc_address: String,
         comet_rpc_address: String,
         request_timeout: std::time::Duration,
@@ -21,8 +75,19 @@ impl SourceHubClient {
             .timeout(request_timeout)
             .build()
             .map_err(ClientError::Http)?;
+        #[cfg(not(target_arch = "wasm32"))]
+        let grpc_channel =
+            tonic::transport::Endpoint::from_shared(normalize_base_url(&grpc_address))
+                .map_err(|error| ClientError::QueryFailed(error.to_string()))?
+                .connect_lazy();
+        #[cfg(target_arch = "wasm32")]
+        let _ = grpc_address;
         Ok(Self {
-            grpc_address,
+            lcd_address,
+            #[cfg(not(target_arch = "wasm32"))]
+            grpc_channel,
+            #[cfg(not(target_arch = "wasm32"))]
+            request_timeout,
             comet_rpc_address,
             http,
         })
@@ -34,7 +99,7 @@ impl SourceHubClient {
         policy_id: &str,
     ) -> Result<Option<PolicyInfo>, ClientError> {
         let url = format!(
-            "{}/sourcenetwork/vera/acp/policy/{}",
+            "{}/sourcenetwork/sourcehub/acp/policy/{}",
             self.rest_base_url(),
             policy_id
         );
@@ -71,7 +136,7 @@ impl SourceHubClient {
         object_id: &str,
     ) -> Result<(bool, String), ClientError> {
         let url = format!(
-            "{}/sourcenetwork/vera/acp/object_owner/{}/{}/{}",
+            "{}/sourcenetwork/sourcehub/acp/object_owner/{}/{}/{}",
             self.rest_base_url(),
             policy_id,
             resource,
@@ -96,8 +161,8 @@ impl SourceHubClient {
 
     /// Verify if an actor has access to an object.
     ///
-    /// Uses CometBFT ABCI query with protobuf-encoded request since
-    /// the REST/LCD endpoint doesn't support repeated nested fields in GET params.
+    /// Uses SourceHub's gRPC API because its REST gateway cannot represent
+    /// the repeated nested operation without dropping it.
     pub(crate) async fn verify_access(
         &self,
         policy_id: &str,
@@ -106,54 +171,59 @@ impl SourceHubClient {
         permission: &str,
         actor_did: &str,
     ) -> Result<bool, ClientError> {
-        // Protobuf-encode the QueryVerifyAccessRequestRequest
-        let request_bytes =
-            encode_verify_access_request(policy_id, resource, object_id, permission, actor_did);
-        let request_hex = hex::encode(&request_bytes);
-
-        let url = format!(
-            "{}/abci_query?path=\"/vera.acp.Query/VerifyAccessRequest\"&data=0x{}",
-            self.comet_rpc_base_url(),
-            request_hex
-        );
-        let resp = self.http.get(&url).send().await?;
-        if !resp.status().is_success() {
+        #[cfg(target_arch = "wasm32")]
+        {
+            let _ = (policy_id, resource, object_id, permission, actor_did);
             return Err(ClientError::QueryFailed(
-                resp.text().await.unwrap_or_default(),
+                "SourceHub access verification requires native gRPC".to_string(),
             ));
         }
-        let body: serde_json::Value = resp.json().await?;
 
-        // Check ABCI response code.
-        // Code 0 means success; any other code means the query itself failed
-        // (invalid request, chain error, etc.) — NOT an access denial.
-        // Returning Ok(false) here would fail-open on SourceHub errors.
-        let abci_code = body["result"]["response"]["code"].as_u64().unwrap_or(0);
-        if abci_code != 0 {
-            let log = body["result"]["response"]["log"]
-                .as_str()
-                .unwrap_or("unknown");
-            tracing::warn!(abci_code, log, "verify_access ABCI query failed");
-            return Err(ClientError::QueryFailed(format!(
-                "ABCI code {}: {}",
-                abci_code, log
-            )));
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let operation = async {
+                let mut grpc = tonic::client::Grpc::new(self.grpc_channel.clone());
+                grpc.ready()
+                    .await
+                    .map_err(|error| ClientError::QueryFailed(error.to_string()))?;
+                let request = VerifyAccessRequest {
+                    policy_id: policy_id.to_string(),
+                    access_request: Some(AccessRequest {
+                        operations: vec![Operation {
+                            object: Some(Object {
+                                resource: resource.to_string(),
+                                id: object_id.to_string(),
+                            }),
+                            permission: permission.to_string(),
+                        }],
+                        actor: Some(Actor {
+                            id: actor_did.to_string(),
+                        }),
+                    }),
+                };
+                let response: tonic::Response<VerifyAccessResponse> = grpc
+                    .unary(
+                        tonic::Request::new(request),
+                        tonic::codegen::http::uri::PathAndQuery::from_static(
+                            "/sourcehub.acp.Query/VerifyAccessRequest",
+                        ),
+                        tonic_prost::ProstCodec::default(),
+                    )
+                    .await
+                    .map_err(|error| ClientError::QueryFailed(error.to_string()))?;
+                let valid = response.into_inner().valid;
+                tracing::debug!(permission, actor_did, valid, "verify_access result");
+                Ok(valid)
+            };
+            tokio::time::timeout(self.request_timeout, operation)
+                .await
+                .map_err(|_| {
+                    ClientError::Timeout(format!(
+                        "gRPC access verification exceeded {:?}",
+                        self.request_timeout
+                    ))
+                })?
         }
-
-        // Decode base64-encoded protobuf response
-        let result_b64 = body["result"]["response"]["value"].as_str().unwrap_or("");
-        if result_b64.is_empty() {
-            return Ok(false);
-        }
-        let result_bytes =
-            base64::Engine::decode(&base64::engine::general_purpose::STANDARD, result_b64)
-                .map_err(|e| ClientError::QueryFailed(format!("base64 decode: {}", e)))?;
-
-        // QueryVerifyAccessRequestResponse: field 1 (bool) valid
-        // Protobuf: tag 0x08 (field 1, varint), value 0x01 (true)
-        let valid = result_bytes.len() >= 2 && result_bytes[0] == 0x08 && result_bytes[1] == 0x01;
-        tracing::debug!(permission, actor_did, valid, "verify_access result");
-        Ok(valid)
     }
 
     /// Query account number and sequence for transaction signing.
@@ -254,12 +324,9 @@ impl SourceHubClient {
         format!("{}::{}", self.comet_rpc_address, address)
     }
 
-    /// Derive REST base URL from gRPC address.
-    /// SourceHub exposes REST on port 1317 by default, but in tests it uses
-    /// the gRPC port. We use the gRPC address directly since the LCD gateway
-    /// runs on the same address in the test environment.
+    /// Normalize the configured LCD base URL.
     fn rest_base_url(&self) -> String {
-        let addr = &self.grpc_address;
+        let addr = &self.lcd_address;
         if addr.starts_with("http") {
             addr.clone()
         } else if let Some(rest) = addr.strip_prefix("tcp://") {
@@ -278,6 +345,16 @@ impl SourceHubClient {
         } else {
             format!("http://{}", addr)
         }
+    }
+}
+
+fn normalize_base_url(address: &str) -> String {
+    if address.starts_with("http") {
+        address.to_string()
+    } else if let Some(rest) = address.strip_prefix("tcp://") {
+        format!("http://{rest}")
+    } else {
+        format!("http://{address}")
     }
 }
 
@@ -322,80 +399,42 @@ impl From<reqwest::Error> for ClientError {
     }
 }
 
-// === Protobuf encoding helpers for ABCI queries ===
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use std::time::{Duration, Instant};
 
-/// Encode QueryVerifyAccessRequestRequest as protobuf bytes.
-///
-/// Proto definition:
-///   message QueryVerifyAccessRequestRequest {
-///     string policy_id = 1;
-///     AccessRequest access_request = 2;
-///   }
-///   message AccessRequest { repeated Operation operations = 1; Actor actor = 2; }
-///   message Operation { Object object = 1; string permission = 2; }
-///   message Object { string resource = 1; string id = 2; }
-///   message Actor { string id = 1; }
-fn encode_verify_access_request(
-    policy_id: &str,
-    resource: &str,
-    object_id: &str,
-    permission: &str,
-    actor_did: &str,
-) -> Vec<u8> {
-    // Build Object { resource, id }
-    let mut object_buf = Vec::new();
-    pb_string(&mut object_buf, 1, resource);
-    pb_string(&mut object_buf, 2, object_id);
+    use tokio::net::TcpListener;
 
-    // Build Operation { object, permission }
-    let mut operation_buf = Vec::new();
-    pb_bytes(&mut operation_buf, 1, &object_buf);
-    pb_string(&mut operation_buf, 2, permission);
+    use super::{ClientError, SourceHubClient};
 
-    // Build Actor { id }
-    let mut actor_buf = Vec::new();
-    pb_string(&mut actor_buf, 1, actor_did);
+    #[tokio::test]
+    async fn grpc_access_verification_obeys_request_timeout() {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("stalled gRPC server should bind");
+        let address = format!(
+            "http://{}",
+            listener
+                .local_addr()
+                .expect("stalled gRPC server should have an address")
+        );
+        tokio::spawn(async move {
+            let _connection = listener
+                .accept()
+                .await
+                .expect("stalled gRPC server should accept");
+            std::future::pending::<()>().await;
+        });
+        let timeout = Duration::from_millis(50);
+        let client = SourceHubClient::new(address.clone(), address.clone(), address, timeout)
+            .expect("client should build");
 
-    // Build AccessRequest { operations: [operation], actor }
-    let mut access_request_buf = Vec::new();
-    pb_bytes(&mut access_request_buf, 1, &operation_buf);
-    pb_bytes(&mut access_request_buf, 2, &actor_buf);
+        let started = Instant::now();
+        let result = client
+            .verify_access("policy", "resource", "object", "read", "did:key:zactor")
+            .await;
 
-    // Build QueryVerifyAccessRequestRequest { policy_id, access_request }
-    let mut buf = Vec::new();
-    pb_string(&mut buf, 1, policy_id);
-    pb_bytes(&mut buf, 2, &access_request_buf);
-
-    buf
-}
-
-// Minimal protobuf encoding helpers (duplicated from tx.rs to avoid coupling)
-
-fn pb_varint(buf: &mut Vec<u8>, mut value: u64) {
-    loop {
-        let byte = (value & 0x7F) as u8;
-        value >>= 7;
-        if value == 0 {
-            buf.push(byte);
-            break;
-        }
-        buf.push(byte | 0x80);
+        assert!(matches!(result, Err(ClientError::Timeout(_))));
+        assert!(started.elapsed() < Duration::from_secs(1));
     }
-}
-
-fn pb_string(buf: &mut Vec<u8>, field_num: u32, value: &str) {
-    if value.is_empty() {
-        return;
-    }
-    let tag = (field_num << 3) | 2;
-    pb_varint(buf, tag as u64);
-    pb_varint(buf, value.len() as u64);
-    buf.extend_from_slice(value.as_bytes());
-}
-
-fn pb_bytes(buf: &mut Vec<u8>, field_num: u32, value: &[u8]) {
-    let tag = (field_num << 3) | 2;
-    pb_varint(buf, tag as u64);
-    pb_varint(buf, value.len() as u64);
-    buf.extend_from_slice(value);
 }

--- a/crates/sourcehub/src/cosmos/cosmos_provider.rs
+++ b/crates/sourcehub/src/cosmos/cosmos_provider.rs
@@ -23,15 +23,42 @@ pub struct CosmosProvider {
 }
 
 impl CosmosProvider {
+    /// Construct a provider for deployments that expose REST and gRPC on the
+    /// same address.
     pub fn new(
+        lcd_address: String,
+        comet_address: String,
+        signer_key: &[u8],
+        chain_id: &str,
+        tuning: &AcpTuning,
+    ) -> Result<Self, ProviderError> {
+        Self::new_with_grpc(
+            lcd_address.clone(),
+            lcd_address,
+            comet_address,
+            signer_key,
+            chain_id,
+            tuning,
+        )
+    }
+
+    /// Construct a provider with distinct SourceHub LCD, gRPC, and CometBFT
+    /// endpoints.
+    pub fn new_with_grpc(
+        lcd_address: String,
         grpc_address: String,
         comet_address: String,
         signer_key: &[u8],
         chain_id: &str,
         tuning: &AcpTuning,
     ) -> Result<Self, ProviderError> {
-        let client = SourceHubClient::new(grpc_address, comet_address, tuning.request_timeout)
-            .map_err(|e| ProviderError::Config(format!("HTTP client: {}", e)))?;
+        let client = SourceHubClient::new(
+            lcd_address,
+            grpc_address,
+            comet_address,
+            tuning.request_timeout,
+        )
+        .map_err(|e| ProviderError::Config(format!("SourceHub client: {}", e)))?;
         let signer = TxSigner::from_secp256k1_bytes(signer_key, chain_id)
             .map_err(|e| ProviderError::Config(e.to_string()))?;
         Ok(Self {

--- a/crates/sourcehub/src/cosmos/event_decoder.rs
+++ b/crates/sourcehub/src/cosmos/event_decoder.rs
@@ -1,12 +1,12 @@
 use base64::Engine as _;
 use prost::Message;
 
-const BEARER_POLICY_COMMAND: &str = "vera.acp.MsgBearerPolicyCmd";
-const CHECK_ACCESS: &str = "vera.acp.MsgCheckAccess";
-const CREATE_POLICY: &str = "vera.acp.MsgCreatePolicy";
-const DIRECT_POLICY_COMMAND: &str = "vera.acp.MsgDirectPolicyCmd";
-const EDIT_POLICY: &str = "vera.acp.MsgEditPolicy";
-const SIGNED_POLICY_COMMAND: &str = "vera.acp.MsgSignedPolicyCmd";
+const BEARER_POLICY_COMMAND: &str = "sourcehub.acp.MsgBearerPolicyCmd";
+const CHECK_ACCESS: &str = "sourcehub.acp.MsgCheckAccess";
+const CREATE_POLICY: &str = "sourcehub.acp.MsgCreatePolicy";
+const DIRECT_POLICY_COMMAND: &str = "sourcehub.acp.MsgDirectPolicyCmd";
+const EDIT_POLICY: &str = "sourcehub.acp.MsgEditPolicy";
+const SIGNED_POLICY_COMMAND: &str = "sourcehub.acp.MsgSignedPolicyCmd";
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(super) enum CacheInvalidation {
@@ -85,45 +85,46 @@ fn decode_transaction(tx_bytes: &[u8]) -> Result<Vec<CacheInvalidation>, EventDe
 
     for message in body.messages {
         let message_type = message.type_url.trim_start_matches('/');
-        let invalidation =
-            match message_type {
-                BEARER_POLICY_COMMAND => {
-                    let command = BearerPolicyCommand::decode(message.value.as_slice()).map_err(
-                        |source| EventDecodeError::AcpMessage {
+        let invalidation = match message_type {
+            BEARER_POLICY_COMMAND => {
+                let command =
+                    BearerPolicyCommand::decode(message.value.as_slice()).map_err(|source| {
+                        EventDecodeError::AcpMessage {
                             message_type: message.type_url.clone(),
                             source,
-                        },
-                    )?;
-                    command_invalidation(command.policy_id, command.command)
-                }
-                DIRECT_POLICY_COMMAND => {
-                    let command = DirectPolicyCommand::decode(message.value.as_slice()).map_err(
-                        |source| EventDecodeError::AcpMessage {
+                        }
+                    })?;
+                command_invalidation(command.policy_id, command.command)
+            }
+            DIRECT_POLICY_COMMAND => {
+                let command =
+                    DirectPolicyCommand::decode(message.value.as_slice()).map_err(|source| {
+                        EventDecodeError::AcpMessage {
                             message_type: message.type_url.clone(),
                             source,
-                        },
-                    )?;
-                    command_invalidation(command.policy_id, command.command)
+                        }
+                    })?;
+                command_invalidation(command.policy_id, command.command)
+            }
+            EDIT_POLICY => {
+                let edit =
+                    EditPolicyCommand::decode(message.value.as_slice()).map_err(|source| {
+                        EventDecodeError::AcpMessage {
+                            message_type: message.type_url.clone(),
+                            source,
+                        }
+                    })?;
+                if edit.policy_id.is_empty() {
+                    CacheInvalidation::All
+                } else {
+                    CacheInvalidation::Policy(edit.policy_id)
                 }
-                EDIT_POLICY => {
-                    let edit =
-                        EditPolicyCommand::decode(message.value.as_slice()).map_err(|source| {
-                            EventDecodeError::AcpMessage {
-                                message_type: message.type_url.clone(),
-                                source,
-                            }
-                        })?;
-                    if edit.policy_id.is_empty() {
-                        CacheInvalidation::All
-                    } else {
-                        CacheInvalidation::Policy(edit.policy_id)
-                    }
-                }
-                SIGNED_POLICY_COMMAND => CacheInvalidation::All,
-                CREATE_POLICY | CHECK_ACCESS => continue,
-                message_type if message_type.starts_with("vera.acp.") => CacheInvalidation::All,
-                _ => continue,
-            };
+            }
+            SIGNED_POLICY_COMMAND => CacheInvalidation::All,
+            CREATE_POLICY | CHECK_ACCESS => continue,
+            message_type if message_type.starts_with("sourcehub.acp.") => CacheInvalidation::All,
+            _ => continue,
+        };
 
         if invalidation == CacheInvalidation::All {
             return Ok(vec![CacheInvalidation::All]);
@@ -374,7 +375,7 @@ mod tests {
     fn unknown_acp_message_fails_safe() {
         let event = transaction_event(
             vec![ProtoAny {
-                type_url: "/vera.acp.MsgFuturePolicyMutation".into(),
+                type_url: "/sourcehub.acp.MsgFuturePolicyMutation".into(),
                 value: Vec::new(),
             }],
             0,

--- a/crates/sourcehub/src/cosmos/tx.rs
+++ b/crates/sourcehub/src/cosmos/tx.rs
@@ -39,7 +39,7 @@ impl TxSigner {
 
         let public_key = signing_key.public_key();
         let account_id = public_key
-            .account_id("vera")
+            .account_id("source")
             .map_err(|e| TxSignerError::Key(format!("failed to derive address: {}", e)))?;
 
         let chain_id: cosmrs::tendermint::chain::Id = chain_id
@@ -53,7 +53,7 @@ impl TxSigner {
         })
     }
 
-    /// Get the bech32 account address (e.g., "vera1...").
+    /// Get the bech32 account address (e.g., "source1...").
     pub(crate) fn address(&self) -> String {
         self.account_id.to_string()
     }
@@ -259,7 +259,7 @@ fn build_msg_create_policy(creator: &str, policy: &str) -> Any {
     encode_varint_field(&mut buf, 3, 1);
 
     Any {
-        type_url: "/vera.acp.MsgCreatePolicy".to_string(),
+        type_url: "/sourcehub.acp.MsgCreatePolicy".to_string(),
         value: buf,
     }
 }
@@ -285,7 +285,7 @@ fn build_msg_bearer_policy_cmd(
     encode_bytes_field(&mut buf, 4, &cmd_bytes);
 
     Any {
-        type_url: "/vera.acp.MsgBearerPolicyCmd".to_string(),
+        type_url: "/sourcehub.acp.MsgBearerPolicyCmd".to_string(),
         value: buf,
     }
 }

--- a/crates/sourcehub/src/cosmos/tx/tests.rs
+++ b/crates/sourcehub/src/cosmos/tx/tests.rs
@@ -39,6 +39,11 @@ impl RpcState {
     }
 }
 
+#[test]
+fn signer_uses_sourcehub_account_prefix() {
+    assert!(test_signer().address().starts_with("source1"));
+}
+
 #[tokio::test]
 async fn sign_and_broadcast_holds_sequence_lock_until_inclusion() {
     let state = Arc::new(RpcState::new(ServerMode::DelayFirstTx));
@@ -277,6 +282,7 @@ fn successful_tx_response() -> String {
 
 fn test_client(base_url: &str) -> SourceHubClient {
     SourceHubClient::new(
+        base_url.to_string(),
         base_url.to_string(),
         base_url.to_string(),
         Duration::from_secs(5),

--- a/proofs/Cargo.toml
+++ b/proofs/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = "1.0"
 anyhow = "1.0"
 
 [dev-dependencies]
-defra-harness = { git = "https://github.com/sourcenetwork/backbone.git", rev = "9526a4ebfaa1cebf07fc3592de6f0a62d77f9e30" }
+defra-harness = { git = "https://github.com/sourcenetwork/backbone.git", rev = "3d1544ec783b093186422d82b5af326457e63609" }
 tokio = { workspace = true, features = ["rt", "macros", "sync", "time"] }
 serial_test = "3"
 

--- a/proofs/Cargo.toml
+++ b/proofs/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = "1.0"
 anyhow = "1.0"
 
 [dev-dependencies]
-defra-harness = { git = "https://github.com/sourcenetwork/backbone.git", rev = "3d1544ec783b093186422d82b5af326457e63609" }
+defra-harness = { git = "https://github.com/sourcenetwork/backbone.git", rev = "e0c42841f212119a385ee6c10465c3afe6fc62d4" }
 tokio = { workspace = true, features = ["rt", "macros", "sync", "time"] }
 serial_test = "3"
 

--- a/tools/integration-test/Cargo.toml
+++ b/tools/integration-test/Cargo.toml
@@ -114,8 +114,8 @@ name = "client_authored"
 path = "tests/client_authored.rs"
 
 [dependencies]
-hub-harness = { git = "https://github.com/sourcenetwork/backbone.git", rev = "9526a4ebfaa1cebf07fc3592de6f0a62d77f9e30" }
-defra-harness = { git = "https://github.com/sourcenetwork/backbone.git", rev = "9526a4ebfaa1cebf07fc3592de6f0a62d77f9e30" }
+hub-harness = { git = "https://github.com/sourcenetwork/backbone.git", rev = "3d1544ec783b093186422d82b5af326457e63609" }
+defra-harness = { git = "https://github.com/sourcenetwork/backbone.git", rev = "3d1544ec783b093186422d82b5af326457e63609" }
 document = { path = "../../crates/document" }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time"] }
 reqwest = { version = "0.12", default-features = false, features = [

--- a/tools/integration-test/Cargo.toml
+++ b/tools/integration-test/Cargo.toml
@@ -114,8 +114,8 @@ name = "client_authored"
 path = "tests/client_authored.rs"
 
 [dependencies]
-hub-harness = { git = "https://github.com/sourcenetwork/backbone.git", rev = "3d1544ec783b093186422d82b5af326457e63609" }
-defra-harness = { git = "https://github.com/sourcenetwork/backbone.git", rev = "3d1544ec783b093186422d82b5af326457e63609" }
+hub-harness = { git = "https://github.com/sourcenetwork/backbone.git", rev = "e0c42841f212119a385ee6c10465c3afe6fc62d4" }
+defra-harness = { git = "https://github.com/sourcenetwork/backbone.git", rev = "e0c42841f212119a385ee6c10465c3afe6fc62d4" }
 document = { path = "../../crates/document" }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time"] }
 reqwest = { version = "0.12", default-features = false, features = [

--- a/tools/integration-test/tests/p2p_iroh/acp/dac.rs
+++ b/tools/integration-test/tests/p2p_iroh/acp/dac.rs
@@ -12,8 +12,8 @@
 use std::time::Duration;
 
 use integration_test::{
-    extract_p2p_addr, generate_identity, poll_until, users_schema_with_policy, TestCluster,
-    USER_ACP_POLICY,
+    extract_p2p_addr, generate_identity, poll_until, users_schema_with_policy, BinarySource,
+    TestCluster, USER_ACP_POLICY,
 };
 use serial_test::serial;
 
@@ -81,6 +81,7 @@ async fn setup_sourcehub_cluster() -> Option<(TestCluster, String, String)> {
         .rust_nodes(2)
         .with_source_hub()
         .with_iroh_transport()
+        .with_rust_binary(BinarySource::Path(support::sourcehub_iroh_binary()))
         .with_identity(&owner_key)
         .build()
         .await

--- a/tools/integration-test/tests/p2p_iroh/support.rs
+++ b/tools/integration-test/tests/p2p_iroh/support.rs
@@ -1,6 +1,9 @@
 use std::path::PathBuf;
+use std::sync::OnceLock;
 
 use integration_test::{build_cli_variant, workspace_root};
+
+static SOURCEHUB_IROH_BINARY: OnceLock<PathBuf> = OnceLock::new();
 
 #[ctor::ctor]
 fn prepare_iroh_binary() {
@@ -21,6 +24,18 @@ pub fn sourcehub_binary_available() -> bool {
     std::env::var_os("SOURCEHUB_BINARY").is_some()
         || std::env::var_os("SOURCEHUB_WORKSPACE").is_some()
         || path_contains_binary("sourcehubd")
+}
+
+pub fn sourcehub_iroh_binary() -> PathBuf {
+    SOURCEHUB_IROH_BINARY
+        .get_or_init(|| {
+            build_cli_variant(
+                &workspace_root(),
+                &["iroh", "sourcehub"],
+                "defra-iroh-sourcehub",
+            )
+        })
+        .clone()
 }
 
 fn path_contains_binary(name: &str) -> bool {

--- a/tools/integration-test/tests/sourcehub/acp_tuning.rs
+++ b/tools/integration-test/tests/sourcehub/acp_tuning.rs
@@ -9,7 +9,7 @@ use integration_test::{generate_identity, users_schema_with_policy, TestCluster,
 #[serial_test::serial]
 async fn rust_circuit_breaker_threshold_1_trips_immediately() {
     let binary = RustNode::from_workspace().binary_path().to_path_buf();
-    RustNode::build().expect("build rust binary");
+    RustNode::build_with_features(&["sourcehub"]).expect("build sourcehub-enabled rust binary");
     let jack = generate_identity(&binary).expect("Jack identity");
     let bob = generate_identity(&binary).expect("Bob identity");
 
@@ -95,7 +95,7 @@ async fn rust_circuit_breaker_threshold_1_trips_immediately() {
 #[serial_test::serial]
 async fn rust_cache_ttl_expiry_with_short_ttl() {
     let binary = RustNode::from_workspace().binary_path().to_path_buf();
-    RustNode::build().expect("build rust binary");
+    RustNode::build_with_features(&["sourcehub"]).expect("build sourcehub-enabled rust binary");
     let alice = generate_identity(&binary).expect("Alice identity");
     let bob = generate_identity(&binary).expect("Bob identity");
 
@@ -185,7 +185,7 @@ async fn rust_cache_ttl_expiry_with_short_ttl() {
 #[serial_test::serial]
 async fn rust_short_request_timeout_fail_closed() {
     let binary = RustNode::from_workspace().binary_path().to_path_buf();
-    RustNode::build().expect("build rust binary");
+    RustNode::build_with_features(&["sourcehub"]).expect("build sourcehub-enabled rust binary");
     let jack = generate_identity(&binary).expect("Jack identity");
     let bob = generate_identity(&binary).expect("Bob identity");
 
@@ -261,7 +261,7 @@ async fn rust_short_request_timeout_fail_closed() {
 #[serial_test::serial]
 async fn rust_access_cache_grant_revoke_invalidation() {
     let binary = RustNode::from_workspace().binary_path().to_path_buf();
-    RustNode::build().expect("build rust binary");
+    RustNode::build_with_features(&["sourcehub"]).expect("build sourcehub-enabled rust binary");
     let alice = generate_identity(&binary).expect("Alice identity");
     let bob = generate_identity(&binary).expect("Bob identity");
 

--- a/tools/integration-test/tests/sourcehub/compartments.rs
+++ b/tools/integration-test/tests/sourcehub/compartments.rs
@@ -34,7 +34,7 @@ fn add_policy(node: &integration_test::DefraClient, policy: &str, identity: &str
 #[serial_test::serial]
 async fn rust_sourcehub_compartments() {
     let binary = RustNode::from_workspace().binary_path().to_path_buf();
-    RustNode::build().expect("build rust binary");
+    RustNode::build_with_features(&["sourcehub"]).expect("build sourcehub-enabled rust binary");
     let jack = generate_identity(&binary).expect("Jack identity");
 
     let cluster = TestCluster::builder()

--- a/tools/integration-test/tests/sourcehub/encryption_acp.rs
+++ b/tools/integration-test/tests/sourcehub/encryption_acp.rs
@@ -107,8 +107,8 @@ async fn wait_for_names(
 /// + the Users schema on both nodes, and return `(cluster, policy_id, ids)`.
 ///
 /// This deliberately does NOT wire node0 -> node1 replication. Callers connect
-/// node1 explicitly via [`connect_and_replicate`] at the point they want the
-/// doc to start syncing — this lets the positive test grant the on-chain
+/// node1 explicitly via [`connect_and_replicate_without_delegation`] when they
+/// want the doc to start syncing. This lets the positive test grant on-chain
 /// `reader` relations BEFORE node1 ever sees the encrypted block, mirroring
 /// Go's grant-then-`WaitForSync` ordering (peer_acp_test.go).
 ///
@@ -117,7 +117,7 @@ async fn wait_for_names(
 /// meaningful for the KMS node-gate.
 async fn setup_two_nodes() -> (TestCluster, String, NodeIds) {
     let binary = RustNode::from_workspace().binary_path().to_path_buf();
-    RustNode::build().expect("build rust binary");
+    RustNode::build_with_features(&["sourcehub"]).expect("build sourcehub-enabled rust binary");
     let node0 = generate_identity(&binary).expect("node0 identity");
     let node1 = generate_identity(&binary).expect("node1 identity");
 
@@ -156,7 +156,8 @@ async fn setup_two_nodes() -> (TestCluster, String, NodeIds) {
 
     // Collections are registered for P2P on both nodes here; the actual
     // connection + replicator (which starts the push of the encrypted DAG to
-    // node1) is deferred to `connect_and_replicate` so callers control timing.
+    // node1) is deferred to `connect_and_replicate_without_delegation` so
+    // callers control timing.
     c0.p2p_collection_add(&["Users"]).expect("col add node0");
     c1.p2p_collection_add(&["Users"]).expect("col add node1");
 
@@ -177,15 +178,17 @@ struct NodeIds {
     node1_did: String,
 }
 
-/// Connect node0 -> node1 and set node0's replicator so the (already-created,
-/// already-granted) encrypted DAG starts pushing to node1. Call this only AFTER
-/// the relevant `reader` grants are durable on-chain so node1's KMS fetch is
-/// served against an already-registered, already-authorized document.
-fn connect_and_replicate(cluster: &TestCluster, node0_key: &str) {
+/// Connect node0 -> node1 without an explicit-replay delegation.
+///
+/// An identity-bearing replicator request intentionally delegates the
+/// authorizer's collection access to the target peer, including its KMS fetch.
+/// Tests that assert the target node remains unauthorized must therefore use
+/// the ordinary node-authenticated replication path.
+fn connect_and_replicate_without_delegation(cluster: &TestCluster) {
     let addr1 = extract_p2p_addr(cluster, 1);
     let c0 = cluster.client(0);
     c0.p2p_connect(&[&addr1]).expect("connect");
-    c0.p2p_replicator_set_with_identity(&["Users"], &addr1, node0_key)
+    c0.p2p_replicator_set(&["Users"], &addr1)
         .expect("set replicator");
 }
 
@@ -231,7 +234,7 @@ async fn encryption_acp_user_and_node_access() {
         .expect("grant node1 reader");
 
     // Only now wire replication so the doc syncs to node1 with grants in place.
-    connect_and_replicate(&cluster, &ids.node0_key);
+    connect_and_replicate_without_delegation(&cluster);
 
     // The user on node1 should eventually see the decrypted doc.
     let names = wait_for_names(
@@ -290,9 +293,10 @@ async fn encryption_acp_user_access_not_node() {
     c0.acp_relationship_add("Users", &doc_id, "reader", &user.did, &ids.node0_key)
         .expect("grant user reader");
 
-    // Now wire replication. node1 receives the ciphertext DAG but its KMS DEK
-    // fetch is denied by node0's serve-gate (node1 has no `reader` grant).
-    connect_and_replicate(&cluster, &ids.node0_key);
+    // Now wire replication without an explicit-replay delegation. The target
+    // node has no `reader` grant, so neither private replay admission nor a
+    // KMS DEK fetch can borrow the owner's authority.
+    connect_and_replicate_without_delegation(&cluster);
 
     // Give replication + (failed) key-fetch a chance to settle.
     tokio::time::sleep(Duration::from_secs(8)).await;
@@ -308,12 +312,10 @@ async fn encryption_acp_user_access_not_node() {
         users
     );
 
-    // Without node-level rights, node1 must not hold the decryptable doc;
-    // the user query above already asserts this. (The Go original also asserts
-    // empty `_commits`, but the Rust explicit-replicator push delivers the
-    // ciphertext DAG regardless — only the DEK is gated — so commit blocks may
-    // be present. The security-critical property is that the doc cannot be
-    // decrypted, which the empty-result assertion above enforces.)
+    // Without node-level rights, node1 must not expose the document. Private
+    // replay admission can reject it before storage; if it reaches storage,
+    // the KMS gate must still prevent decryption. The empty result asserts the
+    // end-to-end security property without depending on which gate rejects it.
 }
 
 /// Port: TestDocEncryptionACP_IfNodeHasAccessToSomeDocs_ShouldFetchOnlyThem
@@ -410,7 +412,7 @@ async fn encryption_acp_node_partial_access() {
     let _shahzad = public_create("Shahzad", false);
 
     // Grants are now durable on-chain; wire replication so node1 starts syncing.
-    connect_and_replicate(&cluster, &ids.node0_key);
+    connect_and_replicate_without_delegation(&cluster);
 
     // node1 queries as itself. The node-identity full-access shortcut means
     // node1 sees everything it physically *has*; the gating happened at sync /
@@ -456,7 +458,7 @@ async fn encryption_acp_node_partial_access() {
 #[ignore = "SourceHub harness funds only one account (node0); node1 cannot sign its merge-side ACP registration or a post-shutdown grant (account not found) — single-signer harness funding limitation, not the DEK-leak race (#976)"]
 async fn encryption_acp_server_not_available() {
     let binary = RustNode::from_workspace().binary_path().to_path_buf();
-    RustNode::build().expect("build rust binary");
+    RustNode::build_with_features(&["sourcehub"]).expect("build sourcehub-enabled rust binary");
     let node0 = generate_identity(&binary).expect("node0 identity");
     let node1 = generate_identity(&binary).expect("node1 identity");
     let node2 = generate_identity(&binary).expect("node2 identity");

--- a/tools/integration-test/tests/sourcehub/policy_lifecycle.rs
+++ b/tools/integration-test/tests/sourcehub/policy_lifecycle.rs
@@ -15,7 +15,7 @@ use integration_test::{generate_identity, users_schema_with_policy, TestCluster,
 #[serial_test::serial]
 async fn rust_sourcehub_policy_lifecycle() {
     let binary = RustNode::from_workspace().binary_path().to_path_buf();
-    RustNode::build().expect("build rust binary");
+    RustNode::build_with_features(&["sourcehub"]).expect("build sourcehub-enabled rust binary");
     let alice = generate_identity(&binary).expect("Alice identity");
 
     let cluster = TestCluster::builder()

--- a/tools/integration-test/tests/sourcehub/resilience.rs
+++ b/tools/integration-test/tests/sourcehub/resilience.rs
@@ -15,7 +15,7 @@ use integration_test::{generate_identity, users_schema_with_policy, TestCluster,
 #[serial_test::serial]
 async fn rust_circuit_breaker_trip_recovery() {
     let binary = RustNode::from_workspace().binary_path().to_path_buf();
-    RustNode::build().expect("build rust binary");
+    RustNode::build_with_features(&["sourcehub"]).expect("build sourcehub-enabled rust binary");
     let jack = generate_identity(&binary).expect("Jack identity");
     let bob = generate_identity(&binary).expect("Bob identity");
 
@@ -112,7 +112,7 @@ async fn rust_circuit_breaker_trip_recovery() {
 #[serial_test::serial]
 async fn rust_policy_cache_ttl_expiry() {
     let binary = RustNode::from_workspace().binary_path().to_path_buf();
-    RustNode::build().expect("build rust binary");
+    RustNode::build_with_features(&["sourcehub"]).expect("build sourcehub-enabled rust binary");
     let alice = generate_identity(&binary).expect("Alice identity");
     let bob = generate_identity(&binary).expect("Bob identity");
 
@@ -196,7 +196,7 @@ async fn rust_policy_cache_ttl_expiry() {
 #[ignore = "Go node with SourceHub not yet supported"]
 async fn go_circuit_breaker_trip_recovery() {
     let binary = RustNode::from_workspace().binary_path().to_path_buf();
-    RustNode::build().expect("build rust binary");
+    RustNode::build_with_features(&["sourcehub"]).expect("build sourcehub-enabled rust binary");
     let jack = generate_identity(&binary).expect("Jack identity");
 
     let cluster = TestCluster::builder()
@@ -239,7 +239,7 @@ async fn go_circuit_breaker_trip_recovery() {
 #[ignore = "Go node with SourceHub not yet supported"]
 async fn go_policy_cache_ttl_expiry() {
     let binary = RustNode::from_workspace().binary_path().to_path_buf();
-    RustNode::build().expect("build rust binary");
+    RustNode::build_with_features(&["sourcehub"]).expect("build sourcehub-enabled rust binary");
     let alice = generate_identity(&binary).expect("Alice identity");
 
     let cluster = TestCluster::builder()

--- a/tools/integration-test/tests/sourcehub/smoke.rs
+++ b/tools/integration-test/tests/sourcehub/smoke.rs
@@ -16,7 +16,7 @@ use integration_test::node::{DefraNode, RustNode};
 async fn rust_sourcehub_smoke() {
     // Pre-generate Jack's identity so the node starts with his key
     let binary = RustNode::from_workspace().binary_path().to_path_buf();
-    RustNode::build().expect("build rust binary");
+    RustNode::build_with_features(&["sourcehub"]).expect("build sourcehub-enabled rust binary");
     let jack = generate_identity(&binary).expect("failed to generate Jack identity");
 
     let cluster = TestCluster::builder()


### PR DESCRIPTION
## Summary

Align the Rust SourceHub client with the current SourceHub Cosmos wire contract
and make ACP verification usable on the current split REST/gRPC deployment.

- derive signer addresses with the `source` bech32 prefix;
- emit and recognize `sourcehub.acp` protobuf type URLs and query paths;
- send nested access-verification operations through native Tonic gRPC instead
  of the REST gateway, reusing a channel and enforcing the configured timeout;
- support distinct SourceHub LCD and gRPC endpoints in the CLI, `defra-node`,
  and `embedded` builders while preserving the existing single-address API;
- build SourceHub integration binaries with the required feature;
- give SourceHub-backed Iroh DAC tests an explicit `iroh,sourcehub` binary.

This removes test-order-dependent binary feature selection and fixes the ACP
requests rejected by current SourceHub as legacy `vera` traffic.

Depends on sourcenetwork/backbone#32, which exposes the SourceHub gRPC address
to the integration harness.

## Validation

- `cargo test --profile super-dev -p sourcehub`: 48 passed, including a stalled
  gRPC timeout regression.
- CLI configuration tests: 18 passed.
- Current SourceHub smoke passes.
- SourceHub integration: all active cases pass after correcting the
  non-delegated encryption negative case.
- SourceHub-backed Iroh DAC slice: 10 passed.
- Targeted all-feature clippy for `sourcehub`, `cli`, `defra-node`, and
  `embedded` passes with warnings denied.
- Hub.rs is explicitly outside this PR's gate; its independent ownership/read
  failures are not hidden or changed here.

The workspace-wide all-target/all-feature clippy command reaches a pre-existing
unrelated bench error: `NoopExecutor` in `benches/benches/transport.rs` does not
implement `abandon_txn`.

## Stack

Base: #1731 (native document-state observation).
Next: closed-QUIC sender-slot release, then storage-owner release wakeup.
