### PR TITLE
Release closed Iroh sender attempts promptly

### DIFF
--- a/crates/p2p/src/iroh/endpoint_rpc.rs
+++ b/crates/p2p/src/iroh/endpoint_rpc.rs
@@ -457,7 +457,19 @@ pub(super) async fn handle_two_stream_request(
         }
     };
 
-    tokio::time::timeout(REQUEST_RESPONSE_TIMEOUT, wait_for_reply)
+    // A stream reset can still receive a legacy reverse-stream reply. A closed
+    // connection must release this attempt so durable retry and newer heads do
+    // not wait behind dead requests occupying every per-peer sender slot.
+    let wait_for_reply_or_disconnect = async {
+        tokio::select! {
+            biased;
+            reply = wait_for_reply => reply,
+            reason = connection.closed() => Err(crate::error::Error::Transport(
+                format!("PushLog connection closed before acknowledgement: {reason}")
+            )),
+        }
+    };
+    tokio::time::timeout(REQUEST_RESPONSE_TIMEOUT, wait_for_reply_or_disconnect)
         .await
         .map_err(|_| {
             warn!(

--- a/crates/p2p/src/iroh/two_stream_tests.rs
+++ b/crates/p2p/src/iroh/two_stream_tests.rs
@@ -235,6 +235,51 @@ async fn two_stream_request_still_accepts_legacy_reverse_stream_reply() {
 }
 
 #[tokio::test]
+async fn disconnected_two_stream_requests_release_send_slots_before_reply_timeout() {
+    let sender = TestNode::spawn().await;
+    let mut receiver = TestNode::spawn().await;
+    connect(&sender.transport, &receiver.transport).await;
+
+    let mut sends = Vec::new();
+    for index in 0..4 {
+        let request = signed_request(&sender.transport, &format!("disconnect-{index}"));
+        let transport = sender.transport.clone();
+        let peer = receiver.transport.local_peer_id().clone();
+        sends.push(tokio::spawn(async move {
+            transport.send_two_stream_request(&peer, request).await
+        }));
+    }
+    // Every request reached the peer, but neither reply format is returned.
+    let mut response_tokens = Vec::new();
+    for _ in 0..4 {
+        let (_, _, token) = next_two_stream_request(&mut receiver.events).await;
+        response_tokens.push(token);
+    }
+    receiver
+        .transport
+        .disconnect(sender.transport.local_peer_id())
+        .await
+        .unwrap();
+    let completed = timeout(Duration::from_secs(1), async {
+        for send in &mut sends {
+            assert!(send.await.unwrap().is_err());
+        }
+    })
+    .await;
+    // Clean up even on the red path: the 30-second legacy wait must not leak.
+    for send in sends {
+        send.abort();
+    }
+    drop(response_tokens);
+    sender.shutdown().await;
+    receiver.shutdown().await;
+    assert!(
+        completed.is_ok(),
+        "closed QUIC connection retained pending PushLog requests"
+    );
+}
+
+#[tokio::test]
 async fn concurrent_two_stream_fan_in_replies_on_request_streams() {
     const SENDERS: usize = 32;
 


### PR DESCRIPTION
## Summary

Release a PushLog attempt as soon as its QUIC connection closes, rather than
holding a bounded sender slot until the 30-second legacy reply timeout.

Keep the existing timeout for live connections and preserve reverse-stream
legacy replies after a stream-only reset. Prefer an already available reply
when reply and connection-close become ready together. Durable retry ownership
and the wire protocol do not change.

Fixes #1733.

## Regression and validation

Four real requests reach the receiver, which retains their response tokens and
disconnects without replying. All four sends must finish with errors within one
second. The test fails before the change and passes afterward. Same-stream,
legacy reverse-stream, explicit authorization and concurrent fan-in tests pass.

Combined candidate: 606 P2P tests pass. Canonical Gents aged-history
offline/reopen/follow-up tests pass with the local dependency candidate.

## Stack

Base: SourceHub current-protocol ACP compatibility (stacked above #1731).
Next: storage-owner release wakeup; then portable downstream dependency pins.
No release, merge, or deployment is included.
