### PR TITLE
Wake pending DAGs when storage owners release

### DIFF
--- a/crates/p2p/src/sync/coordinator/broadcast.rs
+++ b/crates/p2p/src/sync/coordinator/broadcast.rs
@@ -245,8 +245,12 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     async fn push_jobs(&self, push: &PendingPush) -> Result<Vec<PushJobSpec>> {
         let replicators = self.list_replicators_for_push().await?;
         let mut jobs = Vec::new();
+        let mut collection_misses = 0usize;
+        let mut missing_documents = 0usize;
+        let mut filter_misses = 0usize;
         for rep in &replicators {
             if !Self::replicator_in_collection(rep, &push.collection_id) {
+                collection_misses += 1;
                 continue;
             }
             let Some(peer_id) = Self::peer_id_for_replicator(rep) else {
@@ -254,6 +258,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             };
             if rep.is_filtered_for_collection(&push.collection_id) {
                 let Some(document) = push.document.as_ref() else {
+                    missing_documents += 1;
                     continue;
                 };
                 if !rep.matches_filter(
@@ -261,6 +266,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                     &push.collection_id,
                     document,
                 ) {
+                    filter_misses += 1;
                     continue;
                 }
             }
@@ -273,6 +279,18 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 push.block.clone(),
             ));
         }
+        tracing::debug!(
+            target: "p2p::sync::delivery_admission",
+            doc_id = %push.doc_id,
+            collection_id = %push.collection_id,
+            cid = %push.cid,
+            replicators = replicators.len(),
+            jobs = jobs.len(),
+            collection_misses,
+            missing_documents,
+            filter_misses,
+            "Committed head sender selection"
+        );
         Ok(jobs)
     }
 

--- a/crates/p2p/src/sync/coordinator/event_handler/car.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/car.rs
@@ -473,6 +473,8 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         {
             Ok(owners) => owners,
             Err(conflicting_cid) => {
+                self.manager
+                    .defer_pending_dag_for_storage(&root_cid, conflicting_cid);
                 self.manager.diagnostics.record_single_flight_suppressed();
                 let same_root = conflicting_cid == root_cid;
                 tracing::debug!(

--- a/crates/p2p/src/sync/manager/pending.rs
+++ b/crates/p2p/src/sync/manager/pending.rs
@@ -61,6 +61,8 @@ pub struct PendingDag {
     pub next_retry_at: tokio::time::Instant,
     /// Fetch dispatches claimed for this root (drives the backoff rung).
     pub dispatches: u32,
+    /// Transient local contention; discarded with this bounded pending root.
+    pub storage_blocker: Option<Cid>,
 }
 
 /// Pending roots and the reverse index used to route arriving blocks only to

--- a/crates/p2p/src/sync/manager/process/pending_dag.rs
+++ b/crates/p2p/src/sync/manager/process/pending_dag.rs
@@ -119,7 +119,19 @@ impl<B: Blockstore + 'static> SyncManager<B> {
 
     /// Wake the existing dispatch owner without creating another fetch owner.
     pub(crate) async fn pending_dag_ready(&self) {
-        self.pending_dag_ready.notified().await;
+        tokio::select! {
+            _ = self.pending_dag_ready.notified() => {},
+            _ = self.process_queue.released() => {},
+        }
+    }
+
+    /// Remember contention without retaining a transport task or CAR buffer.
+    pub(crate) fn defer_pending_dag_for_storage(&self, root: &Cid, blocker: Cid) {
+        if let Some(dag) = self.pending_dags.write().get_mut(root) {
+            dag.storage_blocker = Some(blocker);
+            // Also wake if the owner released before registration.
+            self.pending_dag_ready.notify_one();
+        }
     }
 
     /// Milliseconds until the earliest due pending-DAG retry, including a
@@ -388,7 +400,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
             self.diagnostics.record_pending_dag_retry_suppressed();
             return false;
         };
-        if !dag.is_recovery_registered || now < dag.next_retry_at {
+        if !dag.is_recovery_registered || dag.storage_blocker.is_some() || now < dag.next_retry_at {
             self.diagnostics.record_pending_dag_retry_suppressed();
             return false;
         }
@@ -417,10 +429,29 @@ impl<B: Blockstore + 'static> SyncManager<B> {
         &self,
         now: tokio::time::Instant,
     ) -> Vec<(Cid, PendingDag)> {
-        let pending = self.pending_dags.read();
+        let mut pending = self.pending_dags.write();
+        let released: Vec<_> = pending
+            .iter()
+            .filter_map(|(root, dag)| {
+                dag.storage_blocker
+                    .filter(|cid| !self.process_queue.is_active(cid))
+                    .map(|_| *root)
+            })
+            .collect();
+        for root in released {
+            let dag = pending
+                .get_mut(&root)
+                .expect("pending root held under write lock");
+            dag.storage_blocker = None;
+            dag.next_retry_at = dag.next_retry_at.min(now);
+        }
         let mut due: Vec<_> = pending
             .iter()
-            .filter(|(_, dag)| dag.is_recovery_registered && now >= dag.next_retry_at)
+            .filter(|(_, dag)| {
+                dag.is_recovery_registered
+                    && dag.storage_blocker.is_none()
+                    && now >= dag.next_retry_at
+            })
             .map(|(cid, dag)| (*cid, dag.clone()))
             .collect();
         due.sort_unstable_by(|(left_cid, left), (right_cid, right)| {
@@ -793,6 +824,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                 last_fetch_error: None,
                 next_retry_at: tokio::time::Instant::now(),
                 dispatches: 0,
+                storage_blocker: None,
             };
 
             let superseded = match self.try_insert_pending_dag(root_cid, dag.clone()) {

--- a/crates/p2p/src/sync/manager/process/pending_dag_tests.rs
+++ b/crates/p2p/src/sync/manager/process/pending_dag_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use std::sync::Arc;
+use std::time::Duration;
 
 use blockstore::DefraBlockstore;
 use defra_core::{Block as DefraBlock, CompositeDeltaPayload, CrdtDelta, DAGLink, LwwDeltaPayload};
@@ -46,6 +47,7 @@ fn pending_dag_from(doc_id: &str, source_peer: Option<&str>, inserted_at: Instan
         last_fetch_error: None,
         next_retry_at: tokio::time::Instant::now(),
         dispatches: 0,
+        storage_blocker: None,
     }
 }
 
@@ -74,6 +76,54 @@ fn linked_dag_providers_require_positive_missing_cid_evidence() {
         vec!["descendant-provider".to_string()],
         "root possession and connectivity alone must not advertise linked-DAG availability"
     );
+}
+
+#[tokio::test]
+async fn storage_release_wakes_only_contended_roots_without_resetting_backoff() {
+    use futures::FutureExt;
+    let manager = test_manager();
+    let root = test_cid(910);
+    let other = test_cid(911);
+    let blocker = test_cid(912);
+    let now = tokio::time::Instant::now();
+    for cid in [root, other] {
+        let mut dag = pending_dag("storage", Instant::now());
+        dag.next_retry_at = now;
+        manager.insert_pending_dag(cid, dag);
+        assert!(manager.try_claim_pending_dag_dispatch(&cid, now));
+    }
+    let owner = manager.process_queue.try_acquire_nowait(&blocker).unwrap();
+    manager.defer_pending_dag_for_storage(&root, blocker);
+    assert!(manager.pending_dag_ready().now_or_never().is_some());
+    assert!(manager.due_pending_dag_retries(now).is_empty());
+    assert!(!manager.try_claim_pending_dag_dispatch(&root, now + Duration::from_secs(60)));
+    drop(owner);
+    assert!(manager.pending_dag_ready().now_or_never().is_some());
+    let due = manager.due_pending_dag_retries(now);
+    assert_eq!(due.len(), 1);
+    assert_eq!(due[0].0, root);
+    assert_eq!(due[0].1.dispatches, 1);
+    assert!(manager.try_claim_pending_dag_dispatch(&root, now));
+    assert!(!manager.try_claim_pending_dag_dispatch(&root, now));
+    assert!(manager.due_pending_dag_retries(now).is_empty());
+}
+
+#[tokio::test]
+async fn storage_release_before_registration_does_not_lose_wakeup() {
+    use futures::FutureExt;
+    let manager = test_manager();
+    let root = test_cid(920);
+    let blocker = test_cid(921);
+    manager.insert_pending_dag(root, pending_dag("storage", Instant::now()));
+    let now = tokio::time::Instant::now();
+    assert!(manager.try_claim_pending_dag_dispatch(&root, now));
+    let owner = manager.process_queue.try_acquire_nowait(&blocker).unwrap();
+    drop(owner);
+    assert!(manager.pending_dag_ready().now_or_never().is_some());
+    assert!(manager.due_pending_dag_retries(now).is_empty());
+    manager.defer_pending_dag_for_storage(&root, blocker);
+    assert!(manager.pending_dag_ready().now_or_never().is_some());
+    assert_eq!(manager.due_pending_dag_retries(now)[0].0, root);
 }
 
 #[tokio::test]

--- a/crates/p2p/src/sync/manager/process/pushlog.rs
+++ b/crates/p2p/src/sync/manager/process/pushlog.rs
@@ -599,6 +599,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                         last_fetch_error: None,
                         next_retry_at: tokio::time::Instant::now(),
                         dispatches: 0,
+                        storage_blocker: None,
                     },
                 );
                 // Report the limit that actually tripped so the nack and its

--- a/crates/p2p/src/sync/queue.rs
+++ b/crates/p2p/src/sync/queue.rs
@@ -31,6 +31,7 @@ impl std::fmt::Debug for ProcessQueue {
 }
 
 struct ProcessQueueInner {
+    released: tokio::sync::Notify,
     /// Map of CID -> list of waiters
     waiters: Mutex<HashMap<Cid, Vec<oneshot::Sender<()>>>>,
 }
@@ -40,6 +41,7 @@ impl ProcessQueue {
     pub fn new() -> Self {
         Self {
             inner: Arc::new(ProcessQueueInner {
+                released: tokio::sync::Notify::new(),
                 waiters: Mutex::new(HashMap::new()),
             }),
         }
@@ -50,6 +52,14 @@ impl ProcessQueue {
     /// Useful for monitoring and debugging.
     pub fn active_count(&self) -> usize {
         self.inner.waiters.lock().len()
+    }
+
+    pub(crate) fn is_active(&self, cid: &Cid) -> bool {
+        self.inner.waiters.lock().contains_key(cid)
+    }
+
+    pub(crate) async fn released(&self) {
+        self.inner.released.notified().await;
     }
 
     /// Get all CIDs currently being processed.
@@ -76,6 +86,7 @@ impl ProcessQueue {
     pub fn force_release(&self, cid: &Cid) -> bool {
         let mut waiters = self.inner.waiters.lock();
         if let Some(waiting) = waiters.remove(cid) {
+            self.inner.released.notify_one();
             tracing::warn!(
                 ?cid,
                 waiter_count = waiting.len(),
@@ -102,6 +113,7 @@ impl ProcessQueue {
         let mut waiters = self.inner.waiters.lock();
         let count = waiters.len();
         if count > 0 {
+            self.inner.released.notify_one();
             tracing::warn!(count = count, "Force-releasing all stuck CIDs");
             for (cid, waiting) in waiters.drain() {
                 tracing::debug!(?cid, "Force-releasing CID");
@@ -213,6 +225,7 @@ impl ProcessQueue {
     fn release_sync(&self, cid: &Cid) {
         let mut waiters = self.inner.waiters.lock();
         if let Some(waiting) = waiters.remove(cid) {
+            self.inner.released.notify_one();
             // Notify all waiters that processing is complete
             let waiter_count = waiting.len();
             let mut notified = 0;


### PR DESCRIPTION
## Summary

Wake the existing pending-DAG retry scheduler when a conflicting local storage
owner releases its CID. Previously a Busy CAR result could wait several seconds
for retry backoff after the owner was already gone.

- Remember one transient blocking CID on each existing bounded pending root.
- Coalesce process-owner release notifications into the existing scheduler.
- Keep held roots out of dispatch, make released roots due, and preserve the
  network retry backoff rung.
- Handle release-before-registration without losing the wakeup.
- Keep CAR handling nonwaiting: no retained network task, CAR buffer queue,
  application retry loop, or persisted sync schema.
- Include debug-only sender admission counts used to distinguish filtering from
  queued delivery; no document contents are logged.

Fixes #1734.

## Validation

Tests cover held-owner suppression, unaffected unrelated retries, preserved
backoff, and release before registration. Combined P2P suite: 606 pass, five
existing ignored doctests.

Local Gents candidate offline recovery samples moved from 8.5–9.9 seconds to
2.8–3.1 seconds, with complete transcript and follow-up assertions unchanged.
These are diagnostic local runs using the companion Regolith change, not
controlled latency percentiles or physical-phone rendering measurements.

Depends on #1739 for the companion Regolith 0.1.4 release pin.

Broad integration results will be recorded before publication. This PR stacks
above the closed-QUIC sender-slot fix, itself above #1731.
