### PR TITLE
fix: preserve retained JSON during unrelated document updates

### DIFF
--- a/crates/db/src/collection/validation.rs
+++ b/crates/db/src/collection/validation.rs
@@ -162,9 +162,31 @@ fn is_value_compatible_with_scalar(value: &NormalValue, scalar: ScalarKind) -> b
                 NormalValue::Bytes(_) | NormalValue::NillableBytes(_) | NormalValue::String(_)
             )
         }
-        // Accept both NormalValue::Json and NormalValue::String for JSON fields
-        // String values are used for @default JSON values (stored as serialized strings)
-        ScalarKind::Json => matches!(value, NormalValue::Json(_) | NormalValue::String(_)),
+        // CBOR preserves JSON content but not the Json wrapper: retained scalar
+        // and array values return as their inferred native variants. Restrict
+        // these to JSON-native values; binary/document/time values remain invalid.
+        ScalarKind::Json => {
+            matches!(
+                value,
+                NormalValue::Json(_)
+                    | NormalValue::JsonArray(_)
+                    | NormalValue::Bool(_)
+                    | NormalValue::Int(_)
+                    | NormalValue::Float64(_)
+                    | NormalValue::Float32(_)
+                    | NormalValue::String(_)
+                    | NormalValue::BoolArray(_)
+                    | NormalValue::IntArray(_)
+                    | NormalValue::Float64Array(_)
+                    | NormalValue::Float32Array(_)
+                    | NormalValue::StringArray(_)
+                    | NormalValue::NillableBoolElementArray(_)
+                    | NormalValue::NillableIntElementArray(_)
+                    | NormalValue::NillableFloat64ElementArray(_)
+                    | NormalValue::NillableFloat32ElementArray(_)
+                    | NormalValue::NillableStringElementArray(_)
+            ) && document::encoding::normal_value_to_json(value).is_ok()
+        }
         _ => false,
     }
 }

--- a/crates/db/tests/collection/validation.rs
+++ b/crates/db/tests/collection/validation.rs
@@ -134,3 +134,53 @@ async fn creation_accepts_supported_scalar_defaults() {
         .await
         .unwrap();
 }
+
+#[test]
+fn json_validation_preserves_non_json_and_nonfinite_rejection() {
+    use document::NormalValue;
+    let collection = Collection::new(CollectionVersion::new(
+        "JsonDoc",
+        "json_doc_version",
+        "json_doc_collection",
+        vec![FieldDescription::new("1", "payload", FieldKind::json())],
+    ));
+    for value in [
+        NormalValue::Bytes(vec![1, 2]),
+        NormalValue::BytesArray(vec![vec![1]]),
+        NormalValue::Document(Box::new(Document::new())),
+        NormalValue::DocumentArray(vec![Document::new()]),
+        NormalValue::Time(chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z").unwrap()),
+        NormalValue::Float64(f64::NAN),
+        NormalValue::Float64(f64::INFINITY),
+        NormalValue::Float64Array(vec![1.0, f64::NEG_INFINITY]),
+        NormalValue::NillableFloat64ElementArray(vec![None, Some(f64::NAN)]),
+        NormalValue::NillableFloat32ElementArray(vec![None, Some(f32::INFINITY)]),
+    ] {
+        let mut doc = Document::new();
+        doc.set("payload", value.clone());
+        assert!(
+            collection.validate_document(&doc).is_err(),
+            "accepted non-JSON {value:?}"
+        );
+    }
+}
+
+#[test]
+fn retained_json_scalar_values_do_not_relax_other_field_kinds() {
+    use document::NormalValue;
+    let collection = Collection::new(CollectionVersion::new(
+        "StrictDoc",
+        "strict_doc_version",
+        "strict_doc_collection",
+        vec![FieldDescription::new("1", "payload", FieldKind::string())],
+    ));
+    for value in [
+        NormalValue::Bool(true),
+        NormalValue::Int(1),
+        NormalValue::JsonArray(vec![]),
+    ] {
+        let mut doc = Document::new();
+        doc.set("payload", value);
+        assert!(collection.validate_document(&doc).is_err());
+    }
+}

--- a/crates/defra-node/tests/json_update_revalidation.rs
+++ b/crates/defra-node/tests/json_update_revalidation.rs
@@ -1,0 +1,71 @@
+use anyhow::{Context, Result};
+use defra_node::{EmbeddedNode, ExecuteRetryPolicy, QueryRequest};
+use serde_json::{json, Value};
+
+#[tokio::test]
+async fn retained_json_survives_unrelated_updates() -> Result<()> {
+    let node = EmbeddedNode::builder().build().await?;
+    node.add_schema(
+        "type JsonProbe { key: String @index(unique: true) payload: JSON sibling: String }",
+    )
+    .await?;
+    let payloads = [
+        json!({"arbitrary-key": []}),
+        json!([{"name":"model", "efforts":null}]),
+        json!([]),
+        json!([1, 2]),
+        json!(["one", "two"]),
+        json!(true),
+        json!(42),
+        json!("literal"),
+        json!([1, "two", false, null, {"nested":[]}]),
+        json!([true, null, false]),
+        json!([1, null, 2]),
+        json!([1.5, null, 2.5]),
+        json!(["one", null]),
+        Value::Null,
+    ];
+    for (index, payload) in payloads.into_iter().enumerate() {
+        let created = node.execute_request_with_retry(
+            QueryRequest::new("mutation($key:String!,$payload:JSON){create_JsonProbe(input:{key:$key,payload:$payload,sibling:\"before\"}){_docID}}")
+                .with_variables(json!({"key":index.to_string(),"payload":payload})),
+            ExecuteRetryPolicy::default(),
+        ).await;
+        assert!(
+            !created.has_errors(),
+            "create {payload}: {:?}",
+            created.errors
+        );
+        let query = format!(
+            "{{ JsonProbe(filter:{{key:{{_eq:\"{index}\"}}}}){{_docID payload sibling}} }}"
+        );
+        let before = node.execute(&query).await;
+        assert!(!before.has_errors(), "read {payload}: {:?}", before.errors);
+        let row = &before.data.as_ref().context("missing data")?["JsonProbe"][0];
+        let id = row["_docID"].as_str().context("missing document ID")?;
+        let changed = node
+            .execute(&format!(
+                "mutation{{update_JsonProbe(docID:\"{id}\",input:{{sibling:\"after\"}}){{_docID}}}}"
+            ))
+            .await;
+        assert!(
+            !changed.has_errors(),
+            "update retaining {payload}: {:?}",
+            changed.errors
+        );
+        let after = node.execute(&query).await;
+        assert!(
+            !after.has_errors(),
+            "read updated {payload}: {:?}",
+            after.errors
+        );
+        let after = &after.data.as_ref().context("missing updated data")?["JsonProbe"][0];
+        assert_eq!(
+            after["payload"], row["payload"],
+            "changed retained JSON {payload}"
+        );
+        assert_eq!(after["sibling"], "after");
+    }
+    node.shutdown().await;
+    Ok(())
+}

--- a/crates/document/src/encoding.rs
+++ b/crates/document/src/encoding.rs
@@ -378,6 +378,24 @@ pub fn normal_value_to_json(value: &NormalValue) -> Result<serde_json::Value> {
             }
             Ok(serde_json::Value::Array(result))
         }
+        NormalValue::NillableFloat64ElementArray(arr) => arr
+            .iter()
+            .map(|value| {
+                value
+                    .map(float64_to_json)
+                    .unwrap_or(Ok(serde_json::Value::Null))
+            })
+            .collect::<Result<Vec<_>>>()
+            .map(serde_json::Value::Array),
+        NormalValue::NillableFloat32ElementArray(arr) => arr
+            .iter()
+            .map(|value| {
+                value
+                    .map(|value| float64_to_json(value as f64))
+                    .unwrap_or(Ok(serde_json::Value::Null))
+            })
+            .collect::<Result<Vec<_>>>()
+            .map(serde_json::Value::Array),
         NormalValue::JsonArray(arr) => Ok(serde_json::Value::Array(arr.clone())),
         // Nillable variants
         NormalValue::NillableBool(opt) => Ok(opt

--- a/crates/document/tests/encoding_tests.rs
+++ b/crates/document/tests/encoding_tests.rs
@@ -382,3 +382,27 @@ fn unrepresentable_value_returns_none() {
         None
     );
 }
+
+#[test]
+fn nullable_float_elements_preserve_null_and_reject_nonfinite_values() {
+    for value in [
+        NormalValue::NillableFloat64ElementArray(vec![Some(1.5), None, Some(2.5)]),
+        NormalValue::NillableFloat32ElementArray(vec![Some(1.5), None, Some(2.5)]),
+    ] {
+        assert_eq!(
+            document::encoding::normal_value_to_json(&value).unwrap(),
+            serde_json::json!([1.5, null, 2.5])
+        );
+    }
+    for value in [
+        NormalValue::NillableFloat64ElementArray(vec![None, Some(f64::NAN)]),
+        NormalValue::NillableFloat64ElementArray(vec![Some(f64::INFINITY)]),
+        NormalValue::NillableFloat32ElementArray(vec![None, Some(f32::NAN)]),
+        NormalValue::NillableFloat32ElementArray(vec![Some(f32::NEG_INFINITY)]),
+    ] {
+        assert!(
+            document::encoding::normal_value_to_json(&value).is_err(),
+            "accepted {value:?}"
+        );
+    }
+}


### PR DESCRIPTION
Updating an unrelated field failed when a document retained a JSON array, boolean, or number. CBOR decodes those values into native variants, while collection validation only accepted the JSON wrapper or a string.

Accept JSON-native retained variants through the existing JSON conversion owner, preserving rejection of binary, document, timestamp, and non-finite values. Nullable float arrays now use the same finite-value conversion as other floats instead of silently turning non-finite elements into null.

Validation:

- Native unrelated-update regression fails on the pinned baseline and passes for 14 retained JSON shapes with the fix.
- Full collection target: 94 tests pass.
- Full document crate: 146 tests, including doc tests, pass.
- Documented native workspace suite: 4,994 pass, 75 ignored.
- Rust ACP integration: 110 pass, 7 ignored; Rust Basic integration: 32 pass. Both use the current CLI and an isolated `DEFRA_ROOTDIR`.
- `cargo fmt --all --check` and `git diff --check` pass.

`cargo clippy --all -- -D warnings` fails at unchanged `crates/db/src/block/heads.rs:211` (`nonminimal_bool` with Rust 1.95); the identical failure was reproduced on the exact unmodified baseline. Full integration was attempted but the required Go binary at `13c46ec9` is unavailable, so full Go parity is not verified. The first broad test attempt also picked up an obsolete binary/user config; the explicit-current-binary, isolated-root Rust integration reruns above passed.

This draft contains only the five-file fix, based on pinned revision `03e1035f364dc0914016e9cf8bde4e4f1a000f06`; no dependency or schema changes.
