### PR TITLE
feat: share one peer key between libp2p and iroh

### DIFF
--- a/crates/cli/src/commands/start/server_p2p/iroh.rs
+++ b/crates/cli/src/commands/start/server_p2p/iroh.rs
@@ -479,15 +479,21 @@ impl Node {
             manage_requester: Some(manage_requester),
         })
     }
+    /// Both transports are Ed25519, so the iroh endpoint reuses the peer key's
+    /// seed and the node keeps one identity whichever transport it runs.
     fn iroh_secret_key(peer_keypair: Option<&p2p::Keypair>) -> Result<iroh_net::SecretKey> {
-        if let Some(kp) = peer_keypair {
-            let seed = kp.derive_secret(b"iroh-transport").ok_or_else(|| {
-                Error::InvalidConfig("iroh transport requires Ed25519 key".into())
+        let Some(kp) = peer_keypair else {
+            return Ok(iroh_net::SecretKey::generate());
+        };
+        let ed25519 = kp
+            .clone()
+            .try_into_ed25519()
+            .map_err(|_| Error::InvalidConfig("iroh transport requires Ed25519 key".into()))?;
+        let seed: [u8; 32] =
+            ed25519.secret().as_ref().try_into().map_err(|_| {
+                Error::InvalidConfig("Ed25519 peer key seed must be 32 bytes".into())
             })?;
-            Ok(iroh_net::SecretKey::from_bytes(&seed))
-        } else {
-            Ok(iroh_net::SecretKey::generate())
-        }
+        Ok(iroh_net::SecretKey::from_bytes(&seed))
     }
 
     fn iroh_relay_mode(config: &Config) -> Result<p2p::iroh::IrohRelayModeConfig> {
@@ -546,5 +552,20 @@ impl Node {
             (false, None, None) => Ok(p2p::iroh::IrohDiscoveryConfig::Disabled),
             (true, None, None) => Ok(p2p::iroh::IrohDiscoveryConfig::N0),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn iroh_secret_key_is_the_peer_key() {
+        let keypair = p2p::Keypair::generate_ed25519();
+        let libp2p_public = keypair.public().try_into_ed25519().unwrap().to_bytes();
+
+        let iroh_key = Node::iroh_secret_key(Some(&keypair)).unwrap();
+
+        assert_eq!(iroh_key.public().as_bytes(), &libp2p_public);
     }
 }

--- a/crates/embedded/Cargo.toml
+++ b/crates/embedded/Cargo.toml
@@ -47,6 +47,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt", "macros", "fs", "sync", "time"] }
 tracing.workspace = true
+zeroize = "1"
 
 [features]
 default = ["native", "wasmtime-runtime", "libp2p"]
@@ -72,7 +73,6 @@ iroh = ["p2p/iroh-transport", "p2p/kms", "defra-p2p-adapter/iroh"]
 base64 = { workspace = true }
 tempfile = "3.17"
 tokio = { workspace = true, features = ["rt-multi-thread"] }
-zeroize = "1"
 zstd = "0.13"
 tar = "0.4"
 

--- a/crates/embedded/src/lib.rs
+++ b/crates/embedded/src/lib.rs
@@ -2,6 +2,8 @@ mod node;
 mod node_acp;
 mod node_identity;
 mod node_p2p;
+#[cfg(any(feature = "libp2p", feature = "iroh"))]
+mod node_peer_key;
 mod node_recovery;
 mod node_tasks;
 
@@ -59,6 +61,8 @@ pub struct IrohConfig {
     pub relay_mode: p2p::iroh::IrohRelayModeConfig,
     pub discovery: p2p::iroh::IrohDiscoveryConfig,
     pub max_concurrent_multipath_paths: Option<u32>,
+    /// Iroh key file from before the node shared one peer key across transports.
+    /// Imported as the node's peer key when the store has none; never written.
     pub secret_key_path: Option<std::path::PathBuf>,
 }
 

--- a/crates/embedded/src/node_p2p.rs
+++ b/crates/embedded/src/node_p2p.rs
@@ -112,29 +112,10 @@ where
     let blockstore = Arc::new(EmbeddedBlockstore::new(store.clone(), true));
     let bitswap_store = BitswapStoreAdapter::new(blockstore.clone());
 
-    let p2p_keypair = {
-        let peerstore = Peerstore::new(store.clone());
-        let key_id = "__local_p2p_identity__";
-        match peerstore.get_replicator(key_id).await {
-            Ok(Some(bytes)) => match libp2p::identity::Keypair::from_protobuf_encoding(&bytes) {
-                Ok(keypair) => keypair,
-                Err(_) => {
-                    let keypair = libp2p::identity::Keypair::generate_ed25519();
-                    if let Ok(encoded) = keypair.to_protobuf_encoding() {
-                        let _ = peerstore.create_replicator(key_id, &encoded).await;
-                    }
-                    keypair
-                }
-            },
-            _ => {
-                let keypair = libp2p::identity::Keypair::generate_ed25519();
-                if let Ok(encoded) = keypair.to_protobuf_encoding() {
-                    let _ = peerstore.create_replicator(key_id, &encoded).await;
-                }
-                keypair
-            }
-        }
-    };
+    let mut seed =
+        crate::node_peer_key::load_or_create(&Peerstore::new(store.clone()), None).await?;
+    let p2p_keypair = libp2p::identity::Keypair::ed25519_from_bytes(&mut *seed)
+        .map_err(|error| anyhow!("invalid peer key: {error}"))?;
 
     let classifier = defra_p2p_adapter::DbBlockClassifier::new_arc(database.clone());
     let serve_acp = Arc::new(p2p::bitswap::LateBoundServeAcp::new());
@@ -465,8 +446,12 @@ where
     use crate::node_recovery::{restore_iroh_documents, restore_iroh_replicators};
     use crate::node_tasks::spawn_iroh_event_handler;
 
-    let secret_key =
-        p2p::iroh::load_or_generate_secret_key(config.secret_key_path.as_deref()).await?;
+    let seed = crate::node_peer_key::load_or_create(
+        &Peerstore::new(store.clone()),
+        config.secret_key_path.as_deref(),
+    )
+    .await?;
+    let secret_key = p2p::iroh::SecretKey::from_bytes(&seed);
     let iroh_config = p2p::iroh::IrohEndpointConfig {
         secret_key: secret_key.clone(),
         node_identity,

--- a/crates/embedded/src/node_peer_key.rs
+++ b/crates/embedded/src/node_peer_key.rs
@@ -1,0 +1,241 @@
+//! The node's peer key: one Ed25519 seed that libp2p and iroh both use, so a
+//! node keeps one identity whichever transport it runs.
+
+use std::path::Path;
+
+use anyhow::{anyhow, Context, Result};
+use storage::stores::Peerstore;
+use zeroize::Zeroizing;
+
+/// Replicator slot where libp2p kept its keypair before the shared peer key.
+#[cfg(feature = "libp2p")]
+const LEGACY_LIBP2P_KEY_ID: &str = "__local_p2p_identity__";
+
+pub(crate) type Seed = Zeroizing<[u8; 32]>;
+
+/// Load the node's peer key seed, creating it on first start.
+///
+/// A node that predates the shared key keeps the identity its transport
+/// already had: the iroh key file, else libp2p's peerstore entry, is imported
+/// once. `legacy_iroh_key` is only ever read.
+pub(crate) async fn load_or_create<S: storage::corekv::Store>(
+    peerstore: &Peerstore<S>,
+    legacy_iroh_key: Option<&Path>,
+) -> Result<Seed> {
+    if let Some(bytes) = peerstore
+        .get_local_peer_key()
+        .await
+        .context("failed to read peer key")?
+    {
+        return seed_from_slice(&bytes).context("stored peer key is corrupt");
+    }
+
+    let seed = match legacy_iroh_seed(legacy_iroh_key).await? {
+        Some(seed) => seed,
+        None => match legacy_libp2p_seed(peerstore).await? {
+            Some(seed) => seed,
+            None => generate()?,
+        },
+    };
+    peerstore
+        .set_local_peer_key(seed.as_slice())
+        .await
+        .context("failed to store peer key")?;
+    remove_legacy_libp2p_key(peerstore).await?;
+    Ok(seed)
+}
+
+async fn legacy_iroh_seed(path: Option<&Path>) -> Result<Option<Seed>> {
+    let Some(path) = path else {
+        return Ok(None);
+    };
+    match tokio::fs::read(path).await {
+        Ok(bytes) => seed_from_slice(&Zeroizing::new(bytes))
+            .with_context(|| format!("iroh key file '{}' is corrupt", path.display()))
+            .map(Some),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => {
+            Err(error).with_context(|| format!("failed to read iroh key file '{}'", path.display()))
+        }
+    }
+}
+
+#[cfg(feature = "libp2p")]
+async fn legacy_libp2p_seed<S: storage::corekv::Store>(
+    peerstore: &Peerstore<S>,
+) -> Result<Option<Seed>> {
+    let Some(bytes) = peerstore
+        .get_replicator(LEGACY_LIBP2P_KEY_ID)
+        .await
+        .context("failed to read legacy libp2p peer key")?
+    else {
+        return Ok(None);
+    };
+    let keypair = libp2p::identity::Keypair::from_protobuf_encoding(&bytes)
+        .map_err(|error| anyhow!("legacy libp2p peer key is corrupt: {error}"))?;
+    let ed25519 = keypair
+        .try_into_ed25519()
+        .map_err(|_| anyhow!("legacy libp2p peer key is not Ed25519"))?;
+    seed_from_slice(ed25519.secret().as_ref()).map(Some)
+}
+
+#[cfg(not(feature = "libp2p"))]
+async fn legacy_libp2p_seed<S: storage::corekv::Store>(
+    _peerstore: &Peerstore<S>,
+) -> Result<Option<Seed>> {
+    Ok(None)
+}
+
+#[cfg(feature = "libp2p")]
+async fn remove_legacy_libp2p_key<S: storage::corekv::Store>(
+    peerstore: &Peerstore<S>,
+) -> Result<()> {
+    peerstore
+        .delete_replicator(LEGACY_LIBP2P_KEY_ID)
+        .await
+        .context("failed to remove legacy libp2p peer key")
+}
+
+#[cfg(not(feature = "libp2p"))]
+async fn remove_legacy_libp2p_key<S: storage::corekv::Store>(
+    _peerstore: &Peerstore<S>,
+) -> Result<()> {
+    Ok(())
+}
+
+fn generate() -> Result<Seed> {
+    use crypto::Key;
+
+    let key = crypto::generate_ed25519()
+        .map_err(|error| anyhow!("failed to generate peer key: {error}"))?;
+    seed_from_slice(&key.raw()[..32])
+}
+
+fn seed_from_slice(bytes: &[u8]) -> Result<Seed> {
+    let seed: [u8; 32] = bytes
+        .try_into()
+        .map_err(|_| anyhow!("expected a 32-byte Ed25519 seed, got {} bytes", bytes.len()))?;
+    Ok(Zeroizing::new(seed))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+
+    fn peerstore() -> Peerstore<storage::RegolithStore> {
+        Peerstore::new(Arc::new(storage::RegolithStore::in_memory().unwrap()))
+    }
+
+    #[tokio::test]
+    async fn created_key_is_reused() {
+        let peerstore = peerstore();
+
+        let first = load_or_create(&peerstore, None).await.unwrap();
+        let second = load_or_create(&peerstore, None).await.unwrap();
+
+        assert_eq!(*first, *second);
+    }
+
+    #[tokio::test]
+    async fn iroh_key_file_is_imported_once_and_left_untouched() {
+        let peerstore = peerstore();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("node.iroh.key");
+        std::fs::write(&path, [7u8; 32]).unwrap();
+
+        let imported = load_or_create(&peerstore, Some(&path)).await.unwrap();
+        assert_eq!(*imported, [7u8; 32]);
+        assert_eq!(std::fs::read(&path).unwrap(), [7u8; 32]);
+
+        std::fs::remove_file(&path).unwrap();
+        let reloaded = load_or_create(&peerstore, Some(&path)).await.unwrap();
+        assert_eq!(*reloaded, [7u8; 32]);
+    }
+
+    #[tokio::test]
+    async fn missing_iroh_key_file_is_not_created() {
+        let peerstore = peerstore();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("node.iroh.key");
+
+        load_or_create(&peerstore, Some(&path)).await.unwrap();
+
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn corrupt_stored_key_fails_instead_of_regenerating() {
+        let peerstore = peerstore();
+        peerstore.set_local_peer_key(b"short").await.unwrap();
+
+        assert!(load_or_create(&peerstore, None).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn corrupt_iroh_key_file_fails() {
+        let peerstore = peerstore();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("node.iroh.key");
+        std::fs::write(&path, b"short").unwrap();
+
+        assert!(load_or_create(&peerstore, Some(&path)).await.is_err());
+    }
+
+    #[cfg(feature = "libp2p")]
+    fn legacy_libp2p_key_bytes(seed: [u8; 32]) -> Vec<u8> {
+        libp2p::identity::Keypair::ed25519_from_bytes(seed)
+            .unwrap()
+            .to_protobuf_encoding()
+            .unwrap()
+    }
+
+    #[cfg(feature = "libp2p")]
+    #[tokio::test]
+    async fn legacy_libp2p_key_is_imported_and_removed() {
+        let peerstore = peerstore();
+        peerstore
+            .create_replicator(LEGACY_LIBP2P_KEY_ID, &legacy_libp2p_key_bytes([9u8; 32]))
+            .await
+            .unwrap();
+
+        let imported = load_or_create(&peerstore, None).await.unwrap();
+
+        assert_eq!(*imported, [9u8; 32]);
+        assert!(peerstore
+            .get_replicator(LEGACY_LIBP2P_KEY_ID)
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[cfg(feature = "libp2p")]
+    #[tokio::test]
+    async fn iroh_key_file_wins_over_legacy_libp2p_key() {
+        let peerstore = peerstore();
+        peerstore
+            .create_replicator(LEGACY_LIBP2P_KEY_ID, &legacy_libp2p_key_bytes([9u8; 32]))
+            .await
+            .unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("node.iroh.key");
+        std::fs::write(&path, [7u8; 32]).unwrap();
+
+        let imported = load_or_create(&peerstore, Some(&path)).await.unwrap();
+
+        assert_eq!(*imported, [7u8; 32]);
+    }
+
+    #[cfg(feature = "libp2p")]
+    #[tokio::test]
+    async fn corrupt_legacy_libp2p_key_fails() {
+        let peerstore = peerstore();
+        peerstore
+            .create_replicator(LEGACY_LIBP2P_KEY_ID, b"not a keypair")
+            .await
+            .unwrap();
+
+        assert!(load_or_create(&peerstore, None).await.is_err());
+    }
+}

--- a/crates/embedded/tests/peer_key.rs
+++ b/crates/embedded/tests/peer_key.rs
@@ -1,0 +1,58 @@
+#![cfg(all(feature = "libp2p", feature = "iroh"))]
+
+use std::net::{IpAddr, Ipv4Addr};
+
+use anyhow::{anyhow, Context, Result};
+use embedded::{EmbeddedNode, EmbeddedStore, IrohConfig, NodeBuilder};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn libp2p_and_iroh_share_the_node_key() -> Result<()> {
+    let dir = tempfile::tempdir()?;
+    let data_path = dir.path().join("node");
+
+    let libp2p_node = NodeBuilder::default()
+        .data_path(data_path.clone())
+        .with_libp2p("/ip4/127.0.0.1/tcp/0")
+        .build()
+        .await?;
+    let libp2p_id = local_peer_id(&libp2p_node).await?;
+    libp2p_node.shutdown().await;
+    drop(libp2p_node);
+
+    let iroh_node = NodeBuilder::default()
+        .data_path(data_path)
+        .with_iroh(iroh_config())
+        .build()
+        .await?;
+    let iroh_id = local_peer_id(&iroh_node).await?;
+    iroh_node.shutdown().await;
+
+    assert_eq!(iroh_id, hex::encode(libp2p_ed25519_public(&libp2p_id)?));
+    Ok(())
+}
+
+async fn local_peer_id(node: &EmbeddedNode<EmbeddedStore>) -> Result<String> {
+    node.p2p()
+        .context("node has no p2p system")?
+        .ops()
+        .local_peer_id()
+        .await
+        .map_err(|error| anyhow!(error))
+}
+
+fn libp2p_ed25519_public(peer_id: &str) -> Result<[u8; 32]> {
+    let peer_id: libp2p::PeerId = peer_id.parse()?;
+    let public = libp2p::identity::PublicKey::try_decode_protobuf(peer_id.as_ref().digest())?;
+    Ok(public.try_into_ed25519()?.to_bytes())
+}
+
+fn iroh_config() -> IrohConfig {
+    IrohConfig {
+        bind_addr: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+        bind_port: Some(0),
+        relay_mode: p2p::iroh::IrohRelayModeConfig::Disabled,
+        discovery: p2p::iroh::IrohDiscoveryConfig::Disabled,
+        max_concurrent_multipath_paths: None,
+        secret_key_path: None,
+    }
+}

--- a/crates/ffi/src/mobile_config.rs
+++ b/crates/ffi/src/mobile_config.rs
@@ -58,6 +58,8 @@ pub(crate) struct MobileIrohConfig {
     pub discovery: Option<bool>,
     pub discovery_origin_domain: Option<String>,
     pub pkarr_relay_url: Option<String>,
+    /// Iroh key file from before the node shared one peer key across transports.
+    /// Imported as the node's peer key when the store has none; never written.
     pub key_path: Option<String>,
 }
 

--- a/crates/ffi/src/types.rs
+++ b/crates/ffi/src/types.rs
@@ -212,7 +212,8 @@ pub struct NodeInitOptions {
     pub iroh_discovery_origin_domain: *const c_char,
     /// Optional custom pkarr relay URL for iroh discovery publishing.
     pub iroh_pkarr_relay_url: *const c_char,
-    /// Optional path to persist the iroh secret key.
+    /// Iroh key file from before the node shared one peer key across transports.
+    /// Imported as the node's peer key when the store has none; never written.
     pub iroh_key_path: *const c_char,
     /// Maximum concurrent DAG fetch tasks. 0 means use default.
     pub max_concurrent_dag_fetches: usize,

--- a/crates/p2p/src/iroh/mod.rs
+++ b/crates/p2p/src/iroh/mod.rs
@@ -36,5 +36,6 @@ pub use config::{IrohDiscoveryConfig, IrohRelayModeConfig};
 pub use endpoint::spawn_endpoint;
 pub use endpoint_config::IrohEndpointConfig;
 pub use gossip_heal::GossipHealConfig;
+pub use iroh::SecretKey;
 pub use secret_key::load_or_generate_secret_key;
 pub use transport::IrohTransport;

--- a/crates/storage/src/stores/peerstore.rs
+++ b/crates/storage/src/stores/peerstore.rs
@@ -250,6 +250,19 @@ impl<S: Store> Peerstore<S> {
         txn.has(&key.bytes()).await
     }
 
+    /// Store the node's Ed25519 peer key seed, shared by every transport.
+    pub async fn set_local_peer_key(&self, seed: &[u8]) -> Result<()> {
+        let mut txn = self.store.new_txn(false).await?;
+        txn.set(b"/p2p/local-peer-key", seed).await?;
+        txn.commit().await
+    }
+
+    /// Load the node's Ed25519 peer key seed.
+    pub async fn get_local_peer_key(&self) -> Result<Option<Bytes>> {
+        let txn = self.store.new_txn(true).await?;
+        txn.get(b"/p2p/local-peer-key").await
+    }
+
     /// Store P2P collection subscriptions (persists across restarts).
     pub async fn set_p2p_collections(&self, data: &[u8]) -> Result<()> {
         let mut txn = self.store.new_txn(false).await?;


### PR DESCRIPTION
## Summary

Every node now has one Ed25519 peer key, and libp2p and iroh both use it. A node's libp2p peer ID and iroh node ID come from the same public key.

**CLI (`defra start`).** The iroh secret was derived from the keyring peer key with `derive_secret(b"iroh-transport")`. Both transports are Ed25519 and a node only runs one of them, so the derived key wasn't keeping anything apart. The iroh endpoint now uses the peer key's seed directly.

**Embedded / FFI / mobile.** A node used to keep two unrelated keys:
- a libp2p keypair stored as a fake replicator entry (`__local_p2p_identity__`)
- an iroh key in a `<db>.iroh.key` file

Now there is one seed in the peerstore at `/p2p/local-peer-key`, loaded by `embedded::node_peer_key::load_or_create` for whichever transport starts.

## Migration

Existing embedded nodes keep their identity. On the first start after this change, the key the configured transport already had is imported once:

- **iroh:** the key file (explicit path or `<db>.iroh.key`), falling back to the legacy libp2p entry
- **libp2p:** the legacy libp2p entry

After the import, the legacy libp2p entry is removed. This also ends the `failed to decode replicator info` warning that replicator restore logged for that entry on every start.

## Behaviour changes

- **CLI iroh node IDs change once.** A CLI node on the iroh transport gets a new node ID on its first start after this change. libp2p peer IDs are unchanged.
- **Corrupt keys now fail the start.** A corrupt or unreadable key fails the start instead of silently creating a new identity.
- **The iroh key path options are import-only.** `IrohConfig::secret_key_path`, `NodeInitOptions.iroh_key_path` and `p2p.iroh.keyPath` keep their shape, so the C ABI is untouched, but nothing writes the file any more. As a result, a node with an in-memory store and an explicit key path that doesn't exist yet now gets a temporary identity. Nothing in the repo uses that combination.
- **Databases that have run both transports.** If a database has both a legacy libp2p entry and an iroh key file, the key of the transport it starts with wins, and the other identity is dropped.

`defra-node` is iroh-only, so it has no second key and is unchanged.

## Test plan

- [x] `cli`: `iroh_secret_key_is_the_peer_key`
- [x] `embedded` unit tests (`node_peer_key`): key created then reused; iroh file imported once and left untouched; missing file not created; legacy libp2p entry imported and removed; iroh file wins over the legacy entry when starting on iroh; corrupt stored key, file or legacy entry fails the start
- [x] `embedded` end-to-end (`tests/peer_key.rs`): the same database started under libp2p and then iroh gives matching public keys
- [x] `embedded` `iroh_smoke`
- [x] clippy `-D warnings`: `cli` (iroh), `embedded` (libp2p+iroh, iroh-only), `ffi`, `storage`, `p2p`
- [ ] `just integration-suite p2p_iroh`: not run locally because the disk was full; relying on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
