### PR TITLE
feat(p2p): opt-in inbound peer allowlist for the iroh transport

### DIFF
--- a/crates/cli/src/commands/start/server_p2p/iroh.rs
+++ b/crates/cli/src/commands/start/server_p2p/iroh.rs
@@ -40,7 +40,7 @@ impl Node {
                 bind_addr: config.net.iroh_bind_addr,
                 max_concurrent_multipath_paths: config.net.iroh_max_concurrent_multipath_paths,
                 gossip_heal: p2p::iroh::GossipHealConfig::from_env(),
-                allowlist: p2p::iroh::IrohAllowlistConfig::AcceptAll,
+                allowlist: Self::iroh_allowlist(config),
             })
             .await
             .map_err(Error::P2P)?;
@@ -528,6 +528,25 @@ impl Node {
         urls
     }
 
+    /// Who may open an inbound connection.
+    ///
+    /// An empty `iroh_allowed_peers` keeps the behaviour every existing
+    /// deployment has: accept everyone. Listing any id restricts inbound
+    /// connections to the ids listed, and
+    /// [`IrohTransport::allow_peer`](p2p::iroh::IrohTransport::allow_peer)
+    /// can add more while the node runs. That runtime call is a no-op under
+    /// `AcceptAll`, so without this setting the allowlist could not be
+    /// turned on for this binary at all.
+    fn iroh_allowlist(config: &Config) -> p2p::iroh::IrohAllowlistConfig {
+        if config.net.iroh_allowed_peers.is_empty() {
+            p2p::iroh::IrohAllowlistConfig::AcceptAll
+        } else {
+            p2p::iroh::IrohAllowlistConfig::Explicit(
+                config.net.iroh_allowed_peers.iter().cloned().collect(),
+            )
+        }
+    }
+
     fn iroh_discovery(config: &Config) -> Result<p2p::iroh::IrohDiscoveryConfig> {
         match (
             config.net.iroh_discovery,
@@ -547,5 +566,37 @@ impl Node {
             (false, None, None) => Ok(p2p::iroh::IrohDiscoveryConfig::Disabled),
             (true, None, None) => Ok(p2p::iroh::IrohDiscoveryConfig::N0),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The setting is what turns the allowlist on for this binary.
+    ///
+    /// `IrohTransport::allow_peer` is a no-op under `AcceptAll`, so a
+    /// deployment that cannot express `Explicit` here cannot restrict
+    /// inbound connections at all, whatever it does at runtime. Both
+    /// directions are asserted: the default stays open, matching every
+    /// existing deployment, and a listed id closes it to exactly that set.
+    #[test]
+    fn listed_peers_switch_the_endpoint_to_an_explicit_allowlist() {
+        let mut config = Config::default();
+        assert_eq!(
+            Node::iroh_allowlist(&config),
+            p2p::iroh::IrohAllowlistConfig::AcceptAll,
+            "an unset allowlist must not change what an existing node accepts"
+        );
+
+        config.net.iroh_allowed_peers = vec!["peer-one".to_string(), "peer-two".to_string()];
+        assert_eq!(
+            Node::iroh_allowlist(&config),
+            p2p::iroh::IrohAllowlistConfig::Explicit(
+                ["peer-one".to_string(), "peer-two".to_string()]
+                    .into_iter()
+                    .collect()
+            )
+        );
     }
 }

--- a/crates/cli/src/commands/start/server_p2p/iroh.rs
+++ b/crates/cli/src/commands/start/server_p2p/iroh.rs
@@ -40,6 +40,7 @@ impl Node {
                 bind_addr: config.net.iroh_bind_addr,
                 max_concurrent_multipath_paths: config.net.iroh_max_concurrent_multipath_paths,
                 gossip_heal: p2p::iroh::GossipHealConfig::from_env(),
+                allowlist: p2p::iroh::IrohAllowlistConfig::AcceptAll,
             })
             .await
             .map_err(Error::P2P)?;

--- a/crates/cli/src/config/sections.rs
+++ b/crates/cli/src/config/sections.rs
@@ -328,6 +328,16 @@ pub struct NetConfig {
     /// LAN addresses to peers on different networks. None = 0.0.0.0 (all interfaces).
     #[serde(default)]
     pub iroh_bind_addr: Option<std::net::IpAddr>,
+    /// Endpoint ids allowed to open an inbound iroh connection. Empty (the
+    /// default) accepts every peer, which is the behaviour this option was
+    /// added alongside and is fine on a private network. Listing any id
+    /// switches the transport to accepting only the ids listed, which is
+    /// what a node reachable over relays needs: a gossip topic is named by a
+    /// content-derived collection id, identical for anyone holding the same
+    /// schema, so an open endpoint hands its documents to any peer that can
+    /// name a collection.
+    #[serde(default)]
+    pub iroh_allowed_peers: Vec<String>,
     /// Maximum concurrent QUIC paths per iroh connection. None keeps iroh's
     /// default; custom values must be at least 9.
     #[serde(default)]
@@ -439,6 +449,7 @@ impl Default for NetConfig {
             iroh_pkarr_relay_url: None,
             iroh_bind_port: None,
             iroh_bind_addr: None,
+            iroh_allowed_peers: Vec::new(),
             iroh_max_concurrent_multipath_paths: None,
             p2p_rate_limit_burst: default_rate_limit_burst(),
             p2p_rate_limit_rate: default_rate_limit_rate(),

--- a/crates/defra-node/src/config.rs
+++ b/crates/defra-node/src/config.rs
@@ -113,6 +113,10 @@ pub struct P2PConfig {
     pub relay_mode: p2p::iroh::IrohRelayModeConfig,
     /// Address publishing / lookup behavior.
     pub discovery: p2p::iroh::IrohDiscoveryConfig,
+    /// Inbound-connection authorization. Defaults to accepting every peer;
+    /// restrict to an explicit set of iroh endpoint ids once this node is
+    /// reachable from the internet (relay-enabled).
+    pub allowlist: p2p::iroh::IrohAllowlistConfig,
     /// Maximum concurrent QUIC paths per connection. None keeps iroh's default.
     pub max_concurrent_multipath_paths: Option<u32>,
     /// Path to persist secret key. None = ephemeral (new identity each restart).

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -624,6 +624,27 @@ impl EmbeddedNode {
         self.p2p_ops.as_ref().map(Arc::clone)
     }
 
+    /// Authorize a peer to open an inbound P2P connection to this node while
+    /// it is running, without a restart.
+    ///
+    /// Widens who may connect in: it does not itself dial, connect to, or
+    /// disconnect from the peer, and it is a no-op when the active transport
+    /// already accepts every inbound peer. Returns an error if P2P is not
+    /// enabled, or if the active transport has no concept of an inbound
+    /// allowlist.
+    #[cfg(feature = "p2p")]
+    pub async fn allow_p2p_peer(&self, peer_id: &str) -> anyhow::Result<()> {
+        let ops = self
+            .p2p_ops
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("P2P is not enabled for this node"))?;
+        let peer_id = defra_http::TransportPeerId::new(peer_id)
+            .map_err(|error| anyhow::anyhow!("invalid peer ID: {error}"))?;
+        ops.allow_peer(&peer_id)
+            .await
+            .map_err(|error| anyhow::anyhow!("failed to authorize peer: {error}"))
+    }
+
     /// Gracefully stop background services owned by this embedded node.
     ///
     /// **The node should not be used after this call.** When the `otel`

--- a/crates/defra-node/src/p2p_bench.rs
+++ b/crates/defra-node/src/p2p_bench.rs
@@ -64,6 +64,7 @@ fn bench_p2p_config() -> P2PConfig {
         bind_addr: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
         relay_mode: p2p::iroh::IrohRelayModeConfig::Disabled,
         discovery: p2p::iroh::IrohDiscoveryConfig::Disabled,
+        allowlist: p2p::iroh::IrohAllowlistConfig::AcceptAll,
         max_concurrent_multipath_paths: None,
         secret_key_path: None,
         load_persisted_collections: false,

--- a/crates/defra-node/src/p2p_runtime.rs
+++ b/crates/defra-node/src/p2p_runtime.rs
@@ -189,6 +189,7 @@ pub(super) async fn setup_p2p<S: storage::corekv::Store + 'static>(
         bind_addr: config.bind_addr,
         max_concurrent_multipath_paths: config.max_concurrent_multipath_paths,
         gossip_heal: p2p::iroh::GossipHealConfig::from_env(),
+        allowlist: config.allowlist.clone(),
     };
     let (command_tx, iroh_events, replicator_registry, endpoint_task) =
         p2p::iroh::spawn_endpoint(iroh_config)

--- a/crates/defra-node/src/p2p_tests.rs
+++ b/crates/defra-node/src/p2p_tests.rs
@@ -36,6 +36,7 @@ fn test_p2p_config() -> P2PConfig {
         bind_addr: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
         relay_mode: p2p::iroh::IrohRelayModeConfig::Disabled,
         discovery: p2p::iroh::IrohDiscoveryConfig::Disabled,
+        allowlist: p2p::iroh::IrohAllowlistConfig::AcceptAll,
         max_concurrent_multipath_paths: None,
         secret_key_path: None,
         load_persisted_collections: false,

--- a/crates/defra-node/src/p2p_tests.rs
+++ b/crates/defra-node/src/p2p_tests.rs
@@ -1988,3 +1988,74 @@ async fn encrypted_create_replicates_plaintext_to_replicator() {
     writer.shutdown().await;
     replica.shutdown().await;
 }
+
+/// `EmbeddedNode::allow_p2p_peer` is the only reachable way to widen an
+/// already-running node's inbound allowlist: it must actually flow through
+/// `p2p-adapter` down to `IrohTransport::allow_peer`, not stop at the
+/// transport layer, or an operator admitting a new peer at runtime would
+/// have no way to do so short of a restart.
+#[tokio::test]
+async fn allow_p2p_peer_authorizes_a_peer_refused_by_the_allowlist() {
+    init_tracing();
+
+    let node_a = EmbeddedNode::builder()
+        .with_p2p(test_p2p_config())
+        .build()
+        .await
+        .expect("build node_a");
+
+    // node_b starts with an explicit allowlist that excludes node_a.
+    let mut config_b = test_p2p_config();
+    config_b.allowlist = p2p::iroh::IrohAllowlistConfig::Explicit(Default::default());
+    let node_b = EmbeddedNode::builder()
+        .with_p2p(config_b)
+        .build()
+        .await
+        .expect("build node_b");
+
+    let addr_b = wait_for_listen_addr(&node_b).await;
+    let p2p_a = node_a.p2p().expect("node_a p2p");
+    let p2p_b = node_b.p2p().expect("node_b p2p");
+    let peer_a = p2p_a.local_peer_id().await.expect("node_a peer id");
+
+    p2p_a
+        .connect_peer(&addr_b)
+        .await
+        .expect("dial reaches node_b");
+
+    let deadline = Instant::now() + Duration::from_millis(500);
+    while Instant::now() < deadline {
+        let connected = p2p_b
+            .connected_peers()
+            .await
+            .expect("node_b connected_peers");
+        assert!(
+            connected.is_empty(),
+            "a peer refused by the allowlist must never appear connected"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    // Clear node_a's stale local view of the refused attempt before
+    // redialing, so the next connect cannot short-circuit as "already
+    // connected".
+    p2p_a
+        .disconnect_peer(&addr_b)
+        .await
+        .expect("clear stale attempt");
+
+    node_b
+        .allow_p2p_peer(&peer_a)
+        .await
+        .expect("authorize node_a at runtime");
+
+    p2p_a
+        .connect_peer(&addr_b)
+        .await
+        .expect("connect after authorization");
+    wait_for_connected_peer(&node_a).await;
+    wait_for_connected_peer(&node_b).await;
+
+    node_a.shutdown().await;
+    node_b.shutdown().await;
+}

--- a/crates/embedded/src/lib.rs
+++ b/crates/embedded/src/lib.rs
@@ -51,6 +51,16 @@ pub struct Libp2pConfig {
 }
 
 /// Iroh transport configuration.
+///
+/// # Migrating
+///
+/// This struct gained an `allowlist` field. It is not `#[non_exhaustive]`,
+/// so an existing struct literal that names every field no longer compiles:
+/// either add `allowlist: Default::default()`, which keeps exactly the
+/// behaviour the code had (accept every inbound peer), or switch the
+/// literal to `..Default::default()` so a later field costs nothing. Only
+/// construction is affected; a node built from a literal that compiled
+/// before behaves identically after.
 #[cfg(feature = "iroh")]
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct IrohConfig {

--- a/crates/embedded/src/lib.rs
+++ b/crates/embedded/src/lib.rs
@@ -60,6 +60,13 @@ pub struct IrohConfig {
     pub discovery: p2p::iroh::IrohDiscoveryConfig,
     pub max_concurrent_multipath_paths: Option<u32>,
     pub secret_key_path: Option<std::path::PathBuf>,
+    /// Who may open an inbound connection. `AcceptAll` (the default) keeps
+    /// the behaviour every existing embedder has. `Explicit` restricts
+    /// inbound connections to the listed endpoint ids, and
+    /// `P2POperations::allow_peer` can add more while the node runs. That
+    /// runtime call is a no-op under `AcceptAll`, so an embedder that never
+    /// sets this cannot turn the allowlist on at all.
+    pub allowlist: p2p::iroh::IrohAllowlistConfig,
 }
 
 /// Node signing configuration.

--- a/crates/embedded/src/node_p2p.rs
+++ b/crates/embedded/src/node_p2p.rs
@@ -476,7 +476,7 @@ where
         bind_addr: config.bind_addr,
         max_concurrent_multipath_paths: config.max_concurrent_multipath_paths,
         gossip_heal: p2p::iroh::GossipHealConfig::from_env(),
-        allowlist: p2p::iroh::IrohAllowlistConfig::AcceptAll,
+        allowlist: config.allowlist.clone(),
     };
     let (command_tx, event_rx, replicator_registry, endpoint_task) =
         p2p::iroh::spawn_endpoint(iroh_config)

--- a/crates/embedded/src/node_p2p.rs
+++ b/crates/embedded/src/node_p2p.rs
@@ -476,6 +476,7 @@ where
         bind_addr: config.bind_addr,
         max_concurrent_multipath_paths: config.max_concurrent_multipath_paths,
         gossip_heal: p2p::iroh::GossipHealConfig::from_env(),
+        allowlist: p2p::iroh::IrohAllowlistConfig::AcceptAll,
     };
     let (command_tx, event_rx, replicator_registry, endpoint_task) =
         p2p::iroh::spawn_endpoint(iroh_config)

--- a/crates/embedded/tests/iroh_smoke.rs
+++ b/crates/embedded/tests/iroh_smoke.rs
@@ -64,47 +64,65 @@ async fn two_embedded_iroh_nodes_connect_and_replicate() -> Result<()> {
     Ok(())
 }
 
-/// A node configured with an explicit allowlist starts, listens, and
-/// authorizes a peer at runtime.
+/// A node built with an explicit allowlist admits the peer it is told to
+/// admit, and that peer's inbound connection lands.
 ///
 /// The allowlist is only reachable from an embedder through
-/// [`IrohConfig::allowlist`], and `allow_p2p_peer` is a no-op under
+/// [`IrohConfig::allowlist`], and admitting a peer is a no-op under
 /// `AcceptAll`, so a node that could not be built with `Explicit` could not
-/// use the feature at all. Starting empty (`Explicit(Default::default())`)
-/// is the strictest case: nothing is authorized yet, and the endpoint still
-/// has to come up and answer.
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn an_embedded_node_starts_with_an_explicit_allowlist() -> Result<()> {
-    let node = NodeBuilder::default()
+/// use the feature at all. Starting from an empty explicit set is the
+/// strictest case: nothing is authorized yet, so the connection that
+/// succeeds below succeeds because of the authorization and nothing else.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn an_explicit_allowlist_admits_the_peer_it_is_given() -> Result<()> {
+    let listener = NodeBuilder::default()
         .with_iroh(IrohConfig {
             allowlist: p2p::iroh::IrohAllowlistConfig::Explicit(Default::default()),
             ..test_iroh_config()
         })
         .build()
         .await?;
+    let dialer = NodeBuilder::default()
+        .with_iroh(test_iroh_config())
+        .build()
+        .await?;
 
-    let p2p = node.p2p().cloned().context("node missing p2p system")?;
-    let addr = wait_for_connectable_iroh_addr(&p2p).await?;
-    assert!(
-        !addr.is_empty(),
-        "a node with an explicit allowlist must still listen"
-    );
+    let listener_p2p = listener
+        .p2p()
+        .cloned()
+        .context("listener missing p2p system")?;
+    let dialer_p2p = dialer.p2p().cloned().context("dialer missing p2p system")?;
 
-    // The runtime half of the same feature: with the allowlist on, admitting
-    // a peer is a real change rather than the no-op it is under AcceptAll.
-    let peer = p2p
+    let dialer_peer = dialer_p2p
         .ops()
         .local_peer_id()
         .await
         .map_err(|error| anyhow::anyhow!(error))?;
-    let peer = defra_http::TransportPeerId::new(peer).map_err(|error| anyhow::anyhow!(error))?;
-    p2p.ops()
-        .allow_peer(&peer)
+    let listener_addr = wait_for_connectable_iroh_addr(&listener_p2p).await?;
+
+    // Authorize the other node, by its own endpoint id, before it dials.
+    let admitted =
+        defra_http::TransportPeerId::new(dialer_peer.clone()).map_err(|e| anyhow::anyhow!(e))?;
+    listener_p2p
+        .ops()
+        .allow_peer(&admitted)
         .await
         .map_err(|error| anyhow::anyhow!(error))?;
 
-    p2p.shutdown().await;
-    node.database.close().await?;
+    dialer_p2p
+        .ops()
+        .connect_peer(&listener_addr)
+        .await
+        .map_err(|error| anyhow::anyhow!(error))?;
+
+    // The inbound side is what the allowlist governs, so the assertion is
+    // that the listener sees the peer, not merely that the dial returned.
+    wait_for_connected_peer(&listener_p2p, &dialer_peer).await?;
+
+    listener_p2p.shutdown().await;
+    dialer_p2p.shutdown().await;
+    listener.database.close().await?;
+    dialer.database.close().await?;
     Ok(())
 }
 

--- a/crates/embedded/tests/iroh_smoke.rs
+++ b/crates/embedded/tests/iroh_smoke.rs
@@ -64,6 +64,50 @@ async fn two_embedded_iroh_nodes_connect_and_replicate() -> Result<()> {
     Ok(())
 }
 
+/// A node configured with an explicit allowlist starts, listens, and
+/// authorizes a peer at runtime.
+///
+/// The allowlist is only reachable from an embedder through
+/// [`IrohConfig::allowlist`], and `allow_p2p_peer` is a no-op under
+/// `AcceptAll`, so a node that could not be built with `Explicit` could not
+/// use the feature at all. Starting empty (`Explicit(Default::default())`)
+/// is the strictest case: nothing is authorized yet, and the endpoint still
+/// has to come up and answer.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn an_embedded_node_starts_with_an_explicit_allowlist() -> Result<()> {
+    let node = NodeBuilder::default()
+        .with_iroh(IrohConfig {
+            allowlist: p2p::iroh::IrohAllowlistConfig::Explicit(Default::default()),
+            ..test_iroh_config()
+        })
+        .build()
+        .await?;
+
+    let p2p = node.p2p().cloned().context("node missing p2p system")?;
+    let addr = wait_for_connectable_iroh_addr(&p2p).await?;
+    assert!(
+        !addr.is_empty(),
+        "a node with an explicit allowlist must still listen"
+    );
+
+    // The runtime half of the same feature: with the allowlist on, admitting
+    // a peer is a real change rather than the no-op it is under AcceptAll.
+    let peer = p2p
+        .ops()
+        .local_peer_id()
+        .await
+        .map_err(|error| anyhow::anyhow!(error))?;
+    let peer = defra_http::TransportPeerId::new(peer).map_err(|error| anyhow::anyhow!(error))?;
+    p2p.ops()
+        .allow_peer(&peer)
+        .await
+        .map_err(|error| anyhow::anyhow!(error))?;
+
+    p2p.shutdown().await;
+    node.database.close().await?;
+    Ok(())
+}
+
 fn test_iroh_config() -> IrohConfig {
     IrohConfig {
         bind_addr: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
@@ -72,6 +116,7 @@ fn test_iroh_config() -> IrohConfig {
         discovery: p2p::iroh::IrohDiscoveryConfig::Disabled,
         max_concurrent_multipath_paths: None,
         secret_key_path: None,
+        allowlist: Default::default(),
     }
 }
 

--- a/crates/embedded/tests/se_owner.rs
+++ b/crates/embedded/tests/se_owner.rs
@@ -137,6 +137,7 @@ async fn embedded_iroh_se_owner_queries_replicator() -> Result<()> {
             discovery: p2p::iroh::IrohDiscoveryConfig::Disabled,
             max_concurrent_multipath_paths: None,
             secret_key_path: None,
+            allowlist: Default::default(),
         }
     }
 

--- a/crates/http/src/router/traits.rs
+++ b/crates/http/src/router/traits.rs
@@ -239,6 +239,20 @@ pub trait P2POperations: Send + Sync {
     /// Disconnect the live connection to the peer at the given address.
     async fn disconnect_peer(&self, addr: &str) -> P2PResult<()>;
 
+    /// Authorize a peer to open an inbound connection to this node while it
+    /// is running, without a restart.
+    ///
+    /// Widens who may connect in: it does not itself dial, connect to, or
+    /// disconnect from the peer, and it is a no-op when the transport already
+    /// accepts every inbound peer. The input is a canonical raw transport
+    /// peer ID, never an address returned by `connected_peers`. Transports
+    /// without an inbound allowlist concept return an unsupported error.
+    async fn allow_peer(&self, _peer_id: &TransportPeerId) -> P2PResult<()> {
+        Err(P2PError::unsupported(
+            "inbound peer allowlisting is unavailable",
+        ))
+    }
+
     /// Notify the transport that local network conditions may have changed.
     ///
     /// Some transports, such as iroh, use this to refresh relay/direct

--- a/crates/p2p-adapter/src/iroh.rs
+++ b/crates/p2p-adapter/src/iroh.rs
@@ -350,6 +350,18 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         Ok(())
     }
 
+    async fn allow_peer(&self, peer_id: &TransportPeerId) -> P2PResult<()> {
+        self.check_nac(acp::nac::NodePermission::P2pPeerConnect)
+            .await?;
+
+        let peer_id = parse_canonical_peer_id(peer_id.as_str())
+            .map_err(|error| P2PError::invalid_input(error.to_string()))?;
+        self.transport
+            .allow_peer(&peer_id)
+            .await
+            .map_err(|error| P2PError::transport(error.to_string()))
+    }
+
     async fn notify_network_change(&self) -> P2PResult<()> {
         self.transport
             .network_change()
@@ -977,8 +989,8 @@ mod tests {
     use bytes::Bytes;
     use cid::Cid;
     use p2p::iroh::{
-        is_ticket_string, load_or_generate_secret_key, spawn_endpoint, IrohDiscoveryConfig,
-        IrohEndpointConfig, IrohRelayModeConfig,
+        is_ticket_string, load_or_generate_secret_key, spawn_endpoint, IrohAllowlistConfig,
+        IrohDiscoveryConfig, IrohEndpointConfig, IrohRelayModeConfig,
     };
     use p2p::P2PTransport;
 
@@ -1121,6 +1133,77 @@ mod tests {
             .connect_peer(&format!("{phantom}@127.0.0.1:1"))
             .await
             .expect_err("dial to an unconnected, undialable peer must fail");
+    }
+
+    /// `allow_peer` mirrors `connect_peer`/`disconnect_peer`: parse the
+    /// canonical peer id and delegate to the transport. Regression for the
+    /// runtime-authorization path: `IrohTransport::allow_peer` is unreachable
+    /// from anything above the transport unless the adapter passes it through.
+    #[tokio::test]
+    async fn allow_peer_authorizes_a_peer_refused_by_the_allowlist() {
+        let key_a = load_or_generate_secret_key(None).await.expect("key a");
+        let key_b = load_or_generate_secret_key(None).await.expect("key b");
+        let (command_tx_a, _events_a, _replicators_a, _task_a) =
+            spawn_endpoint(test_endpoint_config(key_a.clone()))
+                .await
+                .expect("endpoint a");
+
+        // Endpoint b starts with an explicit allowlist that excludes a.
+        let mut config_b = test_endpoint_config(key_b.clone());
+        config_b.allowlist = IrohAllowlistConfig::Explicit(Default::default());
+        let (command_tx_b, _events_b, _replicators_b, _task_b) =
+            spawn_endpoint(config_b).await.expect("endpoint b");
+
+        let transport_a = IrohTransport::new(command_tx_a, key_a);
+        let transport_b = IrohTransport::new(command_tx_b, key_b);
+        let adapter_a = IrohP2PAdapter::<NoopBlockstore>::for_tests(transport_a.clone());
+        let adapter_b = IrohP2PAdapter::<NoopBlockstore>::for_tests(transport_b.clone());
+
+        let dial_addr = dialable_ticket(&transport_b).await;
+        adapter_a
+            .connect_peer(&dial_addr)
+            .await
+            .expect("dial reaches endpoint b");
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
+        while std::time::Instant::now() < deadline {
+            let connected = transport_b
+                .connected_peers()
+                .await
+                .expect("endpoint b connected_peers");
+            assert!(
+                connected.is_empty(),
+                "a peer refused by the allowlist must never appear connected"
+            );
+            tokio::task::yield_now().await;
+        }
+
+        // Clear a's stale local view of the refused attempt before redialing,
+        // so the next `connect_peer` cannot short-circuit on it as "already
+        // connected".
+        adapter_a
+            .disconnect_peer(&dial_addr)
+            .await
+            .expect("clear stale attempt");
+
+        let peer_a =
+            TransportPeerId::new(transport_a.local_peer_id().as_str()).expect("canonical peer id");
+        adapter_b
+            .allow_peer(&peer_a)
+            .await
+            .expect("authorize a at runtime");
+
+        adapter_a
+            .connect_peer(&dial_addr)
+            .await
+            .expect("connect after authorization");
+        transport_b
+            .poll_until_connected(
+                transport_a.local_peer_id(),
+                std::time::Duration::from_secs(5),
+            )
+            .await
+            .expect("endpoint b sees the authorized peer connected");
     }
 
     /// `add_replicator` shares the rationale: installing a replicator over an

--- a/crates/p2p-adapter/src/iroh.rs
+++ b/crates/p2p-adapter/src/iroh.rs
@@ -1033,6 +1033,7 @@ mod tests {
             bind_addr: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
             max_concurrent_multipath_paths: None,
             gossip_heal: Default::default(),
+            allowlist: Default::default(),
         }
     }
 

--- a/crates/p2p/src/iroh/allowlist_tests.rs
+++ b/crates/p2p/src/iroh/allowlist_tests.rs
@@ -11,7 +11,7 @@ use bytes::Bytes;
 use iroh::SecretKey;
 use tokio::sync::mpsc::Receiver;
 use tokio::task::JoinHandle;
-use tokio::time::timeout;
+use tokio::time::{timeout, Instant};
 
 use super::{
     spawn_endpoint, IrohAllowlistConfig, IrohDiscoveryConfig, IrohEndpointConfig, IrohTransport,
@@ -142,6 +142,11 @@ async fn shutdown_all(
     server_task.await.unwrap();
 }
 
+/// How long a refused peer is given to deliver gossip before the test
+/// concludes that it cannot. Long enough for the mesh to have healed and
+/// retried several times if the allowlist were not holding.
+const GOSSIP_OBSERVATION_WINDOW: Duration = Duration::from_secs(2);
+
 /// A peer not on the allowlist is refused: it never appears connected on the
 /// accepting side, and no gossip message crosses (the gossip ALPN connection
 /// the mesh would open is refused by the same check).
@@ -161,14 +166,30 @@ async fn refuses_a_peer_not_on_the_allowlist_and_blocks_gossip() {
     let topic = DefraTopic::collection("collection");
     dialer.subscribe(topic.clone()).await.unwrap();
     server.subscribe(topic.clone()).await.unwrap();
-    dialer.publish(topic, test_broadcast()).await.unwrap();
 
-    let outcome = timeout(Duration::from_millis(500), server_events.recv()).await;
-    if let Ok(Some(event)) = outcome {
-        assert!(
-            !matches!(event, TransportEvent::GossipMessage { .. }),
-            "a refused peer must not be able to deliver gossip: {event:?}"
-        );
+    // Publish throughout the observation window and inspect every event the
+    // server sees, rather than sampling the first one. One publish followed
+    // by one `recv` passes the moment any unrelated event arrives first,
+    // which proves nothing: what has to hold is that no `GossipMessage`
+    // appears at all before the deadline.
+    let deadline = Instant::now() + GOSSIP_OBSERVATION_WINDOW;
+    while Instant::now() < deadline {
+        dialer
+            .publish(topic.clone(), test_broadcast())
+            .await
+            .unwrap();
+        match timeout(Duration::from_millis(100), server_events.recv()).await {
+            Ok(Some(event)) => assert!(
+                !matches!(event, TransportEvent::GossipMessage { .. }),
+                "a refused peer must not be able to deliver gossip: {event:?}"
+            ),
+            // The endpoint closed its event stream; there is nothing left to
+            // observe and nothing was delivered.
+            Ok(None) => break,
+            // A quiet tick, which is the expected shape of this test: keep
+            // publishing until the window is over.
+            Err(_) => {}
+        }
     }
 
     shutdown_all(dialer, server, dialer_task, server_task).await;

--- a/crates/p2p/src/iroh/allowlist_tests.rs
+++ b/crates/p2p/src/iroh/allowlist_tests.rs
@@ -1,0 +1,293 @@
+//! Inbound-connection allowlist tests.
+//!
+//! Enforcement lives in `handle_incoming`, before a peer's identity
+//! (established from the accepted QUIC connection itself) ever reaches the
+//! gossip layer or the mux layer.
+
+use std::net::{IpAddr, Ipv4Addr};
+use std::time::Duration;
+
+use bytes::Bytes;
+use iroh::SecretKey;
+use tokio::sync::mpsc::Receiver;
+use tokio::task::JoinHandle;
+use tokio::time::timeout;
+
+use super::{
+    spawn_endpoint, IrohAllowlistConfig, IrohDiscoveryConfig, IrohEndpointConfig, IrohTransport,
+};
+use crate::message::PushLogBroadcast;
+use crate::topics::DefraTopic;
+use crate::transport::{P2PTransport, TransportEvent};
+
+type Events = Receiver<TransportEvent<iroh::endpoint::SendStream>>;
+
+fn config(secret_key: SecretKey, allowlist: IrohAllowlistConfig) -> IrohEndpointConfig {
+    IrohEndpointConfig {
+        secret_key,
+        node_identity: None,
+        relay_mode: super::IrohRelayModeConfig::Disabled,
+        discovery: IrohDiscoveryConfig::Disabled,
+        bind_port: None,
+        bind_addr: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+        max_concurrent_multipath_paths: None,
+        gossip_heal: Default::default(),
+        allowlist,
+    }
+}
+
+async fn spawn_node(allowlist: IrohAllowlistConfig) -> (IrohTransport, Events, JoinHandle<()>) {
+    let secret_key = SecretKey::generate();
+    let (command_tx, events, _replicators, task) =
+        spawn_endpoint(config(secret_key.clone(), allowlist))
+            .await
+            .unwrap();
+    (IrohTransport::new(command_tx, secret_key), events, task)
+}
+
+fn test_broadcast() -> PushLogBroadcast {
+    PushLogBroadcast::new(
+        "doc".to_string(),
+        Bytes::from_static(&[1, 2, 3]),
+        "collection".to_string(),
+        "creator".to_string(),
+        Bytes::from_static(&[4, 5, 6]),
+    )
+}
+
+/// Wait for `PeerSubscribed` on `topic`: proof the gossip mesh grafted a
+/// neighbor before a publish is attempted, so the send is deliverable rather
+/// than dropped on an empty topic.
+async fn wait_peer_subscribed(events: &mut Events, topic: &str) {
+    loop {
+        let event = timeout(Duration::from_secs(5), events.recv())
+            .await
+            .expect("timed out waiting for peer subscription")
+            .expect("iroh event channel closed");
+        if let TransportEvent::PeerSubscribed { topic: t, .. } = &event {
+            if t == topic {
+                return;
+            }
+        }
+    }
+}
+
+/// Wait for a `GossipMessage` from `dialer`, ignoring any other event that
+/// arrives first (a `PeerSubscribed` from a still-forming mesh, say).
+async fn wait_gossip_message(events: &mut Events, dialer: &IrohTransport) {
+    loop {
+        let event = timeout(Duration::from_secs(5), events.recv())
+            .await
+            .expect("timed out waiting for gossip message")
+            .expect("iroh event channel closed");
+        if let TransportEvent::GossipMessage {
+            propagation_source, ..
+        } = event
+        {
+            assert_eq!(propagation_source, *dialer.local_peer_id());
+            return;
+        }
+    }
+}
+
+/// A peer refused by the allowlist must never appear connected on the
+/// accepting side, for as long as we keep checking.
+async fn assert_never_connects(dialer: &IrohTransport, server: &IrohTransport, window: Duration) {
+    let deadline = tokio::time::Instant::now() + window;
+    while tokio::time::Instant::now() < deadline {
+        let connected = server.connected_peers().await.unwrap();
+        assert!(
+            !connected.iter().any(|p| p == dialer.local_peer_id()),
+            "a peer refused by the allowlist must never appear connected on the accepting side"
+        );
+        tokio::task::yield_now().await;
+    }
+}
+
+/// Dial `server` from `dialer` and wait until the dialer's own view shows the
+/// connection came up. Proves the dial actually reached the server (the
+/// dialer's QUIC handshake completes locally before the server's allowlist
+/// check, running in the accept path, can close it), without depending on
+/// whether the server ends up accepting or refusing it.
+async fn dial_and_wait_for_local_handshake(dialer: &IrohTransport, server: &IrohTransport) {
+    let addrs = server.listen_addresses().await.unwrap();
+    let _ = dialer.dial(server.local_peer_id(), addrs).await;
+    timeout(Duration::from_secs(5), async {
+        loop {
+            if dialer
+                .connected_peers()
+                .await
+                .unwrap()
+                .iter()
+                .any(|p| p == server.local_peer_id())
+            {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("dial never reached the server");
+}
+
+async fn shutdown_all(
+    dialer: IrohTransport,
+    server: IrohTransport,
+    dialer_task: JoinHandle<()>,
+    server_task: JoinHandle<()>,
+) {
+    dialer.shutdown().await.unwrap();
+    server.shutdown().await.unwrap();
+    dialer_task.await.unwrap();
+    server_task.await.unwrap();
+}
+
+/// A peer not on the allowlist is refused: it never appears connected on the
+/// accepting side, and no gossip message crosses (the gossip ALPN connection
+/// the mesh would open is refused by the same check).
+#[tokio::test]
+async fn refuses_a_peer_not_on_the_allowlist_and_blocks_gossip() {
+    let (dialer, _dialer_events, dialer_task) = spawn_node(IrohAllowlistConfig::AcceptAll).await;
+    // An allowlist naming someone else only: the dialer is never in it.
+    let unrelated = SecretKey::generate().public().to_string();
+    let (server, mut server_events, server_task) = spawn_node(IrohAllowlistConfig::Explicit(
+        [unrelated].into_iter().collect(),
+    ))
+    .await;
+
+    dial_and_wait_for_local_handshake(&dialer, &server).await;
+    assert_never_connects(&dialer, &server, Duration::from_millis(500)).await;
+
+    let topic = DefraTopic::collection("collection");
+    dialer.subscribe(topic.clone()).await.unwrap();
+    server.subscribe(topic.clone()).await.unwrap();
+    dialer.publish(topic, test_broadcast()).await.unwrap();
+
+    let outcome = timeout(Duration::from_millis(500), server_events.recv()).await;
+    if let Ok(Some(event)) = outcome {
+        assert!(
+            !matches!(event, TransportEvent::GossipMessage { .. }),
+            "a refused peer must not be able to deliver gossip: {event:?}"
+        );
+    }
+
+    shutdown_all(dialer, server, dialer_task, server_task).await;
+}
+
+/// A peer on the allowlist connects and exchanges gossip exactly as it would
+/// without one configured.
+#[tokio::test]
+async fn accepts_a_peer_on_the_allowlist_and_exchanges_gossip() {
+    let (dialer, mut dialer_events, dialer_task) = spawn_node(IrohAllowlistConfig::AcceptAll).await;
+    let (server, mut server_events, server_task) = spawn_node(IrohAllowlistConfig::Explicit(
+        [dialer.local_peer_id().to_string()].into_iter().collect(),
+    ))
+    .await;
+
+    dialer
+        .dial(
+            server.local_peer_id(),
+            server.listen_addresses().await.unwrap(),
+        )
+        .await
+        .unwrap();
+    dialer
+        .poll_until_connected(server.local_peer_id(), Duration::from_secs(5))
+        .await
+        .unwrap();
+    server
+        .poll_until_connected(dialer.local_peer_id(), Duration::from_secs(5))
+        .await
+        .unwrap();
+
+    let topic = DefraTopic::collection("collection");
+    dialer.subscribe(topic.clone()).await.unwrap();
+    server.subscribe(topic.clone()).await.unwrap();
+    wait_peer_subscribed(&mut dialer_events, &topic.to_string()).await;
+    wait_peer_subscribed(&mut server_events, &topic.to_string()).await;
+
+    dialer.publish(topic, test_broadcast()).await.unwrap();
+    wait_gossip_message(&mut server_events, &dialer).await;
+
+    shutdown_all(dialer, server, dialer_task, server_task).await;
+}
+
+/// Neither side names the other: relies entirely on `IrohAllowlistConfig`'s
+/// `Default` (`AcceptAll`), matching the transport's behavior before this
+/// allowlist existed.
+#[tokio::test]
+async fn default_allowlist_accepts_every_peer_like_before() {
+    let (dialer, mut dialer_events, dialer_task) = spawn_node(IrohAllowlistConfig::default()).await;
+    let (server, mut server_events, server_task) = spawn_node(IrohAllowlistConfig::default()).await;
+
+    dialer
+        .dial(
+            server.local_peer_id(),
+            server.listen_addresses().await.unwrap(),
+        )
+        .await
+        .unwrap();
+    dialer
+        .poll_until_connected(server.local_peer_id(), Duration::from_secs(5))
+        .await
+        .unwrap();
+    server
+        .poll_until_connected(dialer.local_peer_id(), Duration::from_secs(5))
+        .await
+        .unwrap();
+
+    let topic = DefraTopic::collection("collection");
+    dialer.subscribe(topic.clone()).await.unwrap();
+    server.subscribe(topic.clone()).await.unwrap();
+    wait_peer_subscribed(&mut dialer_events, &topic.to_string()).await;
+    wait_peer_subscribed(&mut server_events, &topic.to_string()).await;
+
+    dialer.publish(topic, test_broadcast()).await.unwrap();
+    wait_gossip_message(&mut server_events, &dialer).await;
+
+    shutdown_all(dialer, server, dialer_task, server_task).await;
+}
+
+/// A peer added to the allowlist while the endpoint is running is accepted
+/// on the very next dial, without a restart.
+#[tokio::test]
+async fn allow_peer_authorizes_a_peer_added_at_runtime() {
+    let (dialer, mut dialer_events, dialer_task) = spawn_node(IrohAllowlistConfig::AcceptAll).await;
+    let (server, mut server_events, server_task) =
+        spawn_node(IrohAllowlistConfig::Explicit(Default::default())).await;
+
+    // Refused before the runtime update.
+    dial_and_wait_for_local_handshake(&dialer, &server).await;
+    assert_never_connects(&dialer, &server, Duration::from_millis(300)).await;
+
+    server.allow_peer(dialer.local_peer_id()).await.unwrap();
+
+    // The refused attempt above was torn down by the server; redial now that
+    // the peer is authorized.
+    dialer
+        .dial(
+            server.local_peer_id(),
+            server.listen_addresses().await.unwrap(),
+        )
+        .await
+        .unwrap();
+    dialer
+        .poll_until_connected(server.local_peer_id(), Duration::from_secs(5))
+        .await
+        .unwrap();
+    server
+        .poll_until_connected(dialer.local_peer_id(), Duration::from_secs(5))
+        .await
+        .unwrap();
+
+    let topic = DefraTopic::collection("collection");
+    dialer.subscribe(topic.clone()).await.unwrap();
+    server.subscribe(topic.clone()).await.unwrap();
+    wait_peer_subscribed(&mut dialer_events, &topic.to_string()).await;
+    wait_peer_subscribed(&mut server_events, &topic.to_string()).await;
+
+    dialer.publish(topic, test_broadcast()).await.unwrap();
+    wait_gossip_message(&mut server_events, &dialer).await;
+
+    shutdown_all(dialer, server, dialer_task, server_task).await;
+}

--- a/crates/p2p/src/iroh/command.rs
+++ b/crates/p2p/src/iroh/command.rs
@@ -25,6 +25,13 @@ pub enum IrohCommand {
         peer_id: PeerId,
         reply: oneshot::Sender<crate::error::Result<()>>,
     },
+    /// Add an endpoint id to the inbound allowlist while the endpoint is
+    /// running. A no-op when the endpoint was configured to accept every
+    /// peer: nothing is narrowed by adding one more.
+    AllowPeer {
+        peer_id: PeerId,
+        reply: oneshot::Sender<crate::error::Result<()>>,
+    },
     Listen {
         addr: PeerAddr,
         reply: oneshot::Sender<crate::error::Result<()>>,

--- a/crates/p2p/src/iroh/config.rs
+++ b/crates/p2p/src/iroh/config.rs
@@ -1,5 +1,27 @@
 //! Public configuration types for Defra's iroh transport.
 
+use std::collections::HashSet;
+
+/// Inbound-connection authorization for an iroh endpoint.
+///
+/// The iroh transport otherwise accepts every inbound QUIC connection: gossip
+/// topic ids are derived from collection ids, which are content-derived and
+/// therefore guessable by anyone running the same schema. `AcceptAll` keeps
+/// today's behavior (fine on a private network); `Explicit` restricts inbound
+/// connections to a known set of iroh endpoint ids, which matters once a node
+/// is reachable from the internet (relay-enabled).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub enum IrohAllowlistConfig {
+    /// Accept an inbound connection from any peer. Matches the transport's
+    /// behavior before this allowlist existed.
+    #[default]
+    AcceptAll,
+    /// Accept an inbound connection only from the listed iroh endpoint ids
+    /// (each the string form of an `iroh::EndpointId`).
+    Explicit(HashSet<String>),
+}
+
 /// Relay configuration for an iroh endpoint.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 #[non_exhaustive]

--- a/crates/p2p/src/iroh/endpoint.rs
+++ b/crates/p2p/src/iroh/endpoint.rs
@@ -22,8 +22,8 @@ use crate::transport::{PeerAddr, PeerId, TransportEvent};
 use super::command::IrohCommand;
 use super::endpoint_commands::handle_command;
 use super::endpoint_config::{
-    apply_bind_config, apply_discovery_config, apply_multipath_config, relay_mode_from_config,
-    IrohEndpointConfig,
+    allowlist_state_from_config, apply_bind_config, apply_discovery_config, apply_multipath_config,
+    relay_mode_from_config, AllowlistState, IrohEndpointConfig,
 };
 use super::endpoint_rpc::{new_connection_cache, ConnectionCache};
 use super::endpoint_streams::handle_incoming;
@@ -48,6 +48,7 @@ pub(super) struct EndpointResources {
     pub(super) healer: Arc<GossipHealer>,
     pub(super) spawned_tasks: SpawnedTasks,
     pub(super) node_identity: Option<Arc<identity::RawIdentity>>,
+    pub(super) allowlist: Arc<AllowlistState>,
 }
 
 /// Handle to a gossip topic subscription.
@@ -131,6 +132,7 @@ pub async fn spawn_endpoint(
     ];
 
     let relay_mode = relay_mode_from_config(&config.relay_mode)?;
+    let allowlist = Arc::new(allowlist_state_from_config(&config.allowlist)?);
     let node_identity = config.node_identity.clone();
     let relay_urls: Vec<String> = relay_mode
         .relay_map()
@@ -163,6 +165,7 @@ pub async fn spawn_endpoint(
         gossip,
         gossip_heal,
         node_identity,
+        allowlist,
         command_rx,
         event_tx,
         replicators.clone(),
@@ -176,11 +179,13 @@ pub async fn spawn_endpoint(
 mod lifecycle_tests;
 
 /// Main event loop processing incoming connections, gossip, and commands.
+#[allow(clippy::too_many_arguments)]
 async fn run_event_loop(
     endpoint: Endpoint,
     gossip: Gossip,
     gossip_heal_config: super::gossip_heal::GossipHealConfig,
     node_identity: Option<Arc<identity::RawIdentity>>,
+    allowlist: Arc<AllowlistState>,
     mut command_rx: mpsc::Receiver<IrohCommand>,
     event_tx: mpsc::Sender<TransportEvent<iroh::endpoint::SendStream>>,
     replicators: Arc<ReplicatorRegistry>,
@@ -210,6 +215,7 @@ async fn run_event_loop(
         healer: Arc::new(GossipHealer::new(gossip_heal_config)),
         spawned_tasks: Arc::clone(&spawned_tasks),
         node_identity,
+        allowlist,
     };
 
     // Emit Listening event with our endpoint address

--- a/crates/p2p/src/iroh/endpoint_commands.rs
+++ b/crates/p2p/src/iroh/endpoint_commands.rs
@@ -131,6 +131,10 @@ pub(super) async fn handle_command(
             let result = handle_disconnect(peer_id, resources);
             let _ = reply.send(result);
         }
+        IrohCommand::AllowPeer { peer_id, reply } => {
+            let result = parse_endpoint_id(&peer_id).map(|id| resources.allowlist.allow(id));
+            let _ = reply.send(result);
+        }
         IrohCommand::Listen { addr: _, reply } => {
             // iroh endpoint is already listening after bind
             let _ = reply.send(Ok(()));

--- a/crates/p2p/src/iroh/endpoint_config.rs
+++ b/crates/p2p/src/iroh/endpoint_config.rs
@@ -1,10 +1,12 @@
 //! Configuration helpers for the iroh endpoint.
 
-use iroh::endpoint::BindOpts;
-use iroh::SecretKey;
+use std::collections::HashSet;
 use std::sync::Arc;
 
-use super::config::{IrohDiscoveryConfig, IrohRelayModeConfig};
+use iroh::endpoint::BindOpts;
+use iroh::{EndpointId, SecretKey};
+
+use super::config::{IrohAllowlistConfig, IrohDiscoveryConfig, IrohRelayModeConfig};
 use super::gossip_heal::GossipHealConfig;
 
 // iroh 1.0 silently ignores custom values below its internal default plus one.
@@ -32,6 +34,9 @@ pub struct IrohEndpointConfig {
     pub max_concurrent_multipath_paths: Option<u32>,
     /// Gossip send-path healing (#1092).
     pub gossip_heal: GossipHealConfig,
+    /// Inbound-connection authorization. Defaults to accepting every peer,
+    /// matching the transport's behavior before this allowlist existed.
+    pub allowlist: IrohAllowlistConfig,
 }
 
 impl Default for IrohEndpointConfig {
@@ -45,6 +50,57 @@ impl Default for IrohEndpointConfig {
             bind_addr: None,
             max_concurrent_multipath_paths: None,
             gossip_heal: GossipHealConfig::default(),
+            allowlist: IrohAllowlistConfig::default(),
+        }
+    }
+}
+
+/// Runtime inbound-allowlist state, held by the endpoint for the life of the
+/// process.
+///
+/// Mirrors [`IrohAllowlistConfig`] but keeps the explicit set behind a lock so
+/// [`IrohCommand::AllowPeer`](super::command::IrohCommand::AllowPeer) can add
+/// a newly authorized peer while the endpoint is running, without a restart.
+pub(super) enum AllowlistState {
+    AcceptAll,
+    Explicit(parking_lot::Mutex<HashSet<EndpointId>>),
+}
+
+impl AllowlistState {
+    /// Whether an inbound connection from `id` may proceed.
+    pub(super) fn is_allowed(&self, id: &EndpointId) -> bool {
+        match self {
+            Self::AcceptAll => true,
+            Self::Explicit(ids) => ids.lock().contains(id),
+        }
+    }
+
+    /// Add `id` to the explicit set. A no-op under `AcceptAll`: every peer is
+    /// already accepted, so there is nothing to widen.
+    pub(super) fn allow(&self, id: EndpointId) {
+        if let Self::Explicit(ids) = self {
+            ids.lock().insert(id);
+        }
+    }
+}
+
+pub(super) fn allowlist_state_from_config(
+    config: &IrohAllowlistConfig,
+) -> crate::error::Result<AllowlistState> {
+    match config {
+        IrohAllowlistConfig::AcceptAll => Ok(AllowlistState::AcceptAll),
+        IrohAllowlistConfig::Explicit(ids) => {
+            let mut parsed = HashSet::with_capacity(ids.len());
+            for id in ids {
+                let endpoint_id: EndpointId = id.parse().map_err(|e: iroh::KeyParsingError| {
+                    crate::error::Error::Transport(format!(
+                        "invalid allowlisted iroh endpoint id '{}': {}",
+                        id, e
+                    ))
+                })?;
+                parsed.insert(endpoint_id);
+            }
+            Ok(AllowlistState::Explicit(parking_lot::Mutex::new(parsed)))
         }
     }
 }
@@ -179,5 +235,59 @@ mod tests {
         assert!(
             apply_multipath_config(builder, Some(super::MIN_CONCURRENT_MULTIPATH_PATHS),).is_ok()
         );
+    }
+
+    #[test]
+    fn accept_all_allows_any_endpoint_id() {
+        let state = allowlist_state_from_config(&IrohAllowlistConfig::AcceptAll).unwrap();
+        let id = iroh::SecretKey::generate().public();
+
+        assert!(state.is_allowed(&id));
+    }
+
+    #[test]
+    fn explicit_allowlist_rejects_unlisted_ids() {
+        let listed = iroh::SecretKey::generate().public();
+        let unlisted = iroh::SecretKey::generate().public();
+        let state = allowlist_state_from_config(&IrohAllowlistConfig::Explicit(
+            [listed.to_string()].into_iter().collect(),
+        ))
+        .unwrap();
+
+        assert!(state.is_allowed(&listed));
+        assert!(!state.is_allowed(&unlisted));
+    }
+
+    #[test]
+    fn explicit_allowlist_rejects_malformed_endpoint_id() {
+        let result = allowlist_state_from_config(&IrohAllowlistConfig::Explicit(
+            ["not-an-endpoint-id".to_string()].into_iter().collect(),
+        ));
+
+        assert!(matches!(
+            result,
+            Err(crate::error::Error::Transport(message))
+                if message.contains("invalid allowlisted iroh endpoint id")
+        ));
+    }
+
+    #[test]
+    fn allow_adds_a_peer_to_an_explicit_allowlist() {
+        let newly_allowed = iroh::SecretKey::generate().public();
+        let state =
+            allowlist_state_from_config(&IrohAllowlistConfig::Explicit(HashSet::new())).unwrap();
+
+        assert!(!state.is_allowed(&newly_allowed));
+        state.allow(newly_allowed);
+        assert!(state.is_allowed(&newly_allowed));
+    }
+
+    #[test]
+    fn allow_is_a_no_op_under_accept_all() {
+        let id = iroh::SecretKey::generate().public();
+        let state = allowlist_state_from_config(&IrohAllowlistConfig::AcceptAll).unwrap();
+
+        state.allow(id);
+        assert!(matches!(state, AllowlistState::AcceptAll));
     }
 }

--- a/crates/p2p/src/iroh/endpoint_streams.rs
+++ b/crates/p2p/src/iroh/endpoint_streams.rs
@@ -18,6 +18,10 @@ use super::gossip_heal;
 use super::peer_map::{endpoint_id_to_peer_id, PeerMap};
 use super::protocols;
 
+/// QUIC application error code closing a connection refused by the inbound
+/// allowlist. Distinct from the disconnect code (0) used elsewhere.
+const REFUSED_CONNECTION_CODE: u32 = 1;
+
 /// Handle an incoming QUIC connection.
 pub(super) async fn handle_incoming(
     incoming: iroh::endpoint::Incoming,
@@ -59,6 +63,20 @@ pub(super) async fn handle_incoming(
         }
     };
 
+    // Establish identity from the accepted connection itself (the iroh
+    // endpoint id authenticated by the QUIC/TLS handshake), never from
+    // anything the caller sends in a payload. A refused peer is closed here,
+    // before it reaches the gossip layer or the mux layer below.
+    let remote_id = connection.remote_id();
+    if !resources.allowlist.is_allowed(&remote_id) {
+        warn!(
+            peer_id = %endpoint_id_to_peer_id(&remote_id),
+            "Refused inbound Iroh connection: peer is not on the inbound allowlist"
+        );
+        connection.close(REFUSED_CONNECTION_CODE.into(), b"peer not authorized");
+        return;
+    }
+
     let conn_alpn = connection.alpn().to_vec();
 
     // If it's a gossip ALPN, hand off to the gossip layer
@@ -68,8 +86,6 @@ pub(super) async fn handle_incoming(
         }
         return;
     }
-
-    let remote_id = connection.remote_id();
 
     let is_new =
         resources

--- a/crates/p2p/src/iroh/mod.rs
+++ b/crates/p2p/src/iroh/mod.rs
@@ -10,6 +10,8 @@
 //! - Communication via `IrohCommand` enum over mpsc channel
 
 mod addr;
+#[cfg(test)]
+mod allowlist_tests;
 mod command;
 mod config;
 mod endpoint;
@@ -32,7 +34,7 @@ pub use addr::{
     endpoint_ticket_string, format_public_listen_addrs, is_ticket_string, parse_canonical_peer_id,
     parse_public_peer_addr,
 };
-pub use config::{IrohDiscoveryConfig, IrohRelayModeConfig};
+pub use config::{IrohAllowlistConfig, IrohDiscoveryConfig, IrohRelayModeConfig};
 pub use endpoint::spawn_endpoint;
 pub use endpoint_config::IrohEndpointConfig;
 pub use gossip_heal::GossipHealConfig;

--- a/crates/p2p/src/iroh/mux_tests.rs
+++ b/crates/p2p/src/iroh/mux_tests.rs
@@ -118,6 +118,7 @@ async fn spawn_transport() -> (IrohTransport, JoinHandle<()>) {
         bind_addr: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
         max_concurrent_multipath_paths: None,
         gossip_heal: Default::default(),
+        allowlist: Default::default(),
     };
     let (command_tx, _events, _replicators, task) = spawn_endpoint(config).await.unwrap();
     (IrohTransport::new(command_tx, secret_key), task)

--- a/crates/p2p/src/iroh/transport.rs
+++ b/crates/p2p/src/iroh/transport.rs
@@ -104,6 +104,20 @@ impl IrohTransport {
             .await
     }
 
+    /// Authorize an inbound connection from `peer_id` while the endpoint is
+    /// running, without a restart.
+    ///
+    /// Only meaningful when the endpoint was configured with an explicit
+    /// inbound allowlist (`IrohAllowlistConfig::Explicit`); a no-op when it
+    /// was configured to accept every peer.
+    pub async fn allow_peer(&self, peer_id: &PeerId) -> Result<()> {
+        self.send_command(|reply| IrohCommand::AllowPeer {
+            peer_id: peer_id.clone(),
+            reply,
+        })
+        .await
+    }
+
     /// Resolve a peer's Defra identity over its authenticated QUIC endpoint.
     ///
     /// The returned token is signed by the remote DID and audience-bound to
@@ -621,6 +635,7 @@ mod tests {
             bind_addr: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
             max_concurrent_multipath_paths: None,
             gossip_heal: Default::default(),
+            allowlist: Default::default(),
         }
     }
 

--- a/crates/p2p/src/iroh/two_stream_tests.rs
+++ b/crates/p2p/src/iroh/two_stream_tests.rs
@@ -35,6 +35,7 @@ impl TestNode {
             bind_addr: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
             max_concurrent_multipath_paths: None,
             gossip_heal: Default::default(),
+            allowlist: Default::default(),
         };
         let (command_tx, events, _replicators, task) = spawn_endpoint(config).await.unwrap();
         Self {

--- a/tools/integration-test/tests/p2p_iroh/connection/gossip_heal.rs
+++ b/tools/integration-test/tests/p2p_iroh/connection/gossip_heal.rs
@@ -33,6 +33,7 @@ async fn test_config(gossip_heal: GossipHealConfig) -> IrohEndpointConfig {
         bind_addr: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
         max_concurrent_multipath_paths: None,
         gossip_heal,
+        allowlist: Default::default(),
     }
 }
 

--- a/tools/integration-test/tests/p2p_iroh/connection/se_query.rs
+++ b/tools/integration-test/tests/p2p_iroh/connection/se_query.rs
@@ -26,6 +26,7 @@ async fn test_config() -> IrohEndpointConfig {
         bind_addr: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
         max_concurrent_multipath_paths: None,
         gossip_heal: Default::default(),
+        allowlist: Default::default(),
     }
 }
 


### PR DESCRIPTION
The iroh transport accepts every inbound connection. `handle_incoming` accepts and, for a gossip ALPN, hands the connection straight to the gossip layer without checking who the remote peer is. Gossip topic ids are derived from collection ids, which are content-derived and identical for anyone holding the same schema, so any peer that can reach the endpoint and can name a collection joins that topic's mesh and receives its documents.

That is fine while a node is only reachable on a private network. It stops being fine the moment relays are enabled, which is what makes a node reachable from the internet.

## What this adds

`IrohAllowlistConfig`, in the same shape as the existing `IrohRelayModeConfig` and `IrohDiscoveryConfig`:

- `AcceptAll`, the default, so every existing caller is unaffected
- `Explicit(HashSet<String>)`, the string form of iroh endpoint ids

Enforcement is in `handle_incoming`, on the accepted connection's own TLS-authenticated `remote_id()`, never on anything the caller sends in a payload. It runs before the gossip branch and before the mux path's peer bookkeeping, so a refused peer reaches neither. The connection is closed and one warning is logged.

A peer can be authorized while the node runs: `IrohCommand::AllowPeer`, surfaced as `IrohTransport::allow_peer`, then through `P2POperations::allow_peer` (a default method returning "unsupported", so the libp2p adapter inherits an honest answer rather than a fabricated success), the iroh adapter, and finally `EmbeddedNode::allow_p2p_peer`. Without that passthrough the runtime command would be unreachable from any real caller, since consumers drive the node, not the transport.

## Tests

Two-endpoint tests that exercise the behaviour rather than the configuration:

- a peer not on the allowlist: never appears connected, and no gossip crosses
- a peer on the allowlist: connects and exchanges as before
- the default configuration: unchanged from today
- a peer added at runtime: refused, then allowed, then connects
- the same runtime scenario again at the adapter layer and at the `EmbeddedNode` layer

Plus unit tests for the config itself, including a malformed endpoint id rejected at construction rather than silently ignored.

## Verification

- `cargo test -p p2p --features iroh-transport`: 431 passed, 0 failed
- `cargo test -p defra-p2p-adapter`: 62 passed, 0 failed
- `cargo test -p defra-node --features p2p`: 57 passed, 0 failed
- `cargo clippy --all-targets -- -D warnings` clean for `p2p`, `defra-node`, `defra-p2p-adapter`, `defra-http`
- `cargo fmt --check` clean

## Where this came from

A deployment that runs DefraDB nodes which a customer's own nodes need to reach from outside the private network. Reachability without an accept-side authorization would have exposed tenant documents, so the authorization is built here, where it belongs, rather than worked around downstream.

