### PR TITLE
perf(p2p): batch collection subscriptions

### DIFF
--- a/crates/p2p-adapter/src/doc_sync/test_support.rs
+++ b/crates/p2p-adapter/src/doc_sync/test_support.rs
@@ -75,6 +75,10 @@ impl TransportDocPusher for StubPusher {
         unimplemented!("not reached by doc-sync tests")
     }
 
+    fn get_collection_name(&self, _collection_id: &str) -> P2PResult<Option<String>> {
+        unimplemented!("not reached by doc-sync tests")
+    }
+
     fn list_collections(&self) -> P2PResult<Vec<String>> {
         unimplemented!("not reached by doc-sync tests")
     }

--- a/crates/p2p-adapter/src/iroh.rs
+++ b/crates/p2p-adapter/src/iroh.rs
@@ -702,35 +702,26 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
             .await?;
 
         if let Some(ref coordinator) = self.sync_coordinator {
-            for collection_name in collections {
-                let topic_id = if let Some(ref pusher) = self.doc_pusher {
-                    if let Some(collection_id) = pusher.get_collection_id(&collection_name) {
-                        collection_id
+            let topic_ids = collections
+                .into_iter()
+                .map(|collection_name| {
+                    if let Some(ref pusher) = self.doc_pusher {
+                        pusher.get_collection_id(&collection_name).ok_or_else(|| {
+                            P2PError::not_found(format!(
+                                "collection '{}' not found - add schema before subscribing to P2P",
+                                collection_name
+                            ))
+                        })
                     } else {
-                        return Err(P2PError::not_found(format!(
-                            "collection '{}' not found - add schema before subscribing to P2P",
-                            collection_name
-                        )));
+                        Ok(collection_name)
                     }
-                } else {
-                    collection_name.clone()
-                };
+                })
+                .collect::<P2PResult<Vec<_>>>()?;
 
-                coordinator
-                    .subscribe_collection(&topic_id)
-                    .await
-                    .map_err(|error| P2PError::transport(error.to_string()))?;
-            }
-
-            if let Some(ref pusher) = self.doc_pusher {
-                let all_cols = coordinator
-                    .get_subscribed_collections()
-                    .await
-                    .map_err(|error| P2PError::transport(error.to_string()))?;
-                if let Err(error) = pusher.persist_p2p_collections(&all_cols).await {
-                    tracing::warn!(error = %error, "failed to persist P2P collections");
-                }
-            }
+            coordinator
+                .subscribe_collections(&topic_ids)
+                .await
+                .map_err(|error| P2PError::transport(error.to_string()))?;
 
             Ok(())
         } else {
@@ -766,16 +757,6 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
                     .unsubscribe_collection(&topic_id)
                     .await
                     .map_err(|error| P2PError::transport(error.to_string()))?;
-            }
-
-            if let Some(ref pusher) = self.doc_pusher {
-                let all_cols = coordinator
-                    .get_subscribed_collections()
-                    .await
-                    .map_err(|error| P2PError::transport(error.to_string()))?;
-                if let Err(error) = pusher.persist_p2p_collections(&all_cols).await {
-                    tracing::warn!(error = %error, "failed to persist P2P collections after removal");
-                }
             }
 
             Ok(())

--- a/crates/p2p-adapter/src/iroh.rs
+++ b/crates/p2p-adapter/src/iroh.rs
@@ -688,10 +688,24 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
             .await?;
 
         if let Some(ref coordinator) = self.sync_coordinator {
-            coordinator
+            let collection_ids = coordinator
                 .get_subscribed_collections()
                 .await
-                .map_err(|error| P2PError::transport(error.to_string()))
+                .map_err(|error| P2PError::transport(error.to_string()))?;
+            if let Some(ref pusher) = self.doc_pusher {
+                collection_ids
+                    .into_iter()
+                    .map(|collection_id| {
+                        pusher.get_collection_name(&collection_id)?.ok_or_else(|| {
+                            P2PError::not_found(format!(
+                                "collection with ID '{collection_id}' not found"
+                            ))
+                        })
+                    })
+                    .collect()
+            } else {
+                Ok(collection_ids)
+            }
         } else {
             Ok(Vec::new())
         }
@@ -752,12 +766,10 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
                 })
                 .collect::<P2PResult<Vec<_>>>()?;
 
-            for topic_id in topic_ids {
-                coordinator
-                    .unsubscribe_collection(&topic_id)
-                    .await
-                    .map_err(|error| P2PError::transport(error.to_string()))?;
-            }
+            coordinator
+                .unsubscribe_collections(&topic_ids)
+                .await
+                .map_err(|error| P2PError::transport(error.to_string()))?;
 
             Ok(())
         } else {

--- a/crates/p2p-adapter/src/libp2p.rs
+++ b/crates/p2p-adapter/src/libp2p.rs
@@ -686,10 +686,24 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
             .await?;
 
         if let Some(ref coordinator) = self.sync_coordinator {
-            coordinator
+            let collection_ids = coordinator
                 .get_subscribed_collections()
                 .await
-                .map_err(|error| P2PError::transport(error.to_string()))
+                .map_err(|error| P2PError::transport(error.to_string()))?;
+            if let Some(ref pusher) = self.doc_pusher {
+                collection_ids
+                    .into_iter()
+                    .map(|collection_id| {
+                        pusher.get_collection_name(&collection_id)?.ok_or_else(|| {
+                            P2PError::not_found(format!(
+                                "collection with ID '{collection_id}' not found"
+                            ))
+                        })
+                    })
+                    .collect()
+            } else {
+                Ok(collection_ids)
+            }
         } else {
             Ok(Vec::new())
         }
@@ -750,12 +764,10 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
                 })
                 .collect::<P2PResult<Vec<_>>>()?;
 
-            for topic_id in topic_ids {
-                coordinator
-                    .unsubscribe_collection(&topic_id)
-                    .await
-                    .map_err(|error| P2PError::transport(error.to_string()))?;
-            }
+            coordinator
+                .unsubscribe_collections(&topic_ids)
+                .await
+                .map_err(|error| P2PError::transport(error.to_string()))?;
 
             Ok(())
         } else {

--- a/crates/p2p-adapter/src/libp2p.rs
+++ b/crates/p2p-adapter/src/libp2p.rs
@@ -700,35 +700,26 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
             .await?;
 
         if let Some(ref coordinator) = self.sync_coordinator {
-            for collection_name in collections {
-                let topic_id = if let Some(ref pusher) = self.doc_pusher {
-                    if let Some(collection_id) = pusher.get_collection_id(&collection_name) {
-                        collection_id
+            let topic_ids = collections
+                .into_iter()
+                .map(|collection_name| {
+                    if let Some(ref pusher) = self.doc_pusher {
+                        pusher.get_collection_id(&collection_name).ok_or_else(|| {
+                            P2PError::not_found(format!(
+                                "collection '{}' not found - add schema before subscribing to P2P",
+                                collection_name
+                            ))
+                        })
                     } else {
-                        return Err(P2PError::not_found(format!(
-                            "collection '{}' not found - add schema before subscribing to P2P",
-                            collection_name
-                        )));
+                        Ok(collection_name)
                     }
-                } else {
-                    collection_name.clone()
-                };
+                })
+                .collect::<P2PResult<Vec<_>>>()?;
 
-                coordinator
-                    .subscribe_collection(&topic_id)
-                    .await
-                    .map_err(|error| P2PError::transport(error.to_string()))?;
-            }
-
-            if let Some(ref pusher) = self.doc_pusher {
-                let all_cols = coordinator
-                    .get_subscribed_collections()
-                    .await
-                    .map_err(|error| P2PError::transport(error.to_string()))?;
-                if let Err(error) = pusher.persist_p2p_collections(&all_cols).await {
-                    tracing::warn!(error = %error, "failed to persist P2P collections");
-                }
-            }
+            coordinator
+                .subscribe_collections(&topic_ids)
+                .await
+                .map_err(|error| P2PError::transport(error.to_string()))?;
 
             Ok(())
         } else {
@@ -764,16 +755,6 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
                     .unsubscribe_collection(&topic_id)
                     .await
                     .map_err(|error| P2PError::transport(error.to_string()))?;
-            }
-
-            if let Some(ref pusher) = self.doc_pusher {
-                let all_cols = coordinator
-                    .get_subscribed_collections()
-                    .await
-                    .map_err(|error| P2PError::transport(error.to_string()))?;
-                if let Err(error) = pusher.persist_p2p_collections(&all_cols).await {
-                    tracing::warn!(error = %error, "failed to persist P2P collections after removal");
-                }
             }
 
             Ok(())

--- a/crates/p2p-adapter/src/transport_doc_pusher.rs
+++ b/crates/p2p-adapter/src/transport_doc_pusher.rs
@@ -57,6 +57,8 @@ pub trait TransportDocPusher: Send + Sync {
 
     fn get_collection_id(&self, name: &str) -> Option<String>;
 
+    fn get_collection_name(&self, collection_id: &str) -> P2PResult<Option<String>>;
+
     fn list_collections(&self) -> P2PResult<Vec<String>>;
 
     fn validate_replication_filters(&self, _filters: &p2p::ReplicationFilters) -> P2PResult<()> {
@@ -302,6 +304,17 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
                 None
             }
         }
+    }
+
+    fn get_collection_name(&self, collection_id: &str) -> P2PResult<Option<String>> {
+        self.db
+            .find_collection_by_id(collection_id)
+            .map(|collection| collection.map(|collection| collection.name().to_string()))
+            .map_err(|error| {
+                P2PError::internal(format!(
+                    "failed to find collection '{collection_id}': {error}"
+                ))
+            })
     }
 
     fn list_collections(&self) -> P2PResult<Vec<String>> {

--- a/crates/p2p/src/sync/collection_store.rs
+++ b/crates/p2p/src/sync/collection_store.rs
@@ -25,6 +25,9 @@ pub trait P2PCollectionStorage: Send + Sync {
     /// Remove a collection subscription from persistent storage.
     async fn remove_collection(&self, collection_id: &str) -> Result<()>;
 
+    /// Remove multiple collection subscriptions atomically.
+    async fn remove_collections(&self, collection_ids: &[String]) -> Result<()>;
+
     /// Get all subscribed collection IDs from persistent storage.
     async fn get_all_collections(&self) -> Result<Vec<String>>;
 
@@ -93,16 +96,26 @@ impl<S: Store + 'static> P2PCollectionStorage for P2PCollectionStore<S> {
     }
 
     async fn remove_collection(&self, collection_id: &str) -> Result<()> {
-        let key = P2PCollectionKey::new(collection_id);
+        self.remove_collections(&[collection_id.to_string()]).await
+    }
+
+    async fn remove_collections(&self, collection_ids: &[String]) -> Result<()> {
+        if collection_ids.is_empty() {
+            return Ok(());
+        }
+
         let mut txn = self
             .systemstore
             .new_txn(false)
             .await
             .map_err(|e| Error::Storage(e.to_string()))?;
 
-        txn.delete(&key.bytes())
-            .await
-            .map_err(|e| Error::Storage(e.to_string()))?;
+        for collection_id in collection_ids {
+            let key = P2PCollectionKey::new(collection_id);
+            txn.delete(&key.bytes())
+                .await
+                .map_err(|e| Error::Storage(e.to_string()))?;
+        }
 
         txn.commit()
             .await
@@ -182,6 +195,10 @@ impl P2PCollectionStorage for NoOpCollectionStorage {
     }
 
     async fn remove_collection(&self, _collection_id: &str) -> Result<()> {
+        Ok(())
+    }
+
+    async fn remove_collections(&self, _collection_ids: &[String]) -> Result<()> {
         Ok(())
     }
 
@@ -266,6 +283,30 @@ mod tests {
             .into_iter()
             .collect::<std::collections::HashSet<_>>();
         assert_eq!(stored, collections.into_iter().collect());
+    }
+
+    #[tokio::test]
+    async fn removes_collection_batch_from_systemstore_namespace() {
+        use storage::RegolithStore;
+
+        let store = Arc::new(RegolithStore::in_memory().unwrap());
+        let p2p_store = P2PCollectionStore::new(store);
+        let collections = vec![
+            "users".to_string(),
+            "messages".to_string(),
+            "sessions".to_string(),
+        ];
+        p2p_store.add_collections(&collections).await.unwrap();
+
+        p2p_store
+            .remove_collections(&collections[..2])
+            .await
+            .unwrap();
+
+        assert_eq!(
+            p2p_store.get_all_collections().await.unwrap(),
+            vec!["sessions".to_string()]
+        );
     }
 
     #[tokio::test]

--- a/crates/p2p/src/sync/collection_store.rs
+++ b/crates/p2p/src/sync/collection_store.rs
@@ -19,6 +19,9 @@ pub trait P2PCollectionStorage: Send + Sync {
     /// Add a collection subscription to persistent storage.
     async fn add_collection(&self, collection_id: &str) -> Result<()>;
 
+    /// Add multiple collection subscriptions atomically.
+    async fn add_collections(&self, collection_ids: &[String]) -> Result<()>;
+
     /// Remove a collection subscription from persistent storage.
     async fn remove_collection(&self, collection_id: &str) -> Result<()>;
 
@@ -56,6 +59,31 @@ impl<S: Store + 'static> P2PCollectionStorage for P2PCollectionStore<S> {
         txn.set(&key.bytes(), &[COLLECTION_MARKER])
             .await
             .map_err(|e| Error::Storage(e.to_string()))?;
+
+        txn.commit()
+            .await
+            .map_err(|e| Error::Storage(e.to_string()))?;
+
+        Ok(())
+    }
+
+    async fn add_collections(&self, collection_ids: &[String]) -> Result<()> {
+        if collection_ids.is_empty() {
+            return Ok(());
+        }
+
+        let mut txn = self
+            .systemstore
+            .new_txn(false)
+            .await
+            .map_err(|e| Error::Storage(e.to_string()))?;
+
+        for collection_id in collection_ids {
+            let key = P2PCollectionKey::new(collection_id);
+            txn.set(&key.bytes(), &[COLLECTION_MARKER])
+                .await
+                .map_err(|e| Error::Storage(e.to_string()))?;
+        }
 
         txn.commit()
             .await
@@ -149,6 +177,10 @@ impl P2PCollectionStorage for NoOpCollectionStorage {
         Ok(())
     }
 
+    async fn add_collections(&self, _collection_ids: &[String]) -> Result<()> {
+        Ok(())
+    }
+
     async fn remove_collection(&self, _collection_id: &str) -> Result<()> {
         Ok(())
     }
@@ -211,6 +243,29 @@ mod tests {
             None,
             "Go-compatible P2P collection state must live in Systemstore, not the raw root store"
         );
+    }
+
+    #[tokio::test]
+    async fn stores_collection_batch_in_systemstore_namespace() {
+        use storage::RegolithStore;
+
+        let store = Arc::new(RegolithStore::in_memory().unwrap());
+        let p2p_store = P2PCollectionStore::new(store);
+        let collections = vec![
+            "users".to_string(),
+            "messages".to_string(),
+            "sessions".to_string(),
+        ];
+
+        p2p_store.add_collections(&collections).await.unwrap();
+
+        let stored = p2p_store
+            .get_all_collections()
+            .await
+            .unwrap()
+            .into_iter()
+            .collect::<std::collections::HashSet<_>>();
+        assert_eq!(stored, collections.into_iter().collect());
     }
 
     #[tokio::test]

--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -365,6 +365,9 @@ fn create_test_coordinator_with_blockstore_and_head_provider<B: Blockstore + 'st
             subscribed_collections: Arc::new(tokio::sync::RwLock::new(
                 std::collections::HashSet::new(),
             )),
+            retrying_subscribes: Arc::new(
+                tokio::sync::Mutex::new(std::collections::HashSet::new()),
+            ),
             retrying_unsubscribes: Arc::new(tokio::sync::Mutex::new(
                 std::collections::HashSet::new(),
             )),

--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -361,6 +361,7 @@ fn create_test_coordinator_with_blockstore_and_head_provider<B: Blockstore + 'st
             gossip_direction_filtered: std::sync::atomic::AtomicU64::new(0),
         },
         subscriptions: SyncSubscriptionState {
+            mutation: tokio::sync::Mutex::new(()),
             subscribed_collections: Arc::new(tokio::sync::RwLock::new(
                 std::collections::HashSet::new(),
             )),

--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -361,8 +361,11 @@ fn create_test_coordinator_with_blockstore_and_head_provider<B: Blockstore + 'st
             gossip_direction_filtered: std::sync::atomic::AtomicU64::new(0),
         },
         subscriptions: SyncSubscriptionState {
-            mutation: tokio::sync::Mutex::new(()),
+            mutation: Arc::new(tokio::sync::Mutex::new(())),
             subscribed_collections: Arc::new(tokio::sync::RwLock::new(
+                std::collections::HashSet::new(),
+            )),
+            retrying_unsubscribes: Arc::new(tokio::sync::Mutex::new(
                 std::collections::HashSet::new(),
             )),
             collection_store: Arc::new(NoOpCollectionStorage),

--- a/crates/p2p/src/sync/coordinator/constructor.rs
+++ b/crates/p2p/src/sync/coordinator/constructor.rs
@@ -260,8 +260,11 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                     gossip_direction_filtered: AtomicU64::new(0),
                 },
                 subscriptions: SyncSubscriptionState {
-                    mutation: tokio::sync::Mutex::new(()),
+                    mutation: Arc::new(tokio::sync::Mutex::new(())),
                     subscribed_collections,
+                    retrying_unsubscribes: Arc::new(tokio::sync::Mutex::new(
+                        std::collections::HashSet::new(),
+                    )),
                     collection_store,
                     head_provider,
                 },

--- a/crates/p2p/src/sync/coordinator/constructor.rs
+++ b/crates/p2p/src/sync/coordinator/constructor.rs
@@ -262,6 +262,9 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 subscriptions: SyncSubscriptionState {
                     mutation: Arc::new(tokio::sync::Mutex::new(())),
                     subscribed_collections,
+                    retrying_subscribes: Arc::new(tokio::sync::Mutex::new(
+                        std::collections::HashSet::new(),
+                    )),
                     retrying_unsubscribes: Arc::new(tokio::sync::Mutex::new(
                         std::collections::HashSet::new(),
                     )),

--- a/crates/p2p/src/sync/coordinator/constructor.rs
+++ b/crates/p2p/src/sync/coordinator/constructor.rs
@@ -260,6 +260,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                     gossip_direction_filtered: AtomicU64::new(0),
                 },
                 subscriptions: SyncSubscriptionState {
+                    mutation: tokio::sync::Mutex::new(()),
                     subscribed_collections,
                     collection_store,
                     head_provider,

--- a/crates/p2p/src/sync/coordinator/mod.rs
+++ b/crates/p2p/src/sync/coordinator/mod.rs
@@ -693,6 +693,9 @@ pub(super) struct SyncSubscriptionState {
     /// Set of subscribed collection IDs for P2P sync (in-memory cache).
     pub(super) subscribed_collections: Arc<tokio::sync::RwLock<std::collections::HashSet<String>>>,
 
+    /// Desired topics with one background installation retry owner.
+    pub(super) retrying_subscribes: Arc<tokio::sync::Mutex<std::collections::HashSet<String>>>,
+
     /// Undesired live topics with one background removal retry owner.
     pub(super) retrying_unsubscribes: Arc<tokio::sync::Mutex<std::collections::HashSet<String>>>,
 

--- a/crates/p2p/src/sync/coordinator/mod.rs
+++ b/crates/p2p/src/sync/coordinator/mod.rs
@@ -688,10 +688,13 @@ pub(super) struct SyncAccessState {
 pub(super) struct SyncSubscriptionState {
     /// Serializes durable subscription mutations without blocking readers of
     /// the live installed-topic set while transport I/O is in flight.
-    pub(super) mutation: tokio::sync::Mutex<()>,
+    pub(super) mutation: Arc<tokio::sync::Mutex<()>>,
 
     /// Set of subscribed collection IDs for P2P sync (in-memory cache).
     pub(super) subscribed_collections: Arc<tokio::sync::RwLock<std::collections::HashSet<String>>>,
+
+    /// Undesired live topics with one background removal retry owner.
+    pub(super) retrying_unsubscribes: Arc<tokio::sync::Mutex<std::collections::HashSet<String>>>,
 
     /// Persistent storage for P2P collection subscriptions.
     pub(super) collection_store: Arc<dyn P2PCollectionStorage>,

--- a/crates/p2p/src/sync/coordinator/mod.rs
+++ b/crates/p2p/src/sync/coordinator/mod.rs
@@ -686,6 +686,10 @@ pub(super) struct SyncAccessState {
 
 /// Subscription and document head support state for the coordinator.
 pub(super) struct SyncSubscriptionState {
+    /// Serializes durable subscription mutations without blocking readers of
+    /// the live installed-topic set while transport I/O is in flight.
+    pub(super) mutation: tokio::sync::Mutex<()>,
+
     /// Set of subscribed collection IDs for P2P sync (in-memory cache).
     pub(super) subscribed_collections: Arc<tokio::sync::RwLock<std::collections::HashSet<String>>>,
 

--- a/crates/p2p/src/sync/coordinator/subscriptions.rs
+++ b/crates/p2p/src/sync/coordinator/subscriptions.rs
@@ -143,13 +143,13 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 "timed out unsubscribing from collection {collection_id}"
             )))
         });
+        let result = result?;
+
         self.subscriptions
             .subscribed_collections
             .write()
             .await
             .remove(collection_id);
-
-        let result = result?;
 
         if result {
             tracing::debug!(collection_id = %collection_id, "Unsubscribed from collection (persisted)");
@@ -302,6 +302,7 @@ mod tests {
         pubkey: Vec<u8>,
         subscribed: Arc<Mutex<HashSet<String>>>,
         fail_subscribe: Arc<Mutex<HashSet<String>>>,
+        fail_unsubscribe_once: Arc<Mutex<HashSet<String>>>,
         subscribe_calls: Arc<AtomicUsize>,
         subscribe_delay: Duration,
         subscribe_in_flight: Arc<AtomicUsize>,
@@ -316,6 +317,7 @@ mod tests {
                 pubkey: vec![1, 2, 3],
                 subscribed: Arc::new(Mutex::new(HashSet::new())),
                 fail_subscribe: Arc::new(Mutex::new(HashSet::new())),
+                fail_unsubscribe_once: Arc::new(Mutex::new(HashSet::new())),
                 subscribe_calls: Arc::new(AtomicUsize::new(0)),
                 subscribe_delay: Duration::ZERO,
                 subscribe_in_flight: Arc::new(AtomicUsize::new(0)),
@@ -334,6 +336,14 @@ mod tests {
 
         fn with_subscribe_delay(mut self, delay: Duration) -> Self {
             self.subscribe_delay = delay;
+            self
+        }
+
+        fn fail_unsubscribe_once(self, topic: &str) -> Self {
+            self.fail_unsubscribe_once
+                .lock()
+                .unwrap()
+                .insert(topic.to_string());
             self
         }
 
@@ -422,11 +432,13 @@ mod tests {
         }
 
         async fn unsubscribe(&self, topic: DefraTopic) -> crate::Result<bool> {
-            Ok(self
-                .subscribed
-                .lock()
-                .unwrap()
-                .remove(&topic.topic_string()))
+            let topic = topic.topic_string();
+            if self.fail_unsubscribe_once.lock().unwrap().remove(&topic) {
+                return Err(crate::error::Error::Transport(format!(
+                    "injected unsubscribe failure for {topic}"
+                )));
+            }
+            Ok(self.subscribed.lock().unwrap().remove(&topic))
         }
 
         async fn publish(
@@ -853,5 +865,48 @@ mod tests {
 
         assert_eq!(restored, 1, "restart should retry durable desired state");
         assert_eq!(restarted_transport.subscribed_topics(), vec!["users"]);
+    }
+
+    #[tokio::test]
+    async fn unsubscribe_failure_keeps_live_topic_retryable() {
+        let store = Arc::new(RegolithStore::in_memory().unwrap());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let transport = RecordingTransport::new("unsubscribe-peer").fail_unsubscribe_once("users");
+        let collection_store = Arc::new(RecordingCollectionStore::default());
+        let coordinator = new_test_coordinator_with_store(
+            blockstore,
+            transport.clone(),
+            collection_store.clone(),
+        )
+        .await;
+
+        assert!(coordinator.subscribe_collection("users").await.unwrap());
+        let error = coordinator
+            .unsubscribe_collection("users")
+            .await
+            .expect_err("injected transport failure should be returned");
+
+        assert!(error.to_string().contains("injected unsubscribe failure"));
+        assert!(
+            collection_store.collections().is_empty(),
+            "durable desired state must record the unsubscribe before transport work"
+        );
+        assert_eq!(transport.subscribed_topics(), vec!["users"]);
+        assert_eq!(
+            coordinator.get_subscribed_collections().await.unwrap(),
+            vec!["users"],
+            "failed live removal must remain visible for retry"
+        );
+
+        assert!(coordinator.unsubscribe_collection("users").await.unwrap());
+        assert!(transport.subscribed_topics().is_empty());
+        assert!(
+            coordinator
+                .get_subscribed_collections()
+                .await
+                .unwrap()
+                .is_empty(),
+            "successful retry must retire the live topic"
+        );
     }
 }

--- a/crates/p2p/src/sync/coordinator/subscriptions.rs
+++ b/crates/p2p/src/sync/coordinator/subscriptions.rs
@@ -12,6 +12,8 @@ use crate::transport::P2PTransport;
 
 const MAX_CONCURRENT_COLLECTION_SUBSCRIPTIONS: usize = 16;
 const COLLECTION_SUBSCRIPTION_TIMEOUT: Duration = Duration::from_secs(5);
+const COLLECTION_SUBSCRIBE_RETRY_MIN: Duration = Duration::from_millis(100);
+const COLLECTION_SUBSCRIBE_RETRY_MAX: Duration = Duration::from_secs(5);
 const COLLECTION_UNSUBSCRIBE_RETRY_MIN: Duration = Duration::from_millis(100);
 const COLLECTION_UNSUBSCRIBE_RETRY_MAX: Duration = Duration::from_secs(5);
 
@@ -99,7 +101,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
 
         let mut installed = Vec::new();
         let mut newly_installed = 0;
-        let mut first_error = None;
+        let mut failures = Vec::new();
         for (collection_id, result) in results {
             match result {
                 Ok(was_new) => {
@@ -112,9 +114,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                         error = %error,
                         "Failed to install durable collection subscription"
                     );
-                    if first_error.is_none() {
-                        first_error = Some(error);
-                    }
+                    failures.push((collection_id, error));
                 }
             }
         }
@@ -131,7 +131,11 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             transport_installed = newly_installed,
             "Applied durable collection subscription batch"
         );
-        if let Some(error) = first_error {
+        for (collection_id, _) in &failures {
+            self.schedule_collection_subscribe_retry(collection_id.clone())
+                .await;
+        }
+        if let Some((_, error)) = failures.into_iter().next() {
             return Err(error);
         }
         Ok(newly_installed)
@@ -171,16 +175,11 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             .remove_collections(&requested)
             .await?;
 
-        let live = self.subscriptions.subscribed_collections.read().await;
-        let installed = requested
-            .iter()
-            .filter(|collection_id| live.contains(collection_id.as_str()))
-            .cloned()
-            .collect::<Vec<_>>();
-        drop(live);
-
         let broadcaster = self.runtime.broadcaster.clone();
-        let results = stream::iter(installed)
+        // Always issue the idempotent transport removal. A timed-out subscribe
+        // is ambiguous: the topic may be live even though it never reached the
+        // cache, and filtering only by the cache would strand that topic.
+        let results = stream::iter(requested.iter().cloned())
             .map(move |collection_id| {
                 let broadcaster = broadcaster.clone();
                 async move {
@@ -256,6 +255,91 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             .await?;
         collections.sort();
         Ok(collections)
+    }
+
+    async fn schedule_collection_subscribe_retry(&self, collection_id: String) {
+        let mut retrying = self.subscriptions.retrying_subscribes.lock().await;
+        if !retrying.insert(collection_id.clone()) {
+            return;
+        }
+        drop(retrying);
+
+        let broadcaster = self.runtime.broadcaster.clone();
+        let mutation = Arc::clone(&self.subscriptions.mutation);
+        let collection_store = Arc::clone(&self.subscriptions.collection_store);
+        let subscribed = Arc::clone(&self.subscriptions.subscribed_collections);
+        let retrying = Arc::clone(&self.subscriptions.retrying_subscribes);
+        let shutdown = self.runtime.shutdown.clone();
+        let task_shutdown = shutdown.clone();
+        let retry_id = collection_id.clone();
+        let spawned = shutdown.spawn_task(async move {
+            let mut delay = COLLECTION_SUBSCRIBE_RETRY_MIN;
+            loop {
+                tokio::select! {
+                    _ = task_shutdown.cancelled() => break,
+                    _ = tokio::time::sleep(delay) => {}
+                }
+
+                // Desired state, the live cache, and transport installation
+                // are observed under the same mutation guard as foreground
+                // add/remove calls. This makes a concurrent unsubscribe either
+                // cancel the retry or clean up a completed installation.
+                let _mutation = mutation.lock().await;
+                match collection_store.is_subscribed(&retry_id).await {
+                    Ok(false) => {
+                        retrying.lock().await.remove(&retry_id);
+                        return;
+                    }
+                    Ok(true) => {}
+                    Err(error) => {
+                        tracing::warn!(
+                            collection_id = %retry_id,
+                            error = %error,
+                            "Failed to read durable subscription state before subscribe retry"
+                        );
+                        delay = (delay * 2).min(COLLECTION_SUBSCRIBE_RETRY_MAX);
+                        continue;
+                    }
+                }
+
+                if subscribed.read().await.contains(&retry_id) {
+                    retrying.lock().await.remove(&retry_id);
+                    return;
+                }
+
+                let result = tokio::time::timeout(
+                    COLLECTION_SUBSCRIPTION_TIMEOUT,
+                    broadcaster.subscribe_collection(&retry_id),
+                )
+                .await;
+                match result {
+                    Ok(Ok(_)) => {
+                        subscribed.write().await.insert(retry_id.clone());
+                        retrying.lock().await.remove(&retry_id);
+                        return;
+                    }
+                    Ok(Err(error)) => tracing::warn!(
+                        collection_id = %retry_id,
+                        error = %error,
+                        "Collection subscribe retry failed"
+                    ),
+                    Err(_) => tracing::warn!(
+                        collection_id = %retry_id,
+                        "Collection subscribe retry timed out"
+                    ),
+                }
+                delay = (delay * 2).min(COLLECTION_SUBSCRIBE_RETRY_MAX);
+            }
+            retrying.lock().await.remove(&retry_id);
+        });
+
+        if !spawned {
+            self.subscriptions
+                .retrying_subscribes
+                .lock()
+                .await
+                .remove(&collection_id);
+        }
     }
 
     async fn schedule_collection_unsubscribe_retry(&self, collection_id: String) {
@@ -382,6 +466,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             .await;
 
         let mut installed = Vec::new();
+        let mut failed = Vec::new();
         for (collection_id, result) in results {
             match result {
                 Ok(_) => installed.push(collection_id),
@@ -391,6 +476,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                         error = %error,
                         "Failed to subscribe to persisted P2P collection"
                     );
+                    failed.push(collection_id);
                 }
             }
         }
@@ -400,6 +486,11 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             .write()
             .await
             .extend(installed);
+
+        for collection_id in failed {
+            self.schedule_collection_subscribe_retry(collection_id)
+                .await;
+        }
 
         tracing::info!(loaded = loaded, "Finished loading P2P collections");
         Ok(loaded)
@@ -471,6 +562,7 @@ mod tests {
         pubkey: Vec<u8>,
         subscribed: Arc<Mutex<HashSet<String>>>,
         fail_subscribe: Arc<Mutex<HashSet<String>>>,
+        fail_subscribe_remaining: Arc<Mutex<HashMap<String, usize>>>,
         fail_unsubscribe_remaining: Arc<Mutex<HashMap<String, usize>>>,
         unsubscribe_started: Option<Arc<tokio::sync::Notify>>,
         unsubscribe_release: Option<Arc<tokio::sync::Notify>>,
@@ -488,6 +580,7 @@ mod tests {
                 pubkey: vec![1, 2, 3],
                 subscribed: Arc::new(Mutex::new(HashSet::new())),
                 fail_subscribe: Arc::new(Mutex::new(HashSet::new())),
+                fail_subscribe_remaining: Arc::new(Mutex::new(HashMap::new())),
                 fail_unsubscribe_remaining: Arc::new(Mutex::new(HashMap::new())),
                 unsubscribe_started: None,
                 unsubscribe_release: None,
@@ -504,6 +597,14 @@ mod tests {
                 .lock()
                 .unwrap()
                 .insert(topic.to_string());
+            self
+        }
+
+        fn fail_subscribe_once(self, topic: &str) -> Self {
+            self.fail_subscribe_remaining
+                .lock()
+                .unwrap()
+                .insert(topic.to_string(), 1);
             self
         }
 
@@ -607,7 +708,18 @@ mod tests {
                 tokio::time::sleep(self.subscribe_delay).await;
             }
 
-            let result = if self.fail_subscribe.lock().unwrap().contains(&topic) {
+            let should_fail_once = {
+                let mut remaining = self.fail_subscribe_remaining.lock().unwrap();
+                match remaining.get_mut(&topic) {
+                    Some(count) if *count > 0 => {
+                        *count -= 1;
+                        true
+                    }
+                    _ => false,
+                }
+            };
+            let result = if should_fail_once || self.fail_subscribe.lock().unwrap().contains(&topic)
+            {
                 Err(crate::error::Error::Transport(format!(
                     "injected subscribe failure for {topic}"
                 )))
@@ -1019,6 +1131,60 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn failed_subscribe_retries_durable_intent_without_restart() {
+        let store = Arc::new(RegolithStore::in_memory().unwrap());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let transport =
+            RecordingTransport::new("subscribe-retry-peer").fail_subscribe_once("users");
+        let collection_store = Arc::new(RecordingCollectionStore::default());
+        let coordinator = new_test_coordinator_with_store(
+            blockstore,
+            transport.clone(),
+            collection_store.clone(),
+        )
+        .await;
+
+        coordinator
+            .subscribe_collection("users")
+            .await
+            .expect_err("first live installation should fail after intent is durable");
+
+        assert_eq!(
+            coordinator.get_subscribed_collections().await.unwrap(),
+            vec!["users".to_string()],
+            "the public list is durable desired state"
+        );
+        assert!(transport.subscribed_topics().is_empty());
+        assert_eq!(collection_store.add_batches(), 1);
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if transport.subscribed_topics() == vec!["users"] {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("background subscribe retry should converge without a restart or caller sweep");
+
+        assert!(coordinator
+            .subscriptions
+            .subscribed_collections
+            .read()
+            .await
+            .contains("users"));
+        assert!(coordinator
+            .subscriptions
+            .retrying_subscribes
+            .lock()
+            .await
+            .is_empty());
+        assert_eq!(transport.subscribe_calls(), 2);
+        assert_eq!(collection_store.add_batches(), 1);
+    }
+
+    #[tokio::test]
     async fn load_p2p_collections_reinstalls_subscriptions_after_restart() {
         let store = Arc::new(RegolithStore::in_memory().unwrap());
         let initial_transport = RecordingTransport::new("initial-peer");
@@ -1043,6 +1209,51 @@ mod tests {
             restarted.get_subscribed_collections().await.unwrap(),
             vec!["users".to_string()]
         );
+    }
+
+    #[tokio::test]
+    async fn load_p2p_collections_retries_failed_restoration_in_process() {
+        let store = Arc::new(RegolithStore::in_memory().unwrap());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let transport = RecordingTransport::new("restore-retry-peer").fail_subscribe_once("users");
+        let collection_store = Arc::new(RecordingCollectionStore::default());
+        collection_store
+            .add_collections(&["users".to_string()])
+            .await
+            .unwrap();
+        let coordinator = new_test_coordinator_with_store(
+            blockstore,
+            transport.clone(),
+            collection_store.clone(),
+        )
+        .await;
+
+        assert_eq!(
+            coordinator.load_p2p_collections().await.unwrap(),
+            0,
+            "the initial restoration reports only topics installed during that call"
+        );
+        assert!(transport.subscribed_topics().is_empty());
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if transport.subscribed_topics() == vec!["users"] {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("failed startup restoration should converge in-process");
+
+        assert_eq!(transport.subscribe_calls(), 2);
+        assert_eq!(collection_store.add_batches(), 1);
+        assert!(coordinator
+            .subscriptions
+            .retrying_subscribes
+            .lock()
+            .await
+            .is_empty());
     }
 
     #[tokio::test]

--- a/crates/p2p/src/sync/coordinator/subscriptions.rs
+++ b/crates/p2p/src/sync/coordinator/subscriptions.rs
@@ -2,60 +2,116 @@
 
 use blockstore::Blockstore;
 use cid::Cid;
+use futures::{stream, StreamExt};
+use std::time::Duration;
 
 use super::SyncCoordinator;
 use crate::error::Result;
 use crate::transport::P2PTransport;
 
+const MAX_CONCURRENT_COLLECTION_SUBSCRIPTIONS: usize = 16;
+const COLLECTION_SUBSCRIPTION_TIMEOUT: Duration = Duration::from_secs(5);
+
 impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     /// Subscribe to a collection for sync.
-    ///
-    /// Uses a write lock for the entire operation to prevent concurrent
-    /// subscribe calls from racing past the contains-check.
     pub async fn subscribe_collection(&self, collection_id: &str) -> Result<bool> {
-        let mut subscribed_collections = self.subscriptions.subscribed_collections.write().await;
+        let subscribed = self
+            .subscribe_collections(&[collection_id.to_string()])
+            .await?;
+        Ok(subscribed == 1)
+    }
 
-        if subscribed_collections.contains(collection_id) {
-            return Ok(false);
+    /// Subscribe to collection topics as one durable, bounded batch.
+    ///
+    /// The durable set is desired state, matching Go DefraDB: it commits
+    /// atomically before transport work begins and can therefore heal on a
+    /// later call or restart. The live cache contains only topics whose
+    /// transport installation succeeded.
+    pub async fn subscribe_collections(&self, collection_ids: &[String]) -> Result<usize> {
+        let _mutation = self.subscriptions.mutation.lock().await;
+
+        let mut seen = std::collections::HashSet::new();
+        let missing = {
+            let subscribed_collections = self.subscriptions.subscribed_collections.read().await;
+            collection_ids
+                .iter()
+                .filter(|collection_id| {
+                    !subscribed_collections.contains(collection_id.as_str())
+                        && seen.insert((*collection_id).clone())
+                })
+                .cloned()
+                .collect::<Vec<_>>()
+        };
+
+        if missing.is_empty() {
+            return Ok(0);
         }
 
         self.subscriptions
             .collection_store
-            .add_collection(collection_id)
+            .add_collections(&missing)
             .await?;
 
-        let result = self
-            .runtime
-            .broadcaster
-            .subscribe_collection(collection_id)
+        let broadcaster = self.runtime.broadcaster.clone();
+        let results = stream::iter(missing.iter().cloned())
+            .map(move |collection_id| {
+                let broadcaster = broadcaster.clone();
+                async move {
+                    let result = tokio::time::timeout(
+                        COLLECTION_SUBSCRIPTION_TIMEOUT,
+                        broadcaster.subscribe_collection(&collection_id),
+                    )
+                    .await
+                    .unwrap_or_else(|_| {
+                        Err(crate::error::Error::Transport(format!(
+                            "timed out subscribing to collection {collection_id}"
+                        )))
+                    });
+                    (collection_id, result)
+                }
+            })
+            .buffer_unordered(MAX_CONCURRENT_COLLECTION_SUBSCRIPTIONS)
+            .collect::<Vec<_>>()
             .await;
 
-        match result {
-            Ok(subscribed) => {
-                subscribed_collections.insert(collection_id.to_string());
-
-                if subscribed {
-                    tracing::debug!(collection_id = %collection_id, "Subscribed to collection (persisted)");
+        let mut installed = Vec::new();
+        let mut newly_installed = 0;
+        let mut first_error = None;
+        for (collection_id, result) in results {
+            match result {
+                Ok(was_new) => {
+                    newly_installed += usize::from(was_new);
+                    installed.push(collection_id);
                 }
-                Ok(subscribed)
-            }
-            Err(e) => {
-                if let Err(remove_err) = self
-                    .subscriptions
-                    .collection_store
-                    .remove_collection(collection_id)
-                    .await
-                {
-                    tracing::error!(
+                Err(error) => {
+                    tracing::warn!(
                         collection_id = %collection_id,
-                        subscribe_error = %e,
-                        remove_error = %remove_err,
-                        "Failed to rollback storage after GossipSub subscription failure"
+                        error = %error,
+                        "Failed to install durable collection subscription"
                     );
+                    if first_error.is_none() {
+                        first_error = Some(error);
+                    }
                 }
-                Err(e)
             }
         }
+
+        {
+            let mut subscribed_collections =
+                self.subscriptions.subscribed_collections.write().await;
+            subscribed_collections.extend(installed);
+        }
+
+        tracing::debug!(
+            requested = collection_ids.len(),
+            desired_added = missing.len(),
+            transport_installed = newly_installed,
+            "Applied durable collection subscription batch"
+        );
+        if let Some(error) = first_error {
+            return Err(error);
+        }
+        Ok(newly_installed)
     }
 
     /// Subscribe to a specific document for sync.
@@ -65,7 +121,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
 
     /// Unsubscribe from a collection.
     pub async fn unsubscribe_collection(&self, collection_id: &str) -> Result<bool> {
-        let mut subscribed_collections = self.subscriptions.subscribed_collections.write().await;
+        let _mutation = self.subscriptions.mutation.lock().await;
 
         // Persist the desired unsubscribe intent first. If the live transport
         // leave fails, the in-process topic may linger until retry or restart,
@@ -75,12 +131,23 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             .remove_collection(collection_id)
             .await?;
 
-        let result = self
-            .runtime
-            .broadcaster
-            .unsubscribe_collection(collection_id)
-            .await;
-        subscribed_collections.remove(collection_id);
+        let result = tokio::time::timeout(
+            COLLECTION_SUBSCRIPTION_TIMEOUT,
+            self.runtime
+                .broadcaster
+                .unsubscribe_collection(collection_id),
+        )
+        .await
+        .unwrap_or_else(|_| {
+            Err(crate::error::Error::Transport(format!(
+                "timed out unsubscribing from collection {collection_id}"
+            )))
+        });
+        self.subscriptions
+            .subscribed_collections
+            .write()
+            .await
+            .remove(collection_id);
 
         let result = result?;
 
@@ -108,6 +175,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     /// subscription is a transport-level operation independent of the base
     /// doc-sync / sync-branchable service topics.
     pub async fn load_p2p_collections(&self) -> Result<usize> {
+        let _mutation = self.subscriptions.mutation.lock().await;
         let collections = self
             .subscriptions
             .collection_store
@@ -122,41 +190,47 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
 
         tracing::info!(count = count, "Loading persisted P2P collections");
 
-        let mut loaded = 0;
-        for collection_id in collections {
-            match self
-                .runtime
-                .broadcaster
-                .subscribe_collection(&collection_id)
-                .await
-            {
-                Ok(true) => {
-                    self.subscriptions
-                        .subscribed_collections
-                        .write()
-                        .await
-                        .insert(collection_id.clone());
-                    loaded += 1;
-                    tracing::debug!(collection_id = %collection_id, "Loaded P2P collection subscription");
+        let broadcaster = self.runtime.broadcaster.clone();
+        let results = stream::iter(collections)
+            .map(move |collection_id| {
+                let broadcaster = broadcaster.clone();
+                async move {
+                    let result = tokio::time::timeout(
+                        COLLECTION_SUBSCRIPTION_TIMEOUT,
+                        broadcaster.subscribe_collection(&collection_id),
+                    )
+                    .await
+                    .unwrap_or_else(|_| {
+                        Err(crate::error::Error::Transport(format!(
+                            "timed out restoring collection {collection_id}"
+                        )))
+                    });
+                    (collection_id, result)
                 }
-                Ok(false) => {
-                    self.subscriptions
-                        .subscribed_collections
-                        .write()
-                        .await
-                        .insert(collection_id.clone());
-                    loaded += 1;
-                    tracing::debug!(collection_id = %collection_id, "P2P collection already subscribed");
-                }
-                Err(e) => {
+            })
+            .buffer_unordered(MAX_CONCURRENT_COLLECTION_SUBSCRIPTIONS)
+            .collect::<Vec<_>>()
+            .await;
+
+        let mut installed = Vec::new();
+        for (collection_id, result) in results {
+            match result {
+                Ok(_) => installed.push(collection_id),
+                Err(error) => {
                     tracing::warn!(
                         collection_id = %collection_id,
-                        error = %e,
+                        error = %error,
                         "Failed to subscribe to persisted P2P collection"
                     );
                 }
             }
         }
+        let loaded = installed.len();
+        self.subscriptions
+            .subscribed_collections
+            .write()
+            .await
+            .extend(installed);
 
         tracing::info!(loaded = loaded, "Finished loading P2P collections");
         Ok(loaded)
@@ -197,8 +271,9 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
 #[cfg(test)]
 mod tests {
     use std::collections::{HashMap, HashSet};
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
 
     use async_trait::async_trait;
     use blockstore::DefraBlockstore;
@@ -211,13 +286,13 @@ mod tests {
         PushLogReply, PushLogRequest, PushSEArtifactsRequest, QuerySEArtifactsReply,
         QuerySEArtifactsRequest,
     };
-    use crate::sync::collection_store::P2PCollectionStore;
+    use crate::sync::collection_store::{P2PCollectionStorage, P2PCollectionStore};
     use crate::sync::manager::SyncConfig;
     use crate::topics::DefraTopic;
     use crate::transport::{MessageId, P2PTransport, PeerAddr, PeerId};
     use crate::{QueryId, ReplicatorInfo};
 
-    use super::SyncCoordinator;
+    use super::{SyncCoordinator, MAX_CONCURRENT_COLLECTION_SUBSCRIPTIONS};
 
     type TestBlockstore = DefraBlockstore<RegolithStore>;
 
@@ -227,6 +302,10 @@ mod tests {
         pubkey: Vec<u8>,
         subscribed: Arc<Mutex<HashSet<String>>>,
         fail_subscribe: Arc<Mutex<HashSet<String>>>,
+        subscribe_calls: Arc<AtomicUsize>,
+        subscribe_delay: Duration,
+        subscribe_in_flight: Arc<AtomicUsize>,
+        max_subscribe_in_flight: Arc<AtomicUsize>,
         replicators: Arc<Mutex<HashMap<String, Vec<String>>>>,
     }
 
@@ -237,6 +316,10 @@ mod tests {
                 pubkey: vec![1, 2, 3],
                 subscribed: Arc::new(Mutex::new(HashSet::new())),
                 fail_subscribe: Arc::new(Mutex::new(HashSet::new())),
+                subscribe_calls: Arc::new(AtomicUsize::new(0)),
+                subscribe_delay: Duration::ZERO,
+                subscribe_in_flight: Arc::new(AtomicUsize::new(0)),
+                max_subscribe_in_flight: Arc::new(AtomicUsize::new(0)),
                 replicators: Arc::new(Mutex::new(HashMap::new())),
             }
         }
@@ -247,6 +330,19 @@ mod tests {
                 .unwrap()
                 .insert(topic.to_string());
             self
+        }
+
+        fn with_subscribe_delay(mut self, delay: Duration) -> Self {
+            self.subscribe_delay = delay;
+            self
+        }
+
+        fn subscribe_calls(&self) -> usize {
+            self.subscribe_calls.load(Ordering::Relaxed)
+        }
+
+        fn max_subscribe_in_flight(&self) -> usize {
+            self.max_subscribe_in_flight.load(Ordering::Relaxed)
         }
 
         fn subscribed_topics(&self) -> Vec<String> {
@@ -306,12 +402,23 @@ mod tests {
 
         async fn subscribe(&self, topic: DefraTopic) -> crate::Result<bool> {
             let topic = topic.topic_string();
-            if self.fail_subscribe.lock().unwrap().contains(&topic) {
-                return Err(crate::error::Error::Transport(format!(
-                    "injected subscribe failure for {topic}"
-                )));
+            self.subscribe_calls.fetch_add(1, Ordering::Relaxed);
+            let in_flight = self.subscribe_in_flight.fetch_add(1, Ordering::Relaxed) + 1;
+            self.max_subscribe_in_flight
+                .fetch_max(in_flight, Ordering::Relaxed);
+            if !self.subscribe_delay.is_zero() {
+                tokio::time::sleep(self.subscribe_delay).await;
             }
-            Ok(self.subscribed.lock().unwrap().insert(topic))
+
+            let result = if self.fail_subscribe.lock().unwrap().contains(&topic) {
+                Err(crate::error::Error::Transport(format!(
+                    "injected subscribe failure for {topic}"
+                )))
+            } else {
+                Ok(self.subscribed.lock().unwrap().insert(topic))
+            };
+            self.subscribe_in_flight.fetch_sub(1, Ordering::Relaxed);
+            result
         }
 
         async fn unsubscribe(&self, topic: DefraTopic) -> crate::Result<bool> {
@@ -501,12 +608,70 @@ mod tests {
         }
     }
 
+    #[derive(Default)]
+    struct RecordingCollectionStore {
+        collections: Mutex<HashSet<String>>,
+        add_batches: AtomicUsize,
+    }
+
+    impl RecordingCollectionStore {
+        fn add_batches(&self) -> usize {
+            self.add_batches.load(Ordering::Relaxed)
+        }
+
+        fn collections(&self) -> HashSet<String> {
+            self.collections.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl P2PCollectionStorage for RecordingCollectionStore {
+        async fn add_collection(&self, collection_id: &str) -> crate::Result<()> {
+            self.add_batches.fetch_add(1, Ordering::Relaxed);
+            self.collections
+                .lock()
+                .unwrap()
+                .insert(collection_id.to_string());
+            Ok(())
+        }
+
+        async fn add_collections(&self, collection_ids: &[String]) -> crate::Result<()> {
+            self.add_batches.fetch_add(1, Ordering::Relaxed);
+            self.collections
+                .lock()
+                .unwrap()
+                .extend(collection_ids.iter().cloned());
+            Ok(())
+        }
+
+        async fn remove_collection(&self, collection_id: &str) -> crate::Result<()> {
+            self.collections.lock().unwrap().remove(collection_id);
+            Ok(())
+        }
+
+        async fn get_all_collections(&self) -> crate::Result<Vec<String>> {
+            Ok(self.collections.lock().unwrap().iter().cloned().collect())
+        }
+
+        async fn is_subscribed(&self, collection_id: &str) -> crate::Result<bool> {
+            Ok(self.collections.lock().unwrap().contains(collection_id))
+        }
+    }
+
     async fn new_test_coordinator(
         store: Arc<RegolithStore>,
         transport: RecordingTransport,
     ) -> SyncCoordinator<TestBlockstore, RecordingTransport> {
         let blockstore = Arc::new(DefraBlockstore::new(store.clone(), true));
         let collection_store = Arc::new(P2PCollectionStore::new(store));
+        new_test_coordinator_with_store(blockstore, transport, collection_store).await
+    }
+
+    async fn new_test_coordinator_with_store(
+        blockstore: Arc<TestBlockstore>,
+        transport: RecordingTransport,
+        collection_store: Arc<dyn P2PCollectionStorage>,
+    ) -> SyncCoordinator<TestBlockstore, RecordingTransport> {
         let (coordinator, _events) = SyncCoordinator::with_collection_store(
             transport,
             blockstore,
@@ -517,6 +682,111 @@ mod tests {
         .await
         .unwrap();
         coordinator
+    }
+
+    #[tokio::test]
+    async fn subscribe_collections_is_bounded_batched_and_idempotent() {
+        let store = Arc::new(RegolithStore::in_memory().unwrap());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let transport =
+            RecordingTransport::new("batch-peer").with_subscribe_delay(Duration::from_millis(5));
+        let collection_store = Arc::new(RecordingCollectionStore::default());
+        let coordinator = new_test_coordinator_with_store(
+            blockstore,
+            transport.clone(),
+            collection_store.clone(),
+        )
+        .await;
+        let collections = (0..70)
+            .map(|index| format!("collection-{index}"))
+            .collect::<Vec<_>>();
+
+        let started = Instant::now();
+        let added = coordinator
+            .subscribe_collections(&collections)
+            .await
+            .unwrap();
+        let elapsed = started.elapsed();
+
+        assert_eq!(added, 70);
+        assert_eq!(transport.subscribe_calls(), 70);
+        assert_eq!(collection_store.add_batches(), 1);
+        assert_eq!(collection_store.collections().len(), 70);
+        assert!(
+            transport.max_subscribe_in_flight() > 1,
+            "representative bulk install should overlap transport subscriptions"
+        );
+        assert!(
+            transport.max_subscribe_in_flight() <= MAX_CONCURRENT_COLLECTION_SUBSCRIPTIONS,
+            "bulk install must respect its concurrency bound"
+        );
+        assert!(
+            elapsed < Duration::from_millis(250),
+            "70 delayed subscriptions should complete as a bounded batch, elapsed={elapsed:?}"
+        );
+
+        let added_again = coordinator
+            .subscribe_collections(&collections)
+            .await
+            .unwrap();
+        assert_eq!(added_again, 0);
+        assert_eq!(transport.subscribe_calls(), 70);
+        assert_eq!(collection_store.add_batches(), 1);
+    }
+
+    #[tokio::test]
+    async fn subscribe_collections_persists_desired_set_and_restart_heals_partial_failure() {
+        let store = Arc::new(RegolithStore::in_memory().unwrap());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let transport =
+            RecordingTransport::new("partial-failure-peer").fail_subscribe("collection-1");
+        let collection_store = Arc::new(RecordingCollectionStore::default());
+        let coordinator = new_test_coordinator_with_store(
+            blockstore,
+            transport.clone(),
+            collection_store.clone(),
+        )
+        .await;
+        let collections = (0..3)
+            .map(|index| format!("collection-{index}"))
+            .collect::<Vec<_>>();
+
+        let error = coordinator
+            .subscribe_collections(&collections)
+            .await
+            .expect_err("one failed transport subscription must fail the batch");
+
+        assert!(error.to_string().contains("injected subscribe failure"));
+        assert_eq!(
+            transport.subscribed_topics(),
+            vec!["collection-0", "collection-2"]
+        );
+        assert_eq!(collection_store.collections().len(), 3);
+        assert_eq!(collection_store.add_batches(), 1);
+        assert_eq!(
+            coordinator
+                .get_subscribed_collections()
+                .await
+                .unwrap()
+                .into_iter()
+                .collect::<HashSet<_>>(),
+            HashSet::from(["collection-0".to_string(), "collection-2".to_string()])
+        );
+
+        let restarted_blockstore = Arc::new(DefraBlockstore::new(
+            Arc::new(RegolithStore::in_memory().unwrap()),
+            true,
+        ));
+        let restarted_transport = RecordingTransport::new("restarted-peer");
+        let restarted = new_test_coordinator_with_store(
+            restarted_blockstore,
+            restarted_transport.clone(),
+            collection_store,
+        )
+        .await;
+
+        assert_eq!(restarted.load_p2p_collections().await.unwrap(), 3);
+        assert_eq!(restarted_transport.subscribed_topics().len(), 3);
     }
 
     #[tokio::test]
@@ -550,7 +820,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn subscribe_collection_rolls_back_persistence_when_transport_subscribe_fails() {
+    async fn subscribe_collection_keeps_durable_intent_when_transport_subscribe_fails() {
         let store = Arc::new(RegolithStore::in_memory().unwrap());
         let failing_transport = RecordingTransport::new("failing-peer").fail_subscribe("users");
         let failing = new_test_coordinator(store.clone(), failing_transport.clone()).await;
@@ -581,10 +851,7 @@ mod tests {
         let restarted = new_test_coordinator(store, restarted_transport.clone()).await;
         let restored = restarted.load_p2p_collections().await.unwrap();
 
-        assert_eq!(restored, 0, "rolled-back subscription must not reload");
-        assert!(
-            restarted_transport.subscribed_topics().is_empty(),
-            "rolled-back subscription must not persist"
-        );
+        assert_eq!(restored, 1, "restart should retry durable desired state");
+        assert_eq!(restarted_transport.subscribed_topics(), vec!["users"]);
     }
 }

--- a/crates/p2p/src/sync/coordinator/subscriptions.rs
+++ b/crates/p2p/src/sync/coordinator/subscriptions.rs
@@ -3,6 +3,7 @@
 use blockstore::Blockstore;
 use cid::Cid;
 use futures::{stream, StreamExt};
+use std::sync::Arc;
 use std::time::Duration;
 
 use super::SyncCoordinator;
@@ -11,6 +12,8 @@ use crate::transport::P2PTransport;
 
 const MAX_CONCURRENT_COLLECTION_SUBSCRIPTIONS: usize = 16;
 const COLLECTION_SUBSCRIPTION_TIMEOUT: Duration = Duration::from_secs(5);
+const COLLECTION_UNSUBSCRIBE_RETRY_MIN: Duration = Duration::from_millis(100);
+const COLLECTION_UNSUBSCRIBE_RETRY_MAX: Duration = Duration::from_secs(5);
 
 impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     /// Subscribe to a collection for sync.
@@ -31,14 +34,39 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         let _mutation = self.subscriptions.mutation.lock().await;
 
         let mut seen = std::collections::HashSet::new();
+        let requested = collection_ids
+            .iter()
+            .filter(|collection_id| seen.insert((*collection_id).clone()))
+            .cloned()
+            .collect::<Vec<_>>();
+        if requested.is_empty() {
+            return Ok(0);
+        }
+
+        let desired = self
+            .subscriptions
+            .collection_store
+            .get_all_collections()
+            .await?
+            .into_iter()
+            .collect::<std::collections::HashSet<_>>();
+        let desired_missing = requested
+            .iter()
+            .filter(|collection_id| !desired.contains(collection_id.as_str()))
+            .cloned()
+            .collect::<Vec<_>>();
+        if !desired_missing.is_empty() {
+            self.subscriptions
+                .collection_store
+                .add_collections(&desired_missing)
+                .await?;
+        }
+
         let missing = {
             let subscribed_collections = self.subscriptions.subscribed_collections.read().await;
-            collection_ids
+            requested
                 .iter()
-                .filter(|collection_id| {
-                    !subscribed_collections.contains(collection_id.as_str())
-                        && seen.insert((*collection_id).clone())
-                })
+                .filter(|collection_id| !subscribed_collections.contains(collection_id.as_str()))
                 .cloned()
                 .collect::<Vec<_>>()
         };
@@ -46,11 +74,6 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         if missing.is_empty() {
             return Ok(0);
         }
-
-        self.subscriptions
-            .collection_store
-            .add_collections(&missing)
-            .await?;
 
         let broadcaster = self.runtime.broadcaster.clone();
         let results = stream::iter(missing.iter().cloned())
@@ -104,7 +127,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
 
         tracing::debug!(
             requested = collection_ids.len(),
-            desired_added = missing.len(),
+            desired_added = desired_missing.len(),
             transport_installed = newly_installed,
             "Applied durable collection subscription batch"
         );
@@ -121,41 +144,102 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
 
     /// Unsubscribe from a collection.
     pub async fn unsubscribe_collection(&self, collection_id: &str) -> Result<bool> {
+        let removed = self
+            .unsubscribe_collections(&[collection_id.to_string()])
+            .await?;
+        Ok(removed == 1)
+    }
+
+    /// Unsubscribe from collection topics as one durable, bounded batch.
+    pub async fn unsubscribe_collections(&self, collection_ids: &[String]) -> Result<usize> {
         let _mutation = self.subscriptions.mutation.lock().await;
 
-        // Persist the desired unsubscribe intent first. If the live transport
-        // leave fails, the in-process topic may linger until retry or restart,
-        // but durable restore must not re-install it.
-        self.subscriptions
-            .collection_store
-            .remove_collection(collection_id)
-            .await?;
-
-        let result = tokio::time::timeout(
-            COLLECTION_SUBSCRIPTION_TIMEOUT,
-            self.runtime
-                .broadcaster
-                .unsubscribe_collection(collection_id),
-        )
-        .await
-        .unwrap_or_else(|_| {
-            Err(crate::error::Error::Transport(format!(
-                "timed out unsubscribing from collection {collection_id}"
-            )))
-        });
-        let result = result?;
-
-        self.subscriptions
-            .subscribed_collections
-            .write()
-            .await
-            .remove(collection_id);
-
-        if result {
-            tracing::debug!(collection_id = %collection_id, "Unsubscribed from collection (persisted)");
+        let mut seen = std::collections::HashSet::new();
+        let requested = collection_ids
+            .iter()
+            .filter(|collection_id| seen.insert((*collection_id).clone()))
+            .cloned()
+            .collect::<Vec<_>>();
+        if requested.is_empty() {
+            return Ok(0);
         }
 
-        Ok(result)
+        // Match Go DefraDB's commit-first semantics: all durable removals
+        // succeed atomically before any transport topic is touched.
+        self.subscriptions
+            .collection_store
+            .remove_collections(&requested)
+            .await?;
+
+        let live = self.subscriptions.subscribed_collections.read().await;
+        let installed = requested
+            .iter()
+            .filter(|collection_id| live.contains(collection_id.as_str()))
+            .cloned()
+            .collect::<Vec<_>>();
+        drop(live);
+
+        let broadcaster = self.runtime.broadcaster.clone();
+        let results = stream::iter(installed)
+            .map(move |collection_id| {
+                let broadcaster = broadcaster.clone();
+                async move {
+                    let result = tokio::time::timeout(
+                        COLLECTION_SUBSCRIPTION_TIMEOUT,
+                        broadcaster.unsubscribe_collection(&collection_id),
+                    )
+                    .await
+                    .unwrap_or_else(|_| {
+                        Err(crate::error::Error::Transport(format!(
+                            "timed out unsubscribing from collection {collection_id}"
+                        )))
+                    });
+                    (collection_id, result)
+                }
+            })
+            .buffer_unordered(MAX_CONCURRENT_COLLECTION_SUBSCRIPTIONS)
+            .collect::<Vec<_>>()
+            .await;
+
+        let mut removed = Vec::new();
+        let mut newly_removed = 0;
+        let mut failures = Vec::new();
+        for (collection_id, result) in results {
+            match result {
+                Ok(was_removed) => {
+                    newly_removed += usize::from(was_removed);
+                    removed.push(collection_id);
+                }
+                Err(error) => failures.push((collection_id, error)),
+            }
+        }
+
+        let mut live = self.subscriptions.subscribed_collections.write().await;
+        for collection_id in removed {
+            live.remove(&collection_id);
+        }
+        drop(live);
+
+        for (collection_id, _) in &failures {
+            self.schedule_collection_unsubscribe_retry(collection_id.clone())
+                .await;
+        }
+
+        if let Some((collection_id, error)) = failures.into_iter().next() {
+            tracing::warn!(
+                collection_id = %collection_id,
+                error = %error,
+                "Failed to remove durable collection subscription from live transport; retry scheduled"
+            );
+            return Err(error);
+        }
+
+        tracing::debug!(
+            requested = requested.len(),
+            transport_removed = newly_removed,
+            "Removed durable collection subscription batch"
+        );
+        Ok(newly_removed)
     }
 
     /// Unsubscribe from a document.
@@ -165,8 +249,93 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
 
     /// Get the list of subscribed collection IDs.
     pub async fn get_subscribed_collections(&self) -> Result<Vec<String>> {
-        let collections = self.subscriptions.subscribed_collections.read().await;
-        Ok(collections.iter().cloned().collect())
+        let mut collections = self
+            .subscriptions
+            .collection_store
+            .get_all_collections()
+            .await?;
+        collections.sort();
+        Ok(collections)
+    }
+
+    async fn schedule_collection_unsubscribe_retry(&self, collection_id: String) {
+        let mut retrying = self.subscriptions.retrying_unsubscribes.lock().await;
+        if !retrying.insert(collection_id.clone()) {
+            return;
+        }
+        drop(retrying);
+
+        let broadcaster = self.runtime.broadcaster.clone();
+        let mutation = Arc::clone(&self.subscriptions.mutation);
+        let collection_store = Arc::clone(&self.subscriptions.collection_store);
+        let subscribed = Arc::clone(&self.subscriptions.subscribed_collections);
+        let retrying = Arc::clone(&self.subscriptions.retrying_unsubscribes);
+        let shutdown = self.runtime.shutdown.clone();
+        let task_shutdown = shutdown.clone();
+        let retry_id = collection_id.clone();
+        let spawned = shutdown.spawn_task(async move {
+            let mut delay = COLLECTION_UNSUBSCRIBE_RETRY_MIN;
+            loop {
+                tokio::select! {
+                    _ = task_shutdown.cancelled() => break,
+                    _ = tokio::time::sleep(delay) => {}
+                }
+
+                // Serialize the durable check and transport cleanup with
+                // foreground subscription mutations. Either a re-subscribe
+                // wins first and cancels cleanup, or cleanup wins and the
+                // following re-subscribe reinstalls the topic.
+                let _mutation = mutation.lock().await;
+                match collection_store.is_subscribed(&retry_id).await {
+                    Ok(true) => {
+                        retrying.lock().await.remove(&retry_id);
+                        return;
+                    }
+                    Ok(false) => {}
+                    Err(error) => {
+                        tracing::warn!(
+                            collection_id = %retry_id,
+                            error = %error,
+                            "Failed to read durable subscription state before unsubscribe retry"
+                        );
+                        delay = (delay * 2).min(COLLECTION_UNSUBSCRIBE_RETRY_MAX);
+                        continue;
+                    }
+                }
+
+                let result = tokio::time::timeout(
+                    COLLECTION_SUBSCRIPTION_TIMEOUT,
+                    broadcaster.unsubscribe_collection(&retry_id),
+                )
+                .await;
+                match result {
+                    Ok(Ok(_)) => {
+                        subscribed.write().await.remove(&retry_id);
+                        retrying.lock().await.remove(&retry_id);
+                        return;
+                    }
+                    Ok(Err(error)) => tracing::warn!(
+                        collection_id = %retry_id,
+                        error = %error,
+                        "Collection unsubscribe retry failed"
+                    ),
+                    Err(_) => tracing::warn!(
+                        collection_id = %retry_id,
+                        "Collection unsubscribe retry timed out"
+                    ),
+                }
+                delay = (delay * 2).min(COLLECTION_UNSUBSCRIBE_RETRY_MAX);
+            }
+            retrying.lock().await.remove(&retry_id);
+        });
+
+        if !spawned {
+            self.subscriptions
+                .retrying_unsubscribes
+                .lock()
+                .await
+                .remove(&collection_id);
+        }
     }
 
     /// Load and subscribe to all persisted P2P collections.
@@ -302,7 +471,9 @@ mod tests {
         pubkey: Vec<u8>,
         subscribed: Arc<Mutex<HashSet<String>>>,
         fail_subscribe: Arc<Mutex<HashSet<String>>>,
-        fail_unsubscribe_once: Arc<Mutex<HashSet<String>>>,
+        fail_unsubscribe_remaining: Arc<Mutex<HashMap<String, usize>>>,
+        unsubscribe_started: Option<Arc<tokio::sync::Notify>>,
+        unsubscribe_release: Option<Arc<tokio::sync::Notify>>,
         subscribe_calls: Arc<AtomicUsize>,
         subscribe_delay: Duration,
         subscribe_in_flight: Arc<AtomicUsize>,
@@ -317,7 +488,9 @@ mod tests {
                 pubkey: vec![1, 2, 3],
                 subscribed: Arc::new(Mutex::new(HashSet::new())),
                 fail_subscribe: Arc::new(Mutex::new(HashSet::new())),
-                fail_unsubscribe_once: Arc::new(Mutex::new(HashSet::new())),
+                fail_unsubscribe_remaining: Arc::new(Mutex::new(HashMap::new())),
+                unsubscribe_started: None,
+                unsubscribe_release: None,
                 subscribe_calls: Arc::new(AtomicUsize::new(0)),
                 subscribe_delay: Duration::ZERO,
                 subscribe_in_flight: Arc::new(AtomicUsize::new(0)),
@@ -340,10 +513,24 @@ mod tests {
         }
 
         fn fail_unsubscribe_once(self, topic: &str) -> Self {
-            self.fail_unsubscribe_once
+            self.fail_unsubscribe_times(topic, 1)
+        }
+
+        fn fail_unsubscribe_times(self, topic: &str, times: usize) -> Self {
+            self.fail_unsubscribe_remaining
                 .lock()
                 .unwrap()
-                .insert(topic.to_string());
+                .insert(topic.to_string(), times);
+            self
+        }
+
+        fn with_unsubscribe_gate(
+            mut self,
+            started: Arc<tokio::sync::Notify>,
+            release: Arc<tokio::sync::Notify>,
+        ) -> Self {
+            self.unsubscribe_started = Some(started);
+            self.unsubscribe_release = Some(release);
             self
         }
 
@@ -433,10 +620,26 @@ mod tests {
 
         async fn unsubscribe(&self, topic: DefraTopic) -> crate::Result<bool> {
             let topic = topic.topic_string();
-            if self.fail_unsubscribe_once.lock().unwrap().remove(&topic) {
+            let should_fail = {
+                let mut remaining = self.fail_unsubscribe_remaining.lock().unwrap();
+                match remaining.get_mut(&topic) {
+                    Some(count) if *count > 0 => {
+                        *count -= 1;
+                        true
+                    }
+                    _ => false,
+                }
+            };
+            if should_fail {
                 return Err(crate::error::Error::Transport(format!(
                     "injected unsubscribe failure for {topic}"
                 )));
+            }
+            if let Some(started) = &self.unsubscribe_started {
+                started.notify_one();
+            }
+            if let Some(release) = &self.unsubscribe_release {
+                release.notified().await;
             }
             Ok(self.subscribed.lock().unwrap().remove(&topic))
         }
@@ -624,6 +827,7 @@ mod tests {
     struct RecordingCollectionStore {
         collections: Mutex<HashSet<String>>,
         add_batches: AtomicUsize,
+        remove_batches: AtomicUsize,
     }
 
     impl RecordingCollectionStore {
@@ -633,6 +837,10 @@ mod tests {
 
         fn collections(&self) -> HashSet<String> {
             self.collections.lock().unwrap().clone()
+        }
+
+        fn remove_batches(&self) -> usize {
+            self.remove_batches.load(Ordering::Relaxed)
         }
     }
 
@@ -657,7 +865,15 @@ mod tests {
         }
 
         async fn remove_collection(&self, collection_id: &str) -> crate::Result<()> {
-            self.collections.lock().unwrap().remove(collection_id);
+            self.remove_collections(&[collection_id.to_string()]).await
+        }
+
+        async fn remove_collections(&self, collection_ids: &[String]) -> crate::Result<()> {
+            self.remove_batches.fetch_add(1, Ordering::Relaxed);
+            let mut collections = self.collections.lock().unwrap();
+            for collection_id in collection_ids {
+                collections.remove(collection_id);
+            }
             Ok(())
         }
 
@@ -782,7 +998,8 @@ mod tests {
                 .unwrap()
                 .into_iter()
                 .collect::<HashSet<_>>(),
-            HashSet::from(["collection-0".to_string(), "collection-2".to_string()])
+            collections.iter().cloned().collect(),
+            "list reports durable desired state even while one live install needs healing"
         );
 
         let restarted_blockstore = Arc::new(DefraBlockstore::new(
@@ -812,13 +1029,10 @@ mod tests {
 
         let restarted_transport = RecordingTransport::new("restarted-peer");
         let restarted = new_test_coordinator(store, restarted_transport.clone()).await;
-        assert!(
-            restarted
-                .get_subscribed_collections()
-                .await
-                .unwrap()
-                .is_empty(),
-            "a fresh coordinator starts with an empty in-memory subscription cache"
+        assert_eq!(
+            restarted.get_subscribed_collections().await.unwrap(),
+            vec!["users".to_string()],
+            "a fresh coordinator reports durable desired state before live restoration"
         );
 
         let restored = restarted.load_p2p_collections().await.unwrap();
@@ -846,13 +1060,10 @@ mod tests {
             error.to_string().contains("injected subscribe failure"),
             "unexpected error: {error}"
         );
-        assert!(
-            failing
-                .get_subscribed_collections()
-                .await
-                .unwrap()
-                .is_empty(),
-            "failed subscription should not remain in memory"
+        assert_eq!(
+            failing.get_subscribed_collections().await.unwrap(),
+            vec!["users".to_string()],
+            "failed live installation must remain durable desired state"
         );
         assert!(
             failing_transport.subscribed_topics().is_empty(),
@@ -892,21 +1103,246 @@ mod tests {
             "durable desired state must record the unsubscribe before transport work"
         );
         assert_eq!(transport.subscribed_topics(), vec!["users"]);
-        assert_eq!(
-            coordinator.get_subscribed_collections().await.unwrap(),
-            vec!["users"],
-            "failed live removal must remain visible for retry"
+        assert!(coordinator
+            .get_subscribed_collections()
+            .await
+            .unwrap()
+            .is_empty());
+        assert!(
+            coordinator
+                .subscriptions
+                .subscribed_collections
+                .read()
+                .await
+                .contains("users"),
+            "failed live removal must remain cached for retry"
         );
 
-        assert!(coordinator.unsubscribe_collection("users").await.unwrap());
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if transport.subscribed_topics().is_empty() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("background unsubscribe retry should converge");
         assert!(transport.subscribed_topics().is_empty());
         assert!(
             coordinator
-                .get_subscribed_collections()
+                .subscriptions
+                .subscribed_collections
+                .read()
                 .await
-                .unwrap()
                 .is_empty(),
-            "successful retry must retire the live topic"
+            "successful background retry must retire the live topic"
         );
+        assert_eq!(collection_store.remove_batches(), 1);
+    }
+
+    #[tokio::test]
+    async fn resubscribe_after_failed_unsubscribe_restores_durable_intent() {
+        let store = Arc::new(RegolithStore::in_memory().unwrap());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let transport = RecordingTransport::new("resubscribe-peer").fail_unsubscribe_once("users");
+        let collection_store = Arc::new(RecordingCollectionStore::default());
+        let coordinator = new_test_coordinator_with_store(
+            blockstore,
+            transport.clone(),
+            collection_store.clone(),
+        )
+        .await;
+
+        assert!(coordinator.subscribe_collection("users").await.unwrap());
+        coordinator
+            .unsubscribe_collection("users")
+            .await
+            .expect_err("injected transport failure should be returned");
+        assert!(
+            !coordinator.subscribe_collection("users").await.unwrap(),
+            "already-live topic does not need a second transport install"
+        );
+
+        assert_eq!(collection_store.add_batches(), 2);
+        assert_eq!(collection_store.remove_batches(), 1);
+        assert_eq!(
+            coordinator.get_subscribed_collections().await.unwrap(),
+            vec!["users".to_string()]
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert_eq!(
+            transport.subscribed_topics(),
+            vec!["users"],
+            "unsubscribe retry must stop when the topic becomes desired again"
+        );
+
+        let restarted_blockstore = Arc::new(DefraBlockstore::new(
+            Arc::new(RegolithStore::in_memory().unwrap()),
+            true,
+        ));
+        let restarted_transport = RecordingTransport::new("restarted-peer");
+        let restarted = new_test_coordinator_with_store(
+            restarted_blockstore,
+            restarted_transport.clone(),
+            collection_store,
+        )
+        .await;
+        assert_eq!(restarted.load_p2p_collections().await.unwrap(), 1);
+        assert_eq!(restarted_transport.subscribed_topics(), vec!["users"]);
+    }
+
+    #[tokio::test]
+    async fn resubscribe_serializes_with_in_flight_unsubscribe_retry() {
+        let store = Arc::new(RegolithStore::in_memory().unwrap());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let retry_started = Arc::new(tokio::sync::Notify::new());
+        let retry_release = Arc::new(tokio::sync::Notify::new());
+        let transport = RecordingTransport::new("resubscribe-race-peer")
+            .fail_unsubscribe_once("users")
+            .with_unsubscribe_gate(Arc::clone(&retry_started), Arc::clone(&retry_release));
+        let collection_store = Arc::new(RecordingCollectionStore::default());
+        let coordinator = Arc::new(
+            new_test_coordinator_with_store(
+                blockstore,
+                transport.clone(),
+                collection_store.clone(),
+            )
+            .await,
+        );
+
+        assert!(coordinator.subscribe_collection("users").await.unwrap());
+        coordinator
+            .unsubscribe_collection("users")
+            .await
+            .expect_err("injected transport failure should be returned");
+
+        retry_started.notified().await;
+        let retrying_coordinator = Arc::clone(&coordinator);
+        let mut resubscribe =
+            tokio::spawn(async move { retrying_coordinator.subscribe_collection("users").await });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), &mut resubscribe)
+                .await
+                .is_err(),
+            "foreground re-subscribe must wait for in-flight cleanup"
+        );
+
+        retry_release.notify_one();
+        assert!(resubscribe.await.unwrap().unwrap());
+        assert_eq!(
+            coordinator.get_subscribed_collections().await.unwrap(),
+            vec!["users".to_string()]
+        );
+        assert_eq!(transport.subscribed_topics(), vec!["users"]);
+        assert_eq!(collection_store.add_batches(), 2);
+        assert_eq!(collection_store.remove_batches(), 1);
+    }
+
+    #[tokio::test]
+    async fn terminated_retry_releases_ownership_for_a_later_unsubscribe() {
+        let store = Arc::new(RegolithStore::in_memory().unwrap());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let transport =
+            RecordingTransport::new("retry-handoff-peer").fail_unsubscribe_times("users", 2);
+        let collection_store = Arc::new(RecordingCollectionStore::default());
+        let coordinator = new_test_coordinator_with_store(
+            blockstore,
+            transport.clone(),
+            collection_store.clone(),
+        )
+        .await;
+
+        assert!(coordinator.subscribe_collection("users").await.unwrap());
+        coordinator
+            .unsubscribe_collection("users")
+            .await
+            .expect_err("first unsubscribe should fail");
+        assert!(!coordinator.subscribe_collection("users").await.unwrap());
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if coordinator
+                    .subscriptions
+                    .retrying_unsubscribes
+                    .lock()
+                    .await
+                    .is_empty()
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("retry owner should retire after observing restored intent");
+
+        coordinator
+            .unsubscribe_collection("users")
+            .await
+            .expect_err("second unsubscribe should exercise a fresh retry owner");
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if transport.subscribed_topics().is_empty() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("fresh retry owner should remove the undesired live topic");
+
+        assert!(coordinator
+            .get_subscribed_collections()
+            .await
+            .unwrap()
+            .is_empty());
+        assert_eq!(collection_store.add_batches(), 2);
+        assert_eq!(collection_store.remove_batches(), 2);
+    }
+
+    #[tokio::test]
+    async fn unsubscribe_collections_commits_one_durable_batch_before_live_cleanup() {
+        let store = Arc::new(RegolithStore::in_memory().unwrap());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let transport =
+            RecordingTransport::new("remove-batch-peer").fail_unsubscribe_once("collection-1");
+        let collection_store = Arc::new(RecordingCollectionStore::default());
+        let coordinator = new_test_coordinator_with_store(
+            blockstore,
+            transport.clone(),
+            collection_store.clone(),
+        )
+        .await;
+        let collections = (0..3)
+            .map(|index| format!("collection-{index}"))
+            .collect::<Vec<_>>();
+        coordinator
+            .subscribe_collections(&collections)
+            .await
+            .unwrap();
+
+        coordinator
+            .unsubscribe_collections(&collections)
+            .await
+            .expect_err("one failed live removal should report the transport error");
+
+        assert!(collection_store.collections().is_empty());
+        assert_eq!(collection_store.remove_batches(), 1);
+        assert!(coordinator
+            .get_subscribed_collections()
+            .await
+            .unwrap()
+            .is_empty());
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if transport.subscribed_topics().is_empty() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("failed live removal should converge in the background");
     }
 }

--- a/tools/integration-test/tests/p2p_iroh/replication/collection_sub.rs
+++ b/tools/integration-test/tests/p2p_iroh/replication/collection_sub.rs
@@ -62,6 +62,7 @@ async fn collection_add_get_single() {
     let cols = node.p2p_collection_list().expect("list");
     let arr = cols.as_array().expect("not array");
     assert_eq!(arr.len(), 1, "should have 1 collection");
+    assert_eq!(arr[0], "Users", "list should return the collection name");
 }
 
 #[tokio::test]
@@ -104,9 +105,9 @@ async fn collection_subscription_persists_after_restart() {
         .p2p_collection_list()
         .expect("list after restart");
     assert_eq!(
-        after.as_array().expect("not array").len(),
-        1,
-        "collection subscription should persist across restart"
+        after,
+        serde_json::json!(["Users"]),
+        "collection name should persist across restart"
     );
 }
 
@@ -214,8 +215,7 @@ async fn collection_add_erroneous_id() {
     );
 }
 
-/// A mixed batch returns an error after preserving subscriptions completed
-/// before the invalid collection was encountered.
+/// A mixed batch is validated before any subscription is committed.
 #[tokio::test]
 #[serial]
 async fn collection_add_mixed_batch_preserves_prior_subscription() {
@@ -227,10 +227,9 @@ async fn collection_add_mixed_batch_preserves_prior_subscription() {
 
     let cols = node.p2p_collection_list().expect("list");
     let arr = cols.as_array().expect("not array");
-    assert_eq!(
-        arr.len(),
-        1,
-        "the valid collection subscribed before the error should remain"
+    assert!(
+        arr.is_empty(),
+        "an invalid collection should reject the whole batch before commit"
     );
 }
 


### PR DESCRIPTION
## Summary

- batch collection subscribe and unsubscribe through one serialized coordinator boundary
- commit the complete durable desired-state change atomically before bounded concurrent transport work, matching Go DefraDB
- report durable collection names from GET rather than transient live topic IDs
- retry failed desired topic installs and undesired topic removals automatically with bounded exponential backoff
- serialize retry cleanup with foreground mutations so add, remove, re-add, and retry-owner handoff cannot strand a desired or undesired topic
- restore durable topics concurrently at startup and transfer failed restoration to the in-process retry owner
- always issue idempotent transport removal so an ambiguous timed-out subscribe cannot leave a ghost live topic
- remove obsolete application-side JSON mirroring

Rust still reports a transport installation/removal error to its caller, while durable intent remains authoritative and heals in-process or on restart.

## Tests

- 70-topic bounded concurrency, one durable batch, and idempotent replay
- atomic multi-remove with partial transport failure and automatic convergence
- foreground and startup subscribe failures converge in-process from durable intent
- failed unsubscribe, resubscribe-during-cleanup, and retry-owner handoff races
- durable ID-to-name API compatibility across restart
- collection storage: 6/6
- coordinator subscription regressions: 11/11
- P2P unit suite: 364/364
- P2P adapter unit suite: 62/62
- Iroh collection management integration: 16/16
- clippy clean for p2p and defra-p2p-adapter
- independent blocker review: READY at 3173a2e8

Closes #1746

Stacked on #1747.